### PR TITLE
fix: resolve deploy failure from pnpm version mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- remove `version: 10` from `pnpm/action-setup@v4` in `.github/workflows/deploy.yml`
- rely on `packageManager` in `package.json` as the single pnpm version source
- fixes deploy failure caused by `ERR_PNPM_BAD_PM_VERSION` after merging PR #1

## Test plan
- [x] Confirm workflow diff only changes deploy pnpm setup
- [ ] Merge this PR and verify `Deploy to Cloudflare Workers` run succeeds on `main`

Made with [Cursor](https://cursor.com)