### PR TITLE
release: v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibe-replay-monorepo",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Turn AI coding sessions into animated, interactive web replays",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.3 (both monorepo root and CLI package)

## After merging
1. `pnpm --filter vibe-replay publish --no-git-checks`
2. `git tag v0.0.3 && git push origin v0.0.3`


Made with [Cursor](https://cursor.com)