### PR TITLE
feat(website): add GitHub stars widget to nav

### DIFF
--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -11,8 +11,10 @@ const DEMO_URL = "/view/?gist=741fb4ce6491e11ca0e03c042384ac8b";
       <a href="/explore" class="text-text-muted hover:text-text-primary text-sm transition-colors hidden sm:inline">Explore</a>
     </div>
     <div class="flex items-center gap-4">
-      <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-muted hover:text-text-primary transition-colors" title="GitHub">
+      <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="group flex items-center gap-1.5 text-text-muted hover:text-text-primary transition-colors" title="Star on GitHub">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+        <svg class="w-3.5 h-3.5 text-yellow-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+        <span id="gh-stars" class="text-xs font-mono hidden"></span>
       </a>
       <a href="https://www.npmjs.com/package/vibe-replay" target="_blank" rel="noopener" class="text-text-muted hover:text-text-primary transition-colors" title="npm">
         <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331zM10.665 10H12v2.667h-1.335V10z"/></svg>
@@ -254,6 +256,20 @@ const DEMO_URL = "/view/?gist=741fb4ce6491e11ca0e03c042384ac8b";
 </section>
 
 <script>
+  // Fetch GitHub star count
+  fetch("https://api.github.com/repos/tuo-lei/vibe-replay")
+    .then(r => r.json())
+    .then(data => {
+      const el = document.getElementById("gh-stars");
+      if (el && typeof data.stargazers_count === "number") {
+        el.textContent = data.stargazers_count >= 1000
+          ? (data.stargazers_count / 1000).toFixed(1) + "k"
+          : String(data.stargazers_count);
+        el.classList.remove("hidden");
+      }
+    })
+    .catch(() => {});
+
   // Copy button — stop propagation so it doesn't follow the <a> if nested
   document.getElementById("copy-btn")?.addEventListener("click", (e) => {
     e.preventDefault();

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -11,11 +11,7 @@ const DEMO_URL = "/view/?gist=741fb4ce6491e11ca0e03c042384ac8b";
       <a href="/explore" class="text-text-muted hover:text-text-primary text-sm transition-colors hidden sm:inline">Explore</a>
     </div>
     <div class="flex items-center gap-4">
-      <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="group flex items-center gap-1.5 text-text-muted hover:text-text-primary transition-colors" title="Star on GitHub">
-        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-        <svg class="w-3.5 h-3.5 text-yellow-400 opacity-0 group-hover:opacity-100 transition-opacity" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
-        <span id="gh-stars" class="text-xs font-mono hidden"></span>
-      </a>
+      <a class="github-button" href="https://github.com/tuo-lei/vibe-replay" data-color-scheme="dark" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star tuo-lei/vibe-replay on GitHub">Star</a>
       <a href="https://www.npmjs.com/package/vibe-replay" target="_blank" rel="noopener" class="text-text-muted hover:text-text-primary transition-colors" title="npm">
         <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331zM10.665 10H12v2.667h-1.335V10z"/></svg>
       </a>
@@ -256,20 +252,6 @@ const DEMO_URL = "/view/?gist=741fb4ce6491e11ca0e03c042384ac8b";
 </section>
 
 <script>
-  // Fetch GitHub star count
-  fetch("https://api.github.com/repos/tuo-lei/vibe-replay")
-    .then(r => r.json())
-    .then(data => {
-      const el = document.getElementById("gh-stars");
-      if (el && typeof data.stargazers_count === "number") {
-        el.textContent = data.stargazers_count >= 1000
-          ? (data.stargazers_count / 1000).toFixed(1) + "k"
-          : String(data.stargazers_count);
-        el.classList.remove("hidden");
-      }
-    })
-    .catch(() => {});
-
   // Copy button — stop propagation so it doesn't follow the <a> if nested
   document.getElementById("copy-btn")?.addEventListener("click", (e) => {
     e.preventDefault();

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -36,6 +36,8 @@ const {
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <!-- GitHub buttons -->
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </head>
   <body class="bg-surface text-text-primary font-sans antialiased">
     <slot />


### PR DESCRIPTION
## Summary
- Replace custom GitHub icon link with official [github-buttons](https://buttons.github.io/) star widget showing live star count
- Load `buttons.github.io/buttons.js` async in Layout head
- Dark color scheme matches site theme

## Test plan
- [ ] Verify star button renders correctly on the website landing page
- [ ] Confirm star count displays and links to the repo
- [ ] Check no layout shift or performance regression from async script

🤖 Generated with [Claude Code](https://claude.com/claude-code)