### PR TITLE
feat: improve mobile UX and polish viewer experience

### DIFF
--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>vibe-replay</title>
   </head>
   <body class="bg-terminal-bg text-terminal-text min-h-screen">

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -56,7 +56,7 @@ export default function App() {
 
   return (
     <div className="h-screen bg-terminal-bg flex flex-col overflow-hidden">
-      <header className="border-b border-terminal-border/50 px-4 py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30">
+      <header className="border-b border-terminal-border/50 px-4 py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30 safe-top">
         {/* Left: branding + project */}
         <div className="flex items-center gap-3 min-w-0">
           <h1 className="text-sm font-mono font-bold text-terminal-green shrink-0">
@@ -99,11 +99,11 @@ export default function App() {
               </button>
             </div>
 
-            {/* Tool collapse toggle — only relevant in All mode */}
+            {/* Tool collapse toggle — only relevant in All mode, hidden on mobile */}
             {!prefs.promptsOnly && (
               <button
                 onClick={() => togglePref("collapseAllTools")}
-                className={`px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
+                className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
                   prefs.collapseAllTools
                     ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
                     : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
@@ -113,11 +113,11 @@ export default function App() {
               </button>
             )}
 
-            {/* Thinking toggle — only show if session has thinking blocks */}
+            {/* Thinking toggle — hidden on mobile */}
             {hasThinking && !prefs.promptsOnly && (
               <button
                 onClick={() => togglePref("hideThinking")}
-                className={`px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
+                className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
                   prefs.hideThinking
                     ? "bg-terminal-purple/10 text-terminal-purple border-terminal-purple/30"
                     : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
@@ -137,8 +137,8 @@ export default function App() {
             </button>
           </div>
 
-          {/* Session info — plain text, non-interactive */}
-          <div className="flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
+          {/* Session info — plain text, hidden on mobile */}
+          <div className="hidden md:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
             {meta.model && (
               <span className="text-terminal-text/60">{meta.model}</span>
             )}

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -71,8 +71,8 @@ export default function App() {
   return (
     <div className="h-screen bg-terminal-bg flex flex-col overflow-hidden">
       <header className="border-b border-terminal-border/50 px-3 md:px-4 py-2 md:py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30 safe-top">
-        {/* Left: branding + project */}
-        <div className="flex items-center gap-3 min-w-0">
+        {/* Left: branding + session info */}
+        <div className="flex items-center gap-2 md:gap-3 min-w-0">
           <a
             href="https://vibe-replay.com"
             target="_blank"
@@ -81,22 +81,27 @@ export default function App() {
           >
             vibe-replay
           </a>
-          <span className="hidden md:inline text-terminal-dim text-xs font-mono truncate">
-            {meta.project}
-          </span>
           {meta.title && (
-            <span className="text-terminal-text text-xs truncate hidden sm:inline">
+            <span className="hidden md:inline text-terminal-text text-xs font-mono truncate max-w-[300px]" title={meta.project}>
               {meta.title}
             </span>
           )}
+          <div className="hidden sm:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
+            {meta.model && (
+              <><span className="text-terminal-border">&middot;</span><span className="text-terminal-text/60">{meta.model}</span></>
+            )}
+            {duration && (
+              <><span className="text-terminal-border">&middot;</span><span>{duration}</span></>
+            )}
+          </div>
         </div>
 
-        <div className="flex items-center gap-1.5 md:gap-3 shrink-0">
+        <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
           {/* View mode: segmented control */}
-          <div className="flex items-center rounded-md overflow-hidden border border-terminal-border/60">
+          <div className="flex items-center h-7 rounded-md overflow-hidden border border-terminal-border/60">
             <button
               onClick={() => { if (prefs.promptsOnly) togglePref("promptsOnly"); }}
-              className={`px-2.5 py-1 text-xs font-mono transition-colors ${
+              className={`h-full px-2.5 text-xs font-mono transition-colors ${
                 !prefs.promptsOnly
                   ? "bg-terminal-green/15 text-terminal-green"
                   : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
@@ -106,7 +111,7 @@ export default function App() {
             </button>
             <button
               onClick={() => { if (!prefs.promptsOnly) togglePref("promptsOnly"); }}
-              className={`px-2.5 py-1 text-xs font-mono transition-colors ${
+              className={`h-full px-2.5 text-xs font-mono transition-colors ${
                 prefs.promptsOnly
                   ? "bg-terminal-green/15 text-terminal-green"
                   : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
@@ -116,94 +121,66 @@ export default function App() {
             </button>
           </div>
 
-          {/* Desktop: inline filter buttons */}
-          {!prefs.promptsOnly && (
+          {/* Settings dropdown — filters + theme */}
+          <div ref={filterRef} className="relative">
             <button
-              onClick={() => togglePref("collapseAllTools")}
-              className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
-                prefs.collapseAllTools
-                  ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
-                  : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
-              }`}
-            >
-              {prefs.collapseAllTools ? "Expand Tools" : "Collapse Tools"}
-            </button>
-          )}
-          {hasThinking && !prefs.promptsOnly && (
-            <button
-              onClick={() => togglePref("hideThinking")}
-              className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
-                prefs.hideThinking
-                  ? "bg-terminal-purple/10 text-terminal-purple border-terminal-purple/30"
-                  : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
-              }`}
-            >
-              {prefs.hideThinking ? "Show Thinking" : "Hide Thinking"}
-            </button>
-          )}
-
-          {/* Mobile: filter dropdown */}
-          {!prefs.promptsOnly && (
-            <div ref={filterRef} className="relative md:hidden">
-              <button
-                onClick={() => setFilterOpen((v) => !v)}
-                className={`w-8 h-8 flex items-center justify-center rounded-md border transition-colors text-xs ${
-                  prefs.collapseAllTools || prefs.hideThinking
+              onClick={() => setFilterOpen((v) => !v)}
+              className={`h-7 w-7 flex items-center justify-center rounded-md border transition-colors text-xs ${
+                filterOpen
+                  ? "bg-terminal-green/15 text-terminal-green border-terminal-green/30"
+                  : prefs.collapseAllTools || prefs.hideThinking
                     ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
-                    : "bg-terminal-surface text-terminal-dim border-terminal-border/60"
-                }`}
-                title="View filters"
-              >
-                {"\u2699"}
-              </button>
-              {filterOpen && (
-                <div className="absolute right-0 top-full mt-1.5 w-44 bg-terminal-bg border border-terminal-border rounded-lg shadow-xl z-50 py-1 overflow-hidden">
-                  <button
-                    onClick={() => { togglePref("collapseAllTools"); setFilterOpen(false); }}
-                    className={`w-full text-left px-3 py-2.5 text-xs font-mono transition-colors ${
-                      prefs.collapseAllTools
-                        ? "text-terminal-orange bg-terminal-orange/5"
-                        : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50"
-                    }`}
-                  >
-                    {prefs.collapseAllTools ? "\u2713 Collapse Tools" : "Collapse Tools"}
-                  </button>
-                  {hasThinking && (
+                    : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
+              }`}
+              title="Settings"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                <line x1="2" y1="4" x2="14" y2="4" /><line x1="2" y1="8" x2="14" y2="8" /><line x1="2" y1="12" x2="14" y2="12" />
+                <circle cx="5" cy="4" r="1.5" fill="currentColor" /><circle cx="10" cy="8" r="1.5" fill="currentColor" /><circle cx="6" cy="12" r="1.5" fill="currentColor" />
+              </svg>
+            </button>
+            {filterOpen && (
+              <div className="absolute right-0 top-full mt-1.5 w-48 bg-terminal-bg border border-terminal-border rounded-lg shadow-xl z-50 py-1.5 overflow-hidden">
+                {!prefs.promptsOnly && (
+                  <>
                     <button
-                      onClick={() => { togglePref("hideThinking"); setFilterOpen(false); }}
-                      className={`w-full text-left px-3 py-2.5 text-xs font-mono transition-colors ${
-                        prefs.hideThinking
-                          ? "text-terminal-purple bg-terminal-purple/5"
-                          : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50"
-                      }`}
+                      onClick={() => togglePref("collapseAllTools")}
+                      className="w-full text-left px-3 py-2 text-xs font-mono text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50 transition-colors flex items-center gap-2"
                     >
-                      {prefs.hideThinking ? "\u2713 Hide Thinking" : "Hide Thinking"}
+                      <span className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[10px] ${
+                        prefs.collapseAllTools
+                          ? "bg-terminal-orange/20 border-terminal-orange/50 text-terminal-orange"
+                          : "border-terminal-border"
+                      }`}>{prefs.collapseAllTools ? "\u2713" : ""}</span>
+                      Collapse Tools
                     </button>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Theme toggle */}
-          <button
-            onClick={toggleTheme}
-            className="w-8 h-8 flex items-center justify-center rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-text transition-colors text-sm"
-            title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-          >
-            {theme === "dark" ? "\u263E" : "\u2600"}
-          </button>
-
-          {/* Session info — desktop only */}
-          <div className="hidden md:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
-            {meta.model && (
-              <span className="text-terminal-text/60">{meta.model}</span>
+                    {hasThinking && (
+                      <button
+                        onClick={() => togglePref("hideThinking")}
+                        className="w-full text-left px-3 py-2 text-xs font-mono text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50 transition-colors flex items-center gap-2"
+                      >
+                        <span className={`w-3.5 h-3.5 rounded border flex items-center justify-center text-[10px] ${
+                          prefs.hideThinking
+                            ? "bg-terminal-purple/20 border-terminal-purple/50 text-terminal-purple"
+                            : "border-terminal-border"
+                        }`}>{prefs.hideThinking ? "\u2713" : ""}</span>
+                        Hide Thinking
+                      </button>
+                    )}
+                    <div className="border-t border-terminal-border/40 my-1.5" />
+                  </>
+                )}
+                <button
+                  onClick={() => { toggleTheme(); setFilterOpen(false); }}
+                  className="w-full text-left px-3 py-2 text-xs font-mono text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50 transition-colors flex items-center gap-2"
+                >
+                  <span className="w-3.5 text-center">{theme === "dark" ? "\u263E" : "\u2600"}</span>
+                  {theme === "dark" ? "Light Mode" : "Dark Mode"}
+                </button>
+              </div>
             )}
-            {meta.model && duration && <span className="text-terminal-border">&middot;</span>}
-            {duration && <span>{duration}</span>}
-            <span className="text-terminal-border">&middot;</span>
-            <span className="tabular-nums">{meta.stats.userPrompts}T / {meta.stats.sceneCount}S</span>
           </div>
+
         </div>
       </header>
       <Player session={session!} viewPrefs={prefs} />

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import Player from "./components/Player";
 import { useSessionLoader } from "./hooks/useSessionLoader";
 import { useTheme } from "./hooks/useTheme";
@@ -25,6 +25,20 @@ export default function App() {
     () => session?.scenes.some((s) => s.type === "thinking") ?? false,
     [session],
   );
+
+  // Mobile filter dropdown
+  const [filterOpen, setFilterOpen] = useState(false);
+  const filterRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!filterOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (filterRef.current && !filterRef.current.contains(e.target as Node)) {
+        setFilterOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [filterOpen]);
 
   if (loadState.status === "loading") {
     return (
@@ -56,13 +70,13 @@ export default function App() {
 
   return (
     <div className="h-screen bg-terminal-bg flex flex-col overflow-hidden">
-      <header className="border-b border-terminal-border/50 px-4 py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30 safe-top">
+      <header className="border-b border-terminal-border/50 px-3 md:px-4 py-2 md:py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30 safe-top">
         {/* Left: branding + project */}
         <div className="flex items-center gap-3 min-w-0">
           <h1 className="text-sm font-mono font-bold text-terminal-green shrink-0">
             vibe-replay
           </h1>
-          <span className="text-terminal-dim text-xs font-mono truncate">
+          <span className="hidden md:inline text-terminal-dim text-xs font-mono truncate">
             {meta.project}
           </span>
           {meta.title && (
@@ -72,72 +86,110 @@ export default function App() {
           )}
         </div>
 
-        <div className="flex items-center gap-3 shrink-0">
-          {/* View controls — interactive, visually distinct */}
-          <div className="flex items-center gap-2">
-            {/* View mode: segmented control */}
-            <div className="flex items-center rounded-md overflow-hidden border border-terminal-border/60">
-              <button
-                onClick={() => { if (prefs.promptsOnly) togglePref("promptsOnly"); }}
-                className={`px-2.5 py-1 text-xs font-mono transition-colors ${
-                  !prefs.promptsOnly
-                    ? "bg-terminal-green/15 text-terminal-green"
-                    : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
-                }`}
-              >
-                All
-              </button>
-              <button
-                onClick={() => { if (!prefs.promptsOnly) togglePref("promptsOnly"); }}
-                className={`px-2.5 py-1 text-xs font-mono transition-colors ${
-                  prefs.promptsOnly
-                    ? "bg-terminal-green/15 text-terminal-green"
-                    : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
-                }`}
-              >
-                Prompts
-              </button>
-            </div>
-
-            {/* Tool collapse toggle — only relevant in All mode, hidden on mobile */}
-            {!prefs.promptsOnly && (
-              <button
-                onClick={() => togglePref("collapseAllTools")}
-                className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
-                  prefs.collapseAllTools
-                    ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
-                    : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
-                }`}
-              >
-                {prefs.collapseAllTools ? "Expand Tools" : "Collapse Tools"}
-              </button>
-            )}
-
-            {/* Thinking toggle — hidden on mobile */}
-            {hasThinking && !prefs.promptsOnly && (
-              <button
-                onClick={() => togglePref("hideThinking")}
-                className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
-                  prefs.hideThinking
-                    ? "bg-terminal-purple/10 text-terminal-purple border-terminal-purple/30"
-                    : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
-                }`}
-              >
-                {prefs.hideThinking ? "Show Thinking" : "Hide Thinking"}
-              </button>
-            )}
-
-            {/* Theme toggle */}
+        <div className="flex items-center gap-1.5 md:gap-3 shrink-0">
+          {/* View mode: segmented control */}
+          <div className="flex items-center rounded-md overflow-hidden border border-terminal-border/60">
             <button
-              onClick={toggleTheme}
-              className="w-8 h-8 flex items-center justify-center rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-text transition-colors text-sm"
-              title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+              onClick={() => { if (prefs.promptsOnly) togglePref("promptsOnly"); }}
+              className={`px-2.5 py-1 text-xs font-mono transition-colors ${
+                !prefs.promptsOnly
+                  ? "bg-terminal-green/15 text-terminal-green"
+                  : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
+              }`}
             >
-              {theme === "dark" ? "\u263E" : "\u2600"}
+              All
+            </button>
+            <button
+              onClick={() => { if (!prefs.promptsOnly) togglePref("promptsOnly"); }}
+              className={`px-2.5 py-1 text-xs font-mono transition-colors ${
+                prefs.promptsOnly
+                  ? "bg-terminal-green/15 text-terminal-green"
+                  : "bg-terminal-surface text-terminal-dim hover:text-terminal-text"
+              }`}
+            >
+              Prompts
             </button>
           </div>
 
-          {/* Session info — plain text, hidden on mobile */}
+          {/* Desktop: inline filter buttons */}
+          {!prefs.promptsOnly && (
+            <button
+              onClick={() => togglePref("collapseAllTools")}
+              className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
+                prefs.collapseAllTools
+                  ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
+                  : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
+              }`}
+            >
+              {prefs.collapseAllTools ? "Expand Tools" : "Collapse Tools"}
+            </button>
+          )}
+          {hasThinking && !prefs.promptsOnly && (
+            <button
+              onClick={() => togglePref("hideThinking")}
+              className={`hidden md:inline-flex px-2.5 py-1 text-xs font-mono rounded-md border transition-colors ${
+                prefs.hideThinking
+                  ? "bg-terminal-purple/10 text-terminal-purple border-terminal-purple/30"
+                  : "bg-terminal-surface text-terminal-dim border-terminal-border/60 hover:text-terminal-text"
+              }`}
+            >
+              {prefs.hideThinking ? "Show Thinking" : "Hide Thinking"}
+            </button>
+          )}
+
+          {/* Mobile: filter dropdown */}
+          {!prefs.promptsOnly && (
+            <div ref={filterRef} className="relative md:hidden">
+              <button
+                onClick={() => setFilterOpen((v) => !v)}
+                className={`w-8 h-8 flex items-center justify-center rounded-md border transition-colors text-xs ${
+                  prefs.collapseAllTools || prefs.hideThinking
+                    ? "bg-terminal-orange/10 text-terminal-orange border-terminal-orange/30"
+                    : "bg-terminal-surface text-terminal-dim border-terminal-border/60"
+                }`}
+                title="View filters"
+              >
+                {"\u2699"}
+              </button>
+              {filterOpen && (
+                <div className="absolute right-0 top-full mt-1.5 w-44 bg-terminal-bg border border-terminal-border rounded-lg shadow-xl z-50 py-1 overflow-hidden">
+                  <button
+                    onClick={() => { togglePref("collapseAllTools"); setFilterOpen(false); }}
+                    className={`w-full text-left px-3 py-2.5 text-xs font-mono transition-colors ${
+                      prefs.collapseAllTools
+                        ? "text-terminal-orange bg-terminal-orange/5"
+                        : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50"
+                    }`}
+                  >
+                    {prefs.collapseAllTools ? "\u2713 Collapse Tools" : "Collapse Tools"}
+                  </button>
+                  {hasThinking && (
+                    <button
+                      onClick={() => { togglePref("hideThinking"); setFilterOpen(false); }}
+                      className={`w-full text-left px-3 py-2.5 text-xs font-mono transition-colors ${
+                        prefs.hideThinking
+                          ? "text-terminal-purple bg-terminal-purple/5"
+                          : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface/50"
+                      }`}
+                    >
+                      {prefs.hideThinking ? "\u2713 Hide Thinking" : "Hide Thinking"}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Theme toggle */}
+          <button
+            onClick={toggleTheme}
+            className="w-8 h-8 flex items-center justify-center rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-text transition-colors text-sm"
+            title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+          >
+            {theme === "dark" ? "\u263E" : "\u2600"}
+          </button>
+
+          {/* Session info — desktop only */}
           <div className="hidden md:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
             {meta.model && (
               <span className="text-terminal-text/60">{meta.model}</span>

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -73,9 +73,14 @@ export default function App() {
       <header className="border-b border-terminal-border/50 px-3 md:px-4 py-2 md:py-2.5 flex items-center justify-between shrink-0 bg-terminal-surface/30 safe-top">
         {/* Left: branding + project */}
         <div className="flex items-center gap-3 min-w-0">
-          <h1 className="text-sm font-mono font-bold text-terminal-green shrink-0">
+          <a
+            href="https://vibe-replay.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-mono font-bold shrink-0 hover:opacity-80 transition-opacity bg-gradient-to-r from-[#3fb950] to-[#58a6ff] bg-clip-text text-transparent"
+          >
             vibe-replay
-          </h1>
+          </a>
           <span className="hidden md:inline text-terminal-dim text-xs font-mono truncate">
             {meta.project}
           </span>

--- a/packages/viewer/src/components/BashBlock.tsx
+++ b/packages/viewer/src/components/BashBlock.tsx
@@ -11,7 +11,7 @@ export default memo(function BashBlock({ command, stdout, isActive }: Props) {
   const hasOutput = stdout.trim().length > 0;
 
   return (
-    <div className="border border-terminal-border rounded-lg overflow-hidden bg-[#0a0e14]">
+    <div className="border border-terminal-border rounded-lg overflow-hidden bg-terminal-surface">
       <button
         onClick={() => hasOutput && setExpanded(!expanded)}
         className="w-full flex items-center gap-2 px-3 py-2 bg-terminal-surface/50 hover:bg-terminal-border/20 transition-colors text-left border-b border-terminal-border"

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -1,6 +1,14 @@
-import { useMemo, memo } from "react";
+import { useMemo, memo, useSyncExternalStore } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import { diffLines as computeLineDiff } from "diff";
+
+// Subscribe to dark/light class changes on <html> for prism theme switching
+const subscribe = (cb: () => void) => {
+  const observer = new MutationObserver(cb);
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+  return () => observer.disconnect();
+};
+const getIsDark = () => document.documentElement.classList.contains("dark");
 
 interface Props {
   toolName: string;
@@ -76,6 +84,7 @@ export default memo(function CodeDiffBlock({
     [oldContent, newContent],
   );
   const language = guessLanguage(filePath);
+  const isDark = useSyncExternalStore(subscribe, getIsDark);
   const isNewFile = !oldContent;
 
   return (
@@ -95,7 +104,7 @@ export default memo(function CodeDiffBlock({
       </div>
       <div className="overflow-x-auto max-h-[400px] overflow-y-auto">
         <Highlight
-          theme={themes.nightOwl}
+          theme={isDark ? themes.nightOwl : themes.nightOwlLight}
           code={diffLines.map((l) => l.content).join("\n")}
           language={language}
         >
@@ -106,9 +115,9 @@ export default memo(function CodeDiffBlock({
                 if (!diffLine) return null;
                 const bgClass =
                   diffLine.type === "add"
-                    ? "bg-green-900/30"
+                    ? "bg-green-100 dark:bg-green-900/30"
                     : diffLine.type === "remove"
-                      ? "bg-red-900/30"
+                      ? "bg-red-100 dark:bg-red-900/30"
                       : "";
                 const prefix =
                   diffLine.type === "add"

--- a/packages/viewer/src/components/Controls.tsx
+++ b/packages/viewer/src/components/Controls.tsx
@@ -115,12 +115,12 @@ export default function Controls({
         )}
       </div>
 
-      <div className="flex items-center gap-2 md:gap-3 text-xs text-terminal-dim font-mono shrink-0">
+      <div className="hidden sm:flex items-center gap-2 md:gap-3 text-xs text-terminal-dim font-mono shrink-0">
         {state === "paused" && (
-          <span className="hidden sm:inline text-terminal-orange">PAUSED</span>
+          <span className="text-terminal-orange">PAUSED</span>
         )}
         <span className="tabular-nums">
-          {Math.max(0, currentIndex + 1)}<span className="hidden sm:inline"> </span>/<span className="hidden sm:inline"> </span>{totalScenes}
+          {Math.max(0, currentIndex + 1)} / {totalScenes}
         </span>
         {/* Keyboard hints — desktop only */}
         <span className="hidden lg:inline-flex items-center gap-2 text-terminal-dim/50 border-l border-terminal-border/40 pl-3">

--- a/packages/viewer/src/components/Controls.tsx
+++ b/packages/viewer/src/components/Controls.tsx
@@ -13,6 +13,7 @@ interface Props {
   onPrevPrompt: () => void;
   onNextPrompt: () => void;
   onOpenSearch: () => void;
+  onOpenOutline?: () => void;
 }
 
 const SPEEDS = [1, 5, 10];
@@ -29,6 +30,7 @@ export default function Controls({
   onPrevPrompt,
   onNextPrompt,
   onOpenSearch,
+  onOpenOutline,
 }: Props) {
   const isPlaying = state === "playing";
   const playIcon = isPlaying ? "\u23F8" : "\u25B6";
@@ -46,15 +48,15 @@ export default function Controls({
     flashId === id ? "ring-2 ring-terminal-green/50 scale-105" : "";
 
   return (
-    <div className="flex items-center justify-between px-4 py-2">
-      <div className="flex items-center gap-3">
+    <div className="flex items-center justify-between px-3 md:px-4 py-2">
+      <div className="flex items-center gap-1.5 md:gap-3">
         <button
           onClick={() => { flash("play"); onTogglePlayPause(); }}
-          className={`h-8 flex items-center gap-1.5 px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-green hover:text-terminal-green text-xs font-mono ${btnBase} ${flashClass("play")}`}
+          className={`h-9 md:h-8 flex items-center gap-1.5 px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-green hover:text-terminal-green text-xs font-mono ${btnBase} ${flashClass("play")}`}
           title="Play/Pause (Space)"
         >
           <span>{playIcon}</span>
-          <span>{playLabel}</span>
+          <span className="hidden sm:inline">{playLabel}</span>
         </button>
 
         <div className="flex items-center border border-terminal-border/60 rounded-md overflow-hidden">
@@ -62,7 +64,7 @@ export default function Controls({
             <button
               key={s}
               onClick={() => { flash(`speed-${s}`); onChangeSpeed(s); }}
-              className={`px-2.5 py-1 text-xs font-mono ${btnBase} ${
+              className={`px-2 md:px-2.5 py-1.5 md:py-1 text-xs font-mono ${btnBase} ${
                 speed === s
                   ? "bg-terminal-green/15 text-terminal-green"
                   : "text-terminal-dim hover:text-terminal-text bg-terminal-surface"
@@ -73,20 +75,20 @@ export default function Controls({
           ))}
         </div>
 
-        <div className="flex items-center gap-1 ml-1">
+        <div className="flex items-center gap-0.5 md:gap-1 ml-0.5 md:ml-1">
           <button
             onClick={() => { flash("prev"); onPrevPrompt(); }}
-            className={`px-2 py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("prev")}`}
+            className={`px-2 py-1.5 md:py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("prev")}`}
             title="Previous turn (p)"
           >
             {"<"}
           </button>
-          <span className="text-xs font-mono text-terminal-dim px-1 tabular-nums">
-            Turn {currentTurn}/{userPromptCount}
+          <span className="text-xs font-mono text-terminal-dim px-0.5 md:px-1 tabular-nums">
+            <span className="hidden sm:inline">Turn </span>{currentTurn}/{userPromptCount}
           </span>
           <button
             onClick={() => { flash("next"); onNextPrompt(); }}
-            className={`px-2 py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("next")}`}
+            className={`px-2 py-1.5 md:py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("next")}`}
             title="Next turn (n)"
           >
             {">"}
@@ -95,20 +97,30 @@ export default function Controls({
 
         <button
           onClick={() => { flash("search"); onOpenSearch(); }}
-          className={`h-8 flex items-center gap-1.5 px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-blue hover:text-terminal-blue text-xs font-mono ${btnBase} ${flashClass("search")}`}
+          className={`h-9 md:h-8 flex items-center gap-1.5 px-2.5 md:px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-blue hover:text-terminal-blue text-xs font-mono ${btnBase} ${flashClass("search")}`}
           title="Search (Cmd/Ctrl+K)"
         >
           <span>{"\uD83D\uDD0D"}</span>
-          <span>Search</span>
+          <span className="hidden sm:inline">Search</span>
         </button>
+
+        {onOpenOutline && (
+          <button
+            onClick={() => { flash("outline"); onOpenOutline(); }}
+            className={`md:hidden h-9 flex items-center px-2.5 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-text text-xs font-mono ${btnBase} ${flashClass("outline")}`}
+            title="Outline"
+          >
+            {"\u2630"}
+          </button>
+        )}
       </div>
 
-      <div className="flex items-center gap-3 text-xs text-terminal-dim font-mono">
+      <div className="flex items-center gap-2 md:gap-3 text-xs text-terminal-dim font-mono shrink-0">
         {state === "paused" && (
-          <span className="text-terminal-orange">PAUSED</span>
+          <span className="hidden sm:inline text-terminal-orange">PAUSED</span>
         )}
         <span className="tabular-nums">
-          {Math.max(0, currentIndex + 1)} / {totalScenes}
+          {Math.max(0, currentIndex + 1)}<span className="hidden sm:inline"> </span>/<span className="hidden sm:inline"> </span>{totalScenes}
         </span>
         {/* Keyboard hints — desktop only */}
         <span className="hidden lg:inline-flex items-center gap-2 text-terminal-dim/50 border-l border-terminal-border/40 pl-3">

--- a/packages/viewer/src/components/Controls.tsx
+++ b/packages/viewer/src/components/Controls.tsx
@@ -47,24 +47,31 @@ export default function Controls({
   const flashClass = (id: string) =>
     flashId === id ? "ring-2 ring-terminal-green/50 scale-105" : "";
 
+  const groupStyle = "flex items-center border border-terminal-border/60 rounded-md overflow-hidden";
+  const cellStyle = "px-2.5 md:px-2.5 py-2 md:py-1 text-xs font-mono";
+
   return (
     <div className="flex items-center justify-between px-3 md:px-4 py-2">
       <div className="flex items-center gap-1.5 md:gap-3">
-        <button
-          onClick={() => { flash("play"); onTogglePlayPause(); }}
-          className={`h-9 md:h-8 flex items-center gap-1.5 px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-green hover:text-terminal-green text-xs font-mono ${btnBase} ${flashClass("play")}`}
-          title="Play/Pause (Space)"
-        >
-          <span>{playIcon}</span>
-          <span className="hidden sm:inline">{playLabel}</span>
-        </button>
+        {/* Play/Pause */}
+        <div className={groupStyle}>
+          <button
+            onClick={() => { flash("play"); onTogglePlayPause(); }}
+            className={`${cellStyle} hover:text-terminal-green bg-terminal-surface ${btnBase} ${flashClass("play")}`}
+            title="Play/Pause (Space)"
+          >
+            <span>{playIcon}</span>
+            <span className="hidden sm:inline ml-1.5">{playLabel}</span>
+          </button>
+        </div>
 
-        <div className="flex items-center border border-terminal-border/60 rounded-md overflow-hidden">
+        {/* Speed */}
+        <div className={groupStyle}>
           {SPEEDS.map((s) => (
             <button
               key={s}
               onClick={() => { flash(`speed-${s}`); onChangeSpeed(s); }}
-              className={`px-2 md:px-2.5 py-1.5 md:py-1 text-xs font-mono ${btnBase} ${
+              className={`${cellStyle} ${btnBase} ${
                 speed === s
                   ? "bg-terminal-green/15 text-terminal-green"
                   : "text-terminal-dim hover:text-terminal-text bg-terminal-surface"
@@ -75,43 +82,50 @@ export default function Controls({
           ))}
         </div>
 
-        <div className="flex items-center gap-0.5 md:gap-1 ml-0.5 md:ml-1">
+        {/* Turn navigation */}
+        <div className={groupStyle}>
           <button
             onClick={() => { flash("prev"); onPrevPrompt(); }}
-            className={`px-2 py-1.5 md:py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("prev")}`}
+            className={`${cellStyle} text-terminal-dim hover:text-terminal-green bg-terminal-surface ${btnBase} ${flashClass("prev")}`}
             title="Previous turn (p)"
           >
-            {"<"}
+            {"\u2039"}
           </button>
-          <span className="text-xs font-mono text-terminal-dim px-0.5 md:px-1 tabular-nums">
+          <span className={`${cellStyle} text-terminal-dim tabular-nums bg-terminal-surface border-x border-terminal-border/60`}>
             <span className="hidden sm:inline">Turn </span>{currentTurn}/{userPromptCount}
           </span>
           <button
             onClick={() => { flash("next"); onNextPrompt(); }}
-            className={`px-2 py-1.5 md:py-1 text-xs font-mono text-terminal-dim hover:text-terminal-green ${btnBase} ${flashClass("next")}`}
+            className={`${cellStyle} text-terminal-dim hover:text-terminal-green bg-terminal-surface ${btnBase} ${flashClass("next")}`}
             title="Next turn (n)"
           >
-            {">"}
+            {"\u203A"}
           </button>
         </div>
 
-        <button
-          onClick={() => { flash("search"); onOpenSearch(); }}
-          className={`h-9 md:h-8 flex items-center gap-1.5 px-2.5 md:px-3 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-blue hover:text-terminal-blue text-xs font-mono ${btnBase} ${flashClass("search")}`}
-          title="Search (Cmd/Ctrl+K)"
-        >
-          <span>{"\uD83D\uDD0D"}</span>
-          <span className="hidden sm:inline">Search</span>
-        </button>
-
-        {onOpenOutline && (
+        {/* Search */}
+        <div className={groupStyle}>
           <button
-            onClick={() => { flash("outline"); onOpenOutline(); }}
-            className={`md:hidden h-9 flex items-center px-2.5 rounded-md bg-terminal-surface border border-terminal-border/60 hover:border-terminal-text text-xs font-mono ${btnBase} ${flashClass("outline")}`}
-            title="Outline"
+            onClick={() => { flash("search"); onOpenSearch(); }}
+            className={`${cellStyle} hover:text-terminal-blue bg-terminal-surface ${btnBase} ${flashClass("search")}`}
+            title="Search (Cmd/Ctrl+K)"
           >
-            {"\u2630"}
+            <span>{"\uD83D\uDD0D"}</span>
+            <span className="hidden sm:inline ml-1.5">Search</span>
           </button>
+        </div>
+
+        {/* Outline (mobile only) */}
+        {onOpenOutline && (
+          <div className={`${groupStyle} md:hidden`}>
+            <button
+              onClick={() => { flash("outline"); onOpenOutline(); }}
+              className={`${cellStyle} hover:text-terminal-text bg-terminal-surface ${btnBase} ${flashClass("outline")}`}
+              title="Outline"
+            >
+              {"\u2630"}
+            </button>
+          </div>
         )}
       </div>
 

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -91,13 +91,16 @@ export default function LandingHero({ session, onStart }: Props) {
   }, [onStart]);
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center relative overflow-hidden">
+    <div className="flex-1 flex flex-col items-center overflow-y-auto relative">
       {/* Background glow */}
       <div className="absolute inset-0 bg-gradient-to-b from-terminal-green/[0.03] via-transparent to-transparent pointer-events-none" />
 
-      <div className="max-w-2xl w-full px-6 text-center space-y-8 z-10">
+      {/* Top spacer — shrinks to 0 when content exceeds viewport */}
+      <div className="flex-1 min-h-0" />
+
+      <div className="max-w-2xl w-full px-6 text-center space-y-5 md:space-y-8 z-10 shrink-0">
         {/* Title */}
-        <div className="space-y-3">
+        <div className="space-y-2 md:space-y-3">
           <h2 className="text-2xl sm:text-3xl font-mono font-bold text-terminal-text leading-tight">
             {title}
           </h2>
@@ -112,9 +115,13 @@ export default function LandingHero({ session, onStart }: Props) {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-lg mx-auto">
           <StatPill label="Turns" value={meta.stats.userPrompts} color="text-terminal-green" />
           <StatPill label="Tool Calls" value={meta.stats.toolCalls} color="text-terminal-orange" />
-          <StatPill label="Files" value={stats.filesModified} color="text-terminal-blue" />
           {duration ? (
             <StatPill label="Duration" value={duration} color="text-terminal-text" />
+          ) : (
+            <StatPill label="Files" value={stats.filesModified} color="text-terminal-blue" />
+          )}
+          {meta.stats.costEstimate !== undefined ? (
+            <StatPill label="Cost" value={`$${meta.stats.costEstimate < 0.01 ? meta.stats.costEstimate.toFixed(4) : meta.stats.costEstimate.toFixed(2)}`} color="text-terminal-green" />
           ) : (
             <StatPill label="Scenes" value={meta.stats.sceneCount} color="text-terminal-text" />
           )}
@@ -141,9 +148,9 @@ export default function LandingHero({ session, onStart }: Props) {
         </button>
       </div>
 
-      {/* First prompt teaser at the bottom */}
+      {/* First prompt teaser — normal flow, not absolute */}
       {firstPrompt && (
-        <div className="absolute bottom-0 left-0 right-0 px-6 pb-6">
+        <div className="w-full px-6 mt-6 md:mt-8 pb-6 z-10 shrink-0">
           <div
             onClick={onStart}
             className="max-w-2xl mx-auto cursor-pointer group"
@@ -165,6 +172,9 @@ export default function LandingHero({ session, onStart }: Props) {
           </div>
         </div>
       )}
+
+      {/* Bottom spacer — shrinks to 0 when content exceeds viewport */}
+      <div className="flex-1 min-h-0" />
     </div>
   );
 }

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -100,7 +100,15 @@ export default function LandingHero({ session, onStart }: Props) {
 
       <div className="max-w-2xl w-full px-6 text-center space-y-5 md:space-y-8 z-10 shrink-0">
         {/* Title */}
-        <div className="space-y-2 md:space-y-3">
+        <div className="space-y-3 md:space-y-4">
+          <a
+            href="https://vibe-replay.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-lg sm:text-xl font-mono font-bold hover:opacity-80 transition-opacity bg-gradient-to-r from-[#3fb950] to-[#58a6ff] bg-clip-text text-transparent"
+          >
+            vibe-replay
+          </a>
           <h2 className="text-2xl sm:text-3xl font-mono font-bold text-terminal-text leading-tight">
             {title}
           </h2>
@@ -172,6 +180,19 @@ export default function LandingHero({ session, onStart }: Props) {
           </div>
         </div>
       )}
+
+      {/* Explore link */}
+      <div className="px-6 py-4 z-10 shrink-0">
+        <a
+          href="https://vibe-replay.com/explore"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-xs font-mono text-terminal-dim hover:text-terminal-text transition-colors border border-terminal-border/40 rounded-full px-4 py-1.5 hover:border-terminal-border"
+        >
+          Explore more replays
+          <span className="text-terminal-green">{"\u2192"}</span>
+        </a>
+      </div>
 
       {/* Bottom spacer — shrinks to 0 when content exceeds viewport */}
       <div className="flex-1 min-h-0" />

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -3,7 +3,7 @@ import type { ReplaySession } from "../types";
 
 interface Props {
   session: ReplaySession;
-  onStart: () => void;
+  onStart: (autoPlay?: boolean) => void;
 }
 
 function formatDuration(ms?: number): string {
@@ -54,7 +54,7 @@ export default function LandingHero({ session, onStart }: Props) {
       if (firedRef.current) return;
       if (e.deltaY > 0) {
         firedRef.current = true;
-        onStart();
+        onStart(false);
       }
     };
     const handleTouchStart = (e: TouchEvent) => {
@@ -65,7 +65,7 @@ export default function LandingHero({ session, onStart }: Props) {
       const deltaY = touchStartYRef.current - e.touches[0].clientY;
       if (deltaY > 15) {
         firedRef.current = true;
-        onStart();
+        onStart(false);
       }
     };
     window.addEventListener("wheel", handleWheel, { passive: true });

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -48,19 +48,33 @@ export default function LandingHero({ session, onStart }: Props) {
 
   // Scroll/swipe down triggers start
   const firedRef = useRef(false);
+  const touchStartYRef = useRef(0);
   useEffect(() => {
-    const handler = (e: WheelEvent | TouchEvent) => {
+    const handleWheel = (e: WheelEvent) => {
       if (firedRef.current) return;
-      // Only trigger on downward scroll
-      if (e instanceof WheelEvent && e.deltaY <= 0) return;
-      firedRef.current = true;
-      onStart();
+      if (e.deltaY > 0) {
+        firedRef.current = true;
+        onStart();
+      }
     };
-    window.addEventListener("wheel", handler, { passive: true });
-    window.addEventListener("touchmove", handler, { passive: true });
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartYRef.current = e.touches[0].clientY;
+    };
+    const handleTouchMove = (e: TouchEvent) => {
+      if (firedRef.current) return;
+      const deltaY = touchStartYRef.current - e.touches[0].clientY;
+      if (deltaY > 15) {
+        firedRef.current = true;
+        onStart();
+      }
+    };
+    window.addEventListener("wheel", handleWheel, { passive: true });
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchmove", handleTouchMove, { passive: true });
     return () => {
-      window.removeEventListener("wheel", handler);
-      window.removeEventListener("touchmove", handler);
+      window.removeEventListener("wheel", handleWheel);
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
     };
   }, [onStart]);
 

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -219,7 +219,13 @@ export default function Player({ session, viewPrefs }: Props) {
       ) as HTMLElement | null;
       if (sceneEl) {
         programScrollRef.current = true;
-        sceneEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        // Manual center: place top of target at ~35% from viewport top
+        // (slightly above center feels more natural for reading)
+        const containerRect = el.getBoundingClientRect();
+        const sceneRect = sceneEl.getBoundingClientRect();
+        const offset = sceneRect.top - containerRect.top + el.scrollTop;
+        const target = offset - containerRect.height * 0.35;
+        el.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
         flashJumpTarget(sceneEl);
         setTimeout(() => { programScrollRef.current = false; }, 450);
         pendingSeekRef.current = null;

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -68,10 +68,16 @@ export default function Player({ session, viewPrefs }: Props) {
   const userPromptCount = userPromptIndices.length;
 
   // Start playback when user dismisses landing page
-  const handleStart = useCallback(() => {
+  // autoPlay=true (button click) → play immediately
+  // autoPlay=false (scroll/swipe) → show first scene paused, let user control
+  const handleStart = useCallback((autoPlay = true) => {
     setLanded(true);
-    setTimeout(play, 300);
-  }, [play]);
+    if (autoPlay) {
+      setTimeout(play, 300);
+    } else {
+      setTimeout(() => seekTo(0), 100);
+    }
+  }, [play, seekTo]);
 
   const seekFromNavigation = useCallback(
     (index: number) => {

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -48,6 +48,7 @@ export default function Player({ session, viewPrefs }: Props) {
   const [sidebarTab, setSidebarTab] = useState<"outline" | "stats">("outline");
   const [searchOpen, setSearchOpen] = useState(false);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [scrollHintDismissed, setScrollHintDismissed] = useState(false);
   const pendingSeekRef = useRef<number | null>(null);
   const navFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -111,6 +112,11 @@ export default function Player({ session, viewPrefs }: Props) {
   // Track whether auto-scroll is active (programmatic) vs user-initiated
   const programScrollRef = useRef(false);
 
+  // Reset scroll hint when playback resumes
+  useEffect(() => {
+    if (state === "playing") setScrollHintDismissed(false);
+  }, [state]);
+
   // Auto-scroll to current scene — only during playback
   useEffect(() => {
     if (!scrollRef.current || currentIndex < 0 || state !== "playing") return;
@@ -136,6 +142,8 @@ export default function Player({ session, viewPrefs }: Props) {
     const handleUserScroll = () => {
       // Ignore programmatic scrolls
       if (programScrollRef.current) return;
+      // Dismiss scroll hint on first user scroll
+      setScrollHintDismissed(true);
       // Pause if playing
       if (state === "playing") {
         pause();
@@ -293,6 +301,16 @@ export default function Player({ session, viewPrefs }: Props) {
             focusIndex={navFocusIndex}
           />
         </div>
+
+        {/* Scroll-to-reveal hint */}
+        {state === "paused" && currentIndex < session.scenes.length - 1 && !scrollHintDismissed && (
+          <div className="absolute bottom-[72px] left-1/2 -translate-x-1/2 z-10 pointer-events-none animate-bounce">
+            <div className="px-4 py-1.5 rounded-full bg-terminal-surface/90 border border-terminal-border/60 backdrop-blur-sm text-xs font-mono text-terminal-dim flex items-center gap-2 shadow-lg">
+              <span className="text-terminal-green">{"\u2193"}</span>
+              scroll for more
+            </div>
+          </div>
+        )}
 
         {/* Search overlay */}
         <SearchOverlay

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -47,6 +47,7 @@ export default function Player({ session, viewPrefs }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [sidebarTab, setSidebarTab] = useState<"outline" | "stats">("outline");
   const [searchOpen, setSearchOpen] = useState(false);
+  const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const pendingSeekRef = useRef<number | null>(null);
   const navFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -167,11 +168,25 @@ export default function Player({ session, viewPrefs }: Props) {
       if (e.deltaY > 0) advance();
     };
 
+    // Touch gesture for scroll-to-reveal when content is shorter than viewport
+    let touchStartY = 0;
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartY = e.touches[0].clientY;
+    };
+    const handleTouchEnd = (e: TouchEvent) => {
+      const deltaY = touchStartY - e.changedTouches[0].clientY;
+      if (deltaY > 20) advance();
+    };
+
     el.addEventListener("scroll", advance, { passive: true });
     el.addEventListener("wheel", handleWheel, { passive: true });
+    el.addEventListener("touchstart", handleTouchStart, { passive: true });
+    el.addEventListener("touchend", handleTouchEnd, { passive: true });
     return () => {
       el.removeEventListener("scroll", advance);
       el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("touchstart", handleTouchStart);
+      el.removeEventListener("touchend", handleTouchEnd);
     };
   }, [state, currentIndex, session.scenes.length, seekTo]);
 
@@ -263,7 +278,7 @@ export default function Player({ session, viewPrefs }: Props) {
 
       {/* Main content */}
       <div className="flex flex-col flex-1 min-h-0 min-w-0">
-        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 pb-8 overscroll-contain">
           <ConversationView
             scenes={session.scenes}
             visibleCount={visibleCount}
@@ -284,15 +299,15 @@ export default function Player({ session, viewPrefs }: Props) {
           }}
         />
 
-        {/* Pause overlay */}
+        {/* Pause overlay — hidden on mobile (shown in controls bar instead) */}
         {state === "paused" && visibleCount > 0 && (
-          <div className="absolute top-3 right-3 md:right-3 px-3 py-1.5 rounded-md bg-terminal-orange/10 border border-terminal-orange/20 text-terminal-orange text-xs font-mono pause-overlay pointer-events-none backdrop-blur-sm">
+          <div className="hidden md:block absolute top-3 right-3 px-3 py-1.5 rounded-md bg-terminal-orange/10 border border-terminal-orange/20 text-terminal-orange text-xs font-mono pause-overlay pointer-events-none backdrop-blur-sm">
             PAUSED
           </div>
         )}
 
         {/* Playback bar */}
-        <div className="shrink-0 border-t border-terminal-border/50 bg-terminal-surface/80 backdrop-blur-sm sticky bottom-0">
+        <div className="shrink-0 border-t border-terminal-border/50 bg-terminal-surface/80 backdrop-blur-sm sticky bottom-0 safe-bottom">
           <Timeline
             scenes={session.scenes}
             currentIndex={currentIndex}
@@ -310,7 +325,67 @@ export default function Player({ session, viewPrefs }: Props) {
             onPrevPrompt={seekToPrevPromptWithFeedback}
             onNextPrompt={seekToNextPromptWithFeedback}
             onOpenSearch={() => setSearchOpen(true)}
+            onOpenOutline={() => setMobileDrawerOpen(true)}
           />
+        </div>
+      </div>
+
+      {/* Mobile sidebar drawer */}
+      <div
+        className={`fixed inset-0 z-40 md:hidden transition-opacity duration-300 ${
+          mobileDrawerOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={() => setMobileDrawerOpen(false)}
+      >
+        <div className="absolute inset-0 bg-black/40" />
+        <div
+          className={`absolute bottom-0 left-0 right-0 h-[65vh] bg-terminal-bg border-t border-terminal-border rounded-t-2xl flex flex-col transition-transform duration-300 safe-bottom ${
+            mobileDrawerOpen ? "translate-y-0" : "translate-y-full"
+          }`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Drag handle */}
+          <div className="flex justify-center py-2.5 shrink-0">
+            <div className="w-10 h-1 rounded-full bg-terminal-border" />
+          </div>
+          {/* Tabs */}
+          <div className="flex border-b border-terminal-border/50 shrink-0">
+            <button
+              onClick={() => setSidebarTab("outline")}
+              className={`flex-1 px-3 py-2.5 text-xs font-mono uppercase tracking-wider transition-colors ${
+                sidebarTab === "outline"
+                  ? "text-terminal-green border-b-2 border-terminal-green"
+                  : "text-terminal-dim"
+              }`}
+            >
+              Outline
+            </button>
+            <button
+              onClick={() => setSidebarTab("stats")}
+              className={`flex-1 px-3 py-2.5 text-xs font-mono uppercase tracking-wider transition-colors ${
+                sidebarTab === "stats"
+                  ? "text-terminal-green border-b-2 border-terminal-green"
+                  : "text-terminal-dim"
+              }`}
+            >
+              Stats
+            </button>
+          </div>
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto overscroll-contain">
+            {sidebarTab === "outline" ? (
+              <Minimap
+                scenes={session.scenes}
+                currentIndex={currentIndex}
+                onSeek={(i) => {
+                  seekFromNavigation(i);
+                  setMobileDrawerOpen(false);
+                }}
+              />
+            ) : (
+              <StatsPanel session={session} />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/viewer/src/components/SearchOverlay.tsx
+++ b/packages/viewer/src/components/SearchOverlay.tsx
@@ -137,12 +137,12 @@ export default function SearchOverlay({ scenes, open, onClose, onSeek }: Props) 
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] sm:pt-[15vh]"
       onClick={onClose}
     >
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
       <div
-        className="relative w-full max-w-xl bg-terminal-bg border border-terminal-border rounded-xl shadow-2xl overflow-hidden"
+        className="relative w-full max-w-xl mx-3 sm:mx-0 bg-terminal-bg border border-terminal-border rounded-xl shadow-2xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
       >

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useCallback } from "react";
 import type { Scene } from "../types";
 
 interface Props {
@@ -63,22 +63,28 @@ export default function Timeline({ scenes, currentIndex, onSeek }: Props) {
   const progressPct =
     scenes.length > 0 ? ((currentIndex + 1) / scenes.length) * 100 : 0;
 
+  const barRef = useRef<HTMLDivElement>(null);
+
+  const handleSeekClick = useCallback((e: React.MouseEvent) => {
+    const bar = barRef.current;
+    if (!bar) return;
+    const rect = bar.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const pct = Math.max(0, Math.min(1, x / rect.width));
+    const idx = Math.floor(pct * scenes.length);
+    onSeek(idx);
+  }, [scenes.length, onSeek]);
+
   return (
-    <div className="px-4 pt-2">
+    <div className="px-4 pt-3 pb-1 cursor-pointer" onClick={handleSeekClick}>
       <div
-        className="relative flex h-2 rounded overflow-hidden cursor-pointer bg-terminal-border/30"
-        onClick={(e) => {
-          const rect = e.currentTarget.getBoundingClientRect();
-          const x = e.clientX - rect.left;
-          const pct = x / rect.width;
-          const idx = Math.floor(pct * scenes.length);
-          onSeek(idx);
-        }}
+        ref={barRef}
+        className="relative flex h-2 rounded overflow-hidden bg-terminal-border/30"
       >
         {segments.map((seg, i) => (
           <div
             key={i}
-            className="flex-1 transition-opacity duration-150 hover:opacity-80"
+            className="flex-1 transition-opacity duration-150"
             style={{
               backgroundColor: sceneColor(seg.type),
               opacity: seg.startIndex <= currentIndex ? 1 : 0.15,

--- a/packages/viewer/src/styles/index.css
+++ b/packages/viewer/src/styles/index.css
@@ -55,6 +55,17 @@ html.theme-transition *::after {
   }
 }
 
+/* Mobile interaction improvements */
+button, [role="button"] {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Safe area insets for notched phones */
+@supports (padding: env(safe-area-inset-top)) {
+  .safe-top { padding-top: env(safe-area-inset-top); }
+  .safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+}
+
 @keyframes blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -4,7 +4,7 @@
 <footer class="border-t border-border py-12 px-6">
   <div class="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-6">
     <div class="flex items-center gap-3">
-      <span class="font-mono font-semibold text-text-primary">vibe-replay</span>
+      <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
       <span class="text-text-muted text-sm">&middot;</span>
       <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener" class="text-xs px-2 py-0.5 rounded border border-border text-text-muted hover:text-text-secondary transition-colors">
         MIT

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -6,7 +6,7 @@ const DEMO_URL = "/view/?gist=741fb4ce6491e11ca0e03c042384ac8b";
 <nav class="relative z-20 border-b border-border/50 px-6 py-3">
   <div class="max-w-6xl mx-auto flex items-center justify-between">
     <div class="flex items-center gap-4">
-      <a href="/" class="font-mono font-bold text-accent text-lg">vibe-replay</a>
+      <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
       <span class="text-border hidden sm:inline">|</span>
       <a href="/explore" class="text-text-muted hover:text-text-primary text-sm transition-colors hidden sm:inline">Explore</a>
     </div>

--- a/website/src/pages/explore.astro
+++ b/website/src/pages/explore.astro
@@ -9,7 +9,7 @@ import Footer from "../components/Footer.astro";
     <header class="border-b border-border px-6 py-4">
       <div class="max-w-6xl mx-auto flex items-center justify-between">
         <div class="flex items-center gap-4">
-          <a href="/" class="font-mono font-bold text-accent hover:text-accent-dim transition-colors">vibe-replay</a>
+          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
           <span class="text-text-muted">/</span>
           <span class="font-mono text-text-primary">explore</span>
         </div>


### PR DESCRIPTION
## Summary

A comprehensive pass on mobile UX and overall viewer polish, covering layout, theming, navigation, and discoverability.

### Mobile layout & controls
- Responsive playback controls with grouped bordered segments that scale properly on small screens
- Hide scene counter on mobile to prevent overflow; show mobile-friendly turn indicator instead
- Fix landing page overlap and header layout on narrow viewports
- Mobile sidebar drawer for outline/stats (slide-up bottom sheet)
- Scroll/swipe from landing page enters paused state (not auto-play), letting users explore at their own pace

### Light mode fixes
- Diff blocks: switch prism syntax theme reactively (`nightOwl` ↔ `nightOwlLight`) via `useSyncExternalStore`
- Diff line backgrounds use proper `dark:` Tailwind variants instead of hardcoded dark colors
- Bash blocks: replace hardcoded `bg-[#0a0e14]` with theme-aware `bg-terminal-surface`

### Branding & navigation
- Unified gradient text treatment (`from-[#3fb950] to-[#58a6ff]`) for "vibe-replay" across viewer header, landing hero, website header, footer, and explore page
- All surfaces link back to vibe-replay.com; landing hero adds "Explore more replays" link to `/explore`
- Cross-navigation between viewer ↔ website ↔ explore page

### UX improvements
- Floating "↓ scroll for more" hint appears when paused with remaining scenes; dismisses on first user scroll, resets on play resume
- Sidebar/timeline jump now centers the target scene at ~35% from viewport top (manual scroll calculation) instead of unreliable `scrollIntoView({ block: "center" })`
- Header reorganized: model + duration moved to left side with title; right side is actions only (All/Prompts toggle + unified Settings dropdown with filters + theme)
- Settings dropdown consolidates Collapse Tools, Hide Thinking, and theme toggle into one menu (desktop + mobile)

## Test plan
- [ ] Open a replay on mobile (or narrow viewport) — verify controls don't overflow and are tappable
- [ ] Toggle light/dark mode — diff blocks and bash blocks should look correct in both themes
- [ ] Click outline items / timeline segments — target scene should appear centered, not at bottom
- [ ] Pause playback by scrolling — "scroll for more" hint should appear, dismiss on scroll, reappear after resuming play
- [ ] Verify "vibe-replay" gradient branding is consistent across viewer, landing hero, website, and explore page
- [ ] Test landing page scroll/swipe → should enter paused state, not auto-play

🤖 Generated with [Claude Code](https://claude.com/claude-code)