### PR TITLE
feat: annotations, editor mode, token tracking, compaction summaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Quick intent map:
 - Use `pnpm dev` for daily iteration (viewer + CLI together, choose "Dump to demo.json" dev-only option)
 - Use `pnpm viewer:dev` when only touching UI
 - Use `pnpm cli:dev` when only touching parser/CLI behavior
+- Choose "Open in Editor" in CLI menu for annotation editing, HTML export, and gist publishing via local server
 
 ## Architecture
 
@@ -41,6 +42,7 @@ Quick intent map:
 packages/cli/src/
 ├── index.ts                    # CLI entry
 ├── types.ts                    # Core types (Scene, ReplaySession, SessionInfo)
+├── server.ts                   # Editor mode: Hono HTTP server (annotations, export, gist)
 ├── providers/                  # Provider adapters (pluggable)
 │   ├── types.ts                # Provider interface
 │   ├── index.ts                # Provider registry
@@ -67,7 +69,7 @@ packages/cli/src/
 
 ## Key Architecture Decisions
 
-- **Single HTML output**: viewer built to one file via vite-plugin-singlefile (~480KB), CLI injects `window.__VIBE_REPLAY_DATA__` JSON into `<head>`
+- **Single HTML output**: viewer built to one file via vite-plugin-singlefile (~430KB), CLI injects `window.__VIBE_REPLAY_DATA__` JSON into `<head>` via `<script id="vibe-replay-data">`
 - **`</` escaping**: JSON data in `<script>` MUST escape `</` as `<\/` (see generator.ts)
 - **JSONL grouping**: Assistant messages split across multiple lines sharing same `message.id` — parser groups them. Tool results matched by `tool_use_id`
 - **Cursor dual data source**: Primary: `~/.cursor/chats/<MD5(workspace_path)>/<session-uuid>/store.db` (SQLite with protobuf blob tree — has reasoning, tool-call, tool-result blocks). Fallback: `~/.cursor/projects/<path>/agent-transcripts/*.jsonl` (text-only, uses marker inference + `agent-tools/*.txt` mtime windows). Workspace hash = `MD5(absolute_workspace_path)`
@@ -82,6 +84,9 @@ packages/cli/src/
 - **Multi-file sessions**: Claude Code `/resume` creates new JSONL files — CLI merges them by slug+project, `parse()` accepts `string | string[]`
 - **URL loading**: Viewer supports `?url=<json-url>` and `?gist=<id>` via hosted viewer at vibe-replay.com
 - **Gist republish UX**: CLI stores gist metadata per replay output folder (`.vibe-replay-gist.json`) so users can overwrite an existing gist on subsequent publishes
+- **Editor mode**: "Open in Editor" starts a Hono localhost server (port 3456-3466) serving the viewer with `__VIBE_REPLAY_EDITOR__` flag. Viewer fetches session from `/api/session`, annotations POST to `/api/annotations` (debounced 1s) and persist to `{outputDir}/annotations.json`. Server also handles gist publishing and HTML export via API routes
+- **ViewerMode**: Three-mode enum (`embedded | editor | readonly`) drives viewer behavior — embedded for self-contained HTML, editor for local server, readonly for `?gist=` / `?url=` URLs
+- **Markdown rendering**: Uses `marked` (lightweight, ~37KB) instead of `react-markdown` + `remark-gfm` to keep viewer under 500KB
 
 ## Data Flow
 
@@ -93,6 +98,7 @@ packages/cli/src/
   → transform.ts → ReplaySession (scenes, redacted secrets + paths, metadata)
   → generator.ts → inject into viewer.html → vibe-replay/<slug>/index.html + replay.json
   → publishers/ → local (open browser) | gist (gh gist create → vibe-replay.com viewer)
+  → server.ts → editor mode (localhost Hono server → viewer fetches /api/session, saves annotations via API)
 ```
 
 Scene types: `user-prompt`, `thinking`, `text-response`, `tool-call`
@@ -107,7 +113,10 @@ Current `meta` fields include:
 - `provider`, `dataSource`
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
-- `stats`: `sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`
+- `stats`: `sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`, `tokenUsage`, `costEstimate`
+- `compactions`: Array of context window compaction events
+
+`ReplaySession` also has optional `annotations` array (id, sceneIndex, body, author, timestamps, resolved).
 
 Current limitation:
 - No generator metadata yet (e.g. CLI version, schema version, generated timestamp).
@@ -116,7 +125,7 @@ Current limitation:
 
 - Always use **pnpm**
 - TypeScript strict mode, ESM throughout
-- Viewer must remain < 500KB after build (currently ~480KB)
+- Viewer must remain < 500KB after build (currently ~430KB)
 - Output HTML must be fully self-contained (no external requests)
 - Test with real sessions from `~/.claude/projects/`
 - Output path: `vibe-replay/<slug>/index.html`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,9 +41,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@inquirer/prompts": "^7.2.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "hono": "^4.12.5",
     "open": "^10.1.0",
     "ora": "^8.1.0",
     "sql.js": "^1.14.1"

--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -36,8 +36,11 @@ export async function generateOutput(
 
   // Inject session data — escape </ to prevent browser from closing the script tag
   const jsonData = JSON.stringify(session).replace(/<\//g, "<\\/");
-  const dataScript = `<script>window.__VIBE_REPLAY_DATA__ = ${jsonData};</script>`;
-  const outputHtml = viewerHtml.replace("</head>", `${dataScript}\n</head>`);
+  const dataScript = `<script id="vibe-replay-data">window.__VIBE_REPLAY_DATA__ = ${jsonData};</script>`;
+  // Use lastIndexOf to find the ACTUAL </head> HTML tag, not a "</head>" string
+  // that may appear inside minified JS code within the viewer bundle.
+  const headIdx = viewerHtml.lastIndexOf("</head>");
+  const outputHtml = viewerHtml.slice(0, headIdx) + dataScript + "\n" + viewerHtml.slice(headIdx);
 
   // Update title
   const title = session.meta.title || session.meta.slug;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -158,10 +158,10 @@ program
     // Check gh availability for gist option
     const ghStatus = await checkGhStatus();
     const gistLabel = ghStatus.available
-      ? `${chalk.blue("↑")} Publish to GitHub Gist ${chalk.yellow("(public — anyone with the link can view)")}`
+      ? `${chalk.blue("↑")} Publish to Gist now ${chalk.dim("(skip editor, publish directly)")}`
       : ghStatus.reason === "not-installed"
-        ? `${chalk.dim("↑ Publish to GitHub Gist")} ${chalk.dim("(requires gh CLI)")}`
-        : `${chalk.dim("↑ Publish to GitHub Gist")} ${chalk.dim("(gh not logged in)")}`;
+        ? `${chalk.dim("↑ Publish to Gist now")} ${chalk.red("(gh CLI not installed)")}`
+        : `${chalk.dim("↑ Publish to Gist now")} ${chalk.red("(gh not logged in)")}`;
 
     // Publish target
     console.log();
@@ -172,8 +172,8 @@ program
             value: "demo" as const,
           }]
         : []),
-      { name: `${chalk.green("▶")} Open in browser`, value: "local" as const },
       { name: `${chalk.magenta("✎")} Open in Editor ${chalk.dim("(annotate, publish, export)")}`, value: "editor" as const },
+      { name: `${chalk.green("▶")} Quick preview ${chalk.dim("(open HTML in browser, no editing)")}`, value: "local" as const },
       { name: gistLabel, value: "gist" as const },
       { name: `${chalk.dim("✕")} Exit`, value: "exit" as const },
     ];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { transformToReplay } from "./transform.js";
 import { generateOutput, generateDevJson } from "./generator.js";
 import { publishLocal } from "./publishers/local.js";
 import { publishGist, checkGhStatus, loadSavedGistInfo } from "./publishers/gist.js";
+import { startEditor } from "./server.js";
 import { scanForSecrets } from "./scan.js";
 import type { SessionInfo, ReplaySession } from "./types.js";
 
@@ -164,7 +165,7 @@ program
 
     // Publish target
     console.log();
-    const choices: { name: string; value: "demo" | "local" | "gist" | "exit" }[] = [
+    const choices: { name: string; value: "demo" | "local" | "editor" | "gist" | "exit" }[] = [
       ...(DEV_MENU_ENABLED
         ? [{
             name: `${chalk.cyan("⚡")} Dump to demo.json ${chalk.dim("(for pnpm viewer:dev)")}`,
@@ -172,6 +173,7 @@ program
           }]
         : []),
       { name: `${chalk.green("▶")} Open in browser`, value: "local" as const },
+      { name: `${chalk.magenta("✎")} Open in Editor ${chalk.dim("(annotate, publish, export)")}`, value: "editor" as const },
       { name: gistLabel, value: "gist" as const },
       { name: `${chalk.dim("✕")} Exit`, value: "exit" as const },
     ];
@@ -185,6 +187,9 @@ program
       await dumpReplayToDemoJson(replay);
     } else if (target === "local") {
       await publishLocal(outputPath);
+    } else if (target === "editor") {
+      await startEditor(replay, outputDir);
+      return; // startEditor blocks until Ctrl+C
     } else if (target === "gist") {
       if (!ghStatus.available) {
         if (ghStatus.reason === "not-installed") {

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -90,21 +90,29 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
 
     const { role, content: msgContent, id: msgId } = obj.message;
 
-    // User message with string content = human prompt
+    // User message with string content = human prompt (or compaction summary)
     if (role === "user" && typeof msgContent === "string") {
-      userTurns.push({ role: "user", timestamp: obj.timestamp, blocks: [{ type: "text", text: msgContent }] });
+      const isCompaction = msgContent.startsWith("This session is being continued from a previous conversation");
+      userTurns.push({
+        role: "user",
+        ...(isCompaction ? { subtype: "compaction-summary" } : {}),
+        timestamp: obj.timestamp,
+        blocks: [{ type: "text", text: msgContent }],
+      });
       continue;
     }
 
     // User message with array content (may contain text + images, or tool_results)
     if (role === "user" && Array.isArray(msgContent)) {
+      // ToolSearch automated responses have sourceToolAssistantUUID on the raw object.
+      // Process tool_result blocks for result matching, but skip emitting a user turn.
+      const isToolSearchResponse = !!(obj as any).sourceToolAssistantUUID;
+
       const textParts: string[] = [];
       const userImages: string[] = [];
-      let hasToolResult = false;
 
       for (const block of msgContent as ContentBlock[]) {
         if (block.type === "tool_result") {
-          hasToolResult = true;
           const resultText = extractToolResultText(block);
           toolResults.set(block.tool_use_id, resultText);
           const images = extractImages(block);
@@ -123,8 +131,8 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
         }
       }
 
-      // If user message has text or images (not just tool_results), emit as user turn
-      if (textParts.length > 0 || userImages.length > 0) {
+      // Skip emitting user turn for automated ToolSearch responses
+      if (!isToolSearchResponse && (textParts.length > 0 || userImages.length > 0)) {
         const blocks: ContentBlock[] = textParts.map((t) => ({ type: "text", text: t } as ContentBlock));
         if (userImages.length > 0) {
           blocks.push({ type: "_user_images", images: userImages } as any);

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import type { RawMessage, ContentBlock, ParsedTurn } from "../../types.js";
-import type { ProviderParseResult } from "../types.js";
+import type { ProviderParseResult, TokenUsage, Compaction } from "../types.js";
 
 export async function parseClaudeCodeSession(filePaths: string | string[]): Promise<ProviderParseResult> {
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
@@ -22,6 +22,13 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
   let startTime: string | undefined;
   let endTime: string | undefined;
   let totalDurationMs = 0;
+
+  // Token usage: track last usage per message ID to avoid double-counting
+  // (each message.id appears in multiple JSONL lines with the same cumulative usage)
+  const usageByMsgId = new Map<string, { input_tokens?: number; output_tokens?: number; cache_creation_input_tokens?: number; cache_read_input_tokens?: number }>();
+
+  // Compaction events
+  const compactions: Compaction[] = [];
 
   // Group assistant messages by message.id
   const assistantBlocks = new Map<string, ContentBlock[]>();
@@ -67,6 +74,14 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
       if (obj.subtype === "turn_duration" && obj.durationMs) {
         totalDurationMs += obj.durationMs;
         if (obj.timestamp) endTime = obj.timestamp;
+      }
+      if (obj.subtype === "compact_boundary" && obj.timestamp) {
+        const cm = (obj as any).compactMetadata;
+        compactions.push({
+          timestamp: obj.timestamp,
+          trigger: cm?.trigger || "unknown",
+          preTokens: cm?.preTokens,
+        });
       }
       continue;
     }
@@ -123,6 +138,12 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
     // Assistant message — group by message.id
     if (role === "assistant" && msgId && Array.isArray(msgContent)) {
       if (!model && obj.message.model) model = obj.message.model;
+
+      // Track usage per message ID — overwrite so we keep the last (final) value
+      const usage = (obj.message as any).usage;
+      if (usage && msgId) {
+        usageByMsgId.set(msgId, usage);
+      }
 
       if (!assistantBlocks.has(msgId)) {
         assistantBlocks.set(msgId, []);
@@ -202,6 +223,19 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
     });
   }
 
+  // Aggregate token usage from deduplicated per-message data
+  let tokenUsage: TokenUsage | undefined;
+  if (usageByMsgId.size > 0) {
+    const totals: TokenUsage = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
+    for (const u of usageByMsgId.values()) {
+      totals.inputTokens += u.input_tokens || 0;
+      totals.outputTokens += u.output_tokens || 0;
+      totals.cacheCreationTokens += u.cache_creation_input_tokens || 0;
+      totals.cacheReadTokens += u.cache_read_input_tokens || 0;
+    }
+    tokenUsage = totals;
+  }
+
   return {
     sessionId,
     slug,
@@ -212,6 +246,8 @@ export async function parseClaudeCodeSession(filePaths: string | string[]): Prom
     endTime,
     totalDurationMs: totalDurationMs || undefined,
     turns: finalTurns,
+    tokenUsage,
+    compactions: compactions.length > 0 ? compactions : undefined,
   };
 }
 

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -9,6 +9,19 @@ export interface Provider {
 
 export type DataSource = "jsonl" | "sqlite" | "jsonl+tools";
 
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+}
+
+export interface Compaction {
+  timestamp: string;
+  trigger: string;
+  preTokens?: number;
+}
+
 export interface ProviderParseResult {
   sessionId: string;
   slug: string;
@@ -20,4 +33,6 @@ export interface ProviderParseResult {
   totalDurationMs?: number;
   turns: ParsedTurn[];
   dataSource?: DataSource;
+  tokenUsage?: TokenUsage;
+  compactions?: Compaction[];
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,0 +1,147 @@
+import { createServer } from "node:net";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import open from "open";
+import chalk from "chalk";
+import type { ReplaySession, Annotation } from "./types.js";
+import { generateOutput } from "./generator.js";
+import { checkGhStatus, publishGist, loadSavedGistInfo } from "./publishers/gist.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function findFreePort(start: number, end: number): Promise<number> {
+  for (let port = start; port <= end; port++) {
+    const available = await new Promise<boolean>((resolve) => {
+      const server = createServer();
+      server.once("error", () => resolve(false));
+      server.once("listening", () => {
+        server.close();
+        resolve(true);
+      });
+      server.listen(port, "127.0.0.1");
+    });
+    if (available) return port;
+  }
+  throw new Error(`No free port found in range ${start}-${end}`);
+}
+
+async function loadViewerHtml(): Promise<string> {
+  const assetsPaths = [
+    join(__dirname, "..", "assets", "viewer.html"),
+    join(__dirname, "assets", "viewer.html"),
+    join(__dirname, "..", "..", "assets", "viewer.html"),
+  ];
+  for (const p of assetsPaths) {
+    try {
+      return await readFile(p, "utf-8");
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("Could not find viewer.html. Run `pnpm build` first.");
+}
+
+export async function startEditor(
+  session: ReplaySession,
+  outputDir: string,
+): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+
+  // Load existing annotations from disk
+  const annotationsPath = join(outputDir, "annotations.json");
+  try {
+    const raw = await readFile(annotationsPath, "utf-8");
+    const saved = JSON.parse(raw) as Annotation[];
+    if (Array.isArray(saved) && saved.length > 0) {
+      session = { ...session, annotations: saved };
+    }
+  } catch { /* no saved annotations */ }
+
+  // In-memory annotations state
+  let annotations: Annotation[] = session.annotations ?? [];
+
+  const viewerHtml = await loadViewerHtml();
+
+  const app = new Hono();
+
+  // Serve viewer HTML (without embedded data — viewer fetches from API)
+  app.get("/", (c) => {
+    // Inject editor flag before </head>
+    const flag = `<script>window.__VIBE_REPLAY_EDITOR__ = true;</script>`;
+    const headIdx = viewerHtml.lastIndexOf("</head>");
+    const html = viewerHtml.slice(0, headIdx) + flag + "\n" + viewerHtml.slice(headIdx);
+    return c.html(html);
+  });
+
+  // Session data
+  app.get("/api/session", (c) => {
+    return c.json({ ...session, annotations });
+  });
+
+  // Annotations CRUD
+  app.get("/api/annotations", (c) => {
+    return c.json(annotations);
+  });
+
+  app.post("/api/annotations", async (c) => {
+    const body = await c.req.json<Annotation[]>();
+    annotations = body;
+    // Persist to disk
+    try {
+      await writeFile(annotationsPath, JSON.stringify(annotations, null, 2), "utf-8");
+    } catch { /* ignore write errors */ }
+    return c.json({ ok: true });
+  });
+
+  // GitHub CLI status
+  app.get("/api/gh-status", async (c) => {
+    const status = await checkGhStatus();
+    return c.json(status);
+  });
+
+  // Publish to Gist
+  app.post("/api/publish/gist", async (c) => {
+    // Write replay.json with current annotations before publishing
+    const replayWithAnnotations = { ...session, annotations };
+    const jsonPath = join(outputDir, "replay.json");
+    await writeFile(jsonPath, JSON.stringify(replayWithAnnotations), "utf-8");
+
+    const title = session.meta.title || session.meta.slug;
+    const savedGist = await loadSavedGistInfo(outputDir);
+    const result = await publishGist(outputDir, title, {
+      overwrite: savedGist || undefined,
+    });
+    return c.json(result);
+  });
+
+  // Export HTML
+  app.post("/api/export/html", async (c) => {
+    const replayWithAnnotations = { ...session, annotations };
+    const outputPath = await generateOutput(replayWithAnnotations, outputDir);
+    return c.json({ path: outputPath });
+  });
+
+  const port = await findFreePort(3456, 3466);
+  const url = `http://localhost:${port}`;
+
+  serve({ fetch: app.fetch, port }, () => {
+    console.log(
+      chalk.bold.cyan("\n  Editor running at ") +
+        chalk.white(url) +
+        chalk.dim("\n  Press Ctrl+C to stop\n"),
+    );
+    open(url);
+  });
+
+  // Keep alive until Ctrl+C
+  await new Promise<void>((resolve) => {
+    process.on("SIGINT", () => {
+      console.log(chalk.dim("\n  Editor stopped.\n"));
+      resolve();
+      process.exit(0);
+    });
+  });
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -104,24 +104,32 @@ export async function startEditor(
 
   // Publish to Gist
   app.post("/api/publish/gist", async (c) => {
-    // Write replay.json with current annotations before publishing
-    const replayWithAnnotations = { ...session, annotations };
-    const jsonPath = join(outputDir, "replay.json");
-    await writeFile(jsonPath, JSON.stringify(replayWithAnnotations), "utf-8");
+    try {
+      // Write replay.json with current annotations before publishing
+      const replayWithAnnotations = { ...session, annotations };
+      const jsonPath = join(outputDir, "replay.json");
+      await writeFile(jsonPath, JSON.stringify(replayWithAnnotations), "utf-8");
 
-    const title = session.meta.title || session.meta.slug;
-    const savedGist = await loadSavedGistInfo(outputDir);
-    const result = await publishGist(outputDir, title, {
-      overwrite: savedGist || undefined,
-    });
-    return c.json(result);
+      const title = session.meta.title || session.meta.slug;
+      const savedGist = await loadSavedGistInfo(outputDir);
+      const result = await publishGist(outputDir, title, {
+        overwrite: savedGist || undefined,
+      });
+      return c.json(result);
+    } catch (err: any) {
+      return c.json({ error: err.message || "Gist publish failed" }, 500);
+    }
   });
 
   // Export HTML
   app.post("/api/export/html", async (c) => {
-    const replayWithAnnotations = { ...session, annotations };
-    const outputPath = await generateOutput(replayWithAnnotations, outputDir);
-    return c.json({ path: outputPath });
+    try {
+      const replayWithAnnotations = { ...session, annotations };
+      const outputPath = await generateOutput(replayWithAnnotations, outputDir);
+      return c.json({ path: outputPath });
+    } catch (err: any) {
+      return c.json({ error: err.message || "HTML export failed" }, 500);
+    }
   });
 
   const port = await findFreePort(3456, 3466);

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -27,13 +27,21 @@ export function transformToReplay(
       const imageBlock = turn.blocks.find((b) => (b as any).type === "_user_images") as any;
       const images: string[] | undefined = imageBlock?.images;
       if (content.trim() || (images && images.length > 0)) {
-        scenes.push({
-          type: "user-prompt",
-          content: content.trim() ? redactSecrets(redactPath(content)) : "(image)",
-          timestamp: turn.timestamp,
-          ...(images && images.length > 0 ? { images } : {}),
-        });
-        userPrompts++;
+        if (turn.subtype === "compaction-summary") {
+          scenes.push({
+            type: "compaction-summary",
+            content: redactSecrets(redactPath(content)),
+            timestamp: turn.timestamp,
+          });
+        } else {
+          scenes.push({
+            type: "user-prompt",
+            content: content.trim() ? redactSecrets(redactPath(content)) : "(image)",
+            timestamp: turn.timestamp,
+            ...(images && images.length > 0 ? { images } : {}),
+          });
+          userPrompts++;
+        }
       }
       continue;
     }

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -60,6 +60,35 @@ export function transformToReplay(
     }
   }
 
+  // Estimate cost based on model pricing (USD)
+  let costEstimate: number | undefined;
+  if (parsed.tokenUsage) {
+    const u = parsed.tokenUsage;
+    const model = parsed.model || "";
+    // Default to Opus pricing; adjust for other models
+    let inputRate = 15; // $/M tokens
+    let outputRate = 75;
+    let cacheCreateRate = 18.75;
+    let cacheReadRate = 1.875;
+    if (model.includes("haiku")) {
+      inputRate = 0.80;
+      outputRate = 4;
+      cacheCreateRate = 1;
+      cacheReadRate = 0.08;
+    } else if (model.includes("sonnet")) {
+      inputRate = 3;
+      outputRate = 15;
+      cacheCreateRate = 3.75;
+      cacheReadRate = 0.30;
+    }
+    costEstimate = (
+      u.inputTokens * inputRate +
+      u.outputTokens * outputRate +
+      u.cacheCreationTokens * cacheCreateRate +
+      u.cacheReadTokens * cacheReadRate
+    ) / 1_000_000;
+  }
+
   return {
     meta: {
       sessionId: parsed.sessionId,
@@ -78,7 +107,10 @@ export function transformToReplay(
         toolCalls,
         thinkingBlocks,
         durationMs: parsed.totalDurationMs,
+        tokenUsage: parsed.tokenUsage,
+        costEstimate,
       },
+      compactions: parsed.compactions,
     },
     scenes,
   };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -76,6 +76,17 @@ export type Scene =
       images?: string[];
     };
 
+export interface Annotation {
+  id: string;
+  sceneIndex: number;
+  selectedText?: string;
+  body: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  resolved: boolean;
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;
@@ -94,7 +105,20 @@ export interface ReplaySession {
       toolCalls: number;
       thinkingBlocks?: number;
       durationMs?: number;
+      tokenUsage?: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens: number;
+        cacheReadTokens: number;
+      };
+      costEstimate?: number;
     };
+    compactions?: Array<{
+      timestamp: string;
+      trigger: string;
+      preTokens?: number;
+    }>;
   };
   scenes: Scene[];
+  annotations?: Annotation[];
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -20,6 +20,7 @@ export interface SessionInfo {
 
 export interface ParsedTurn {
   role: "user" | "assistant";
+  subtype?: string;
   messageId?: string;
   model?: string;
   timestamp?: string;
@@ -63,6 +64,7 @@ export type ToolResultContent =
 
 export type Scene =
   | { type: "user-prompt"; content: string; timestamp?: string; images?: string[] }
+  | { type: "compaction-summary"; content: string; timestamp?: string }
   | { type: "thinking"; content: string; timestamp?: string }
   | { type: "text-response"; content: string; timestamp?: string }
   | {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -10,11 +10,10 @@
   },
   "dependencies": {
     "diff": "^7.0.0",
+    "marked": "^17.0.4",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/diff": "^6.0.0",

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -20,6 +20,7 @@ export default function App() {
   const { prefs, togglePref } = useViewPrefs();
 
   const session = loadState.status === "ready" ? loadState.session : null;
+  const isReadOnly = loadState.status === "ready" ? loadState.isReadOnly : false;
 
   const hasThinking = useMemo(
     () => session?.scenes.some((s) => s.type === "thinking") ?? false,
@@ -183,7 +184,7 @@ export default function App() {
 
         </div>
       </header>
-      <Player session={session!} viewPrefs={prefs} />
+      <Player session={session!} viewPrefs={prefs} isReadOnly={isReadOnly} />
     </div>
   );
 }

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -20,7 +20,7 @@ export default function App() {
   const { prefs, togglePref } = useViewPrefs();
 
   const session = loadState.status === "ready" ? loadState.session : null;
-  const isReadOnly = loadState.status === "ready" ? loadState.isReadOnly : false;
+  const viewerMode = loadState.status === "ready" ? loadState.mode : "embedded";
 
   const hasThinking = useMemo(
     () => session?.scenes.some((s) => s.type === "thinking") ?? false,
@@ -184,7 +184,7 @@ export default function App() {
 
         </div>
       </header>
-      <Player session={session!} viewPrefs={prefs} isReadOnly={isReadOnly} />
+      <Player session={session!} viewPrefs={prefs} viewerMode={viewerMode} />
     </div>
   );
 }

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -55,9 +55,20 @@ export default function AnnotationPanel({
   onClearAddingTarget,
   readOnly = false,
 }: Props) {
-  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson } = actions;
+  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting } = actions;
   const [internalAdding, setInternalAdding] = useState<number | null>(null);
   const [newBody, setNewBody] = useState("");
+  const [statusMsg, setStatusMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [ghAvailable, setGhAvailable] = useState<boolean | null>(null);
+
+  // Check gh status in editor mode
+  useEffect(() => {
+    if (!publishGist) return;
+    fetch("/api/gh-status")
+      .then((r) => r.json())
+      .then((data) => setGhAvailable(data.available ?? false))
+      .catch(() => setGhAvailable(false));
+  }, [publishGist]);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editBody, setEditBody] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -261,15 +272,63 @@ export default function AnnotationPanel({
         )}
       </div>
 
-      {/* Footer: Save/export buttons — always visible when annotations exist */}
+      {/* Footer: Save/export/publish buttons */}
       {!readOnly && annotations.length > 0 && (
         <div className="shrink-0 border-t border-terminal-border/50 px-3 py-2 space-y-1.5">
-          {hasUnsaved && (
+          {hasUnsaved && !publishGist && (
             <div className="text-[9px] font-mono text-terminal-orange text-center mb-1">
               Unsaved changes
             </div>
           )}
-          {canSaveHtml ? (
+          {statusMsg && (
+            <div className={`text-[9px] font-mono text-center mb-1 ${statusMsg.type === "success" ? "text-terminal-green" : "text-terminal-red"}`}>
+              {statusMsg.text}
+            </div>
+          )}
+
+          {/* Editor mode: server-side actions */}
+          {exportHtml && (
+            <button
+              onClick={async () => {
+                setStatusMsg(null);
+                try {
+                  const path = await exportHtml();
+                  setStatusMsg({ type: "success", text: `Saved: ${path}` });
+                } catch (e: any) {
+                  setStatusMsg({ type: "error", text: e.message });
+                }
+              }}
+              disabled={htmlExporting}
+              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-green/15 text-terminal-green rounded hover:bg-terminal-green/25 transition-colors text-center border border-terminal-green/30 disabled:opacity-50"
+            >
+              {htmlExporting ? "Exporting..." : "Export HTML"}
+            </button>
+          )}
+          {publishGist && ghAvailable && (
+            <button
+              onClick={async () => {
+                setStatusMsg(null);
+                try {
+                  const result = await publishGist();
+                  setStatusMsg({ type: "success", text: result.viewerUrl });
+                } catch (e: any) {
+                  setStatusMsg({ type: "error", text: e.message });
+                }
+              }}
+              disabled={gistPublishing}
+              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-purple/15 text-terminal-purple rounded hover:bg-terminal-purple/25 transition-colors text-center border border-terminal-purple/30 disabled:opacity-50"
+            >
+              {gistPublishing ? "Publishing..." : "Publish to Gist"}
+            </button>
+          )}
+          {publishGist && ghAvailable === false && (
+            <div className="text-[9px] font-mono text-terminal-dim/60 text-center px-2 py-1">
+              Gist requires gh CLI (gh auth login)
+            </div>
+          )}
+
+          {/* Non-editor: client-side actions */}
+          {!exportHtml && canSaveHtml && (
             <button
               onClick={downloadHtml}
               className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-green/15 text-terminal-green rounded hover:bg-terminal-green/25 transition-colors text-center border border-terminal-green/30"
@@ -277,18 +336,21 @@ export default function AnnotationPanel({
             >
               Save HTML with Comments
             </button>
-          ) : (
+          )}
+          {!exportHtml && !canSaveHtml && (
             <div className="text-[9px] font-mono text-terminal-dim/60 text-center px-2 py-1">
               Save HTML requires a production build (use CLI output)
             </div>
           )}
-          <button
-            onClick={downloadJson}
-            className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-blue/10 text-terminal-blue rounded hover:bg-terminal-blue/20 transition-colors text-center border border-terminal-blue/20"
-            title="Download replay.json for re-publishing to gist"
-          >
-            Export JSON (for gist re-publish)
-          </button>
+          {!publishGist && (
+            <button
+              onClick={downloadJson}
+              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-blue/10 text-terminal-blue rounded hover:bg-terminal-blue/20 transition-colors text-center border border-terminal-blue/20"
+              title="Download replay.json for re-publishing to gist"
+            >
+              Export JSON (for gist re-publish)
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -1,0 +1,444 @@
+import { useState, useRef, useEffect, useMemo, memo, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Annotation, Scene } from "../types";
+import type { AnnotationActions } from "../hooks/useAnnotations";
+
+interface Props {
+  actions: AnnotationActions;
+  scenes: Scene[];
+  currentIndex: number;
+  totalScenes: number;
+  onSeek: (index: number) => void;
+  addingForScene: number | null;
+  onClearAddingTarget: () => void;
+  readOnly?: boolean;
+}
+
+/** Get a short preview of what a scene contains */
+function scenePreview(scene: Scene): { label: string; text: string } {
+  switch (scene.type) {
+    case "user-prompt": {
+      const first = scene.content.split("\n").find((l) => l.trim()) || "";
+      return { label: "You", text: first.slice(0, 100) };
+    }
+    case "thinking":
+      return { label: "Thinking", text: scene.content.slice(0, 80) };
+    case "text-response": {
+      const first = scene.content.split("\n").find((l) => l.trim()) || "";
+      return { label: "Response", text: first.slice(0, 100) };
+    }
+    case "tool-call":
+      return {
+        label: scene.toolName,
+        text: scene.diff?.filePath || scene.bashOutput?.command || Object.values(scene.input).filter(v => typeof v === "string").join(", ").slice(0, 80) || "",
+      };
+  }
+}
+
+function sceneLabelColor(scene: Scene): string {
+  switch (scene.type) {
+    case "user-prompt": return "text-terminal-green";
+    case "thinking": return "text-terminal-purple";
+    case "text-response": return "text-terminal-blue";
+    case "tool-call": return "text-terminal-orange";
+  }
+}
+
+export default function AnnotationPanel({
+  actions,
+  scenes,
+  currentIndex,
+  totalScenes,
+  onSeek,
+  addingForScene,
+  onClearAddingTarget,
+  readOnly = false,
+}: Props) {
+  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson } = actions;
+  const [internalAdding, setInternalAdding] = useState<number | null>(null);
+  const [newBody, setNewBody] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editBody, setEditBody] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const addFormRef = useRef<HTMLDivElement>(null);
+
+  // External target from clicking a card's comment icon
+  const activeAdding = addingForScene ?? internalAdding;
+
+  // When an external target arrives, scroll the form into view
+  useEffect(() => {
+    if (addingForScene !== null) {
+      setNewBody("");
+      setInternalAdding(null);
+      // Scroll to the add form after it renders
+      setTimeout(() => {
+        addFormRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        textareaRef.current?.focus();
+      }, 50);
+    }
+  }, [addingForScene]);
+
+  // Focus textarea when adding
+  useEffect(() => {
+    if (activeAdding !== null && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [activeAdding]);
+
+  // Focus textarea when editing
+  useEffect(() => {
+    if (editingId && editTextareaRef.current) {
+      editTextareaRef.current.focus();
+    }
+  }, [editingId]);
+
+  // Sort annotations by sceneIndex
+  const sorted = useMemo(
+    () => [...annotations].sort((a, b) => a.sceneIndex - b.sceneIndex),
+    [annotations],
+  );
+
+  // Auto-scroll to annotations near currentIndex
+  useEffect(() => {
+    if (!panelRef.current || activeAdding !== null) return;
+    const cards = panelRef.current.querySelectorAll("[data-annotation-scene]");
+    let closest: Element | null = null;
+    let closestDist = Infinity;
+    cards.forEach((card) => {
+      const idx = Number(card.getAttribute("data-annotation-scene"));
+      const dist = Math.abs(idx - currentIndex);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closest = card;
+      }
+    });
+    if (closest && closestDist <= 3) {
+      (closest as HTMLElement).scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [currentIndex, activeAdding]);
+
+  const cancelAdding = useCallback(() => {
+    setInternalAdding(null);
+    setNewBody("");
+    onClearAddingTarget();
+  }, [onClearAddingTarget]);
+
+  const handleAdd = useCallback(() => {
+    if (!newBody.trim() || activeAdding === null) return;
+    add(activeAdding, newBody.trim());
+    setNewBody("");
+    setInternalAdding(null);
+    onClearAddingTarget();
+  }, [add, activeAdding, newBody, onClearAddingTarget]);
+
+  const handleUpdate = useCallback(() => {
+    if (!editingId || !editBody.trim()) return;
+    update(editingId, editBody.trim());
+    setEditingId(null);
+    setEditBody("");
+  }, [editingId, editBody, update]);
+
+  // Preview for the scene being commented on
+  const addingPreview = activeAdding !== null && scenes[activeAdding]
+    ? scenePreview(scenes[activeAdding])
+    : null;
+  const addingLabelColor = activeAdding !== null && scenes[activeAdding]
+    ? sceneLabelColor(scenes[activeAdding])
+    : "";
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-terminal-border/50">
+        <span className="text-xs font-mono font-semibold text-terminal-text uppercase tracking-wider">
+          Comments
+        </span>
+        <div className="flex items-center gap-2">
+          {readOnly && (
+            <span className="text-[9px] font-mono text-terminal-dim/60 uppercase px-1.5 py-0.5 rounded border border-terminal-border/40">
+              Read-only
+            </span>
+          )}
+          <span className="text-[10px] font-mono text-terminal-dim">
+            {annotations.length}
+          </span>
+        </div>
+      </div>
+
+      {/* Annotation list */}
+      <div ref={panelRef} className="flex-1 overflow-y-auto">
+        {sorted.length === 0 && activeAdding === null && (
+          <div className="px-3 py-8 text-center">
+            <div className="text-terminal-dim text-xs font-mono mb-2">
+              No comments yet
+            </div>
+            {!readOnly && (
+              <div className="text-terminal-dim/60 text-[10px] font-mono">
+                Hover over any message and click the comment icon to add one
+              </div>
+            )}
+          </div>
+        )}
+
+        {sorted.map((annotation) => (
+          <AnnotationCard
+            key={annotation.id}
+            annotation={annotation}
+            scene={scenes[annotation.sceneIndex]}
+            isCurrent={annotation.sceneIndex === currentIndex}
+            isEditing={!readOnly && editingId === annotation.id}
+            editBody={editingId === annotation.id ? editBody : ""}
+            editTextareaRef={editingId === annotation.id ? editTextareaRef : undefined}
+            onSeek={() => onSeek(annotation.sceneIndex)}
+            onStartEdit={() => {
+              setEditingId(annotation.id);
+              setEditBody(annotation.body);
+            }}
+            onCancelEdit={() => {
+              setEditingId(null);
+              setEditBody("");
+            }}
+            onSaveEdit={handleUpdate}
+            onEditBodyChange={setEditBody}
+            onDelete={() => remove(annotation.id)}
+            readOnly={readOnly}
+          />
+        ))}
+
+        {/* New annotation form */}
+        {!readOnly && activeAdding !== null && (
+          <div ref={addFormRef} className="px-3 py-2.5 border-b border-terminal-border/30 bg-terminal-blue/[0.03]">
+            {/* Scene preview */}
+            {addingPreview && (
+              <div className="flex items-center gap-1.5 mb-2">
+                <span className={`text-[10px] font-mono font-semibold uppercase ${addingLabelColor}`}>
+                  {addingPreview.label}
+                </span>
+                <span className="text-[10px] font-mono text-terminal-dim truncate">
+                  {addingPreview.text}
+                </span>
+              </div>
+            )}
+            <textarea
+              ref={textareaRef}
+              value={newBody}
+              onChange={(e) => setNewBody(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  handleAdd();
+                }
+                if (e.key === "Escape") cancelAdding();
+              }}
+              placeholder="Add a comment... (Markdown supported)"
+              className="w-full bg-terminal-surface border border-terminal-border/50 rounded px-2 py-1.5 text-xs font-mono text-terminal-text placeholder-terminal-dim/50 resize-none focus:outline-none focus:border-terminal-blue/50"
+              rows={3}
+            />
+            <div className="flex items-center justify-between mt-1.5">
+              <span className="text-[9px] font-mono text-terminal-dim/50">
+                {"\u2318"}+Enter to save
+              </span>
+              <div className="flex gap-1.5">
+                <button
+                  onClick={cancelAdding}
+                  className="px-2 py-1 text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleAdd}
+                  disabled={!newBody.trim()}
+                  className="px-2 py-1 text-[10px] font-mono bg-terminal-blue/15 text-terminal-blue rounded hover:bg-terminal-blue/25 transition-colors disabled:opacity-40"
+                >
+                  Comment
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Footer: Save/export buttons — always visible when annotations exist */}
+      {!readOnly && annotations.length > 0 && (
+        <div className="shrink-0 border-t border-terminal-border/50 px-3 py-2 space-y-1.5">
+          {hasUnsaved && (
+            <div className="text-[9px] font-mono text-terminal-orange text-center mb-1">
+              Unsaved changes
+            </div>
+          )}
+          {canSaveHtml ? (
+            <button
+              onClick={downloadHtml}
+              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-green/15 text-terminal-green rounded hover:bg-terminal-green/25 transition-colors text-center border border-terminal-green/30"
+              title="Download HTML with comments embedded"
+            >
+              Save HTML with Comments
+            </button>
+          ) : (
+            <div className="text-[9px] font-mono text-terminal-dim/60 text-center px-2 py-1">
+              Save HTML requires a production build (use CLI output)
+            </div>
+          )}
+          <button
+            onClick={downloadJson}
+            className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-blue/10 text-terminal-blue rounded hover:bg-terminal-blue/20 transition-colors text-center border border-terminal-blue/20"
+            title="Download replay.json for re-publishing to gist"
+          >
+            Export JSON (for gist re-publish)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const AnnotationCard = memo(function AnnotationCard({
+  annotation,
+  scene,
+  isCurrent,
+  isEditing,
+  editBody,
+  editTextareaRef,
+  onSeek,
+  onStartEdit,
+  onCancelEdit,
+  onSaveEdit,
+  onEditBodyChange,
+  onDelete,
+  readOnly = false,
+}: {
+  annotation: Annotation;
+  scene?: Scene;
+  isCurrent: boolean;
+  isEditing: boolean;
+  editBody: string;
+  editTextareaRef?: React.RefObject<HTMLTextAreaElement | null>;
+  onSeek: () => void;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onEditBodyChange: (body: string) => void;
+  onDelete: () => void;
+  readOnly?: boolean;
+}) {
+  const [showActions, setShowActions] = useState(false);
+
+  const preview = scene ? scenePreview(scene) : null;
+  const labelColor = scene ? sceneLabelColor(scene) : "text-terminal-dim";
+
+  const timeStr = useMemo(() => {
+    try {
+      return new Date(annotation.createdAt).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return "";
+    }
+  }, [annotation.createdAt]);
+
+  return (
+    <div
+      data-annotation-scene={annotation.sceneIndex}
+      className={`px-3 py-2 border-b border-terminal-border/30 transition-colors ${
+        isCurrent
+          ? "bg-terminal-blue/10 border-l-2 border-l-terminal-blue"
+          : "hover:bg-terminal-surface/50"
+      }`}
+      onMouseEnter={() => setShowActions(true)}
+      onMouseLeave={() => setShowActions(false)}
+    >
+      {/* Scene reference — click to navigate */}
+      <button
+        onClick={onSeek}
+        className="flex items-center gap-1.5 mb-1 w-full text-left group/ref"
+      >
+        {preview && (
+          <>
+            <span className={`text-[10px] font-mono font-semibold uppercase shrink-0 ${labelColor}`}>
+              {preview.label}
+            </span>
+            <span className="text-[10px] font-mono text-terminal-dim truncate group-hover/ref:text-terminal-text transition-colors">
+              {preview.text}
+            </span>
+          </>
+        )}
+        {!preview && (
+          <span className="text-[10px] font-mono text-terminal-dim">
+            Step {annotation.sceneIndex + 1}
+          </span>
+        )}
+      </button>
+
+      {/* Comment body + actions */}
+      <div className="flex items-start gap-1">
+        <div className="flex-1 min-w-0">
+          {isEditing ? (
+            <div>
+              <textarea
+                ref={editTextareaRef}
+                value={editBody}
+                onChange={(e) => onEditBodyChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    onSaveEdit();
+                  }
+                  if (e.key === "Escape") onCancelEdit();
+                }}
+                className="w-full bg-terminal-surface border border-terminal-border/50 rounded px-2 py-1.5 text-xs font-mono text-terminal-text resize-none focus:outline-none focus:border-terminal-blue/50"
+                rows={3}
+              />
+              <div className="flex justify-end gap-1.5 mt-1">
+                <button
+                  onClick={onCancelEdit}
+                  className="px-2 py-0.5 text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={onSaveEdit}
+                  className="px-2 py-0.5 text-[10px] font-mono bg-terminal-blue/15 text-terminal-blue rounded hover:bg-terminal-blue/25 transition-colors"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="prose-terminal text-xs text-terminal-text/90 leading-relaxed">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{annotation.body}</ReactMarkdown>
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        {!readOnly && showActions && !isEditing && (
+          <div className="flex gap-0.5 shrink-0 pt-0.5">
+            <button
+              onClick={onStartEdit}
+              className="p-0.5 text-[10px] text-terminal-dim hover:text-terminal-blue transition-colors"
+              title="Edit"
+            >
+              {"\u270E"}
+            </button>
+            <button
+              onClick={onDelete}
+              className="p-0.5 text-[10px] text-terminal-dim hover:text-terminal-red transition-colors"
+              title="Delete"
+            >
+              {"\u2715"}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Timestamp */}
+      <div className="text-[9px] font-mono text-terminal-dim/40 mt-1">{timeStr}</div>
+    </div>
+  );
+});

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect, useMemo, memo, useCallback } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { marked } from "marked";
 import type { Annotation, Scene } from "../types";
+
+// Configure marked for short-form annotation text
+marked.setOptions({ breaks: true, gfm: true });
 import type { AnnotationActions } from "../hooks/useAnnotations";
 
 interface Props {
@@ -472,9 +474,10 @@ const AnnotationCard = memo(function AnnotationCard({
               </div>
             </div>
           ) : (
-            <div className="prose-terminal text-xs text-terminal-text/90 leading-relaxed">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{annotation.body}</ReactMarkdown>
-            </div>
+            <div
+              className="prose-terminal text-xs text-terminal-text/90 leading-relaxed"
+              dangerouslySetInnerHTML={{ __html: marked.parse(annotation.body) as string }}
+            />
           )}
         </div>
 

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -287,7 +287,11 @@ export default function AnnotationPanel({
           )}
           {statusMsg && (
             <div className={`text-[9px] font-mono text-center mb-1 ${statusMsg.type === "success" ? "text-terminal-green" : "text-terminal-red"}`}>
-              {statusMsg.text}
+              {statusMsg.type === "success" && statusMsg.text.startsWith("http") ? (
+                <a href={statusMsg.text} target="_blank" rel="noopener noreferrer" className="underline hover:text-terminal-text transition-colors">
+                  {statusMsg.text}
+                </a>
+              ) : statusMsg.text}
             </div>
           )}
 
@@ -327,8 +331,10 @@ export default function AnnotationPanel({
             </button>
           )}
           {publishGist && ghAvailable === false && (
-            <div className="text-[9px] font-mono text-terminal-dim/60 text-center px-2 py-1">
-              Gist requires gh CLI (gh auth login)
+            <div className="text-[9px] font-mono text-terminal-orange/70 text-center px-2 py-1.5 border border-terminal-orange/20 rounded bg-terminal-orange/5">
+              Gist publishing requires{" "}
+              <a href="https://cli.github.com/" target="_blank" rel="noopener noreferrer" className="underline">gh CLI</a>
+              {" "}— install then run <span className="text-terminal-text/70">gh auth login</span>
             </div>
           )}
 

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -24,6 +24,8 @@ function scenePreview(scene: Scene): { label: string; text: string } {
       const first = scene.content.split("\n").find((l) => l.trim()) || "";
       return { label: "You", text: first.slice(0, 100) };
     }
+    case "compaction-summary":
+      return { label: "Compaction", text: scene.content.slice(0, 80) };
     case "thinking":
       return { label: "Thinking", text: scene.content.slice(0, 80) };
     case "text-response": {
@@ -41,6 +43,7 @@ function scenePreview(scene: Scene): { label: string; text: string } {
 function sceneLabelColor(scene: Scene): string {
   switch (scene.type) {
     case "user-prompt": return "text-terminal-green";
+    case "compaction-summary": return "text-terminal-dim";
     case "thinking": return "text-terminal-purple";
     case "text-response": return "text-terminal-blue";
     case "tool-call": return "text-terminal-orange";

--- a/packages/viewer/src/components/CompactionSummaryBlock.tsx
+++ b/packages/viewer/src/components/CompactionSummaryBlock.tsx
@@ -1,0 +1,41 @@
+import { useState, memo } from "react";
+
+interface Props {
+  content: string;
+  isActive: boolean;
+}
+
+const PREVIEW_LINES = 3;
+
+export default memo(function CompactionSummaryBlock({ content, isActive }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const lines = content.split("\n");
+  const isLong = lines.length > PREVIEW_LINES;
+
+  const displayContent = isLong && !expanded
+    ? lines.slice(0, PREVIEW_LINES).join("\n")
+    : content;
+
+  return (
+    <div>
+      <div
+        className={`text-xs font-mono text-terminal-dim/70 whitespace-pre-wrap leading-relaxed ${
+          isActive ? "" : "opacity-80"
+        } ${isLong && !expanded ? "max-h-[4.5em] overflow-hidden relative" : ""}`}
+      >
+        {displayContent}
+        {isLong && !expanded && (
+          <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-terminal-bg to-transparent" />
+        )}
+      </div>
+      {isLong && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-1 text-[11px] font-mono text-terminal-dim/50 hover:text-terminal-text transition-colors"
+        >
+          {expanded ? "Show less" : `Show full summary (${lines.length} lines)`}
+        </button>
+      )}
+    </div>
+  );
+});

--- a/packages/viewer/src/components/Controls.tsx
+++ b/packages/viewer/src/components/Controls.tsx
@@ -14,6 +14,10 @@ interface Props {
   onNextPrompt: () => void;
   onOpenSearch: () => void;
   onOpenOutline?: () => void;
+  annotationCount?: number;
+  annotationPanelOpen?: boolean;
+  onToggleAnnotations?: () => void;
+  hasUnsavedAnnotations?: boolean;
 }
 
 const SPEEDS = [1, 5, 10];
@@ -31,6 +35,10 @@ export default function Controls({
   onNextPrompt,
   onOpenSearch,
   onOpenOutline,
+  annotationCount = 0,
+  annotationPanelOpen = false,
+  onToggleAnnotations,
+  hasUnsavedAnnotations = false,
 }: Props) {
   const isPlaying = state === "playing";
   const playIcon = isPlaying ? "\u23F8" : "\u25B6";
@@ -114,6 +122,29 @@ export default function Controls({
             <span className="hidden sm:inline ml-1.5">Search</span>
           </button>
         </div>
+
+        {/* Annotations toggle */}
+        {onToggleAnnotations && (
+          <div className={`${groupStyle} hidden md:flex`}>
+            <button
+              onClick={() => { flash("annotate"); onToggleAnnotations(); }}
+              className={`${cellStyle} ${btnBase} ${
+                annotationPanelOpen
+                  ? "bg-terminal-blue/15 text-terminal-blue"
+                  : "hover:text-terminal-blue bg-terminal-surface"
+              } ${flashClass("annotate")} relative`}
+              title="Toggle comments panel"
+            >
+              <span>{"\uD83D\uDCAC"}</span>
+              {annotationCount > 0 && (
+                <span className="hidden sm:inline ml-1.5">{annotationCount}</span>
+              )}
+              {hasUnsavedAnnotations && (
+                <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-terminal-orange" />
+              )}
+            </button>
+          </div>
+        )}
 
         {/* Outline (mobile only) */}
         {onOpenOutline && (

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useRef, useEffect, memo } from "react";
 import type { Scene } from "../types";
 import type { ViewPrefs } from "../hooks/useViewPrefs";
 import UserPromptBlock from "./UserPromptBlock";
+import CompactionSummaryBlock from "./CompactionSummaryBlock";
 import ThinkingBlock from "./ThinkingBlock";
 import TextResponseBlock from "./TextResponseBlock";
 import ToolCallBlock from "./ToolCallBlock";
@@ -18,7 +19,7 @@ interface Props {
 }
 
 interface TurnGroup {
-  type: "user" | "assistant";
+  type: "user" | "assistant" | "compaction";
   timestamp?: string;
   scenes: { scene: Scene; index: number }[];
 }
@@ -55,10 +56,10 @@ export default function ConversationView({
 
     for (let i = 0; i < scenes.length; i++) {
       const scene = scenes[i];
-      if (scene.type === "user-prompt") {
+      if (scene.type === "user-prompt" || scene.type === "compaction-summary") {
         if (current && current.scenes.length > 0) result.push(current);
         result.push({
-          type: "user",
+          type: scene.type === "compaction-summary" ? "compaction" : "user",
           timestamp: scene.timestamp,
           scenes: [{ scene, index: i }],
         });
@@ -85,7 +86,7 @@ export default function ConversationView({
       return allGroups
         .filter(
           (g) =>
-            g.type === "user" && g.scenes[0].index < visibleCount,
+            (g.type === "user" || g.type === "compaction") && g.scenes[0].index < visibleCount,
         );
     }
     return allGroups.filter((g) => g.scenes[0].index < visibleCount);
@@ -280,6 +281,36 @@ const GroupCard = memo(function GroupCard({
             />
           </div>
         ))}
+      </div>
+    );
+  }
+
+  if (group.type === "compaction") {
+    const scene = visibleScenes[0]?.scene;
+    if (!scene || scene.type !== "compaction-summary") return null;
+    return (
+      <div
+        id={`scene-${firstIndex}`}
+        data-scene-index={firstIndex}
+        className={`group relative rounded-lg px-4 py-3 transition-colors duration-200 ${
+          groupHasFocusedTarget
+            ? "scene-nav-focused bg-terminal-dim/20 border-2 border-terminal-dim ring-2 ring-terminal-dim/60"
+            : groupHasCurrent
+              ? "bg-terminal-dim/10 border-2 border-terminal-dim/40"
+              : "bg-terminal-dim/[0.03] border border-terminal-border/30 border-dashed"
+        }`}
+      >
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[11px] font-mono font-semibold text-terminal-dim uppercase tracking-wider">
+            Context Compaction
+          </span>
+          {group.timestamp && (
+            <span className="text-[11px] font-mono text-terminal-dim/60">
+              {formatTime(group.timestamp)}
+            </span>
+          )}
+        </div>
+        <CompactionSummaryBlock content={scene.content} isActive={firstIndex === currentIndex} />
       </div>
     );
   }
@@ -561,6 +592,8 @@ const SceneBlock = memo(function SceneBlock({
           isActive={isActive}
         />
       );
+    case "compaction-summary":
+      return <CompactionSummaryBlock content={scene.content} isActive={isActive} />;
     case "thinking":
       return <ThinkingBlock content={scene.content} isActive={isActive} />;
     case "text-response":

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -12,6 +12,9 @@ interface Props {
   currentIndex: number;
   viewPrefs: ViewPrefs;
   focusIndex?: number;
+  annotatedScenes?: Set<number>;
+  annotationCounts?: Map<number, number>;
+  onComment?: (sceneIndex: number) => void;
 }
 
 interface TurnGroup {
@@ -41,6 +44,9 @@ export default function ConversationView({
   currentIndex,
   viewPrefs,
   focusIndex,
+  annotatedScenes,
+  annotationCounts,
+  onComment,
 }: Props) {
   // Pre-compute ALL groups once — stable across playback ticks
   const allGroups = useMemo(() => {
@@ -108,6 +114,9 @@ export default function ConversationView({
             visibleCount={visibleCount}
             viewPrefs={viewPrefs}
             focusIndex={focusIndex}
+            annotatedScenes={annotatedScenes}
+            annotationCounts={annotationCounts}
+            onComment={onComment}
           />
         </LazyGroup>
       ))}
@@ -178,13 +187,21 @@ const GroupCard = memo(function GroupCard({
   visibleCount,
   viewPrefs,
   focusIndex,
+  annotatedScenes,
+  annotationCounts,
+  onComment,
 }: {
   group: TurnGroup;
   currentIndex: number;
   visibleCount: number;
   viewPrefs: ViewPrefs;
   focusIndex?: number;
+  annotatedScenes?: Set<number>;
+  annotationCounts?: Map<number, number>;
+  onComment?: (sceneIndex: number) => void;
 }) {
+  const [hovered, setHovered] = useState(false);
+
   // Only include scenes that are visible so far
   const visibleScenes = useMemo(
     () => group.scenes.filter((s) => s.index < visibleCount),
@@ -199,19 +216,42 @@ const GroupCard = memo(function GroupCard({
 
   if (visibleScenes.length === 0) return null;
 
+  // User groups get a group-level comment button (single scene)
+  const userCommentCount = group.type === "user" ? (annotationCounts?.get(firstIndex) || 0) : 0;
+  const userCommentButton = group.type === "user" && onComment && (userCommentCount > 0 || hovered) ? (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onComment(firstIndex);
+      }}
+      className={`absolute -right-3 top-3 z-10 flex items-center gap-1 px-1.5 py-1 rounded-md border text-[10px] font-mono transition-all duration-150 ${
+        userCommentCount > 0
+          ? "bg-terminal-blue border-terminal-blue text-white shadow-sm"
+          : "bg-terminal-bg border-terminal-border text-terminal-dim hover:text-terminal-blue hover:border-terminal-blue/40 opacity-0 group-hover:opacity-100"
+      }`}
+      title={userCommentCount > 0 ? `${userCommentCount} comment${userCommentCount > 1 ? "s" : ""}` : "Add comment"}
+    >
+      {"\uD83D\uDCAC"}
+      {userCommentCount > 0 && <span>{userCommentCount}</span>}
+    </button>
+  ) : null;
+
   if (group.type === "user") {
     return (
       <div
         id={`scene-${firstIndex}`}
         data-scene-index={firstIndex}
-        className={`rounded-lg px-4 py-3 transition-colors duration-200 ${
+        className={`group relative rounded-lg px-4 py-3 transition-colors duration-200 ${
           groupHasFocusedTarget
             ? "scene-nav-focused bg-terminal-green/30 border-2 border-terminal-green ring-2 ring-terminal-green/60 shadow-lg shadow-terminal-green/30"
             : groupHasCurrent
               ? "bg-terminal-green/20 border-2 border-terminal-green/60 ring-1 ring-terminal-green/40 shadow-md shadow-terminal-green/20"
               : "bg-terminal-green/5 border border-terminal-green/15"
         }`}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
       >
+        {userCommentButton}
         <div className="flex items-center gap-2 mb-2">
           <span className="text-[11px] font-mono font-semibold text-terminal-green uppercase tracking-wider">
             You
@@ -255,7 +295,7 @@ const GroupCard = memo(function GroupCard({
     <div
       id={`scene-${firstIndex}`}
       data-scene-index={firstIndex}
-      className={`rounded-lg px-4 py-3 transition-colors duration-200 ${
+      className={`relative rounded-lg px-4 py-3 transition-colors duration-200 ${
         groupHasFocusedTarget
           ? "scene-nav-focused bg-terminal-blue/20 border-2 border-terminal-blue ring-2 ring-terminal-blue/60 shadow-lg shadow-terminal-blue/30"
           : groupHasCurrent
@@ -287,6 +327,8 @@ const GroupCard = memo(function GroupCard({
           scenes={filteredScenes}
           currentIndex={currentIndex}
           collapseTools={viewPrefs.collapseAllTools}
+          annotationCounts={annotationCounts}
+          onComment={onComment}
         />
       </div>
     </div>
@@ -301,10 +343,14 @@ function BatchedScenes({
   scenes,
   currentIndex,
   collapseTools,
+  annotationCounts,
+  onComment,
 }: {
   scenes: { scene: Scene; index: number }[];
   currentIndex: number;
   collapseTools: boolean;
+  annotationCounts?: Map<number, number>;
+  onComment?: (sceneIndex: number) => void;
 }) {
   // Group consecutive tool calls with the same toolName (only batchable ones)
   const batches: { scene: Scene; index: number }[][] = [];
@@ -334,17 +380,32 @@ function BatchedScenes({
         // Single item or non-batchable
         if (batch.length <= 1) {
           const { scene, index } = batch[0];
+          const count = annotationCounts?.get(index) || 0;
           return (
             <div
               key={index}
               data-scene-index={index}
-              className={`scene-enter ${index === currentIndex ? "" : "opacity-90"}`}
+              className={`group/scene relative scene-enter ${index === currentIndex ? "" : "opacity-90"}`}
             >
               <SceneBlock
                 scene={scene}
                 isActive={index === currentIndex}
                 collapseTools={collapseTools}
               />
+              {onComment && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); onComment(index); }}
+                  className={`absolute -right-2 top-1 z-10 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md border text-[10px] font-mono transition-all duration-150 ${
+                    count > 0
+                      ? "bg-terminal-blue border-terminal-blue text-white shadow-sm"
+                      : "bg-terminal-bg border-terminal-border text-terminal-dim hover:text-terminal-blue hover:border-terminal-blue/40 opacity-0 group-hover/scene:opacity-100"
+                  }`}
+                  title={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
+                >
+                  {"\uD83D\uDCAC"}
+                  {count > 0 && <span>{count}</span>}
+                </button>
+              )}
             </div>
           );
         }
@@ -359,6 +420,8 @@ function BatchedScenes({
             toolName={toolName}
             currentIndex={currentIndex}
             collapseTools={collapseTools}
+            annotationCounts={annotationCounts}
+            onComment={onComment}
           />
         );
       })}
@@ -371,13 +434,22 @@ function ToolBatch({
   toolName,
   currentIndex,
   collapseTools,
+  annotationCounts,
+  onComment,
 }: {
   batch: { scene: Scene; index: number }[];
   toolName: string;
   currentIndex: number;
   collapseTools: boolean;
+  annotationCounts?: Map<number, number>;
+  onComment?: (sceneIndex: number) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+
+  // Total comment count across all items in batch
+  const batchCommentCount = annotationCounts
+    ? batch.reduce((sum, { index }) => sum + (annotationCounts.get(index) || 0), 0)
+    : 0;
 
   // Collapsed view: always show summary
   const summaries = batch.map(({ scene }) => {
@@ -388,7 +460,7 @@ function ToolBatch({
   });
 
   return (
-    <div data-scene-index={batch[0].index}>
+    <div data-scene-index={batch[0].index} className="group/batch relative">
       {/* Collapsed summary — always visible */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -406,23 +478,55 @@ function ToolBatch({
           </span>
         )}
       </button>
+      {/* Batch-level comment button (visible when collapsed) */}
+      {onComment && !expanded && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onComment(batch[0].index); }}
+          className={`absolute -right-2 top-1 z-10 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md border text-[10px] font-mono transition-all duration-150 ${
+            batchCommentCount > 0
+              ? "bg-terminal-blue border-terminal-blue text-white shadow-sm"
+              : "bg-terminal-bg border-terminal-border text-terminal-dim hover:text-terminal-blue hover:border-terminal-blue/40 opacity-0 group-hover/batch:opacity-100"
+          }`}
+          title={batchCommentCount > 0 ? `${batchCommentCount} comment${batchCommentCount > 1 ? "s" : ""}` : "Add comment"}
+        >
+          {"\uD83D\uDCAC"}
+          {batchCommentCount > 0 && <span>{batchCommentCount}</span>}
+        </button>
+      )}
 
-      {/* Expanded: show all individual tool calls */}
+      {/* Expanded: show all individual tool calls with per-scene comment buttons */}
       {expanded && (
         <div className="mt-1 ml-4 space-y-2 border-l border-terminal-border/30 pl-3">
-          {batch.map(({ scene, index }) => (
-            <div
-              key={index}
-              data-scene-index={index}
-              className={`scene-enter ${index === currentIndex ? "" : "opacity-90"}`}
-            >
-              <SceneBlock
-                scene={scene}
-                isActive={index === currentIndex}
-                collapseTools={collapseTools}
-              />
-            </div>
-          ))}
+          {batch.map(({ scene, index }) => {
+            const count = annotationCounts?.get(index) || 0;
+            return (
+              <div
+                key={index}
+                data-scene-index={index}
+                className={`group/scene relative scene-enter ${index === currentIndex ? "" : "opacity-90"}`}
+              >
+                <SceneBlock
+                  scene={scene}
+                  isActive={index === currentIndex}
+                  collapseTools={collapseTools}
+                />
+                {onComment && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onComment(index); }}
+                    className={`absolute -right-2 top-1 z-10 flex items-center gap-0.5 px-1.5 py-0.5 rounded-md border text-[10px] font-mono transition-all duration-150 ${
+                      count > 0
+                        ? "bg-terminal-blue border-terminal-blue text-white shadow-sm"
+                        : "bg-terminal-bg border-terminal-border text-terminal-dim hover:text-terminal-blue hover:border-terminal-blue/40 opacity-0 group-hover/scene:opacity-100"
+                    }`}
+                    title={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
+                  >
+                    {"\uD83D\uDCAC"}
+                    {count > 0 && <span>{count}</span>}
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/viewer/src/components/Minimap.tsx
+++ b/packages/viewer/src/components/Minimap.tsx
@@ -8,6 +8,7 @@ interface Props {
 }
 
 interface TurnOutline {
+  kind: "turn";
   turnNumber: number;
   promptIndex: number;
   prompt: string;
@@ -18,19 +19,30 @@ interface TurnOutline {
   endIndex: number;
 }
 
+interface CompactionOutline {
+  kind: "compaction";
+  promptIndex: number;
+  preview: string;
+}
+
+type OutlineItem = TurnOutline | CompactionOutline;
+
 export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
-  const turns = useMemo(() => {
-    const groups: TurnOutline[] = [];
+  const items = useMemo(() => {
+    const result: OutlineItem[] = [];
     let current: TurnOutline | null = null;
+    let turnCount = 0;
 
     scenes.forEach((scene, i) => {
       if (scene.type === "user-prompt") {
         if (current) {
           current.endIndex = i - 1;
-          groups.push(current);
+          result.push(current);
         }
+        turnCount++;
         current = {
-          turnNumber: groups.length + 1,
+          kind: "turn",
+          turnNumber: turnCount,
           promptIndex: i,
           prompt: scene.content.replace(/\n/g, " ").slice(0, 120),
           toolCalls: 0,
@@ -40,7 +52,16 @@ export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
           endIndex: i,
         };
       } else if (scene.type === "compaction-summary") {
-        // Compaction summaries don't create new turns in the minimap
+        if (current) {
+          current.endIndex = i - 1;
+          result.push(current);
+          current = null;
+        }
+        result.push({
+          kind: "compaction",
+          promptIndex: i,
+          preview: scene.content.replace(/\n/g, " ").slice(0, 80),
+        });
       } else if (current) {
         current.endIndex = i;
         if (scene.type === "tool-call") {
@@ -53,27 +74,48 @@ export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
         else if (scene.type === "text-response") current.textBlocks++;
       }
     });
-    if (current) groups.push(current);
-    return groups;
+    if (current) result.push(current);
+    return result;
   }, [scenes]);
 
-  const activeTurnIdx = useMemo(() => {
-    for (let i = turns.length - 1; i >= 0; i--) {
-      if (currentIndex >= turns[i].promptIndex) return i;
+  const activeIdx = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (currentIndex >= items[i].promptIndex) return i;
     }
     return -1;
-  }, [turns, currentIndex]);
+  }, [items, currentIndex]);
 
   return (
     <div className="flex flex-col gap-px p-2 overflow-y-auto">
-      {turns.map((turn, i) => {
-        const isActive = i === activeTurnIdx;
-        const isPast = i < activeTurnIdx;
+      {items.map((item, i) => {
+        const isActive = i === activeIdx;
+        const isPast = i < activeIdx;
+
+        if (item.kind === "compaction") {
+          return (
+            <button
+              key={`c-${item.promptIndex}`}
+              onClick={() => onSeek(item.promptIndex)}
+              className={`text-left px-3 py-2 rounded-md transition-all border border-dashed ${
+                isActive
+                  ? "border-terminal-dim/40 bg-terminal-dim/10"
+                  : "border-terminal-border/30 hover:bg-terminal-surface/50 opacity-60 hover:opacity-100"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-[10px] font-mono text-terminal-dim/60 shrink-0">{"⟳"}</span>
+                <span className="text-[11px] font-mono text-terminal-dim/70 italic truncate">
+                  Context compacted
+                </span>
+              </div>
+            </button>
+          );
+        }
 
         return (
           <button
-            key={i}
-            onClick={() => onSeek(turn.promptIndex)}
+            key={`t-${item.promptIndex}`}
+            onClick={() => onSeek(item.promptIndex)}
             className={`group text-left px-3 py-2.5 rounded-md transition-all ${
               isActive
                 ? "bg-terminal-green/8 border border-terminal-green/25"
@@ -87,28 +129,28 @@ export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
               <span className={`text-xs font-mono font-semibold shrink-0 mt-px tabular-nums ${
                 isActive ? "text-terminal-green" : "text-terminal-dim"
               }`}>
-                {String(turn.turnNumber).padStart(2, "0")}
+                {String(item.turnNumber).padStart(2, "0")}
               </span>
               <span className={`text-[13px] font-mono leading-snug line-clamp-2 ${
                 isActive ? "text-terminal-text" : "text-terminal-text/80"
               }`}>
-                {turn.prompt}
+                {item.prompt}
               </span>
             </div>
 
             {/* Summary line */}
             <div className="flex items-center gap-2 mt-1.5 ml-6 flex-wrap">
-              {turn.toolCalls > 0 && (
+              {item.toolCalls > 0 && (
                 <span className="text-[11px] font-mono px-1.5 py-px rounded-sm bg-terminal-orange/10 text-terminal-orange/80">
-                  {turn.toolCalls} tool{turn.toolCalls > 1 ? "s" : ""}
+                  {item.toolCalls} tool{item.toolCalls > 1 ? "s" : ""}
                 </span>
               )}
-              {turn.textBlocks > 0 && (
+              {item.textBlocks > 0 && (
                 <span className="text-[11px] font-mono px-1.5 py-px rounded-sm bg-terminal-blue/10 text-terminal-blue/80">
-                  {turn.textBlocks} resp
+                  {item.textBlocks} resp
                 </span>
               )}
-              {turn.thinkingBlocks > 0 && (
+              {item.thinkingBlocks > 0 && (
                 <span className="text-[11px] font-mono px-1.5 py-px rounded-sm bg-terminal-purple/10 text-terminal-purple/80">
                   think
                 </span>
@@ -116,9 +158,9 @@ export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
             </div>
 
             {/* Tool names (only for active turn) */}
-            {isActive && turn.toolNames.length > 0 && (
+            {isActive && item.toolNames.length > 0 && (
               <div className="mt-1.5 ml-6 text-[11px] font-mono text-terminal-dim truncate">
-                {turn.toolNames.join(", ")}
+                {item.toolNames.join(", ")}
               </div>
             )}
           </button>

--- a/packages/viewer/src/components/Minimap.tsx
+++ b/packages/viewer/src/components/Minimap.tsx
@@ -39,6 +39,8 @@ export default function Minimap({ scenes, currentIndex, onSeek }: Props) {
           textBlocks: 0,
           endIndex: i,
         };
+      } else if (scene.type === "compaction-summary") {
+        // Compaction summaries don't create new turns in the minimap
       } else if (current) {
         current.endIndex = i;
         if (scene.type === "tool-call") {

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -3,6 +3,7 @@ import type { ReplaySession } from "../types";
 import type { ViewPrefs } from "../hooks/useViewPrefs";
 import { usePlayback } from "../hooks/usePlayback";
 import { useAnnotations } from "../hooks/useAnnotations";
+import type { ViewerMode } from "../hooks/useSessionLoader";
 import Timeline from "./Timeline";
 import Controls from "./Controls";
 import ConversationView from "./ConversationView";
@@ -15,7 +16,7 @@ import AnnotationPanel from "./AnnotationPanel";
 interface Props {
   session: ReplaySession;
   viewPrefs: ViewPrefs;
-  isReadOnly?: boolean;
+  viewerMode?: ViewerMode;
 }
 
 function flashJumpTarget(el: HTMLElement) {
@@ -28,7 +29,8 @@ function flashJumpTarget(el: HTMLElement) {
   }, 900);
 }
 
-export default function Player({ session, viewPrefs, isReadOnly = false }: Props) {
+export default function Player({ session, viewPrefs, viewerMode = "embedded" }: Props) {
+  const isReadOnly = viewerMode === "readonly";
   const [landed, setLanded] = useState(false);
   const [navFocusIndex, setNavFocusIndex] = useState<number | undefined>(undefined);
   const [navJumpSeq, setNavJumpSeq] = useState(0);
@@ -47,7 +49,7 @@ export default function Player({ session, viewPrefs, isReadOnly = false }: Props
     return false;
   });
   const [commentTargetScene, setCommentTargetScene] = useState<number | null>(null);
-  const annotationActions = useAnnotations(session);
+  const annotationActions = useAnnotations(session, viewerMode);
 
   const {
     state,

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState, useCallback } from "react";
 import type { ReplaySession } from "../types";
 import type { ViewPrefs } from "../hooks/useViewPrefs";
 import { usePlayback } from "../hooks/usePlayback";
+import { useAnnotations } from "../hooks/useAnnotations";
 import Timeline from "./Timeline";
 import Controls from "./Controls";
 import ConversationView from "./ConversationView";
@@ -9,10 +10,12 @@ import Minimap from "./Minimap";
 import StatsPanel from "./StatsPanel";
 import SearchOverlay from "./SearchOverlay";
 import LandingHero from "./LandingHero";
+import AnnotationPanel from "./AnnotationPanel";
 
 interface Props {
   session: ReplaySession;
   viewPrefs: ViewPrefs;
+  isReadOnly?: boolean;
 }
 
 function flashJumpTarget(el: HTMLElement) {
@@ -25,10 +28,26 @@ function flashJumpTarget(el: HTMLElement) {
   }, 900);
 }
 
-export default function Player({ session, viewPrefs }: Props) {
+export default function Player({ session, viewPrefs, isReadOnly = false }: Props) {
   const [landed, setLanded] = useState(false);
   const [navFocusIndex, setNavFocusIndex] = useState<number | undefined>(undefined);
   const [navJumpSeq, setNavJumpSeq] = useState(0);
+  const [annotationPanelOpen, setAnnotationPanelOpen] = useState(() => {
+    // Check embedded annotations
+    if ((session.annotations?.length ?? 0) > 0) return true;
+    // Check localStorage draft (useAnnotations loads from here too)
+    try {
+      const key = "vibe-replay-annotations-" + session.meta.sessionId;
+      const draft = localStorage.getItem(key);
+      if (draft) {
+        const parsed = JSON.parse(draft);
+        return Array.isArray(parsed) && parsed.length > 0;
+      }
+    } catch { /* ignore */ }
+    return false;
+  });
+  const [commentTargetScene, setCommentTargetScene] = useState<number | null>(null);
+  const annotationActions = useAnnotations(session);
 
   const {
     state,
@@ -45,7 +64,7 @@ export default function Player({ session, viewPrefs }: Props) {
   } = usePlayback(session.scenes, viewPrefs.promptsOnly, landed);
 
   const scrollRef = useRef<HTMLDivElement>(null);
-  const [sidebarTab, setSidebarTab] = useState<"outline" | "stats">("outline");
+  const [sidebarTab, setSidebarTab] = useState<"outline" | "stats" | "comments">("outline");
   const [searchOpen, setSearchOpen] = useState(false);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
   const [scrollHintDismissed, setScrollHintDismissed] = useState(false);
@@ -284,57 +303,83 @@ export default function Player({ session, viewPrefs }: Props) {
           </button>
         </div>
         <div className="flex-1 overflow-y-auto">
-          {sidebarTab === "outline" ? (
+          {sidebarTab === "stats" ? (
+            <StatsPanel session={session} />
+          ) : (
             <Minimap
               scenes={session.scenes}
               currentIndex={currentIndex}
               onSeek={seekFromNavigation}
             />
-          ) : (
-            <StatsPanel session={session} />
           )}
         </div>
       </div>
 
       {/* Main content */}
       <div className="flex flex-col flex-1 min-h-0 min-w-0">
-        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 pb-8 overscroll-contain">
-          <ConversationView
-            scenes={session.scenes}
-            visibleCount={visibleCount}
-            currentIndex={currentIndex}
-            viewPrefs={viewPrefs}
-            focusIndex={navFocusIndex}
-          />
-        </div>
-
-        {/* Scroll-to-reveal hint */}
-        {state === "paused" && currentIndex < session.scenes.length - 1 && !scrollHintDismissed && (
-          <div className="absolute bottom-[72px] left-1/2 -translate-x-1/2 z-10 pointer-events-none animate-bounce">
-            <div className="px-4 py-1.5 rounded-full bg-terminal-surface/90 border border-terminal-border/60 backdrop-blur-sm text-xs font-mono text-terminal-dim flex items-center gap-2 shadow-lg">
-              <span className="text-terminal-green">{"\u2193"}</span>
-              scroll for more
+        <div className="flex flex-1 min-h-0">
+          <div className="flex flex-col flex-1 min-h-0 min-w-0 relative">
+            <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 pb-8 overscroll-contain">
+              <ConversationView
+                scenes={session.scenes}
+                visibleCount={visibleCount}
+                currentIndex={currentIndex}
+                viewPrefs={viewPrefs}
+                focusIndex={navFocusIndex}
+                annotatedScenes={annotationActions.annotatedScenes}
+                annotationCounts={annotationActions.annotationCounts}
+                onComment={isReadOnly ? undefined : (sceneIndex) => {
+                  setAnnotationPanelOpen(true);
+                  setCommentTargetScene(sceneIndex);
+                }}
+              />
             </div>
-          </div>
-        )}
 
-        {/* Search overlay */}
-        <SearchOverlay
-          scenes={session.scenes}
-          open={searchOpen}
-          onClose={() => setSearchOpen(false)}
-          onSeek={(i) => {
-            seekFromNavigation(i);
-            setSearchOpen(false);
-          }}
-        />
+            {/* Scroll-to-reveal hint */}
+            {state === "paused" && currentIndex < session.scenes.length - 1 && !scrollHintDismissed && (
+              <div className="absolute bottom-[72px] left-1/2 -translate-x-1/2 z-10 pointer-events-none animate-bounce">
+                <div className="px-4 py-1.5 rounded-full bg-terminal-surface/90 border border-terminal-border/60 backdrop-blur-sm text-xs font-mono text-terminal-dim flex items-center gap-2 shadow-lg">
+                  <span className="text-terminal-green">{"\u2193"}</span>
+                  scroll for more
+                </div>
+              </div>
+            )}
 
-        {/* Pause overlay — hidden on mobile (shown in controls bar instead) */}
-        {state === "paused" && visibleCount > 0 && (
-          <div className="hidden md:block absolute top-3 right-3 px-3 py-1.5 rounded-md bg-terminal-orange/10 border border-terminal-orange/20 text-terminal-orange text-xs font-mono pause-overlay pointer-events-none backdrop-blur-sm">
-            PAUSED
+            {/* Search overlay */}
+            <SearchOverlay
+              scenes={session.scenes}
+              open={searchOpen}
+              onClose={() => setSearchOpen(false)}
+              onSeek={(i) => {
+                seekFromNavigation(i);
+                setSearchOpen(false);
+              }}
+            />
+
+            {/* Pause overlay — hidden on mobile (shown in controls bar instead) */}
+            {state === "paused" && visibleCount > 0 && (
+              <div className="hidden md:block absolute top-3 right-3 px-3 py-1.5 rounded-md bg-terminal-orange/10 border border-terminal-orange/20 text-terminal-orange text-xs font-mono pause-overlay pointer-events-none backdrop-blur-sm">
+                PAUSED
+              </div>
+            )}
           </div>
-        )}
+
+          {/* Annotation panel — right sidebar */}
+          {annotationPanelOpen && (
+            <div className="hidden md:flex w-72 shrink-0 flex-col border-l border-terminal-border/50 bg-terminal-bg">
+              <AnnotationPanel
+                actions={annotationActions}
+                scenes={session.scenes}
+                currentIndex={currentIndex}
+                totalScenes={totalScenes}
+                onSeek={seekFromNavigation}
+                addingForScene={commentTargetScene}
+                onClearAddingTarget={() => setCommentTargetScene(null)}
+                readOnly={isReadOnly}
+              />
+            </div>
+          )}
+        </div>
 
         {/* Playback bar */}
         <div className="shrink-0 border-t border-terminal-border/50 bg-terminal-surface/80 backdrop-blur-sm sticky bottom-0 safe-bottom">
@@ -342,6 +387,7 @@ export default function Player({ session, viewPrefs }: Props) {
             scenes={session.scenes}
             currentIndex={currentIndex}
             onSeek={seekFromNavigation}
+            annotatedScenes={annotationActions.annotatedScenes}
           />
           <Controls
             state={state}
@@ -356,6 +402,10 @@ export default function Player({ session, viewPrefs }: Props) {
             onNextPrompt={seekToNextPromptWithFeedback}
             onOpenSearch={() => setSearchOpen(true)}
             onOpenOutline={() => setMobileDrawerOpen(true)}
+            annotationCount={annotationActions.annotations.length}
+            annotationPanelOpen={annotationPanelOpen}
+            onToggleAnnotations={() => setAnnotationPanelOpen((v) => !v)}
+            hasUnsavedAnnotations={annotationActions.hasUnsaved}
           />
         </div>
       </div>
@@ -400,6 +450,16 @@ export default function Player({ session, viewPrefs }: Props) {
             >
               Stats
             </button>
+            <button
+              onClick={() => setSidebarTab("comments")}
+              className={`flex-1 px-3 py-2.5 text-xs font-mono uppercase tracking-wider transition-colors ${
+                sidebarTab === "comments"
+                  ? "text-terminal-blue border-b-2 border-terminal-blue"
+                  : "text-terminal-dim"
+              }`}
+            >
+              Comments{annotationActions.annotations.length > 0 ? ` (${annotationActions.annotations.length})` : ""}
+            </button>
           </div>
           {/* Content */}
           <div className="flex-1 overflow-y-auto overscroll-contain">
@@ -412,8 +472,22 @@ export default function Player({ session, viewPrefs }: Props) {
                   setMobileDrawerOpen(false);
                 }}
               />
-            ) : (
+            ) : sidebarTab === "stats" ? (
               <StatsPanel session={session} />
+            ) : (
+              <AnnotationPanel
+                actions={annotationActions}
+                scenes={session.scenes}
+                currentIndex={currentIndex}
+                totalScenes={totalScenes}
+                onSeek={(i) => {
+                  seekFromNavigation(i);
+                  setMobileDrawerOpen(false);
+                }}
+                addingForScene={commentTargetScene}
+                onClearAddingTarget={() => setCommentTargetScene(null)}
+                readOnly={isReadOnly}
+              />
             )}
           </div>
         </div>

--- a/packages/viewer/src/components/SearchOverlay.tsx
+++ b/packages/viewer/src/components/SearchOverlay.tsx
@@ -19,6 +19,8 @@ function getSceneText(scene: Scene): string {
   switch (scene.type) {
     case "user-prompt":
       return scene.content;
+    case "compaction-summary":
+      return scene.content;
     case "thinking":
       return scene.content;
     case "text-response":
@@ -47,6 +49,7 @@ function highlightMatch(text: string, query: string): string {
 
 const TYPE_LABELS: Record<string, string> = {
   "user-prompt": "User",
+  "compaction-summary": "Compaction",
   thinking: "Thinking",
   "text-response": "Response",
   "tool-call": "Tool",
@@ -54,6 +57,7 @@ const TYPE_LABELS: Record<string, string> = {
 
 const TYPE_COLORS: Record<string, string> = {
   "user-prompt": "text-terminal-green",
+  "compaction-summary": "text-terminal-dim",
   thinking: "text-terminal-purple",
   "text-response": "text-terminal-blue",
   "tool-call": "text-terminal-orange",

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -56,13 +56,29 @@ export default function StatsPanel({ session }: Props) {
       filesModified: filesModified.size,
       topTools,
       durationMs: meta.stats.durationMs,
+      tokenUsage: meta.stats.tokenUsage,
+      costEstimate: meta.stats.costEstimate,
+      compactions: meta.compactions,
     };
   }, [session]);
 
+  const { meta } = session;
+
   return (
     <div className="p-3 space-y-4 text-xs font-mono">
-      <div className="text-terminal-dim uppercase tracking-wider text-[11px] font-semibold">
-        Stats
+      {/* Session info */}
+      <div>
+        <div className="text-terminal-dim uppercase tracking-wider text-[11px] font-semibold mb-1.5">
+          Session
+        </div>
+        {meta.title && (
+          <div className="text-terminal-text text-xs mb-0.5 truncate" title={meta.title}>{meta.title}</div>
+        )}
+        <div className="text-terminal-dim truncate" title={meta.cwd}>{meta.project}</div>
+        <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap">
+          {meta.model && <span className="text-terminal-text/60">{meta.model}</span>}
+          {meta.provider && <span>{meta.provider}</span>}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-2">
@@ -72,9 +88,37 @@ export default function StatsPanel({ session }: Props) {
         <StatCard label="Files Modified" value={stats.filesModified} color="text-terminal-blue" />
       </div>
 
-      {stats.durationMs && (
-        <div className="text-terminal-dim">
-          Duration: <span className="text-terminal-text">{formatDuration(stats.durationMs)}</span>
+      {(stats.durationMs || stats.costEstimate !== undefined) && (
+        <div className="text-terminal-dim space-y-0.5">
+          {stats.durationMs && (
+            <div>
+              Duration: <span className="text-terminal-text">{formatDuration(stats.durationMs)}</span>
+            </div>
+          )}
+          {stats.costEstimate !== undefined && (
+            <div>
+              Cost: <span className="text-terminal-green">${stats.costEstimate < 0.01 ? stats.costEstimate.toFixed(4) : stats.costEstimate.toFixed(2)}</span>
+              <span className="text-terminal-dim/60"> (estimate)</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {stats.tokenUsage && (
+        <div>
+          <div className="text-terminal-dim mb-1.5 text-[11px] font-semibold uppercase tracking-wider">Tokens</div>
+          <div className="text-terminal-dim leading-relaxed space-y-0.5">
+            <div>
+              In: <span className="text-terminal-blue">{fmtNum(stats.tokenUsage.inputTokens)}</span>
+              {" / "}
+              Out: <span className="text-terminal-green">{fmtNum(stats.tokenUsage.outputTokens)}</span>
+            </div>
+            <div>
+              Cache: <span className="text-terminal-purple">{fmtNum(stats.tokenUsage.cacheReadTokens)}</span> read
+              {" / "}
+              <span className="text-terminal-orange">{fmtNum(stats.tokenUsage.cacheCreationTokens)}</span> created
+            </div>
+          </div>
         </div>
       )}
 
@@ -85,6 +129,25 @@ export default function StatsPanel({ session }: Props) {
         {" / "}
         <span className="text-terminal-blue">{fmtNum(stats.responseChars)}</span> response
       </div>
+
+      {stats.compactions && stats.compactions.length > 0 && (
+        <div>
+          <div className="text-terminal-dim mb-1.5 text-[11px] font-semibold uppercase tracking-wider">
+            Context Compactions ({stats.compactions.length})
+          </div>
+          <div className="space-y-1">
+            {stats.compactions.map((c, i) => (
+              <div key={i} className="text-terminal-dim text-[11px] flex items-baseline gap-1.5">
+                <span className="text-terminal-orange">●</span>
+                <span>{c.trigger}</span>
+                {c.preTokens && (
+                  <span className="text-terminal-text">{fmtNum(c.preTokens)} tokens</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {stats.topTools.length > 0 && (
         <div>

--- a/packages/viewer/src/components/TextResponseBlock.tsx
+++ b/packages/viewer/src/components/TextResponseBlock.tsx
@@ -1,6 +1,5 @@
-import { useState, memo } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { useState, memo, useMemo } from "react";
+import { marked } from "marked";
 
 interface Props {
   content: string;
@@ -16,6 +15,8 @@ export default memo(function TextResponseBlock({ content, isActive }: Props) {
   const displayContent =
     isLong && !expanded ? content.slice(0, COLLAPSE_THRESHOLD) + "..." : content;
 
+  const html = useMemo(() => marked.parse(displayContent) as string, [displayContent]);
+
   return (
     <div>
       <div
@@ -23,7 +24,7 @@ export default memo(function TextResponseBlock({ content, isActive }: Props) {
           isActive ? "typing-cursor" : ""
         } ${isLong && !expanded ? "max-h-[200px] overflow-hidden relative" : ""}`}
       >
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{displayContent}</ReactMarkdown>
+        <div dangerouslySetInnerHTML={{ __html: html }} />
         {isLong && !expanded && (
           <div className="absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-terminal-bg to-transparent" />
         )}

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -5,6 +5,7 @@ interface Props {
   scenes: Scene[];
   currentIndex: number;
   onSeek: (index: number) => void;
+  annotatedScenes?: Set<number>;
 }
 
 function sceneColor(type: Scene["type"]): string {
@@ -20,7 +21,7 @@ function sceneColor(type: Scene["type"]): string {
   }
 }
 
-export default function Timeline({ scenes, currentIndex, onSeek }: Props) {
+export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes }: Props) {
   if (scenes.length === 0) return null;
 
   // For large sessions (>200 scenes), bucket into segments to avoid rendering 700+ divs
@@ -75,8 +76,32 @@ export default function Timeline({ scenes, currentIndex, onSeek }: Props) {
     onSeek(idx);
   }, [scenes.length, onSeek]);
 
+  // Compute annotation dot positions
+  const annotationDots = useMemo(() => {
+    if (!annotatedScenes || annotatedScenes.size === 0) return [];
+    const dots: number[] = [];
+    annotatedScenes.forEach((idx) => {
+      if (idx >= 0 && idx < scenes.length) {
+        dots.push(((idx + 0.5) / scenes.length) * 100);
+      }
+    });
+    return dots;
+  }, [annotatedScenes, scenes.length]);
+
   return (
     <div className="px-4 pt-3 pb-1 cursor-pointer" onClick={handleSeekClick}>
+      {/* Annotation dots above timeline */}
+      {annotationDots.length > 0 && (
+        <div className="relative h-2 mb-0.5">
+          {annotationDots.map((pct, i) => (
+            <div
+              key={i}
+              className="absolute w-1.5 h-1.5 rounded-full bg-terminal-blue shadow-sm shadow-terminal-blue/50"
+              style={{ left: `${pct}%`, top: "50%", transform: "translate(-50%, -50%)" }}
+            />
+          ))}
+        </div>
+      )}
       <div
         ref={barRef}
         className="relative flex h-2 rounded overflow-hidden bg-terminal-border/30"

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -12,6 +12,8 @@ function sceneColor(type: Scene["type"]): string {
   switch (type) {
     case "user-prompt":
       return "#3fb950";
+    case "compaction-summary":
+      return "#666666";
     case "thinking":
       return "#bc8cff";
     case "text-response":
@@ -43,6 +45,7 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
       // Use the most "interesting" type in the bucket (user > tool > text > thinking)
       const typePriority: Record<Scene["type"], number> = {
         "user-prompt": 4,
+        "compaction-summary": 1,
         "tool-call": 3,
         "text-response": 2,
         thinking: 1,

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import type { Annotation, ReplaySession } from "../types";
+import type { ViewerMode } from "./useSessionLoader";
 
 export interface AnnotationActions {
   annotations: Annotation[];
@@ -12,6 +13,12 @@ export interface AnnotationActions {
   canSaveHtml: boolean;
   downloadHtml: () => void;
   downloadJson: () => void;
+  /** Editor mode: publish to gist via server API */
+  publishGist: (() => Promise<{ gistUrl: string; viewerUrl: string }>) | null;
+  /** Editor mode: export HTML via server API */
+  exportHtml: (() => Promise<string>) | null;
+  gistPublishing: boolean;
+  htmlExporting: boolean;
 }
 
 const LS_PREFIX = "vibe-replay-annotations-";
@@ -20,41 +27,63 @@ function storageKey(sessionId: string): string {
   return LS_PREFIX + sessionId;
 }
 
-export function useAnnotations(session: ReplaySession): AnnotationActions {
+export function useAnnotations(
+  session: ReplaySession,
+  mode: ViewerMode = "embedded",
+): AnnotationActions {
   const sessionId = session.meta.sessionId;
+  const isEditor = mode === "editor";
 
-  // Save HTML only works from self-contained production builds (data embedded inline).
-  // In dev mode (?file=), document.documentElement.outerHTML captures Vite dev scripts
-  // that won't work standalone. Use Export JSON instead.
-  const canSaveHtml = !!window.__VIBE_REPLAY_DATA__;
+  // Save HTML only works from self-contained production builds (data embedded inline)
+  // or in editor mode (server generates it).
+  const canSaveHtml = !!window.__VIBE_REPLAY_DATA__ || isEditor;
 
   // Initialize from embedded data, then overlay localStorage draft
   const [annotations, setAnnotations] = useState<Annotation[]>(() => {
     const embedded = session.annotations ?? [];
+    if (isEditor) return embedded; // Editor mode: server is source of truth
     try {
       const draft = localStorage.getItem(storageKey(sessionId));
       if (draft) {
         const parsed = JSON.parse(draft) as Annotation[];
-        // Draft takes precedence if it has content
         if (parsed.length > 0 || embedded.length === 0) return parsed;
       }
     } catch { /* ignore */ }
     return embedded;
   });
 
-  // Track whether we've diverged from embedded
+  // Track whether we've diverged from embedded/server state
   const [savedSnapshot, setSavedSnapshot] = useState(() =>
     JSON.stringify(session.annotations ?? []),
   );
 
   const hasUnsaved = JSON.stringify(annotations) !== savedSnapshot;
 
-  // Autosave to localStorage on changes
+  // Autosave: localStorage for embedded/readonly, API for editor
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
+    if (isEditor) {
+      // Debounced save to server API
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        fetch("/api/annotations", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(annotations),
+        }).then(() => {
+          setSavedSnapshot(JSON.stringify(annotations));
+        }).catch(() => { /* silent */ });
+      }, 1000);
+      return () => {
+        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      };
+    }
+    // Non-editor: save to localStorage
     try {
       localStorage.setItem(storageKey(sessionId), JSON.stringify(annotations));
     } catch { /* quota exceeded — silent */ }
-  }, [annotations, sessionId]);
+  }, [annotations, sessionId, isEditor]);
 
   const annotatedScenes = useMemo(
     () => new Set(annotations.map((a) => a.sceneIndex)),
@@ -96,24 +125,23 @@ export function useAnnotations(session: ReplaySession): AnnotationActions {
   }, []);
 
   const downloadHtml = useCallback(() => {
+    if (isEditor) return; // Editor mode uses exportHtml instead
+
     // Build the updated data assignment (escape </ for safe embedding in <script>)
     const updatedSession: ReplaySession = { ...session, annotations };
     const jsonData = JSON.stringify(updatedSession).replace(/<\//g, "<\\/");
     const dataAssignment = "window.__VIBE_REPLAY_DATA__ = " + jsonData + ";";
 
     // Use DOM manipulation to update the data script — no fragile regex needed.
-    // generator.ts injects <script id="vibe-replay-data">, so we can find it by ID.
     const dataEl = document.getElementById("vibe-replay-data");
     if (dataEl) {
-      // Swap content, serialize, restore (so the running page isn't affected)
       const original = dataEl.textContent;
       dataEl.textContent = dataAssignment;
       const updatedHtml = "<!DOCTYPE html>\n" + document.documentElement.outerHTML;
       dataEl.textContent = original;
       triggerDownload(updatedHtml);
     } else {
-      // Legacy fallback for HTML generated before the id attribute was added:
-      // Insert a new identified script into <head>, serialize, then remove it.
+      // Legacy fallback
       const script = document.createElement("script");
       script.id = "vibe-replay-data";
       script.textContent = dataAssignment;
@@ -135,12 +163,11 @@ export function useAnnotations(session: ReplaySession): AnnotationActions {
       URL.revokeObjectURL(url);
     }
 
-    // Mark as saved
     setSavedSnapshot(JSON.stringify(annotations));
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch { /* ignore */ }
-  }, [session, annotations, sessionId]);
+  }, [session, annotations, sessionId, isEditor]);
 
   const downloadJson = useCallback(() => {
     const updatedSession: ReplaySession = { ...session, annotations };
@@ -155,12 +182,65 @@ export function useAnnotations(session: ReplaySession): AnnotationActions {
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    // Mark as saved
     setSavedSnapshot(JSON.stringify(annotations));
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch { /* ignore */ }
   }, [session, annotations, sessionId]);
 
-  return { annotations, annotatedScenes, annotationCounts, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson };
+  // Editor mode: server-side gist publishing
+  const [gistPublishing, setGistPublishing] = useState(false);
+  const publishGist = isEditor
+    ? async () => {
+        setGistPublishing(true);
+        try {
+          // Ensure latest annotations are saved first
+          await fetch("/api/annotations", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(annotations),
+          });
+          const resp = await fetch("/api/publish/gist", { method: "POST" });
+          if (!resp.ok) {
+            const err = await resp.text();
+            throw new Error(err || `Server error: ${resp.status}`);
+          }
+          const result = await resp.json();
+          setSavedSnapshot(JSON.stringify(annotations));
+          return result as { gistUrl: string; viewerUrl: string };
+        } finally {
+          setGistPublishing(false);
+        }
+      }
+    : null;
+
+  // Editor mode: server-side HTML export
+  const [htmlExporting, setHtmlExporting] = useState(false);
+  const exportHtml = isEditor
+    ? async () => {
+        setHtmlExporting(true);
+        try {
+          await fetch("/api/annotations", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(annotations),
+          });
+          const resp = await fetch("/api/export/html", { method: "POST" });
+          if (!resp.ok) throw new Error(`Export failed: ${resp.status}`);
+          const { path } = await resp.json();
+          setSavedSnapshot(JSON.stringify(annotations));
+          return path as string;
+        } finally {
+          setHtmlExporting(false);
+        }
+      }
+    : null;
+
+  return {
+    annotations, annotatedScenes, annotationCounts,
+    add, update, remove, hasUnsaved, canSaveHtml,
+    downloadHtml, downloadJson,
+    publishGist, exportHtml,
+    gistPublishing, htmlExporting,
+  };
 }

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -1,0 +1,166 @@
+import { useState, useCallback, useEffect, useMemo } from "react";
+import type { Annotation, ReplaySession } from "../types";
+
+export interface AnnotationActions {
+  annotations: Annotation[];
+  annotatedScenes: Set<number>;
+  annotationCounts: Map<number, number>;
+  add: (sceneIndex: number, body: string) => void;
+  update: (id: string, body: string) => void;
+  remove: (id: string) => void;
+  hasUnsaved: boolean;
+  canSaveHtml: boolean;
+  downloadHtml: () => void;
+  downloadJson: () => void;
+}
+
+const LS_PREFIX = "vibe-replay-annotations-";
+
+function storageKey(sessionId: string): string {
+  return LS_PREFIX + sessionId;
+}
+
+export function useAnnotations(session: ReplaySession): AnnotationActions {
+  const sessionId = session.meta.sessionId;
+
+  // Save HTML only works from self-contained production builds (data embedded inline).
+  // In dev mode (?file=), document.documentElement.outerHTML captures Vite dev scripts
+  // that won't work standalone. Use Export JSON instead.
+  const canSaveHtml = !!window.__VIBE_REPLAY_DATA__;
+
+  // Initialize from embedded data, then overlay localStorage draft
+  const [annotations, setAnnotations] = useState<Annotation[]>(() => {
+    const embedded = session.annotations ?? [];
+    try {
+      const draft = localStorage.getItem(storageKey(sessionId));
+      if (draft) {
+        const parsed = JSON.parse(draft) as Annotation[];
+        // Draft takes precedence if it has content
+        if (parsed.length > 0 || embedded.length === 0) return parsed;
+      }
+    } catch { /* ignore */ }
+    return embedded;
+  });
+
+  // Track whether we've diverged from embedded
+  const [savedSnapshot, setSavedSnapshot] = useState(() =>
+    JSON.stringify(session.annotations ?? []),
+  );
+
+  const hasUnsaved = JSON.stringify(annotations) !== savedSnapshot;
+
+  // Autosave to localStorage on changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey(sessionId), JSON.stringify(annotations));
+    } catch { /* quota exceeded — silent */ }
+  }, [annotations, sessionId]);
+
+  const annotatedScenes = useMemo(
+    () => new Set(annotations.map((a) => a.sceneIndex)),
+    [annotations],
+  );
+
+  const annotationCounts = useMemo(() => {
+    const counts = new Map<number, number>();
+    for (const a of annotations) {
+      counts.set(a.sceneIndex, (counts.get(a.sceneIndex) || 0) + 1);
+    }
+    return counts;
+  }, [annotations]);
+
+  const add = useCallback((sceneIndex: number, body: string) => {
+    const now = new Date().toISOString();
+    const annotation: Annotation = {
+      id: crypto.randomUUID(),
+      sceneIndex,
+      body,
+      author: "anonymous",
+      createdAt: now,
+      updatedAt: now,
+      resolved: false,
+    };
+    setAnnotations((prev) => [...prev, annotation]);
+  }, []);
+
+  const update = useCallback((id: string, body: string) => {
+    setAnnotations((prev) =>
+      prev.map((a) =>
+        a.id === id ? { ...a, body, updatedAt: new Date().toISOString() } : a,
+      ),
+    );
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setAnnotations((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  const downloadHtml = useCallback(() => {
+    // Build the updated data assignment (escape </ for safe embedding in <script>)
+    const updatedSession: ReplaySession = { ...session, annotations };
+    const jsonData = JSON.stringify(updatedSession).replace(/<\//g, "<\\/");
+    const dataAssignment = "window.__VIBE_REPLAY_DATA__ = " + jsonData + ";";
+
+    // Use DOM manipulation to update the data script — no fragile regex needed.
+    // generator.ts injects <script id="vibe-replay-data">, so we can find it by ID.
+    const dataEl = document.getElementById("vibe-replay-data");
+    if (dataEl) {
+      // Swap content, serialize, restore (so the running page isn't affected)
+      const original = dataEl.textContent;
+      dataEl.textContent = dataAssignment;
+      const updatedHtml = "<!DOCTYPE html>\n" + document.documentElement.outerHTML;
+      dataEl.textContent = original;
+      triggerDownload(updatedHtml);
+    } else {
+      // Legacy fallback for HTML generated before the id attribute was added:
+      // Insert a new identified script into <head>, serialize, then remove it.
+      const script = document.createElement("script");
+      script.id = "vibe-replay-data";
+      script.textContent = dataAssignment;
+      document.head.appendChild(script);
+      const updatedHtml = "<!DOCTYPE html>\n" + document.documentElement.outerHTML;
+      document.head.removeChild(script);
+      triggerDownload(updatedHtml);
+    }
+
+    function triggerDownload(html: string) {
+      const blob = new Blob([html], { type: "text/html" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${session.meta.slug || "replay"}.html`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    // Mark as saved
+    setSavedSnapshot(JSON.stringify(annotations));
+    try {
+      localStorage.removeItem(storageKey(sessionId));
+    } catch { /* ignore */ }
+  }, [session, annotations, sessionId]);
+
+  const downloadJson = useCallback(() => {
+    const updatedSession: ReplaySession = { ...session, annotations };
+    const json = JSON.stringify(updatedSession, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "replay.json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    // Mark as saved
+    setSavedSnapshot(JSON.stringify(annotations));
+    try {
+      localStorage.removeItem(storageKey(sessionId));
+    } catch { /* ignore */ }
+  }, [session, annotations, sessionId]);
+
+  return { annotations, annotatedScenes, annotationCounts, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson };
+}

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -201,11 +201,10 @@ export function useAnnotations(
             body: JSON.stringify(annotations),
           });
           const resp = await fetch("/api/publish/gist", { method: "POST" });
-          if (!resp.ok) {
-            const err = await resp.text();
-            throw new Error(err || `Server error: ${resp.status}`);
-          }
           const result = await resp.json();
+          if (!resp.ok) {
+            throw new Error(result.error || `Server error: ${resp.status}`);
+          }
           setSavedSnapshot(JSON.stringify(annotations));
           return result as { gistUrl: string; viewerUrl: string };
         } finally {
@@ -226,8 +225,9 @@ export function useAnnotations(
             body: JSON.stringify(annotations),
           });
           const resp = await fetch("/api/export/html", { method: "POST" });
-          if (!resp.ok) throw new Error(`Export failed: ${resp.status}`);
-          const { path } = await resp.json();
+          const data = await resp.json();
+          if (!resp.ok) throw new Error(data.error || `Export failed: ${resp.status}`);
+          const { path } = data;
           setSavedSnapshot(JSON.stringify(annotations));
           return path as string;
         } finally {

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -1,28 +1,31 @@
 import { useState, useEffect } from "react";
 import type { ReplaySession } from "../types";
 
+export type ViewerMode = "embedded" | "editor" | "readonly";
+
 type LoadState =
   | { status: "loading" }
-  | { status: "ready"; session: ReplaySession; isReadOnly: boolean }
+  | { status: "ready"; session: ReplaySession; mode: ViewerMode }
   | { status: "error"; message: string };
 
 interface LoadResult {
   session: ReplaySession;
-  isReadOnly: boolean;
+  mode: ViewerMode;
 }
 
 /**
  * Load session data from one of:
  * 1. window.__VIBE_REPLAY_DATA__ (embedded by CLI)
- * 2. ?url=<jsonl-or-json-url> (fetch from URL, e.g., raw gist)
- * 3. ?file=<local-path> (dev mode, fetch from Vite public/)
+ * 2. Editor mode (served by local CLI server)
+ * 3. ?url=<jsonl-or-json-url> (fetch from URL, e.g., raw gist)
+ * 4. ?file=<local-path> (dev mode, fetch from Vite public/)
  */
 export function useSessionLoader(): LoadState {
   const [state, setState] = useState<LoadState>({ status: "loading" });
 
   useEffect(() => {
     loadSession().then(
-      (result) => setState({ status: "ready", session: result.session, isReadOnly: result.isReadOnly }),
+      (result) => setState({ status: "ready", session: result.session, mode: result.mode }),
       (err) => setState({ status: "error", message: String(err.message || err) }),
     );
   }, []);
@@ -30,15 +33,27 @@ export function useSessionLoader(): LoadState {
   return state;
 }
 
+function isEditorMode(): boolean {
+  return !!window.__VIBE_REPLAY_EDITOR__;
+}
+
 async function loadSession(): Promise<LoadResult> {
   // 1. Embedded data (from CLI generator)
   if (window.__VIBE_REPLAY_DATA__) {
-    return { session: window.__VIBE_REPLAY_DATA__, isReadOnly: false };
+    return { session: window.__VIBE_REPLAY_DATA__, mode: "embedded" };
+  }
+
+  // 2. Editor mode (served by CLI local server)
+  if (isEditorMode()) {
+    const resp = await fetch("/api/session");
+    if (!resp.ok) throw new Error(`Editor API error: ${resp.status}`);
+    const session = (await resp.json()) as ReplaySession;
+    return { session, mode: "editor" };
   }
 
   const params = new URLSearchParams(window.location.search);
 
-  // 2. Gist parameter — resolve gist ID to raw JSON URL via GitHub API
+  // 3. Gist parameter — resolve gist ID to raw JSON URL via GitHub API
   const gistId = params.get("gist");
   if (gistId) {
     // Only allow hex gist IDs (GitHub gist IDs are 32 hex chars)
@@ -49,21 +64,21 @@ async function loadSession(): Promise<LoadResult> {
     const session = await fetchJson(rawUrl);
     // Register replay in gallery (fire-and-forget)
     registerReplay(gistId, session).catch(() => {});
-    return { session, isReadOnly: true };
+    return { session, mode: "readonly" };
   }
 
-  // 3. URL parameter — fetch JSON from a remote URL (read-only)
+  // 4. URL parameter — fetch JSON from a remote URL (read-only)
   const url = params.get("url");
   if (url) {
-    return { session: await fetchJson(url), isReadOnly: true };
+    return { session: await fetchJson(url), mode: "readonly" };
   }
 
-  // 4. Local file parameter — for dev mode
+  // 5. Local file parameter — for dev mode
   const file = params.get("file");
   if (file) {
     const resp = await fetch(file);
     if (!resp.ok) throw new Error(`Failed to load file: ${resp.status}`);
-    return { session: (await resp.json()) as ReplaySession, isReadOnly: false };
+    return { session: (await resp.json()) as ReplaySession, mode: "embedded" };
   }
 
   throw new Error(

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -3,8 +3,13 @@ import type { ReplaySession } from "../types";
 
 type LoadState =
   | { status: "loading" }
-  | { status: "ready"; session: ReplaySession }
+  | { status: "ready"; session: ReplaySession; isReadOnly: boolean }
   | { status: "error"; message: string };
+
+interface LoadResult {
+  session: ReplaySession;
+  isReadOnly: boolean;
+}
 
 /**
  * Load session data from one of:
@@ -17,7 +22,7 @@ export function useSessionLoader(): LoadState {
 
   useEffect(() => {
     loadSession().then(
-      (session) => setState({ status: "ready", session }),
+      (result) => setState({ status: "ready", session: result.session, isReadOnly: result.isReadOnly }),
       (err) => setState({ status: "error", message: String(err.message || err) }),
     );
   }, []);
@@ -25,10 +30,10 @@ export function useSessionLoader(): LoadState {
   return state;
 }
 
-async function loadSession(): Promise<ReplaySession> {
+async function loadSession(): Promise<LoadResult> {
   // 1. Embedded data (from CLI generator)
   if (window.__VIBE_REPLAY_DATA__) {
-    return window.__VIBE_REPLAY_DATA__;
+    return { session: window.__VIBE_REPLAY_DATA__, isReadOnly: false };
   }
 
   const params = new URLSearchParams(window.location.search);
@@ -44,21 +49,21 @@ async function loadSession(): Promise<ReplaySession> {
     const session = await fetchJson(rawUrl);
     // Register replay in gallery (fire-and-forget)
     registerReplay(gistId, session).catch(() => {});
-    return session;
+    return { session, isReadOnly: true };
   }
 
-  // 3. URL parameter — fetch JSON from a remote URL
+  // 3. URL parameter — fetch JSON from a remote URL (read-only)
   const url = params.get("url");
   if (url) {
-    return await fetchJson(url);
+    return { session: await fetchJson(url), isReadOnly: true };
   }
 
-  // 3. Local file parameter — for dev mode
+  // 4. Local file parameter — for dev mode
   const file = params.get("file");
   if (file) {
     const resp = await fetch(file);
     if (!resp.ok) throw new Error(`Failed to load file: ${resp.status}`);
-    return (await resp.json()) as ReplaySession;
+    return { session: (await resp.json()) as ReplaySession, isReadOnly: false };
   }
 
   throw new Error(

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -1,5 +1,6 @@
 export type Scene =
   | { type: "user-prompt"; content: string; timestamp?: string; images?: string[] }
+  | { type: "compaction-summary"; content: string; timestamp?: string }
   | { type: "thinking"; content: string; timestamp?: string }
   | { type: "text-response"; content: string; timestamp?: string }
   | {

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -13,6 +13,17 @@ export type Scene =
       images?: string[];
     };
 
+export interface Annotation {
+  id: string;
+  sceneIndex: number;
+  selectedText?: string;
+  body: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  resolved: boolean;
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;
@@ -31,9 +42,22 @@ export interface ReplaySession {
       toolCalls: number;
       thinkingBlocks?: number;
       durationMs?: number;
+      tokenUsage?: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens: number;
+        cacheReadTokens: number;
+      };
+      costEstimate?: number;
     };
+    compactions?: Array<{
+      timestamp: string;
+      trigger: string;
+      preTokens?: number;
+    }>;
   };
   scenes: Scene[];
+  annotations?: Annotation[];
 }
 
 declare global {

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -63,5 +63,6 @@ export interface ReplaySession {
 declare global {
   interface Window {
     __VIBE_REPLAY_DATA__?: ReplaySession;
+    __VIBE_REPLAY_EDITOR__?: boolean;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.5)
       '@inquirer/prompts':
         specifier: ^7.2.0
         version: 7.10.1(@types/node@22.19.13)
@@ -39,6 +42,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      hono:
+        specifier: ^4.12.5
+        version: 4.12.5
       open:
         specifier: ^10.1.0
         version: 10.2.0
@@ -902,6 +908,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2230,6 +2242,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+    engines: {node: '>=16.9.0'}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -3988,6 +4004,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@hono/node-server@1.19.11(hono@4.12.5)':
+    dependencies:
+      hono: 4.12.5
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -5307,6 +5327,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  hono@4.12.5: {}
 
   html-escaper@3.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       diff:
         specifier: ^7.0.0
         version: 7.0.0
+      marked:
+        specifier: ^17.0.4
+        version: 17.0.4
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.4)
@@ -85,12 +88,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
-      react-markdown:
-        specifier: ^9.0.1
-        version: 9.1.0(@types/react@19.2.14)(react@19.2.4)
-      remark-gfm:
-        specifier: ^4.0.0
-        version: 4.0.1
     devDependencies:
       '@types/diff':
         specifier: ^6.0.0
@@ -1532,9 +1529,6 @@ packages:
   '@types/diff@6.0.0':
     resolution: {integrity: sha512-dhVCYGv3ZSbzmQaBSagrv1WJ6rXCdkyTcDyoNu1MD8JohI7pR7k8wdZEm+mvdxRKXyHVwckFzWU1vJc+Z29MlA==}
 
-  '@types/estree-jsx@1.0.5':
-    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1563,9 +1557,6 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
-  '@types/unist@2.0.11':
-    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1769,9 +1760,6 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
-
-  character-reference-invalid@2.0.1:
-    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -2092,9 +2080,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  estree-util-is-identifier-name@3.0.0:
-    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
-
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -2228,9 +2213,6 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
-  hast-util-to-jsx-runtime@2.3.6:
-    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
-
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
@@ -2249,9 +2231,6 @@ packages:
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
-
-  html-url-attributes@3.0.1:
-    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -2275,15 +2254,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  inline-style-parser@0.2.7:
-    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  is-alphabetical@2.0.1:
-    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
-
-  is-alphanumerical@2.0.1:
-    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
-
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
@@ -2294,9 +2264,6 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
-
-  is-decimal@2.0.1:
-    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -2318,9 +2285,6 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
-
-  is-hexadecimal@2.0.1:
-    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -2430,6 +2394,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@17.0.4:
+    resolution: {integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
 
@@ -2456,15 +2425,6 @@ packages:
 
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
-
-  mdast-util-mdx-expression@2.0.1:
-    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
-
-  mdast-util-mdx-jsx@3.2.0:
-    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
-
-  mdast-util-mdxjs-esm@2.0.1:
-    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -2685,9 +2645,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  parse-entities@4.0.2:
-    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
-
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
@@ -2836,12 +2793,6 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
-
-  react-markdown@9.1.0:
-    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
-    peerDependencies:
-      '@types/react': '>=18'
-      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -3066,12 +3017,6 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-
-  style-to-js@1.1.21:
-    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
-
-  style-to-object@1.0.14:
-    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -4521,10 +4466,6 @@ snapshots:
 
   '@types/diff@6.0.0': {}
 
-  '@types/estree-jsx@1.0.5':
-    dependencies:
-      '@types/estree': 1.0.8
-
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
@@ -4554,8 +4495,6 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
-
-  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -4829,8 +4768,6 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
-
-  character-reference-invalid@2.0.1: {}
 
   chardet@2.1.1: {}
 
@@ -5113,8 +5050,6 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  estree-util-is-identifier-name@3.0.0: {}
-
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -5279,26 +5214,6 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6:
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      estree-util-is-identifier-name: 3.0.0
-      hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
-      style-to-js: 1.1.21
-      unist-util-position: 5.0.0
-      vfile-message: 4.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   hast-util-to-parse5@8.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -5332,8 +5247,6 @@ snapshots:
 
   html-escaper@3.0.3: {}
 
-  html-url-attributes@3.0.1: {}
-
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
@@ -5353,15 +5266,6 @@ snapshots:
   ini@1.3.8:
     optional: true
 
-  inline-style-parser@0.2.7: {}
-
-  is-alphabetical@2.0.1: {}
-
-  is-alphanumerical@2.0.1:
-    dependencies:
-      is-alphabetical: 2.0.1
-      is-decimal: 2.0.1
-
   is-arrayish@0.3.4:
     optional: true
 
@@ -5372,8 +5276,6 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
-
-  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -5386,8 +5288,6 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-
-  is-hexadecimal@2.0.1: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -5472,6 +5372,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@17.0.4: {}
+
   mdast-util-definitions@6.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5555,45 +5457,6 @@ snapshots:
       mdast-util-gfm-strikethrough: 2.0.0
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-expression@2.0.1:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdx-jsx@3.2.0:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      ccount: 2.0.1
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      parse-entities: 4.0.2
-      stringify-entities: 4.0.4
-      unist-util-stringify-position: 4.0.0
-      vfile-message: 4.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-mdxjs-esm@2.0.1:
-    dependencies:
-      '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5952,16 +5815,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  parse-entities@4.0.2:
-    dependencies:
-      '@types/unist': 2.0.11
-      character-entities-legacy: 3.0.0
-      character-reference-invalid: 2.0.1
-      decode-named-character-reference: 1.3.0
-      is-alphanumerical: 2.0.1
-      is-decimal: 2.0.1
-      is-hexadecimal: 2.0.1
-
   parse-latin@7.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -6108,24 +5961,6 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
-
-  react-markdown@9.1.0(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.14
-      devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6
-      html-url-attributes: 3.0.1
-      mdast-util-to-hast: 13.2.1
-      react: 19.2.4
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      unified: 11.0.5
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -6469,14 +6304,6 @@ snapshots:
 
   strip-json-comments@2.0.1:
     optional: true
-
-  style-to-js@1.1.21:
-    dependencies:
-      style-to-object: 1.0.14
-
-  style-to-object@1.0.14:
-    dependencies:
-      inline-style-parser: 0.2.7
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
https://vibe-replay.com/view/?gist=c40137e4c224dc883fe2eaa668e2d8ba comment session generated
<img width="1312" height="1317" alt="image" src="https://github.com/user-attachments/assets/7cdce278-74ff-4aa9-af38-cc487460435a" />


## Summary

Major feature PR adding annotation/commenting, a local editor server, token usage tracking, and compaction summary handling.

- **Annotation system**: Per-scene comments with localStorage autosave, HTML/JSON export, read-only mode for shared replays
- **Editor mode**: "Open in Editor" launches a Hono localhost server with full backend — server-side annotation persistence, gist publishing, HTML export via API
- **Token usage tracking**: Parse cumulative token usage from Claude Code JSONL, compaction event detection, cost estimation in Stats panel
- **Compaction summaries**: New `compaction-summary` scene type — renders with muted style, collapsed by default, shown in outline
- **ToolSearch filtering**: Automated "Tool loaded." messages no longer clutter replays
- **Bundle size reduction**: Replaced `react-markdown` + `remark-gfm` with `marked` (548KB → 435KB)

## Key changes

### Editor mode (`packages/cli/`)
- `server.ts` — Hono HTTP server with `/api/session`, `/api/annotations`, `/api/publish/gist`, `/api/export/html`
- `index.ts` — "Open in Editor" as primary menu choice; "Quick preview" and "Publish to Gist now" as alternatives
- Annotations persist to `{outputDir}/annotations.json` on disk

### Annotation system (`packages/viewer/`)
- `useAnnotations.ts` — CRUD, localStorage draft (embedded mode) or debounced API saves (editor mode), HTML/JSON download
- `AnnotationPanel.tsx` — Right sidebar with markdown comments, clickable gist URLs, gh CLI install guidance
- `ConversationView.tsx` — Per-scene hover comment buttons with count badges
- `Player.tsx` — Three-mode architecture (`embedded | editor | readonly`), auto-open panel when annotations exist
- `Controls.tsx` — Comment toggle button with count
- `Timeline.tsx` — Blue dots for annotated scenes

### Parser fixes (`packages/cli/`)
- `parser.ts` — Skip ToolSearch automated responses (`sourceToolAssistantUUID`), detect compaction summaries
- `transform.ts` — Emit `compaction-summary` scene type (not counted in `userPrompts` stats)
- Token usage: deduplicated per-message aggregation + compaction boundary events

### Viewer updates
- `CompactionSummaryBlock.tsx` — Collapsed-by-default display with "Show full summary" toggle
- `Minimap.tsx` — Compaction markers between turns (dashed border, ⟳ icon, no turn number)
- `TextResponseBlock.tsx` — Switched from `react-markdown` to `marked`
- `StatsPanel.tsx` — Token breakdown, cache hit ratio, cost estimation
- `SearchOverlay.tsx` — Compaction summaries included in search results

### Infrastructure
- `generator.ts` — `<script id="vibe-replay-data">` for safe DOM-based HTML rewriting
- `useSessionLoader.ts` — `ViewerMode` type (`embedded | editor | readonly`), editor flag detection
- `CLAUDE.md` — Updated architecture, data flow, conventions

## Test plan

- [ ] `pnpm build` succeeds, viewer < 500KB
- [ ] CLI menu: Editor first, Quick preview second, Gist third with gh status
- [ ] Open in Editor → server starts, browser opens, annotations persist across refresh
- [ ] Editor: Export HTML → self-contained file with annotations embedded
- [ ] Editor: Publish to Gist → clickable URL shown; gh unavailable → install guidance shown
- [ ] Generate replay → open HTML → add comments → Save HTML → reopen saved file
- [ ] View `?gist=<id>` replay → comments visible, read-only (no edit controls)
- [ ] Parse session with ToolSearch → no "Tool loaded." user prompts
- [ ] Parse session with compaction → distinct "Context Compaction" card, shown in outline
- [ ] Token usage + cost displays correctly in Stats panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)