### PR TITLE
feat: improve Cursor replay fidelity and AI Coach options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ packages/cli/src/
 - **Cursor thinking supplement**: When parsing DB-backed Cursor sessions, parser overlays missing assistant thinking markers from JSONL transcripts (if present) while keeping DB tool-call/tool-result payloads as source of truth.
 - **`sql.js` for portability**: SQLite parsing uses sql.js (WASM) instead of native bindings — no C++ compiler needed, works everywhere via `npx`
 - **`dataSource` metadata**: `ReplaySession.meta.dataSource` tracks which source was used (`sqlite`, `global-state`, `jsonl`, `jsonl+tools`) for diagnostics and transparency
+- **`dataSourceInfo` metadata**: `ReplaySession.meta.dataSourceInfo` carries debug-friendly source details (primary source, source list, supplements, notes)
 - **Skip `progress` lines**: Subagent streaming artifacts
 - **Provider adapter pattern**: Each IDE/tool has its own discover + parser, transform is shared
 - **Package name `vibe-replay`**: CLI package name enables `npx vibe-replay` directly
@@ -117,6 +118,7 @@ Both local HTML output and Gist output use the same `ReplaySession.meta` payload
 Current `meta` fields include:
 - `sessionId`, `slug`, `title`
 - `provider`, `dataSource`
+- `dataSourceInfo` (`primary`, `sources`, optional `supplements`, optional `notes`)
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
 - `stats`: `sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`, `tokenUsage`, `costEstimate`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ packages/cli/src/
 │   │   └── parser.ts           # JSONL → ParsedTurn[]
 │   └── cursor/                 # Cursor provider
 │       ├── index.ts
-│       ├── discover.ts         # Scan ~/.cursor/projects/ + detect store.db
+│       ├── discover.ts         # Scan JSONL + detect SQLite/globalState sessions
 │       ├── parser.ts           # JSONL fallback parser
-│       └── sqlite-reader.ts    # SQLite store.db parser (primary)
+│       └── sqlite-reader.ts    # Cursor SQLite readers (store.db + global state.vscdb)
 ├── transform.ts                # Provider-agnostic: turns → Scene[] + secret redaction
 ├── generator.ts                # Inject JSON into viewer HTML
 ├── feedback.ts                 # AI feedback: detect CLI tools, run headlessly, parse results
@@ -73,9 +73,11 @@ packages/cli/src/
 - **Single HTML output**: viewer built to one file via vite-plugin-singlefile (~430KB), CLI injects `window.__VIBE_REPLAY_DATA__` JSON into `<head>` via `<script id="vibe-replay-data">`
 - **`</` escaping**: JSON data in `<script>` MUST escape `</` as `<\/` (see generator.ts)
 - **JSONL grouping**: Assistant messages split across multiple lines sharing same `message.id` — parser groups them. Tool results matched by `tool_use_id`
-- **Cursor dual data source**: Primary: `~/.cursor/chats/<MD5(workspace_path)>/<session-uuid>/store.db` (SQLite with protobuf blob tree — has reasoning, tool-call, tool-result blocks). Fallback: `~/.cursor/projects/<path>/agent-transcripts/*.jsonl` (text-only, uses marker inference + `agent-tools/*.txt` mtime windows). Workspace hash = `MD5(absolute_workspace_path)`
+- **Cursor tri-source ingestion**: Cursor sessions may come from three sources: `~/.cursor/chats/<MD5(workspace_path)>/<session-uuid>/store.db` (protobuf blob tree), `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (`cursorDiskKV` keys `composerData:*` + `bubbleId:*`), or `~/.cursor/projects/<path>/agent-transcripts/*.jsonl` (+ `agent-tools/*.txt`). Workspace hash = `MD5(absolute_workspace_path)`.
+- **Cursor devcontainer/SSH-remote behavior**: Devcontainer sessions can miss `~/.cursor/chats/*/store.db` but still exist in host `globalStorage/state.vscdb`; JSONL may live only inside the container. Discovery merges all host-visible sources and marks sessions with DB-backed rich data.
+- **Cursor thinking supplement**: When parsing DB-backed Cursor sessions, parser overlays missing assistant thinking markers from JSONL transcripts (if present) while keeping DB tool-call/tool-result payloads as source of truth.
 - **`sql.js` for portability**: SQLite parsing uses sql.js (WASM) instead of native bindings — no C++ compiler needed, works everywhere via `npx`
-- **`dataSource` metadata**: `ReplaySession.meta.dataSource` tracks which source was used (`sqlite`, `jsonl`, `jsonl+tools`) for diagnostics and transparency
+- **`dataSource` metadata**: `ReplaySession.meta.dataSource` tracks which source was used (`sqlite`, `global-state`, `jsonl`, `jsonl+tools`) for diagnostics and transparency
 - **Skip `progress` lines**: Subagent streaming artifacts
 - **Provider adapter pattern**: Each IDE/tool has its own discover + parser, transform is shared
 - **Package name `vibe-replay`**: CLI package name enables `npx vibe-replay` directly
@@ -95,6 +97,7 @@ packages/cli/src/
 ```
 ~/.claude/projects/<path>/<session>.jsonl                          (Claude Code — JSONL)
 ~/.cursor/chats/<md5>/<uuid>/store.db                              (Cursor — SQLite, primary)
+~/Library/Application Support/Cursor/User/globalStorage/state.vscdb (Cursor — SQLite global state)
 ~/.cursor/projects/<path>/agent-transcripts/*.jsonl + agent-tools/  (Cursor — JSONL, fallback)
   → providers/<name>/parser.ts → ProviderParseResult (turns, timestamps, dataSource)
   → transform.ts → ReplaySession (scenes, redacted secrets + paths, metadata)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ packages/cli/src/
 - **JSONL grouping**: Assistant messages split across multiple lines sharing same `message.id` — parser groups them. Tool results matched by `tool_use_id`
 - **Cursor tri-source ingestion**: Cursor sessions may come from three sources: `~/.cursor/chats/<MD5(workspace_path)>/<session-uuid>/store.db` (protobuf blob tree), `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (`cursorDiskKV` keys `composerData:*` + `bubbleId:*`), or `~/.cursor/projects/<path>/agent-transcripts/*.jsonl` (+ `agent-tools/*.txt`). Workspace hash = `MD5(absolute_workspace_path)`.
 - **Cursor devcontainer/SSH-remote behavior**: Devcontainer sessions can miss `~/.cursor/chats/*/store.db` but still exist in host `globalStorage/state.vscdb`; JSONL may live only inside the container. Discovery merges all host-visible sources and marks sessions with DB-backed rich data.
-- **Cursor thinking supplement**: When parsing DB-backed Cursor sessions, parser overlays missing assistant thinking markers from JSONL transcripts (if present) while keeping DB tool-call/tool-result payloads as source of truth.
+- **Cursor JSONL supplements**: When parsing DB-backed Cursor sessions, parser overlays missing assistant thinking markers and user image attachments from JSONL transcripts (if present) while keeping DB tool-call/tool-result payloads as source of truth.
 - **`sql.js` for portability**: SQLite parsing uses sql.js (WASM) instead of native bindings — no C++ compiler needed, works everywhere via `npx`
 - **`dataSource` metadata**: `ReplaySession.meta.dataSource` tracks which source was used (`sqlite`, `global-state`, `jsonl`, `jsonl+tools`) for diagnostics and transparency
 - **`dataSourceInfo` metadata**: `ReplaySession.meta.dataSourceInfo` carries debug-friendly source details (primary source, source list, supplements, notes)
@@ -91,7 +91,7 @@ packages/cli/src/
 - **Editor mode**: "Open in Editor" starts a Hono localhost server (port 3456-3466) serving the viewer with `__VIBE_REPLAY_EDITOR__` flag. Viewer fetches session from `/api/session`, annotations POST to `/api/annotations` (debounced 1s) and persist to `{outputDir}/annotations.json`. Server also handles gist publishing and HTML export via API routes
 - **ViewerMode**: Three-mode enum (`embedded | editor | readonly`) drives viewer behavior — embedded for self-contained HTML, editor for local server, readonly for `?gist=` / `?url=` URLs
 - **Markdown rendering**: Uses `marked` (lightweight, ~37KB) instead of `react-markdown` + `remark-gfm` to keep viewer under 500KB
-- **vibe-feedback (experimental)**: AI-powered prompting feedback. Detects `claude` or `opencode` CLI tools, runs headlessly with structured prompt, parses JSON output (with repair for truncated/malformed responses), generates annotations with `author: "vibe-feedback"`. Skips `claude` when inside a Claude Code session (env `CLAUDECODE`). Uses stdin pipe for opencode, stdin for claude. Viewer shows AI feedback annotations with purple "AI Coach" badge
+- **vibe-feedback (experimental)**: AI-powered prompting feedback. Detects `claude`, `agent` (Cursor Agent CLI), or `opencode`, runs headlessly with structured prompt, parses JSON output (with repair for truncated/malformed responses), and generates annotations with `author: "vibe-feedback"`. Skips `claude` when inside a Claude Code session (env `CLAUDECODE`). Viewer can choose among available AI Coach tools in editor mode.
 
 ## Data Flow
 
@@ -121,13 +121,11 @@ Current `meta` fields include:
 - `dataSourceInfo` (`primary`, `sources`, optional `supplements`, optional `notes`)
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
+- `generator`: replay generator metadata (`name`, `version`, `generatedAt`)
 - `stats`: `sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`, `tokenUsage`, `costEstimate`
 - `compactions`: Array of context window compaction events
 
 `ReplaySession` also has optional `annotations` array (id, sceneIndex, body, author, timestamps, resolved).
-
-Current limitation:
-- No generator metadata yet (e.g. CLI version, schema version, generated timestamp).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Host the viewer once and load different replays via URL parameter.
 - `sessionId`, `slug`, `title`
 - `provider` (`claude-code` or `cursor`)
 - `dataSource` (`sqlite`, `global-state`, `jsonl`, or `jsonl+tools` when available)
+- `dataSourceInfo` (debug details: primary source, source list, supplements, notes)
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
 - `stats` (`sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Most people only need:
 
 ## What It Does
 
-Reads AI coding session files (supports Claude Code and Cursor), parses the conversation data, and generates a **self-contained single HTML file** (~0.5-4MB) with:
+Reads AI coding session files (supports Claude Code and Cursor), parses the conversation data, and generates a **self-contained single HTML file** (~0.5-4MB for typical sessions, larger when many images are embedded) with:
 
 - Animated replay with play/pause/seek controls
 - Speed control (1x / 5x / 10x)
@@ -86,9 +86,8 @@ Host the viewer once and load different replays via URL parameter.
 - `dataSourceInfo` (debug details: primary source, source list, supplements, notes)
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
+- `generator` (`name`, `version`, `generatedAt`)
 - `stats` (`sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`)
-
-Current limitation: replay metadata does **not** yet include generator/build metadata like CLI version, schema version, or generated timestamp.
 
 ## Supported Providers
 
@@ -102,7 +101,7 @@ Current limitation: replay metadata does **not** yet include generator/build met
 Cursor parsing behavior:
 - Prefers DB-backed sources (`store.db` / `globalStorage.state.vscdb`) for rich tool data
 - Uses JSONL as fallback
-- Supplements missing assistant thinking markers from JSONL when DB-backed parsing is available
+- Supplements missing assistant thinking markers and user image attachments from JSONL when DB-backed parsing is available
 
 Adding a new provider means implementing `discover()` and `parse()` in a new directory under `packages/cli/src/providers/`.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Host the viewer once and load different replays via URL parameter.
 
 - `sessionId`, `slug`, `title`
 - `provider` (`claude-code` or `cursor`)
-- `dataSource` (`sqlite`, `jsonl`, or `jsonl+tools` when available)
+- `dataSource` (`sqlite`, `global-state`, `jsonl`, or `jsonl+tools` when available)
 - `startTime`, `endTime`, `model`
 - `cwd`, `project`
 - `stats` (`sceneCount`, `userPrompts`, `toolCalls`, `thinkingBlocks`, `durationMs`)
@@ -94,9 +94,14 @@ Current limitation: replay metadata does **not** yet include generator/build met
 | Provider | Status |
 |----------|--------|
 | Claude Code | Supported |
-| Cursor | Supported (transcripts + `agent-tools` outputs) |
+| Cursor | Supported (`store.db`, `globalStorage/state.vscdb`, transcripts + `agent-tools`) |
 | Codex | Planned |
 | Gemini CLI | Planned |
+
+Cursor parsing behavior:
+- Prefers DB-backed sources (`store.db` / `globalStorage.state.vscdb`) for rich tool data
+- Uses JSONL as fallback
+- Supplements missing assistant thinking markers from JSONL when DB-backed parsing is available
 
 Adding a new provider means implementing `discover()` and `parse()` in a new directory under `packages/cli/src/providers/`.
 

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -1,7 +1,7 @@
 /**
  * vibe-feedback: AI-powered prompting feedback for coding sessions.
  *
- * Detects available AI CLI tools (claude, opencode) and runs them headlessly
+ * Detects available AI CLI tools (claude, agent, opencode) and runs them headlessly
  * to analyze a replay session and generate structured feedback on the user's
  * prompting technique. Feedback is returned as Annotation[] that merges
  * directly into the replay.
@@ -18,7 +18,7 @@ import type { ReplaySession, Scene, Annotation } from "./types.js";
 // ---------------------------------------------------------------------------
 
 export interface FeedbackTool {
-  name: "claude" | "opencode";
+  name: "claude" | "agent" | "opencode";
   command: string;
 }
 
@@ -48,25 +48,37 @@ export interface FeedbackResult {
 // Detection
 // ---------------------------------------------------------------------------
 
-/** Detect which AI CLI tool is available (prefer claude, fallback opencode). */
-export async function detectFeedbackTools(): Promise<FeedbackTool | null> {
+const TOOL_PRIORITY: FeedbackTool["name"][] = ["claude", "agent", "opencode"];
+
+/** Detect available AI CLI tools and pick a default by priority. */
+export async function detectFeedbackTools(): Promise<{
+  tools: FeedbackTool[];
+  defaultTool: FeedbackTool | null;
+}> {
   // Skip claude when running inside a Claude Code session (nested sessions crash)
   const insideClaude = !!process.env.CLAUDECODE;
 
   const candidates: { name: FeedbackTool["name"]; cmd: string }[] = [
     ...(!insideClaude ? [{ name: "claude" as const, cmd: "claude" }] : []),
+    { name: "agent" as const, cmd: "agent" },
     { name: "opencode" as const, cmd: "opencode" },
   ];
 
+  const tools: FeedbackTool[] = [];
   for (const tool of candidates) {
     try {
       const path = await shell(`which ${tool.cmd}`);
-      if (path.trim()) return { name: tool.name, command: path.trim() };
+      if (path.trim()) tools.push({ name: tool.name, command: path.trim() });
     } catch {
       /* not found */
     }
   }
-  return null;
+
+  const defaultTool = TOOL_PRIORITY
+    .map((name) => tools.find((t) => t.name === name))
+    .find((tool): tool is FeedbackTool => !!tool) || null;
+
+  return { tools, defaultTool };
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +287,9 @@ async function executeFeedback(
   if (tool.name === "claude") {
     return runClaude(prompt, tool.command);
   }
+  if (tool.name === "agent") {
+    return runAgent(prompt, tool.command);
+  }
   return runOpencode(prompt, tool.command);
 }
 
@@ -339,6 +354,45 @@ function runOpencode(prompt: string, cmd: string): Promise<string> {
 
     proc.on("error", (err) =>
       reject(new Error(`Failed to start opencode: ${err.message}`)),
+    );
+
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+  });
+}
+
+function runAgent(prompt: string, cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      cmd,
+      ["-p", "--output-format", "json", "--mode", "ask", "--trust"],
+      {
+        env: { ...process.env, NO_COLOR: "1" },
+        timeout: 600_000,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d) => (stdout += d.toString()));
+    proc.stderr.on("data", (d) => (stderr += d.toString()));
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        try {
+          const parsed = JSON.parse(stdout);
+          resolve(typeof parsed.result === "string" ? parsed.result : stdout);
+        } catch {
+          resolve(stdout);
+        }
+      } else {
+        reject(new Error(`agent exited ${code}: ${stderr.slice(0, 500)}`));
+      }
+    });
+
+    proc.on("error", (err) =>
+      reject(new Error(`Failed to start agent: ${err.message}`)),
     );
 
     proc.stdin.write(prompt);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,19 +10,20 @@ import { publishGist, checkGhStatus, loadSavedGistInfo } from "./publishers/gist
 import { startEditor } from "./server.js";
 import { scanForSecrets } from "./scan.js";
 import type { SessionInfo, ReplaySession } from "./types.js";
+import { CLI_VERSION } from "./version.js";
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
 
 program
   .name("vibe-replay")
   .description("AI Coding Session Replay & Sharing Tool")
-  .version("0.0.3")
+  .version(CLI_VERSION)
   .option("-s, --session <path>", "Path to a specific JSONL session file")
   .option("-p, --provider <name>", "Provider name (default: claude-code)", "claude-code")
   .option("-t, --title <name>", "Custom title for the replay (shown on landing page & shared links)")
   .option("--dev", "Write demo.json to viewer public/ for HMR development and exit")
   .action(async (opts) => {
-    console.log(chalk.bold.cyan("\n  vibe-replay") + chalk.dim(" v0.0.3\n"));
+    console.log(chalk.bold.cyan("\n  vibe-replay") + chalk.dim(` v${CLI_VERSION}\n`));
 
     let sessionInfo: SessionInfo | undefined;
     let sessionPaths: string | string[];
@@ -84,7 +85,13 @@ program
     const project = rawProject.startsWith(home)
       ? "~" + rawProject.slice(home.length)
       : rawProject;
-    const replay = transformToReplay(parsed, providerName, project);
+    const replay = transformToReplay(parsed, providerName, project, {
+      generator: {
+        name: "vibe-replay",
+        version: CLI_VERSION,
+        generatedAt: new Date().toISOString(),
+      },
+    });
 
     const thinkingStr = replay.meta.stats.thinkingBlocks
       ? `, ${replay.meta.stats.thinkingBlocks} thinking`

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -2,7 +2,11 @@ import { readdir, stat, readFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
 import type { SessionInfo } from "../../types.js";
-import { storeDbExists } from "./sqlite-reader.js";
+import {
+  storeDbExists,
+  discoverSqliteOnlySessions,
+  discoverGlobalStateOnlySessions,
+} from "./sqlite-reader.js";
 
 const CURSOR_DIR = join(homedir(), ".cursor", "projects");
 
@@ -45,12 +49,28 @@ export async function discoverCursorSessions(): Promise<SessionInfo[]> {
       );
       if (!info) continue;
 
-      // Check if SQLite store.db is available for richer data
-      const hasSqlite = await storeDbExists(project, info.sessionId);
       info.workspacePath = project;
-      info.hasSqlite = hasSqlite;
+      info.hasSqlite = false;
       sessions.push(info);
     }
+  }
+
+  // Discover SQLite-only sessions (devcontainer, SSH-remote, etc.)
+  const transcriptSessions = sessions.slice();
+  const knownIds = new Set(transcriptSessions.map((s) => s.sessionId));
+  const decodedPaths = [...new Set(sessions.map((s) => s.cwd).filter(Boolean))];
+  const sqliteOnly = await discoverSqliteOnlySessions(knownIds, decodedPaths);
+  sessions.push(...sqliteOnly);
+  for (const s of sqliteOnly) knownIds.add(s.sessionId);
+
+  // Discover sessions kept in Cursor global state DB (composerData/bubbleId).
+  const globalState = await discoverGlobalStateOnlySessions(knownIds, decodedPaths);
+  sessions.push(...globalState.sessions);
+
+  // Mark transcript-discovered sessions that have any SQLite-backed rich data.
+  for (const session of transcriptSessions) {
+    const hasStoreDb = await storeDbExists(session.workspacePath || "", session.sessionId);
+    session.hasSqlite = hasStoreDb || globalState.sessionIds.has(session.sessionId);
   }
 
   sessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
 import type { ParsedTurn, SessionInfo } from "../../types.js";
-import type { ProviderParseResult } from "../types.js";
+import type { DataSourceInfo, ProviderParseResult } from "../types.js";
 import { parseCursorSqlite } from "./sqlite-reader.js";
 
 export async function parseCursorSession(
@@ -22,10 +22,19 @@ export async function parseCursorSession(
       // Keep SQLite/global-state as source of truth, but supplement missing
       // thinking markers from JSONL when transcript files are available.
       if (transcriptPaths.length > 0) {
+        const thinkingBefore = countThinkingBlocks(sqliteResult.turns);
         const jsonlThinking = await parseCursorJsonl(transcriptPaths, [], { inferToolPaths: false });
         sqliteResult.turns = mergeJsonlThinkingIntoCursorTurns(
           sqliteResult.turns,
           jsonlThinking.turns,
+        );
+        const thinkingAfter = countThinkingBlocks(sqliteResult.turns);
+        const supplementedThinkingBlocks = Math.max(0, thinkingAfter - thinkingBefore);
+        sqliteResult.dataSourceInfo = withSupplement(
+          sqliteResult.dataSourceInfo || defaultDataSourceInfo(sqliteResult.dataSource),
+          supplementedThinkingBlocks > 0
+            ? `cursor/projects/agent-transcripts/*.jsonl (thinking +${supplementedThinkingBlocks})`
+            : "cursor/projects/agent-transcripts/*.jsonl (thinking +0)",
         );
       }
       return sqliteResult;
@@ -41,6 +50,24 @@ export async function parseCursorSession(
 
 interface ParseJsonlOptions {
   inferToolPaths: boolean;
+}
+
+function defaultDataSourceInfo(dataSource?: ProviderParseResult["dataSource"]): DataSourceInfo | undefined {
+  if (!dataSource) return undefined;
+  return {
+    primary: dataSource,
+    sources: [],
+  };
+}
+
+function withSupplement(
+  info: DataSourceInfo | undefined,
+  supplement: string,
+): DataSourceInfo | undefined {
+  if (!info) return undefined;
+  const supplements = [...(info.supplements || [])];
+  if (!supplements.includes(supplement)) supplements.push(supplement);
+  return { ...info, supplements };
 }
 
 async function parseCursorJsonl(
@@ -131,6 +158,13 @@ async function parseCursorJsonl(
     cwd: "",
     turns: allTurns,
     dataSource: hasToolData ? "jsonl+tools" : "jsonl",
+    dataSourceInfo: {
+      primary: hasToolData ? "jsonl+tools" : "jsonl",
+      sources: [
+        "cursor/projects/agent-transcripts/*.jsonl",
+        ...(hasToolData ? ["cursor/projects/agent-tools/*.txt"] : []),
+      ],
+    },
   };
 }
 
@@ -146,6 +180,16 @@ function collectThinkingTexts(turn: ParsedTurn): string[] {
 
 function buildThinkingBlocks(texts: string[]): any[] {
   return texts.map((thinking) => ({ type: "thinking", thinking }));
+}
+
+function countThinkingBlocks(turns: ParsedTurn[]): number {
+  let count = 0;
+  for (const turn of turns) {
+    for (const block of turn.blocks as any[]) {
+      if (block?.type === "thinking") count++;
+    }
+  }
+  return count;
 }
 
 /**

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
+import { homedir } from "node:os";
 import type { ParsedTurn, SessionInfo } from "../../types.js";
 import type { DataSourceInfo, ProviderParseResult } from "../types.js";
 import { parseCursorSqlite } from "./sqlite-reader.js";
@@ -20,21 +21,22 @@ export async function parseCursorSession(
     );
     if (sqliteResult) {
       // Keep SQLite/global-state as source of truth, but supplement missing
-      // thinking markers from JSONL when transcript files are available.
+      // thinking markers and user images from JSONL when transcript files are available.
       if (transcriptPaths.length > 0) {
         const thinkingBefore = countThinkingBlocks(sqliteResult.turns);
+        const userImagesBefore = countUserImages(sqliteResult.turns);
         const jsonlThinking = await parseCursorJsonl(transcriptPaths, [], { inferToolPaths: false });
-        sqliteResult.turns = mergeJsonlThinkingIntoCursorTurns(
+        sqliteResult.turns = mergeJsonlSupplementsIntoCursorTurns(
           sqliteResult.turns,
           jsonlThinking.turns,
         );
         const thinkingAfter = countThinkingBlocks(sqliteResult.turns);
+        const userImagesAfter = countUserImages(sqliteResult.turns);
         const supplementedThinkingBlocks = Math.max(0, thinkingAfter - thinkingBefore);
+        const supplementedUserImages = Math.max(0, userImagesAfter - userImagesBefore);
         sqliteResult.dataSourceInfo = withSupplement(
           sqliteResult.dataSourceInfo || defaultDataSourceInfo(sqliteResult.dataSource),
-          supplementedThinkingBlocks > 0
-            ? `cursor/projects/agent-transcripts/*.jsonl (thinking +${supplementedThinkingBlocks})`
-            : "cursor/projects/agent-transcripts/*.jsonl (thinking +0)",
+          `cursor/projects/agent-transcripts/*.jsonl (thinking +${supplementedThinkingBlocks}, images +${supplementedUserImages})`,
         );
       }
       return sqliteResult;
@@ -97,21 +99,48 @@ async function parseCursorJsonl(
       if (!Array.isArray(contentBlocks)) continue;
 
       const textParts: string[] = [];
+      const userImages: string[] = [];
+      const imageFilePaths = new Set<string>();
       for (const block of contentBlocks) {
         if (block.type === "text" && block.text) {
-          let text = block.text;
-          // Strip Cursor's <user_query> wrapper
-          text = text.replace(/<\/?user_query>/g, "").trim();
+          let text = stripUserQueryWrapper(block.text);
+          const extracted = extractImageFilePathsFromText(text);
+          text = normalizeImagePlaceholderLines(extracted.cleanedText);
+          for (const imagePath of extracted.paths) imageFilePaths.add(imagePath);
           if (text) textParts.push(text);
+        } else if (block.type === "image") {
+          const source = (block as any).source;
+          if (source?.data) {
+            const mediaType = source.media_type || "image/png";
+            userImages.push(`data:${mediaType};base64,${source.data}`);
+          }
         }
       }
 
-      if (textParts.length === 0) continue;
+      for (const imagePath of imageFilePaths) {
+        const dataUrl = await readImageFileAsDataUrl(imagePath);
+        if (dataUrl) userImages.push(dataUrl);
+      }
+
+      if (textParts.length === 0 && userImages.length === 0) continue;
 
       const fullText = textParts.join("\n");
       const markerParsed = role === "assistant" ? splitToolMarker(fullText) : undefined;
       const markerName = markerParsed?.markerName;
       const markerTextBody = markerParsed?.textBody;
+
+      if (role === "user") {
+        const blocks: any[] = [];
+        if (fullText) blocks.push({ type: "text", text: fullText });
+        const dedupedImages = [...new Set(userImages)];
+        if (dedupedImages.length > 0) {
+          blocks.push({ type: "_user_images", images: dedupedImages });
+        }
+        if (blocks.length > 0) {
+          allTurns.push({ role, blocks });
+        }
+        continue;
+      }
 
       if (markerName) {
         // Markers are status indicators — store as a placeholder that
@@ -168,6 +197,55 @@ async function parseCursorJsonl(
   };
 }
 
+function stripUserQueryWrapper(text: string): string {
+  return text.replace(/<\/?user_query>/g, "").trim();
+}
+
+function normalizeImagePlaceholderLines(text: string): string {
+  const lines = text.split("\n");
+  const filtered = lines.filter((line) => !/^\s*\[Image\]\s*$/i.test(line.trim()));
+  return filtered.join("\n").trim();
+}
+
+function resolveImagePath(pathValue: string): string {
+  if (pathValue.startsWith("~/")) return join(homedir(), pathValue.slice(2));
+  return pathValue;
+}
+
+function imageMediaType(pathValue: string): string {
+  const lower = pathValue.toLowerCase();
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".gif")) return "image/gif";
+  return "image/png";
+}
+
+function extractImageFilePathsFromText(text: string): { cleanedText: string; paths: string[] } {
+  const blockPattern = /<image_files>([\s\S]*?)<\/image_files>/gi;
+  const paths = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = blockPattern.exec(text)) !== null) {
+    const blockContent = match[1];
+    const pathRegex = /(?:^|\n)\s*(?:\d+\.\s*)?((?:~\/|\/)[^\n]+\.(?:png|jpe?g|gif|webp))/gi;
+    let pathMatch: RegExpExecArray | null;
+    while ((pathMatch = pathRegex.exec(blockContent)) !== null) {
+      const pathValue = pathMatch[1].trim();
+      if (pathValue) paths.add(resolveImagePath(pathValue));
+    }
+  }
+  const cleanedText = text.replace(blockPattern, "").trim();
+  return { cleanedText, paths: [...paths] };
+}
+
+async function readImageFileAsDataUrl(pathValue: string): Promise<string | null> {
+  try {
+    const data = await readFile(pathValue);
+    return `data:${imageMediaType(pathValue)};base64,${data.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+
 function collectThinkingTexts(turn: ParsedTurn): string[] {
   const texts: string[] = [];
   for (const block of turn.blocks as any[]) {
@@ -188,6 +266,26 @@ function countThinkingBlocks(turns: ParsedTurn[]): number {
     for (const block of turn.blocks as any[]) {
       if (block?.type === "thinking") count++;
     }
+  }
+  return count;
+}
+
+function collectUserImages(turn: ParsedTurn): string[] {
+  const imageBlocks = (turn.blocks as any[]).filter((block) => block?.type === "_user_images");
+  const images: string[] = [];
+  for (const block of imageBlocks) {
+    if (!Array.isArray(block.images)) continue;
+    for (const image of block.images) {
+      if (typeof image === "string" && image.trim()) images.push(image);
+    }
+  }
+  return images;
+}
+
+function countUserImages(turns: ParsedTurn[]): number {
+  let count = 0;
+  for (const turn of turns) {
+    count += collectUserImages(turn).length;
   }
   return count;
 }
@@ -239,6 +337,48 @@ export function mergeJsonlThinkingIntoCursorTurns(
   }
 
   return merged;
+}
+
+function mergeJsonlUserImagesIntoCursorTurns(
+  primaryTurns: ParsedTurn[],
+  jsonlTurns: ParsedTurn[],
+): ParsedTurn[] {
+  if (primaryTurns.length === 0 || jsonlTurns.length === 0) return primaryTurns;
+
+  const merged = primaryTurns.map((turn) => ({
+    ...turn,
+    blocks: [...turn.blocks],
+  }));
+
+  const primaryUserIndices = merged
+    .map((turn, index) => ({ turn, index }))
+    .filter(({ turn }) => turn.role === "user")
+    .map(({ index }) => index);
+  const jsonlUserTurns = jsonlTurns.filter((turn) => turn.role === "user");
+  const paired = Math.min(primaryUserIndices.length, jsonlUserTurns.length);
+
+  for (let i = 0; i < paired; i++) {
+    const targetTurn = merged[primaryUserIndices[i]];
+    const candidateImages = collectUserImages(jsonlUserTurns[i]);
+    if (candidateImages.length === 0) continue;
+
+    const existingImages = collectUserImages(targetTurn);
+    const mergedImages = [...new Set([...existingImages, ...candidateImages])];
+    if (mergedImages.length === existingImages.length) continue;
+
+    const nonImageBlocks = (targetTurn.blocks as any[]).filter((block) => block?.type !== "_user_images");
+    targetTurn.blocks = [...nonImageBlocks, { type: "_user_images", images: mergedImages }] as any;
+  }
+
+  return merged;
+}
+
+export function mergeJsonlSupplementsIntoCursorTurns(
+  primaryTurns: ParsedTurn[],
+  jsonlTurns: ParsedTurn[],
+): ParsedTurn[] {
+  const withThinking = mergeJsonlThinkingIntoCursorTurns(primaryTurns, jsonlTurns);
+  return mergeJsonlUserImagesIntoCursorTurns(withThinking, jsonlTurns);
 }
 
 interface TimestampedPath {

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -8,23 +8,46 @@ export async function parseCursorSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
 ): Promise<ProviderParseResult> {
-  // Try SQLite first if session info with workspace path is available
-  if (sessionInfo?.workspacePath && sessionInfo.sessionId) {
-    const sqliteResult = await parseCursorSqlite(
-      sessionInfo.workspacePath,
-      sessionInfo.sessionId,
-    );
-    if (sqliteResult) return sqliteResult;
-  }
-
-  // Fallback to JSONL parsing
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
   const transcriptPaths = paths.filter((p) => p.endsWith(".jsonl"));
   const explicitToolPaths = paths.filter((p) => p.endsWith(".txt"));
+
+  // Try SQLite first if session info is available
+  if (sessionInfo?.sessionId) {
+    const sqliteResult = await parseCursorSqlite(
+      sessionInfo.workspacePath || "",
+      sessionInfo.sessionId,
+    );
+    if (sqliteResult) {
+      // Keep SQLite/global-state as source of truth, but supplement missing
+      // thinking markers from JSONL when transcript files are available.
+      if (transcriptPaths.length > 0) {
+        const jsonlThinking = await parseCursorJsonl(transcriptPaths, [], { inferToolPaths: false });
+        sqliteResult.turns = mergeJsonlThinkingIntoCursorTurns(
+          sqliteResult.turns,
+          jsonlThinking.turns,
+        );
+      }
+      return sqliteResult;
+    }
+  }
+
+  // Fallback to JSONL parsing
   if (transcriptPaths.length === 0) {
     throw new Error("Cursor parse requires at least one transcript .jsonl path");
   }
+  return parseCursorJsonl(transcriptPaths, explicitToolPaths, { inferToolPaths: true });
+}
 
+interface ParseJsonlOptions {
+  inferToolPaths: boolean;
+}
+
+async function parseCursorJsonl(
+  transcriptPaths: string[],
+  explicitToolPaths: string[],
+  options: ParseJsonlOptions,
+): Promise<ProviderParseResult> {
   const allTurns: ParsedTurn[] = [];
   let syntheticToolId = 0;
   const sortedTranscriptPaths = await sortByMtime(transcriptPaths);
@@ -85,7 +108,9 @@ export async function parseCursorSession(
 
   const toolPaths = explicitToolPaths.length > 0
     ? await sortByMtime(explicitToolPaths)
-    : await inferToolPaths(sortedTranscriptPaths);
+    : options.inferToolPaths
+    ? await inferToolPaths(sortedTranscriptPaths)
+    : [];
   const toolEvents = await loadToolEvents(toolPaths);
   attachToolEvents(allTurns, toolEvents);
 
@@ -107,6 +132,69 @@ export async function parseCursorSession(
     turns: allTurns,
     dataSource: hasToolData ? "jsonl+tools" : "jsonl",
   };
+}
+
+function collectThinkingTexts(turn: ParsedTurn): string[] {
+  const texts: string[] = [];
+  for (const block of turn.blocks as any[]) {
+    if (block?.type !== "thinking") continue;
+    const text = typeof block.thinking === "string" ? block.thinking.trim() : "";
+    if (text) texts.push(text);
+  }
+  return texts;
+}
+
+function buildThinkingBlocks(texts: string[]): any[] {
+  return texts.map((thinking) => ({ type: "thinking", thinking }));
+}
+
+/**
+ * Merge JSONL-only thinking markers into DB-derived turns.
+ * We align assistant turns by index and only add missing thinking blocks.
+ */
+export function mergeJsonlThinkingIntoCursorTurns(
+  primaryTurns: ParsedTurn[],
+  jsonlTurns: ParsedTurn[],
+): ParsedTurn[] {
+  if (primaryTurns.length === 0 || jsonlTurns.length === 0) return primaryTurns;
+
+  const merged = primaryTurns.map((turn) => ({
+    ...turn,
+    blocks: [...turn.blocks],
+  }));
+
+  const primaryAssistantIndices = merged
+    .map((turn, index) => ({ turn, index }))
+    .filter(({ turn }) => turn.role === "assistant")
+    .map(({ index }) => index);
+  const jsonlAssistantTurns = jsonlTurns.filter((turn) => turn.role === "assistant");
+
+  const paired = Math.min(primaryAssistantIndices.length, jsonlAssistantTurns.length);
+  for (let i = 0; i < paired; i++) {
+    const targetTurn = merged[primaryAssistantIndices[i]];
+    const candidateThinking = collectThinkingTexts(jsonlAssistantTurns[i]);
+    if (candidateThinking.length === 0) continue;
+
+    const existingThinking = new Set(collectThinkingTexts(targetTurn));
+    const missingThinking = candidateThinking.filter((text) => !existingThinking.has(text));
+    if (missingThinking.length === 0) continue;
+
+    targetTurn.blocks = [...buildThinkingBlocks(missingThinking), ...targetTurn.blocks] as any;
+  }
+
+  // If JSONL has extra assistant thinking turns (common with marker-only lines),
+  // preserve them as standalone assistant thinking turns.
+  for (let i = paired; i < jsonlAssistantTurns.length; i++) {
+    const extraThinking = collectThinkingTexts(jsonlAssistantTurns[i]);
+    if (extraThinking.length === 0) continue;
+    merged.push({
+      role: "assistant",
+      timestamp: jsonlAssistantTurns[i].timestamp,
+      blocks: buildThinkingBlocks(extraThinking) as any,
+    });
+  }
+
+  return merged;
 }
 
 interface TimestampedPath {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1,11 +1,14 @@
 import { createHash } from "node:crypto";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { stat, readFile, readdir } from "node:fs/promises";
-import type { ParsedTurn, ContentBlock } from "../../types.js";
+import type { ParsedTurn, ContentBlock, SessionInfo } from "../../types.js";
 import type { ProviderParseResult } from "../types.js";
 
 const CURSOR_CHATS_DIR = join(homedir(), ".cursor", "chats");
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MIN_STORE_DB_SIZE = 8192;
 
 export function workspaceHash(absolutePath: string): string {
   return createHash("md5").update(absolutePath).digest("hex");
@@ -13,6 +16,34 @@ export function workspaceHash(absolutePath: string): string {
 
 export function storeDbPath(workspacePath: string, sessionId: string): string {
   return join(CURSOR_CHATS_DIR, workspaceHash(workspacePath), sessionId, "store.db");
+}
+
+function globalStateDbCandidates(): string[] {
+  const candidates = [
+    join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Cursor",
+      "User",
+      "globalStorage",
+      "state.vscdb",
+    ),
+    join(homedir(), ".config", "Cursor", "User", "globalStorage", "state.vscdb"),
+  ];
+  const appData = process.env.APPDATA;
+  if (appData) {
+    candidates.push(join(appData, "Cursor", "User", "globalStorage", "state.vscdb"));
+  }
+  return [...new Set(candidates)];
+}
+
+async function findGlobalStateDb(): Promise<string | null> {
+  for (const candidate of globalStateDbCandidates()) {
+    const s = await stat(candidate).catch(() => null);
+    if (s?.isFile() && s.size >= MIN_STORE_DB_SIZE) return candidate;
+  }
+  return null;
 }
 
 /**
@@ -38,6 +69,326 @@ async function findStoreDb(sessionId: string): Promise<string | null> {
 export async function storeDbExists(_workspacePath: string, sessionId: string): Promise<boolean> {
   const dbPath = await findStoreDb(sessionId);
   return dbPath !== null;
+}
+
+function valueToString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return new TextDecoder().decode(value);
+  if (value == null) return "";
+  return String(value);
+}
+
+function parseJson<T = any>(raw: unknown): T | null {
+  if (typeof raw !== "string") return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function toIsoTimestamp(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const ms = value > 10_000_000_000 ? value : value * 1000;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+  }
+  if (typeof value === "string" && value.trim()) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+  }
+  return undefined;
+}
+
+async function resolveProjectRootFromPath(rawPath: string): Promise<string | null> {
+  let candidate = rawPath
+    .replaceAll("\\\\", "/")
+    .replace(/\\n.*$/, "")
+    .replace(/["']+$/g, "")
+    .replace(/[),]+$/g, "");
+  if (!candidate.startsWith("/")) return null;
+
+  let current = candidate;
+  const initial = await stat(current).catch(() => null);
+  if (initial?.isFile()) current = dirname(current);
+
+  let deepestExisting: string | null = null;
+  while (current && current !== "/") {
+    const dirStat = await stat(current).catch(() => null);
+    if (dirStat?.isDirectory()) {
+      if (!deepestExisting) deepestExisting = current;
+      const gitStat = await stat(join(current, ".git")).catch(() => null);
+      if (gitStat) return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return deepestExisting;
+}
+
+async function inferProjectFromComposerData(
+  rawComposerData: string,
+  decodedWorkspacePaths: string[],
+): Promise<string> {
+  const uniqueDecoded = [...new Set(decodedWorkspacePaths.filter(Boolean))].sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const workspacePath of uniqueDecoded) {
+    const normalized = workspacePath.replaceAll("\\", "/");
+    if (
+      rawComposerData.includes(normalized) ||
+      rawComposerData.includes(normalized.replace(/^\//, ""))
+    ) {
+      return workspacePath;
+    }
+  }
+
+  const matches = rawComposerData.match(/\/(?:Users|home)\/[^"'\s,}{]{1,240}/g) || [];
+  for (const match of matches) {
+    const resolved = await resolveProjectRootFromPath(match);
+    if (resolved) return resolved;
+  }
+  return "";
+}
+
+/**
+ * Build reverse map from workspace MD5 hash → decoded project path.
+ * Accepts pre-decoded workspace paths from the JSONL discovery phase.
+ */
+function buildHashToProjectMap(
+  decodedWorkspacePaths: string[],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const decoded of decodedWorkspacePaths) {
+    if (!decoded) continue;
+    const h = workspaceHash(decoded);
+    map.set(h, decoded);
+  }
+  return map;
+}
+
+/**
+ * Read lightweight metadata from a store.db without full parsing.
+ * Returns null if the DB is empty, corrupt, or has no meta table.
+ */
+async function readStoreDbMeta(
+  dbPath: string,
+): Promise<ChatMeta | null> {
+  let initSqlJs: any;
+  try {
+    initSqlJs = (await import("sql.js")).default;
+  } catch {
+    return null;
+  }
+  const dbBuffer = await readFile(dbPath);
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(dbBuffer);
+  try {
+    const metaRows = db.exec("SELECT value FROM meta WHERE key = '0'");
+    if (!metaRows.length || !metaRows[0].values.length) return null;
+    const metaHex = metaRows[0].values[0][0] as string;
+    return JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Discover sessions that only exist as SQLite store.db (no JSONL transcripts).
+ * This catches devcontainer / SSH-remote sessions where the Cursor server extension
+ * runs inside the container and doesn't write JSONL to the host.
+ */
+export async function discoverSqliteOnlySessions(
+  knownSessionIds: Set<string>,
+  decodedWorkspacePaths: string[] = [],
+): Promise<SessionInfo[]> {
+  const sessions: SessionInfo[] = [];
+  let workspaceHashDirs: string[];
+  try {
+    workspaceHashDirs = await readdir(CURSOR_CHATS_DIR);
+  } catch {
+    return sessions;
+  }
+
+  const hashToProject = buildHashToProjectMap(decodedWorkspacePaths);
+
+  for (const wsHash of workspaceHashDirs) {
+    const wsDir = join(CURSOR_CHATS_DIR, wsHash);
+    const wsStat = await stat(wsDir).catch(() => null);
+    if (!wsStat?.isDirectory()) continue;
+
+    let sessionDirs: string[];
+    try {
+      sessionDirs = await readdir(wsDir);
+    } catch {
+      continue;
+    }
+
+    for (const sessionId of sessionDirs) {
+      if (knownSessionIds.has(sessionId)) continue;
+
+      const dbPath = join(wsDir, sessionId, "store.db");
+      const dbStat = await stat(dbPath).catch(() => null);
+      if (!dbStat?.isFile() || dbStat.size < MIN_STORE_DB_SIZE) continue;
+
+      const meta = await readStoreDbMeta(dbPath);
+      if (!meta) continue;
+
+      const project = hashToProject.get(wsHash) || "";
+      const firstPrompt = meta.name || "(sqlite-only session)";
+      const timestamp = meta.createdAt
+        ? new Date(meta.createdAt).toISOString()
+        : new Date(dbStat.mtimeMs).toISOString();
+
+      sessions.push({
+        provider: "cursor",
+        sessionId,
+        slug: sessionId.slice(0, 8),
+        title: meta.name,
+        project: shortenPath(project),
+        cwd: project,
+        version: "",
+        timestamp,
+        lineCount: 0,
+        fileSize: dbStat.size,
+        filePath: dbPath,
+        filePaths: [],
+        workspacePath: project,
+        hasSqlite: true,
+        firstPrompt,
+      });
+    }
+  }
+
+  return sessions;
+}
+
+export interface GlobalStateDiscoveryResult {
+  sessions: SessionInfo[];
+  sessionIds: Set<string>;
+}
+
+/**
+ * Discover sessions from Cursor's globalStorage state.vscdb.
+ * This is where devcontainer/remote sessions can keep rich `composerData:*`
+ * and `bubbleId:*` payloads even when chat `store.db` files are absent.
+ */
+export async function discoverGlobalStateOnlySessions(
+  knownSessionIds: Set<string>,
+  decodedWorkspacePaths: string[] = [],
+): Promise<GlobalStateDiscoveryResult> {
+  const sessionIds = new Set<string>();
+  const sessions: SessionInfo[] = [];
+  const unknownProjectSessions: SessionInfo[] = [];
+
+  const dbPath = await findGlobalStateDb();
+  if (!dbPath) return { sessions, sessionIds };
+
+  let initSqlJs: any;
+  try {
+    initSqlJs = (await import("sql.js")).default;
+  } catch {
+    return { sessions, sessionIds };
+  }
+
+  const dbBuffer = await readFile(dbPath).catch(() => null);
+  if (!dbBuffer) return { sessions, sessionIds };
+
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(dbBuffer);
+
+  try {
+    const rows = db.exec("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'");
+    if (!rows.length || !rows[0].values.length) return { sessions, sessionIds };
+
+    for (const [keyValue, value] of rows[0].values) {
+      const key = valueToString(keyValue);
+      const sessionId = key.startsWith("composerData:") ? key.slice("composerData:".length) : "";
+      if (!SESSION_ID_RE.test(sessionId)) continue;
+
+      sessionIds.add(sessionId);
+      if (knownSessionIds.has(sessionId)) continue;
+
+      const rawComposer = valueToString(value);
+      const composer = parseJson<Record<string, any>>(rawComposer);
+      if (!composer) continue;
+
+      const timestamp =
+        toIsoTimestamp(composer.lastUpdatedAt) ||
+        toIsoTimestamp(composer.createdAt) ||
+        new Date().toISOString();
+      const title = typeof composer.name === "string" && composer.name.trim()
+        ? composer.name.trim()
+        : undefined;
+      const firstPrompt = title || "(cursor global state session)";
+      const headers = Array.isArray(composer.fullConversationHeadersOnly)
+        ? composer.fullConversationHeadersOnly
+        : [];
+      const projectPath = await inferProjectFromComposerData(rawComposer, decodedWorkspacePaths);
+
+      const sessionInfo: SessionInfo = {
+        provider: "cursor",
+        sessionId,
+        slug: sessionId.slice(0, 8),
+        title,
+        project: projectPath ? shortenPath(projectPath) : "(globalStorage)",
+        cwd: projectPath,
+        version: "",
+        timestamp,
+        lineCount: headers.length,
+        fileSize: Buffer.byteLength(rawComposer, "utf-8"),
+        filePath: `${dbPath}#composerData:${sessionId}`,
+        filePaths: [],
+        workspacePath: projectPath,
+        hasSqlite: true,
+        firstPrompt,
+      };
+
+      if (projectPath) {
+        sessions.push(sessionInfo);
+      } else {
+        unknownProjectSessions.push(sessionInfo);
+      }
+    }
+  } catch {
+    // no-op: ignore malformed db rows and return what we have
+  } finally {
+    db.close();
+  }
+
+  // Keep only the most recent sessions per inferred project.
+  const perProjectLimit = 40;
+  const byProject = new Map<string, SessionInfo[]>();
+  for (const session of sessions) {
+    const key = session.project;
+    if (!byProject.has(key)) byProject.set(key, []);
+    byProject.get(key)!.push(session);
+  }
+  const cappedProjectSessions: SessionInfo[] = [];
+  for (const projectSessions of byProject.values()) {
+    projectSessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    cappedProjectSessions.push(...projectSessions.slice(0, perProjectLimit));
+  }
+
+  // Avoid flooding picker with thousands of unknown-history sessions.
+  const includeUnknownLimit = decodedWorkspacePaths.length > 0 ? 50 : Number.POSITIVE_INFINITY;
+  unknownProjectSessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  const finalSessions = [
+    ...cappedProjectSessions,
+    ...unknownProjectSessions.slice(0, includeUnknownLimit),
+  ];
+  finalSessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  return { sessions: finalSessions, sessionIds };
+}
+
+function shortenPath(path: string): string {
+  const home = homedir();
+  if (path.startsWith(home)) return "~" + path.slice(home.length);
+  return path;
 }
 
 interface ChatMeta {
@@ -86,6 +437,12 @@ export async function parseCursorSqlite(
   _workspacePath: string,
   sessionId: string,
 ): Promise<ProviderParseResult | null> {
+  const storeResult = await parseCursorStoreDb(sessionId);
+  if (storeResult) return storeResult;
+  return parseCursorGlobalStateDb(sessionId);
+}
+
+async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResult | null> {
   let initSqlJs: any;
   try {
     initSqlJs = (await import("sql.js")).default;
@@ -149,6 +506,199 @@ export async function parseCursorSqlite(
       turns,
       dataSource: "sqlite",
     };
+  } finally {
+    db.close();
+  }
+}
+
+function bubbleTypeToRole(type: unknown): "user" | "assistant" {
+  return Number(type) === 1 ? "user" : "assistant";
+}
+
+function parseThinking(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  return trimmed;
+}
+
+function normalizeTurnText(raw: unknown): string {
+  if (typeof raw !== "string") return "";
+  const cleaned = raw.replace(/<\/?user_query>/g, "").trim();
+  if (!cleaned || SYSTEM_CONTEXT_RE.test(cleaned)) return "";
+  return cleaned;
+}
+
+function extractToolResultText(value: unknown): string {
+  if (typeof value === "string") {
+    const parsed = parseJson(value);
+    if (!parsed) return value;
+    return extractToolResultText(parsed);
+  }
+
+  if (Array.isArray(value)) {
+    const parts = value.map((v) => extractToolResultText(v)).filter(Boolean);
+    return parts.join("\n");
+  }
+
+  if (!value || typeof value !== "object") return "";
+  const obj = value as Record<string, any>;
+
+  if (typeof obj.output === "string" && obj.output.trim()) {
+    const exitCode = Number.isFinite(obj.exitCode) ? `\n[exitCode: ${obj.exitCode}]` : "";
+    return obj.output + exitCode;
+  }
+  if (typeof obj.contents === "string" && obj.contents.trim()) return obj.contents;
+  if (typeof obj.markdown === "string" && obj.markdown.trim()) return obj.markdown;
+
+  if (typeof obj.result === "string" && obj.result.trim()) {
+    const nested = parseJson(obj.result);
+    if (nested) {
+      const nestedText = extractToolResultText(nested);
+      if (nestedText.trim()) return nestedText;
+    }
+    return obj.result;
+  }
+
+  if (Array.isArray(obj.content)) {
+    const textItems = obj.content
+      .map((item: any) => (item && typeof item.text === "string" ? item.text : ""))
+      .filter(Boolean);
+    if (textItems.length > 0) return textItems.join("\n");
+  }
+
+  return JSON.stringify(obj, null, 2);
+}
+
+function parseToolFormerBlock(bubbleId: string, toolFormerData: Record<string, any>): ContentBlock | null {
+  const name = typeof toolFormerData.name === "string" ? toolFormerData.name : "";
+  if (!name) return null;
+
+  const paramsRaw = parseJson<Record<string, any>>(toolFormerData.params) || {};
+  const result = extractToolResultText(toolFormerData.result);
+
+  return {
+    type: "tool_use",
+    id:
+      (typeof toolFormerData.toolCallId === "string" && toolFormerData.toolCallId) ||
+      `cursor-bubble-${bubbleId}`,
+    name: mapCursorToolName(name),
+    input: mapToolArgs(name, paramsRaw),
+    _result: result,
+  } as any;
+}
+
+function bubbleToTurn(bubble: Record<string, any>): ParsedTurn | null {
+  const role = bubbleTypeToRole(bubble.type);
+  const blocks: ContentBlock[] = [];
+
+  if (role === "user") {
+    const text = normalizeTurnText(bubble.text);
+    if (text) blocks.push({ type: "text", text });
+  } else {
+    const thinking = parseThinking(bubble.thinking);
+    if (thinking) blocks.push({ type: "thinking", thinking } as ContentBlock);
+
+    const text = normalizeTurnText(bubble.text);
+    if (text) blocks.push({ type: "text", text });
+
+    if (bubble.toolFormerData && typeof bubble.toolFormerData === "object") {
+      const tool = parseToolFormerBlock(
+        typeof bubble.bubbleId === "string" ? bubble.bubbleId : "unknown",
+        bubble.toolFormerData,
+      );
+      if (tool) blocks.push(tool);
+    }
+  }
+
+  if (blocks.length === 0) return null;
+  return {
+    role,
+    timestamp: toIsoTimestamp(bubble.createdAt),
+    blocks,
+  };
+}
+
+async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderParseResult | null> {
+  const dbPath = await findGlobalStateDb();
+  if (!dbPath) return null;
+
+  let initSqlJs: any;
+  try {
+    initSqlJs = (await import("sql.js")).default;
+  } catch {
+    return null;
+  }
+
+  const dbBuffer = await readFile(dbPath).catch(() => null);
+  if (!dbBuffer) return null;
+
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(dbBuffer);
+
+  try {
+    const composerRows = db.exec("SELECT value FROM cursorDiskKV WHERE key = ?", [
+      `composerData:${sessionId}`,
+    ]);
+    if (!composerRows.length || !composerRows[0].values.length) return null;
+
+    const rawComposer = valueToString(composerRows[0].values[0][0]);
+    const composer = parseJson<Record<string, any>>(rawComposer);
+    if (!composer) return null;
+
+    const headers = Array.isArray(composer.fullConversationHeadersOnly)
+      ? composer.fullConversationHeadersOnly
+      : [];
+    if (headers.length === 0) return null;
+
+    const turns: ParsedTurn[] = [];
+    const bubbleStmt = db.prepare("SELECT value FROM cursorDiskKV WHERE key = ?");
+    for (const header of headers) {
+      const bubbleId =
+        header && typeof header === "object" && typeof (header as any).bubbleId === "string"
+          ? (header as any).bubbleId
+          : "";
+      if (!bubbleId) continue;
+
+      bubbleStmt.bind([`bubbleId:${sessionId}:${bubbleId}`]);
+      if (bubbleStmt.step()) {
+        const rawBubble = valueToString(bubbleStmt.get()[0]);
+        const bubble = parseJson<Record<string, any>>(rawBubble);
+        if (bubble) {
+          const turn = bubbleToTurn(bubble);
+          if (turn) turns.push(turn);
+        }
+      }
+      bubbleStmt.reset();
+    }
+    bubbleStmt.free();
+
+    if (turns.length === 0) return null;
+
+    const firstUser = turns.find((t) => t.role === "user");
+    const firstText = firstUser?.blocks.find((b) => b.type === "text") as any;
+    const inferredProject = await inferProjectFromComposerData(rawComposer, []);
+    const modelName =
+      composer.modelConfig &&
+      typeof composer.modelConfig === "object" &&
+      typeof composer.modelConfig.modelName === "string"
+        ? composer.modelConfig.modelName
+        : undefined;
+
+    return {
+      sessionId,
+      slug: sessionId.slice(0, 8),
+      title:
+        (typeof composer.name === "string" && composer.name.trim()) ||
+        (firstText?.text as string | undefined)?.slice(0, 80),
+      cwd: inferredProject || "",
+      model: modelName,
+      startTime: toIsoTimestamp(composer.createdAt),
+      endTime: toIsoTimestamp(composer.lastUpdatedAt),
+      turns,
+      dataSource: "global-state",
+    };
+  } catch {
+    return null;
   } finally {
     db.close();
   }
@@ -250,17 +800,30 @@ function parseAssistantContent(
 function mapCursorToolName(name: string): string {
   const mapping: Record<string, string> = {
     Shell: "Bash",
+    run_terminal_command_v2: "Bash",
     Read: "Read",
     ReadFile: "Read",
+    read_file_v2: "Read",
+    read_lints: "ReadLints",
     Grep: "Grep",
+    ripgrep_raw_search: "Grep",
     Glob: "Glob",
+    glob_file_search: "Glob",
     StrReplace: "Edit",
     EditFile: "Edit",
+    edit_file_v2: "Edit",
     Write: "Write",
     WriteFile: "Write",
     Delete: "Delete",
+    delete_file: "Delete",
     Task: "Task",
+    task_v2: "Task",
+    todo_write: "TodoWrite",
+    ask_question: "AskQuestion",
+    semantic_search_full: "SemanticSearch",
+    web_search: "WebSearch",
     WebFetch: "WebFetch",
+    web_fetch: "WebFetch",
   };
   return mapping[name] || name;
 }
@@ -281,6 +844,61 @@ function mapToolArgs(toolName: string, args: Record<string, any>): Record<string
   }
   if ((toolName === "Read" || toolName === "ReadFile") && args.path) {
     return { file_path: args.path };
+  }
+  if (toolName === "run_terminal_command_v2" && args.command) {
+    return {
+      command: args.command,
+      ...(args.commandDescription ? { description: args.commandDescription } : {}),
+      ...(args.cwd ? { cwd: args.cwd } : {}),
+    };
+  }
+  if (toolName === "read_file_v2" && args.targetFile) {
+    return { file_path: args.targetFile };
+  }
+  if (toolName === "edit_file_v2" && args.relativeWorkspacePath) {
+    return {
+      file_path: args.relativeWorkspacePath,
+      new_string: args.streamingContent ?? "",
+    };
+  }
+  if (toolName === "delete_file" && args.relativeWorkspacePath) {
+    return { file_path: args.relativeWorkspacePath };
+  }
+  if (toolName === "glob_file_search") {
+    return {
+      pattern: args.globPattern ?? "",
+      path: args.targetDirectory ?? "",
+    };
+  }
+  if (toolName === "ripgrep_raw_search") {
+    return {
+      pattern: args.pattern ?? "",
+      path: args.path ?? "",
+      ...(args.glob ? { glob: args.glob } : {}),
+      ...(args.caseInsensitive !== undefined ? { case_insensitive: Boolean(args.caseInsensitive) } : {}),
+    };
+  }
+  if (toolName === "web_search" && args.searchTerm) {
+    return { search_term: args.searchTerm };
+  }
+  if (toolName === "task_v2") {
+    return {
+      ...(args.description ? { description: args.description } : {}),
+      ...(args.prompt ? { prompt: args.prompt } : {}),
+      ...(args.subagentType ? { subagent_type: args.subagentType } : {}),
+    };
+  }
+  if (toolName.startsWith("mcp-") && Array.isArray(args.tools) && args.tools.length > 0) {
+    const first = args.tools[0] || {};
+    const parsedParameters =
+      typeof first.parameters === "string"
+        ? parseJson(first.parameters) ?? first.parameters
+        : first.parameters;
+    return {
+      ...(first.serverName ? { server: first.serverName } : {}),
+      ...(first.name ? { tool_name: first.name } : {}),
+      ...(parsedParameters !== undefined ? { arguments: parsedParameters } : {}),
+    };
   }
   return args;
 }

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -505,6 +505,10 @@ async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResul
       startTime: metaJson.createdAt ? new Date(metaJson.createdAt).toISOString() : undefined,
       turns,
       dataSource: "sqlite",
+      dataSourceInfo: {
+        primary: "sqlite",
+        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      },
     };
   } finally {
     db.close();
@@ -696,6 +700,11 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
       endTime: toIsoTimestamp(composer.lastUpdatedAt),
       turns,
       dataSource: "global-state",
+      dataSourceInfo: {
+        primary: "global-state",
+        sources: ["cursor/user/globalStorage/state.vscdb"],
+        notes: ["cursorDiskKV keys: composerData:* + bubbleId:*"],
+      },
     };
   } catch {
     return null;

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -7,7 +7,7 @@ export interface Provider {
   parse(filePaths: string | string[], sessionInfo?: SessionInfo): Promise<ProviderParseResult>;
 }
 
-export type DataSource = "jsonl" | "sqlite" | "jsonl+tools";
+export type DataSource = "jsonl" | "sqlite" | "jsonl+tools" | "global-state";
 
 export interface TokenUsage {
   inputTokens: number;

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -9,6 +9,13 @@ export interface Provider {
 
 export type DataSource = "jsonl" | "sqlite" | "jsonl+tools" | "global-state";
 
+export interface DataSourceInfo {
+  primary: DataSource;
+  sources: string[];
+  supplements?: string[];
+  notes?: string[];
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -33,6 +40,7 @@ export interface ProviderParseResult {
   totalDurationMs?: number;
   turns: ParsedTurn[];
   dataSource?: DataSource;
+  dataSourceInfo?: DataSourceInfo;
   tokenUsage?: TokenUsage;
   compactions?: Compaction[];
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -136,9 +136,14 @@ export async function startEditor(
   // AI Feedback — detect available CLI tools
   app.get("/api/feedback/detect", async (c) => {
     try {
-      const tool = await detectFeedbackTools();
-      if (tool) {
-        return c.json({ available: true, tool: { name: tool.name } });
+      const detected = await detectFeedbackTools();
+      if (detected.tools.length > 0 && detected.defaultTool) {
+        return c.json({
+          available: true,
+          tool: { name: detected.defaultTool.name },
+          tools: detected.tools.map((t) => ({ name: t.name })),
+          defaultTool: { name: detected.defaultTool.name },
+        });
       }
       return c.json({ available: false });
     } catch {
@@ -149,9 +154,17 @@ export async function startEditor(
   // AI Feedback — generate feedback annotations
   app.post("/api/feedback/generate", async (c) => {
     try {
-      const tool = await detectFeedbackTools();
+      const body = await c.req.json<{ toolName?: string }>().catch(() => ({}));
+      const requestedToolName = typeof body.toolName === "string" ? body.toolName : undefined;
+      const detected = await detectFeedbackTools();
+      if (detected.tools.length === 0) {
+        return c.json({ error: "No AI CLI tool available (claude, agent, or opencode)" }, 400);
+      }
+      const tool = requestedToolName
+        ? detected.tools.find((t) => t.name === requestedToolName) || null
+        : detected.defaultTool;
       if (!tool) {
-        return c.json({ error: "No AI CLI tool available (claude or opencode)" }, 400);
+        return c.json({ error: `Requested AI Coach tool is not available: ${requestedToolName}` }, 400);
       }
       const fb = await generateFeedback({ ...session, annotations }, tool);
       if (!fb) {

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -14,6 +14,9 @@ export function transformToReplay(
   parsed: ProviderParseResult,
   provider: string,
   project: string,
+  options?: {
+    generator?: ReplaySession["meta"]["generator"];
+  },
 ): ReplaySession {
   const scenes: Scene[] = [];
   let userPrompts = 0;
@@ -110,6 +113,7 @@ export function transformToReplay(
       model: parsed.model,
       cwd: redactPath(parsed.cwd),
       project,
+      ...(options?.generator ? { generator: options.generator } : {}),
       stats: {
         sceneCount: scenes.length,
         userPrompts,
@@ -139,11 +143,11 @@ function buildToolScene(
     ...(images && images.length > 0 ? { images } : {}),
   };
 
-  if (toolName === "Edit" && input.file_path && input.old_string !== undefined) {
+  if (toolName === "Edit" && input.file_path) {
     (scene as any).diff = {
       filePath: redactPath(input.file_path),
-      oldContent: input.old_string || "",
-      newContent: input.new_string || "",
+      oldContent: input.old_string ?? "",
+      newContent: input.new_string ?? "",
     };
   } else if (toolName === "Write" && input.file_path) {
     (scene as any).diff = {

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -104,6 +104,7 @@ export function transformToReplay(
       title: parsed.title,
       provider,
       dataSource: parsed.dataSource,
+      dataSourceInfo: parsed.dataSourceInfo,
       startTime: parsed.startTime || new Date().toISOString(),
       endTime: parsed.endTime,
       model: parsed.model,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -89,6 +89,13 @@ export interface Annotation {
   resolved: boolean;
 }
 
+export interface DataSourceInfo {
+  primary: string;
+  sources: string[];
+  supplements?: string[];
+  notes?: string[];
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;
@@ -96,6 +103,7 @@ export interface ReplaySession {
     title?: string;
     provider: string;
     dataSource?: string;
+    dataSourceInfo?: DataSourceInfo;
     startTime: string;
     endTime?: string;
     model?: string;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,8 +13,8 @@ export interface SessionInfo {
   filePath: string;       // primary file (most recent)
   filePaths: string[];    // all JSONL files for this session (sorted by timestamp asc)
   toolPaths?: string[];   // cursor tool outputs associated with this session
-  workspacePath?: string; // absolute workspace path for SQLite lookup (Cursor)
-  hasSqlite?: boolean;    // true if store.db exists for this session
+  workspacePath?: string; // absolute workspace path for Cursor lookup
+  hasSqlite?: boolean;    // true if any Cursor SQLite source exists (store.db or global state DB)
   firstPrompt: string;
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -109,6 +109,11 @@ export interface ReplaySession {
     model?: string;
     cwd: string;
     project: string;
+    generator?: {
+      name: string;
+      version: string;
+      generatedAt: string;
+    };
     stats: {
       sceneCount: number;
       userPrompts: number;

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+let version = "0.0.0";
+try {
+  const pkg = require("../package.json");
+  if (pkg && typeof pkg.version === "string" && pkg.version.trim()) {
+    version = pkg.version;
+  }
+} catch {
+  // Keep fallback when package.json is unavailable.
+}
+
+export const CLI_VERSION = version;

--- a/packages/cli/test/cursor-parser.test.ts
+++ b/packages/cli/test/cursor-parser.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { parseCursorSession } from "../src/providers/cursor/parser.js";
 import { transformToReplay } from "../src/transform.js";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const FIXTURE = join(import.meta.dirname, "fixtures/cursor-session.jsonl");
 const TOOL_FIXTURE_1 = join(import.meta.dirname, "fixtures/cursor-tool-1.txt");
 const TOOL_FIXTURE_2 = join(import.meta.dirname, "fixtures/cursor-tool-2.txt");
+const ONE_BY_ONE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8B6v8AAAAASUVORK5CYII=";
 
 describe("Cursor parser", () => {
   it("parses all turns", async () => {
@@ -28,6 +32,41 @@ describe("Cursor parser", () => {
     expect(text).not.toContain("<user_query>");
     expect(text).not.toContain("</user_query>");
     expect(text).toBe("Fix the login bug in auth.ts");
+  });
+
+  it("extracts <image_files> into _user_images and removes image markers", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-images-"));
+    const imagePath = join(tempDir, "shot.png");
+    const jsonlPath = join(tempDir, "image-session.jsonl");
+    await writeFile(imagePath, Buffer.from(ONE_BY_ONE_PNG_BASE64, "base64"));
+    await writeFile(
+      jsonlPath,
+      JSON.stringify({
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: `<user_query>\n[Image]\nPlease investigate this bug\n<image_files>\n1. ${imagePath}\n</image_files>\n</user_query>`,
+            },
+          ],
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      const result = await parseCursorSession(jsonlPath);
+      const firstUser = result.turns.find((t) => t.role === "user")!;
+      const textBlock = (firstUser.blocks as any[]).find((b) => b.type === "text");
+      const imageBlock = (firstUser.blocks as any[]).find((b) => b.type === "_user_images");
+      expect(textBlock.text).toBe("Please investigate this bug");
+      expect(imageBlock).toBeTruthy();
+      expect(imageBlock.images).toHaveLength(1);
+      expect(imageBlock.images[0]).toMatch(/^data:image\/png;base64,/);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("handles prompts without <user_query> wrapper", async () => {

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -173,6 +173,10 @@ describe("parseCursorSession + JSONL thinking supplement", () => {
     expect((assistant.blocks[0] as any).type).toBe("thinking");
     expect((assistant.blocks[0] as any).thinking).toBe("Inspecting logs");
     expect((assistant.blocks[1] as any).type).toBe("text");
+    expect(result.dataSourceInfo?.primary).toBe("global-state");
+    expect(result.dataSourceInfo?.supplements).toContain(
+      "cursor/projects/agent-transcripts/*.jsonl (thinking +1)",
+    );
   });
 
   it("returns SQLite result directly when no transcript is provided", async () => {
@@ -194,5 +198,6 @@ describe("parseCursorSession + JSONL thinking supplement", () => {
     expect(result.dataSource).toBe("sqlite");
     expect(result.turns).toHaveLength(1);
     expect((result.turns[0].blocks[0] as any).text).toBe("DB only data");
+    expect(result.dataSourceInfo).toBeUndefined();
   });
 });

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -14,8 +14,12 @@ vi.mock("../src/providers/cursor/sqlite-reader.js", () => ({
 
 import {
   parseCursorSession,
+  mergeJsonlSupplementsIntoCursorTurns,
   mergeJsonlThinkingIntoCursorTurns,
 } from "../src/providers/cursor/parser.js";
+
+const ONE_BY_ONE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8B6v8AAAAASUVORK5CYII=";
 
 describe("mergeJsonlThinkingIntoCursorTurns", () => {
   it("prepends missing JSONL thinking into matched assistant turn", () => {
@@ -93,9 +97,34 @@ describe("mergeJsonlThinkingIntoCursorTurns", () => {
   });
 });
 
+describe("mergeJsonlSupplementsIntoCursorTurns", () => {
+  it("merges missing user images from JSONL into primary user turns", () => {
+    const primaryTurns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "Investigate issue" }] as any },
+      { role: "assistant", blocks: [{ type: "text", text: "I will check logs." }] as any },
+    ];
+    const jsonlTurns: ParsedTurn[] = [
+      {
+        role: "user",
+        blocks: [
+          { type: "text", text: "Investigate issue" },
+          { type: "_user_images", images: ["data:image/png;base64,abc"] },
+        ] as any,
+      },
+    ];
+
+    const merged = mergeJsonlSupplementsIntoCursorTurns(primaryTurns, jsonlTurns);
+    const userTurn = merged.find((t) => t.role === "user")!;
+    const imageBlock = (userTurn.blocks as any[]).find((b) => b.type === "_user_images");
+    expect(imageBlock).toBeTruthy();
+    expect(imageBlock.images).toEqual(["data:image/png;base64,abc"]);
+  });
+});
+
 describe("parseCursorSession + JSONL thinking supplement", () => {
   let tempDir: string;
   let jsonlPath: string;
+  let imagePath: string;
 
   const baseSessionInfo: SessionInfo = {
     provider: "cursor",
@@ -117,11 +146,18 @@ describe("parseCursorSession + JSONL thinking supplement", () => {
     mockParseCursorSqlite.mockReset();
     tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-thinking-"));
     jsonlPath = join(tempDir, "synthetic-session.jsonl");
+    imagePath = join(tempDir, "shot.png");
+    await writeFile(imagePath, Buffer.from(ONE_BY_ONE_PNG_BASE64, "base64"));
     const content = [
       JSON.stringify({
         role: "user",
         message: {
-          content: [{ type: "text", text: "<user_query>\nInvestigate issue\n</user_query>" }],
+          content: [
+            {
+              type: "text",
+              text: `<user_query>\n[Image]\nInvestigate issue\n<image_files>\n1. ${imagePath}\n</image_files>\n</user_query>`,
+            },
+          ],
         },
       }),
       JSON.stringify({
@@ -173,9 +209,14 @@ describe("parseCursorSession + JSONL thinking supplement", () => {
     expect((assistant.blocks[0] as any).type).toBe("thinking");
     expect((assistant.blocks[0] as any).thinking).toBe("Inspecting logs");
     expect((assistant.blocks[1] as any).type).toBe("text");
+    const user = result.turns.find((t) => t.role === "user")!;
+    const userImageBlock = (user.blocks as any[]).find((b) => b.type === "_user_images");
+    expect(userImageBlock).toBeTruthy();
+    expect(userImageBlock.images).toHaveLength(1);
+    expect(userImageBlock.images[0]).toMatch(/^data:image\/png;base64,/);
     expect(result.dataSourceInfo?.primary).toBe("global-state");
     expect(result.dataSourceInfo?.supplements).toContain(
-      "cursor/projects/agent-transcripts/*.jsonl (thinking +1)",
+      "cursor/projects/agent-transcripts/*.jsonl (thinking +1, images +1)",
     );
   });
 

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ParsedTurn, SessionInfo } from "../src/types.js";
+
+const { mockParseCursorSqlite } = vi.hoisted(() => ({
+  mockParseCursorSqlite: vi.fn(),
+}));
+
+vi.mock("../src/providers/cursor/sqlite-reader.js", () => ({
+  parseCursorSqlite: mockParseCursorSqlite,
+}));
+
+import {
+  parseCursorSession,
+  mergeJsonlThinkingIntoCursorTurns,
+} from "../src/providers/cursor/parser.js";
+
+describe("mergeJsonlThinkingIntoCursorTurns", () => {
+  it("prepends missing JSONL thinking into matched assistant turn", () => {
+    const primaryTurns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "Fix auth bug" }] as any },
+      {
+        role: "assistant",
+        blocks: [
+          { type: "text", text: "I found the issue." },
+          {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Read",
+            input: { file_path: "/src/auth.ts" },
+          } as any,
+        ] as any,
+      },
+    ];
+    const jsonlTurns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "Fix auth bug" }] as any },
+      {
+        role: "assistant",
+        blocks: [
+          { type: "thinking", thinking: "Inspecting auth flow" },
+          { type: "text", text: "I found the issue." },
+        ] as any,
+      },
+    ];
+
+    const merged = mergeJsonlThinkingIntoCursorTurns(primaryTurns, jsonlTurns);
+    const assistant = merged.find((t) => t.role === "assistant")!;
+    expect((assistant.blocks[0] as any).type).toBe("thinking");
+    expect((assistant.blocks[0] as any).thinking).toBe("Inspecting auth flow");
+    expect(assistant.blocks.some((b: any) => b.type === "tool_use")).toBe(true);
+  });
+
+  it("does not duplicate thinking already present in primary turns", () => {
+    const primaryTurns: ParsedTurn[] = [
+      {
+        role: "assistant",
+        blocks: [
+          { type: "thinking", thinking: "Inspecting auth flow" },
+          { type: "text", text: "Done." },
+        ] as any,
+      },
+    ];
+    const jsonlTurns: ParsedTurn[] = [
+      {
+        role: "assistant",
+        blocks: [{ type: "thinking", thinking: "Inspecting auth flow" }] as any,
+      },
+    ];
+
+    const merged = mergeJsonlThinkingIntoCursorTurns(primaryTurns, jsonlTurns);
+    const thinkingBlocks = merged[0].blocks.filter((b: any) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+  });
+
+  it("appends extra assistant thinking turns when JSONL has more assistant turns", () => {
+    const primaryTurns: ParsedTurn[] = [
+      { role: "assistant", blocks: [{ type: "text", text: "Step 1" }] as any },
+    ];
+    const jsonlTurns: ParsedTurn[] = [
+      { role: "assistant", blocks: [{ type: "text", text: "Step 1" }] as any },
+      {
+        role: "assistant",
+        blocks: [{ type: "thinking", thinking: "Waiting for command output" }] as any,
+      },
+    ];
+
+    const merged = mergeJsonlThinkingIntoCursorTurns(primaryTurns, jsonlTurns);
+    expect(merged).toHaveLength(2);
+    expect((merged[1].blocks[0] as any).type).toBe("thinking");
+    expect((merged[1].blocks[0] as any).thinking).toContain("Waiting for command output");
+  });
+});
+
+describe("parseCursorSession + JSONL thinking supplement", () => {
+  let tempDir: string;
+  let jsonlPath: string;
+
+  const baseSessionInfo: SessionInfo = {
+    provider: "cursor",
+    sessionId: "synthetic-session-001",
+    slug: "11111111",
+    project: "~/Code/synthetic",
+    cwd: "/Users/test/Code/synthetic",
+    version: "",
+    timestamp: new Date().toISOString(),
+    lineCount: 3,
+    fileSize: 100,
+    filePath: "",
+    filePaths: [],
+    workspacePath: "/Users/test/Code/synthetic",
+    firstPrompt: "synthetic",
+  };
+
+  beforeEach(async () => {
+    mockParseCursorSqlite.mockReset();
+    tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-thinking-"));
+    jsonlPath = join(tempDir, "synthetic-session.jsonl");
+    const content = [
+      JSON.stringify({
+        role: "user",
+        message: {
+          content: [{ type: "text", text: "<user_query>\nInvestigate issue\n</user_query>" }],
+        },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [{ type: "text", text: "**Inspecting logs**" }],
+        },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [{ type: "text", text: "Found root cause." }],
+        },
+      }),
+    ].join("\n");
+    await writeFile(jsonlPath, content, "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("supplements SQLite result with thinking marker from JSONL", async () => {
+    mockParseCursorSqlite.mockResolvedValue({
+      sessionId: baseSessionInfo.sessionId,
+      slug: baseSessionInfo.slug,
+      title: "Synthetic",
+      cwd: baseSessionInfo.cwd,
+      turns: [
+        { role: "user", blocks: [{ type: "text", text: "Investigate issue" }] },
+        { role: "assistant", blocks: [{ type: "text", text: "Found root cause." }] },
+      ],
+      dataSource: "global-state",
+    });
+
+    const result = await parseCursorSession(jsonlPath, {
+      ...baseSessionInfo,
+      filePath: jsonlPath,
+      filePaths: [jsonlPath],
+    });
+
+    expect(result.dataSource).toBe("global-state");
+    expect(mockParseCursorSqlite).toHaveBeenCalledWith(
+      baseSessionInfo.workspacePath,
+      baseSessionInfo.sessionId,
+    );
+
+    const assistant = result.turns.find((t) => t.role === "assistant")!;
+    expect((assistant.blocks[0] as any).type).toBe("thinking");
+    expect((assistant.blocks[0] as any).thinking).toBe("Inspecting logs");
+    expect((assistant.blocks[1] as any).type).toBe("text");
+  });
+
+  it("returns SQLite result directly when no transcript is provided", async () => {
+    mockParseCursorSqlite.mockResolvedValue({
+      sessionId: baseSessionInfo.sessionId,
+      slug: baseSessionInfo.slug,
+      title: "Synthetic",
+      cwd: baseSessionInfo.cwd,
+      turns: [{ role: "assistant", blocks: [{ type: "text", text: "DB only data" }] }],
+      dataSource: "sqlite",
+    });
+
+    const result = await parseCursorSession([], {
+      ...baseSessionInfo,
+      filePath: "",
+      filePaths: [],
+    });
+
+    expect(result.dataSource).toBe("sqlite");
+    expect(result.turns).toHaveLength(1);
+    expect((result.turns[0].blocks[0] as any).text).toBe("DB only data");
+  });
+});

--- a/packages/cli/test/transform-security.test.ts
+++ b/packages/cli/test/transform-security.test.ts
@@ -692,6 +692,58 @@ describe("combined path + secret redaction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tool diff generation edge cases
+// ---------------------------------------------------------------------------
+
+describe("tool diff generation", () => {
+  it("creates Edit diff even when old_string is missing", () => {
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Edit",
+            input: {
+              file_path: "/project/src/app.ts",
+              new_string: "console.log('updated')",
+            },
+            _result: "ok",
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const toolScene = replay.scenes.find((s) => s.type === "tool-call") as any;
+    expect(toolScene?.diff).toBeTruthy();
+    expect(toolScene.diff.filePath).toBe("/project/src/app.ts");
+    expect(toolScene.diff.oldContent).toBe("");
+    expect(toolScene.diff.newContent).toContain("updated");
+  });
+});
+
+describe("replay generator metadata", () => {
+  it("includes generator info when provided", () => {
+    const parsed = makeParsed([
+      { role: "user", blocks: [{ type: "text", text: "hello" }] },
+    ]);
+    const replay = transformToReplay(parsed, "test-provider", "~/test", {
+      generator: {
+        name: "vibe-replay",
+        version: "0.0.4",
+        generatedAt: "2026-03-07T00:00:00.000Z",
+      },
+    });
+    expect(replay.meta.generator).toEqual({
+      name: "vibe-replay",
+      version: "0.0.4",
+      generatedAt: "2026-03-07T00:00:00.000Z",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge cases
 // ---------------------------------------------------------------------------
 

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -60,7 +60,27 @@ export default function AnnotationPanel({
   onClearAddingTarget,
   readOnly = false,
 }: Props) {
-  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting, aiCoachTool, runAiCoach, cancelAiCoach, aiCoachRunning } = actions;
+  const {
+    annotations,
+    add,
+    update,
+    remove,
+    hasUnsaved,
+    canSaveHtml,
+    downloadHtml,
+    downloadJson,
+    publishGist,
+    exportHtml,
+    gistPublishing,
+    htmlExporting,
+    aiCoachTool,
+    aiCoachTools,
+    aiCoachToolName,
+    setAiCoachToolName,
+    runAiCoach,
+    cancelAiCoach,
+    aiCoachRunning,
+  } = actions;
   const [internalAdding, setInternalAdding] = useState<number | null>(null);
   const [newBody, setNewBody] = useState("");
   const [statusMsg, setStatusMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -325,6 +345,22 @@ export default function AnnotationPanel({
                     </span>
                   )}
                 </div>
+                {aiCoachTools.length > 1 && setAiCoachToolName && (
+                  <label className="block text-[9px] font-mono text-terminal-dim">
+                    Tool:
+                    <select
+                      value={aiCoachToolName || ""}
+                      onChange={(e) => setAiCoachToolName(e.target.value)}
+                      className="ml-1 bg-terminal-surface border border-terminal-border/50 rounded px-1.5 py-0.5 text-[9px] font-mono text-terminal-text"
+                    >
+                      {aiCoachTools.map((tool) => (
+                        <option key={tool.name} value={tool.name}>
+                          {tool.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                )}
                 <div className="flex gap-1.5 justify-end">
                   <button
                     onClick={() => setShowAiCoachConfirm(false)}

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -79,41 +79,14 @@ export default function StatsPanel({ session }: Props) {
           {meta.model && <span className="text-terminal-text/60">{meta.model}</span>}
           {meta.provider && <span>{meta.provider}</span>}
         </div>
-        {(meta.dataSource || meta.dataSourceInfo) && (
-          <div className="mt-1.5">
-            <div className="text-terminal-dim">
-              Data Source:{" "}
-              <span className="text-terminal-blue">
-                {formatDataSourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
-              </span>
-            </div>
-            {meta.dataSourceInfo?.sources && meta.dataSourceInfo.sources.length > 0 && (
-              <div className="mt-0.5 space-y-0.5">
-                {meta.dataSourceInfo.sources.map((source) => (
-                  <div key={source} className="text-terminal-dim/80 truncate" title={source}>
-                    <span className="text-terminal-green">source:</span> {source}
-                  </div>
-                ))}
-              </div>
-            )}
-            {meta.dataSourceInfo?.supplements && meta.dataSourceInfo.supplements.length > 0 && (
-              <div className="mt-0.5 space-y-0.5">
-                {meta.dataSourceInfo.supplements.map((source) => (
-                  <div key={source} className="text-terminal-dim/80 truncate" title={source}>
-                    <span className="text-terminal-purple">supplement:</span> {source}
-                  </div>
-                ))}
-              </div>
-            )}
-            {meta.dataSourceInfo?.notes && meta.dataSourceInfo.notes.length > 0 && (
-              <div className="mt-0.5 space-y-0.5">
-                {meta.dataSourceInfo.notes.map((note) => (
-                  <div key={note} className="text-terminal-dim/80 truncate" title={note}>
-                    <span className="text-terminal-orange">note:</span> {note}
-                  </div>
-                ))}
-              </div>
-            )}
+        {meta.generator?.version && (
+          <div className="text-terminal-dim/80 mt-0.5 truncate">
+            replay: <span className="text-terminal-text/80">{meta.generator.name} v{meta.generator.version}</span>
+          </div>
+        )}
+        {meta.generator?.generatedAt && (
+          <div className="text-terminal-dim/80 mt-0.5 truncate" title={meta.generator.generatedAt}>
+            generated: <span className="text-terminal-text/80">{formatGeneratedAt(meta.generator.generatedAt)}</span>
           </div>
         )}
       </div>
@@ -205,6 +178,46 @@ export default function StatsPanel({ session }: Props) {
           </div>
         </div>
       )}
+
+      {(meta.dataSource || meta.dataSourceInfo) && (
+        <div className="pt-1 border-t border-terminal-border/30">
+          <div className="text-terminal-dim mb-1.5 text-[11px] font-semibold uppercase tracking-wider">
+            Data Source
+          </div>
+          <div className="text-terminal-dim">
+            <span className="text-terminal-blue">
+              {formatDataSourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
+            </span>
+          </div>
+          {meta.dataSourceInfo?.sources && meta.dataSourceInfo.sources.length > 0 && (
+            <div className="mt-0.5 space-y-0.5">
+              {meta.dataSourceInfo.sources.map((source) => (
+                <div key={source} className="text-terminal-dim/80 truncate" title={source}>
+                  <span className="text-terminal-green">source:</span> {source}
+                </div>
+              ))}
+            </div>
+          )}
+          {meta.dataSourceInfo?.supplements && meta.dataSourceInfo.supplements.length > 0 && (
+            <div className="mt-0.5 space-y-0.5">
+              {meta.dataSourceInfo.supplements.map((source) => (
+                <div key={source} className="text-terminal-dim/80 truncate" title={source}>
+                  <span className="text-terminal-purple">supplement:</span> {source}
+                </div>
+              ))}
+            </div>
+          )}
+          {meta.dataSourceInfo?.notes && meta.dataSourceInfo.notes.length > 0 && (
+            <div className="mt-0.5 space-y-0.5">
+              {meta.dataSourceInfo.notes.map((note) => (
+                <div key={note} className="text-terminal-dim/80 truncate" title={note}>
+                  <span className="text-terminal-orange">note:</span> {note}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -250,4 +263,17 @@ function formatDataSourceLabel(source?: string): string {
     "jsonl+tools": "JSONL + agent-tools",
   };
   return labels[source] || source;
+}
+
+function formatGeneratedAt(iso?: string): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -79,6 +79,43 @@ export default function StatsPanel({ session }: Props) {
           {meta.model && <span className="text-terminal-text/60">{meta.model}</span>}
           {meta.provider && <span>{meta.provider}</span>}
         </div>
+        {(meta.dataSource || meta.dataSourceInfo) && (
+          <div className="mt-1.5">
+            <div className="text-terminal-dim">
+              Data Source:{" "}
+              <span className="text-terminal-blue">
+                {formatDataSourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
+              </span>
+            </div>
+            {meta.dataSourceInfo?.sources && meta.dataSourceInfo.sources.length > 0 && (
+              <div className="mt-0.5 space-y-0.5">
+                {meta.dataSourceInfo.sources.map((source) => (
+                  <div key={source} className="text-terminal-dim/80 truncate" title={source}>
+                    <span className="text-terminal-green">source:</span> {source}
+                  </div>
+                ))}
+              </div>
+            )}
+            {meta.dataSourceInfo?.supplements && meta.dataSourceInfo.supplements.length > 0 && (
+              <div className="mt-0.5 space-y-0.5">
+                {meta.dataSourceInfo.supplements.map((source) => (
+                  <div key={source} className="text-terminal-dim/80 truncate" title={source}>
+                    <span className="text-terminal-purple">supplement:</span> {source}
+                  </div>
+                ))}
+              </div>
+            )}
+            {meta.dataSourceInfo?.notes && meta.dataSourceInfo.notes.length > 0 && (
+              <div className="mt-0.5 space-y-0.5">
+                {meta.dataSourceInfo.notes.map((note) => (
+                  <div key={note} className="text-terminal-dim/80 truncate" title={note}>
+                    <span className="text-terminal-orange">note:</span> {note}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="grid grid-cols-2 gap-2">
@@ -202,4 +239,15 @@ function formatDuration(ms: number): string {
   if (mins < 60) return `${mins}m ${secs % 60}s`;
   const hrs = Math.floor(mins / 60);
   return `${hrs}h ${mins % 60}m`;
+}
+
+function formatDataSourceLabel(source?: string): string {
+  if (!source) return "unknown";
+  const labels: Record<string, string> = {
+    sqlite: "SQLite (store.db)",
+    "global-state": "SQLite (global state.vscdb)",
+    jsonl: "JSONL transcript",
+    "jsonl+tools": "JSONL + agent-tools",
+  };
+  return labels[source] || source;
 }

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -21,6 +21,12 @@ export interface AnnotationActions {
   htmlExporting: boolean;
   /** Editor mode: detected AI Coach tool info (null if unavailable) */
   aiCoachTool: { name: string } | null;
+  /** Editor mode: available AI Coach tool options */
+  aiCoachTools: Array<{ name: string }>;
+  /** Editor mode: selected AI Coach tool name */
+  aiCoachToolName: string | null;
+  /** Editor mode: update selected AI Coach tool */
+  setAiCoachToolName: ((toolName: string) => void) | null;
   /** Editor mode: run AI Coach to generate feedback annotations */
   runAiCoach: (() => Promise<{ score: number; itemCount: number }>) | null;
   /** Editor mode: cancel a running AI Coach operation */
@@ -221,21 +227,38 @@ export function useAnnotations(
     : null;
 
   // AI Coach (editor mode)
-  const [aiCoachTool, setAiCoachTool] = useState<{ name: string } | null>(null);
+  const [aiCoachTools, setAiCoachTools] = useState<Array<{ name: string }>>([]);
+  const [aiCoachToolName, setAiCoachToolNameState] = useState<string | null>(null);
   const [aiCoachRunning, setAiCoachRunning] = useState(false);
   const aiCoachAbortRef = useRef<AbortController | null>(null);
+  const aiCoachTool = useMemo(
+    () => (aiCoachToolName ? aiCoachTools.find((t) => t.name === aiCoachToolName) || null : null),
+    [aiCoachToolName, aiCoachTools],
+  );
 
   useEffect(() => {
     if (!isEditor) return;
     fetch("/api/feedback/detect")
       .then((r) => r.json())
       .then((data) => {
-        if (data.available && data.tool) setAiCoachTool(data.tool);
+        if (!data.available) return;
+        const tools: Array<{ name: string }> = Array.isArray(data.tools)
+          ? data.tools
+          : data.tool
+          ? [data.tool]
+          : [];
+        setAiCoachTools(tools);
+        const defaultToolName =
+          data.defaultTool?.name ||
+          data.tool?.name ||
+          tools[0]?.name ||
+          null;
+        setAiCoachToolNameState(defaultToolName);
       })
       .catch(() => {});
   }, [isEditor]);
 
-  const runAiCoach = isEditor && aiCoachTool
+  const runAiCoach = isEditor && aiCoachToolName
     ? async () => {
         const controller = new AbortController();
         aiCoachAbortRef.current = controller;
@@ -250,6 +273,8 @@ export function useAnnotations(
           });
           const resp = await fetch("/api/feedback/generate", {
             method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ toolName: aiCoachToolName }),
             signal: controller.signal,
           });
           const data = await resp.json();
@@ -261,6 +286,12 @@ export function useAnnotations(
           aiCoachAbortRef.current = null;
           setAiCoachRunning(false);
         }
+      }
+    : null;
+
+  const setAiCoachToolName = isEditor
+    ? (toolName: string) => {
+        setAiCoachToolNameState(toolName);
       }
     : null;
 
@@ -301,6 +332,6 @@ export function useAnnotations(
     downloadHtml, downloadJson,
     publishGist, exportHtml,
     gistPublishing, htmlExporting,
-    aiCoachTool, runAiCoach, cancelAiCoach, aiCoachRunning,
+    aiCoachTool, aiCoachTools, aiCoachToolName, setAiCoachToolName, runAiCoach, cancelAiCoach, aiCoachRunning,
   };
 }

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -45,6 +45,11 @@ export interface ReplaySession {
     model?: string;
     cwd: string;
     project: string;
+    generator?: {
+      name: string;
+      version: string;
+      generatedAt: string;
+    };
     stats: {
       sceneCount: number;
       userPrompts: number;

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -25,6 +25,13 @@ export interface Annotation {
   resolved: boolean;
 }
 
+export interface DataSourceInfo {
+  primary: string;
+  sources: string[];
+  supplements?: string[];
+  notes?: string[];
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;
@@ -32,6 +39,7 @@ export interface ReplaySession {
     title?: string;
     provider: string;
     dataSource?: string;
+    dataSourceInfo?: DataSourceInfo;
     startTime: string;
     endTime?: string;
     model?: string;


### PR DESCRIPTION
## Summary
- ingest Cursor sessions from host `globalStorage/state.vscdb` and keep DB-backed parsing (`store.db` / global-state) as the primary source of truth
- supplement DB-backed sessions with JSONL-only signals: missing assistant thinking blocks and user image attachments from `<image_files>` paths (embedded as data URLs)
- expose richer replay metadata (`dataSourceInfo` + `generator` with `name/version/generatedAt`) and show generator info/time in the Stats panel
- add `agent` as an AI Coach backend option (alongside `claude` and `opencode`) with tool selection in editor mode; keep `claude` as default priority
- improve transform behavior/tests around edit diffs and add synthetic coverage for image supplementation + generator metadata

## Test plan
- [x] `pnpm --filter vibe-replay test`
- [x] `pnpm build`
- [x] Headless tool probing on this machine:
  - `agent -p --output-format json --mode ask --trust "Reply with exactly: HELLO_JSON_SHAPE"`
  - verified JSON shape includes `result`, and feedback runner reads `result` correctly