### PR TITLE
feat: vibe-feedback — AI-powered prompting coach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ packages/cli/src/
 │       └── sqlite-reader.ts    # SQLite store.db parser (primary)
 ├── transform.ts                # Provider-agnostic: turns → Scene[] + secret redaction
 ├── generator.ts                # Inject JSON into viewer HTML
+├── feedback.ts                 # AI feedback: detect CLI tools, run headlessly, parse results
 └── publishers/                 # Publish targets
     ├── local.ts                # Open in browser
     └── gist.ts                 # Publish to GitHub Gist
@@ -87,6 +88,7 @@ packages/cli/src/
 - **Editor mode**: "Open in Editor" starts a Hono localhost server (port 3456-3466) serving the viewer with `__VIBE_REPLAY_EDITOR__` flag. Viewer fetches session from `/api/session`, annotations POST to `/api/annotations` (debounced 1s) and persist to `{outputDir}/annotations.json`. Server also handles gist publishing and HTML export via API routes
 - **ViewerMode**: Three-mode enum (`embedded | editor | readonly`) drives viewer behavior — embedded for self-contained HTML, editor for local server, readonly for `?gist=` / `?url=` URLs
 - **Markdown rendering**: Uses `marked` (lightweight, ~37KB) instead of `react-markdown` + `remark-gfm` to keep viewer under 500KB
+- **vibe-feedback (experimental)**: AI-powered prompting feedback. Detects `claude` or `opencode` CLI tools, runs headlessly with structured prompt, parses JSON output (with repair for truncated/malformed responses), generates annotations with `author: "vibe-feedback"`. Skips `claude` when inside a Claude Code session (env `CLAUDECODE`). Uses stdin pipe for opencode, stdin for claude. Viewer shows AI feedback annotations with purple "AI Coach" badge
 
 ## Data Flow
 
@@ -99,6 +101,7 @@ packages/cli/src/
   → generator.ts → inject into viewer.html → vibe-replay/<slug>/index.html + replay.json
   → publishers/ → local (open browser) | gist (gh gist create → vibe-replay.com viewer)
   → server.ts → editor mode (localhost Hono server → viewer fetches /api/session, saves annotations via API)
+  → feedback.ts → (optional) detect CLI tool → headless AI analysis → annotations with author "vibe-feedback"
 ```
 
 Scene types: `user-prompt`, `thinking`, `text-response`, `tool-call`

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -1,0 +1,694 @@
+/**
+ * vibe-feedback: AI-powered prompting feedback for coding sessions.
+ *
+ * Detects available AI CLI tools (claude, opencode) and runs them headlessly
+ * to analyze a replay session and generate structured feedback on the user's
+ * prompting technique. Feedback is returned as Annotation[] that merges
+ * directly into the replay.
+ *
+ * Experimental feature — output quality depends on the model behind the CLI.
+ */
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import type { ReplaySession, Scene, Annotation } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FeedbackTool {
+  name: "claude" | "opencode";
+  command: string;
+}
+
+export interface FeedbackItem {
+  sceneIndex: number;
+  title: string;
+  feedback: string;
+  category:
+    | "clarity"
+    | "specificity"
+    | "context"
+    | "efficiency"
+    | "iteration"
+    | "tool-usage";
+  improvedPrompt?: string;
+}
+
+export interface FeedbackResult {
+  summary: string;
+  score: number;
+  strengths: string[];
+  improvements: string[];
+  feedbackItems: FeedbackItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/** Detect which AI CLI tool is available (prefer claude, fallback opencode). */
+export async function detectFeedbackTools(): Promise<FeedbackTool | null> {
+  // Skip claude when running inside a Claude Code session (nested sessions crash)
+  const insideClaude = !!process.env.CLAUDECODE;
+
+  const candidates: { name: FeedbackTool["name"]; cmd: string }[] = [
+    ...(!insideClaude ? [{ name: "claude" as const, cmd: "claude" }] : []),
+    { name: "opencode" as const, cmd: "opencode" },
+  ];
+
+  for (const tool of candidates) {
+    try {
+      const path = await shell(`which ${tool.cmd}`);
+      if (path.trim()) return { name: tool.name, command: path.trim() };
+    } catch {
+      /* not found */
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Session digest — condense session for AI consumption
+// ---------------------------------------------------------------------------
+
+function buildSessionDigest(session: ReplaySession): string {
+  const lines: string[] = [];
+  const promptCount = session.meta.stats.userPrompts;
+
+  // Adaptive truncation budgets based on number of prompts
+  const maxPromptChars = Math.min(3000, Math.floor(25000 / Math.max(promptCount, 1)));
+  const maxResponseChars = Math.min(800, Math.floor(12000 / Math.max(promptCount, 1)));
+
+  let turnNum = 0;
+  let turnLines: string[] = [];
+  let responseChars = 0;
+
+  const flush = () => {
+    if (turnLines.length) {
+      lines.push(...turnLines, "");
+      turnLines = [];
+      responseChars = 0;
+    }
+  };
+
+  for (let i = 0; i < session.scenes.length; i++) {
+    const scene = session.scenes[i];
+
+    if (scene.type === "user-prompt") {
+      flush();
+      turnNum++;
+      turnLines.push(`=== TURN ${turnNum} (scene ${i}) ===`);
+      turnLines.push("[USER PROMPT]:");
+      const content =
+        scene.content.length > maxPromptChars
+          ? scene.content.slice(0, maxPromptChars) + "\n...(truncated)"
+          : scene.content;
+      turnLines.push(content);
+      turnLines.push("");
+      turnLines.push("[ASSISTANT RESPONSE]:");
+    } else if (scene.type === "thinking") {
+      if (responseChars < maxResponseChars) {
+        const summary =
+          scene.content.length > 200
+            ? scene.content.slice(0, 200) + "..."
+            : scene.content;
+        turnLines.push(`  - Thinking: ${summary}`);
+        responseChars += summary.length;
+      }
+    } else if (scene.type === "text-response") {
+      if (responseChars < maxResponseChars) {
+        const budget = maxResponseChars - responseChars;
+        const summary =
+          scene.content.length > budget
+            ? scene.content.slice(0, budget) + "..."
+            : scene.content;
+        turnLines.push(`  - Text: ${summary}`);
+        responseChars += summary.length;
+      }
+    } else if (scene.type === "tool-call") {
+      if (scene.diff) {
+        turnLines.push(
+          `  - ${scene.toolName}: ${scene.diff.filePath}`,
+        );
+      } else if (scene.bashOutput) {
+        const cmd =
+          scene.bashOutput.command.length > 120
+            ? scene.bashOutput.command.slice(0, 120) + "..."
+            : scene.bashOutput.command;
+        turnLines.push(`  - Bash: ${cmd}`);
+      } else {
+        const input = JSON.stringify(scene.input).slice(0, 100);
+        turnLines.push(`  - ${scene.toolName}: ${input}`);
+      }
+    } else if (scene.type === "compaction-summary") {
+      turnLines.push("  - [Context compaction — earlier context was summarized]");
+    }
+  }
+  flush();
+
+  // Hard cap for safety (roughly 30KB ≈ ~7500 tokens)
+  const digest = lines.join("\n");
+  if (digest.length > 35000) {
+    return (
+      digest.slice(0, 35000) +
+      "\n\n... (remaining turns omitted due to length)"
+    );
+  }
+  return digest;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt construction
+// ---------------------------------------------------------------------------
+
+const FEEDBACK_SCHEMA = `{
+  "summary": "<string: 2-3 paragraph overall assessment>",
+  "score": <number 1-10>,
+  "strengths": ["<string>", ...],
+  "improvements": ["<string>", ...],
+  "feedbackItems": [
+    {
+      "sceneIndex": <number: must be a user-prompt scene index from the transcript>,
+      "title": "<string: short descriptive title>",
+      "feedback": "<string: detailed actionable feedback>",
+      "category": "<clarity|specificity|context|efficiency|iteration|tool-usage>",
+      "improvedPrompt": "<string|null: optional rewritten prompt>"
+    }
+  ]
+}`;
+
+const FEEDBACK_EXAMPLE = `{
+  "summary": "The user demonstrates good instincts for task decomposition, breaking complex work into manageable steps. However, several prompts lack specificity — the AI had to spend extra turns searching for context that could have been provided upfront. The strongest prompts came later in the session after the user learned what information the AI needed.",
+  "score": 6,
+  "strengths": [
+    "Good task decomposition — complex feature was broken into clear steps",
+    "Effective recovery when the AI went off-track in turn 3"
+  ],
+  "improvements": [
+    "Include file paths when referencing specific code",
+    "State expected behavior alongside the bug description",
+    "Provide constraints (performance, compatibility) upfront rather than after rework"
+  ],
+  "feedbackItems": [
+    {
+      "sceneIndex": 0,
+      "title": "Vague bug description",
+      "feedback": "The prompt says 'fix the auth bug' without specifying the symptom, expected behavior, or relevant files. This forced the AI to spend 3 tool calls searching for the issue. Providing the error message and file path would have saved significant time.",
+      "category": "context",
+      "improvedPrompt": "Fix the authentication bug in src/auth/login.ts — users get 401 errors with valid credentials. The issue started after the token validation refactor last week. Expected: valid JWT tokens should pass validation."
+    }
+  ]
+}`;
+
+function buildFeedbackPrompt(
+  digest: string,
+  session: ReplaySession,
+): string {
+  const userPromptIndices = session.scenes
+    .map((s, i) => (s.type === "user-prompt" ? i : -1))
+    .filter((i) => i !== -1);
+
+  const durationStr = session.meta.stats.durationMs
+    ? `${Math.round(session.meta.stats.durationMs / 60000)} min`
+    : "unknown";
+  const costStr = session.meta.stats.costEstimate
+    ? `$${session.meta.stats.costEstimate.toFixed(2)}`
+    : "unknown";
+
+  return `You are an expert AI coding coach. Analyze this recorded AI coding session and provide detailed, constructive feedback on the user's prompting technique.
+
+## Session Info
+- Provider: ${session.meta.provider}
+- Model: ${session.meta.model || "unknown"}
+- Project: ${session.meta.project}
+- Duration: ${durationStr}
+- User prompts: ${session.meta.stats.userPrompts}
+- Tool calls: ${session.meta.stats.toolCalls}
+- Estimated cost: ${costStr}
+
+## Session Transcript
+
+${digest}
+
+## Valid User-Prompt Scene Indices
+ONLY use these values for sceneIndex: [${userPromptIndices.join(", ")}]
+
+## Analysis Guidelines
+For each user prompt, consider:
+1. **Clarity** — Was it unambiguous? Could the AI misinterpret?
+2. **Specificity** — Enough detail, file paths, constraints?
+3. **Context** — Did the user explain what they're trying to achieve?
+4. **Efficiency** — Could fewer or better prompts achieve the same result?
+5. **Iteration** — When things went wrong, how well did the user course-correct?
+6. **Tool-usage** — Did the user leverage the AI's capabilities (search, test, etc.)?
+
+## Required Output
+Respond with ONLY a valid JSON object. No markdown code fences. No explanation before or after.
+
+Schema:
+${FEEDBACK_SCHEMA}
+
+Example (for reference only — analyze the ACTUAL session above):
+${FEEDBACK_EXAMPLE}
+
+CRITICAL RULES:
+- DO NOT use any tools, file reads, or web searches. Analyze ONLY the transcript above.
+- Output ONLY the JSON object — no other text
+- sceneIndex MUST be one of: [${userPromptIndices.join(", ")}]
+- Provide feedback for the most impactful prompts (at least ${Math.min(userPromptIndices.length, 3)}, up to ${Math.min(userPromptIndices.length, 10)})
+- score: 1 = very poor, 5 = average, 8 = strong, 10 = expert
+- Be constructive and encouraging, but honest
+- improvedPrompt is optional — only when you have a concretely better version
+- Think step by step about each prompt in context before judging it`;
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+async function executeFeedback(
+  prompt: string,
+  tool: FeedbackTool,
+): Promise<string> {
+  if (tool.name === "claude") {
+    return runClaude(prompt, tool.command);
+  }
+  return runOpencode(prompt, tool.command);
+}
+
+function runClaude(prompt: string, cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, ["-p", "--output-format", "json"], {
+      env: { ...process.env, NO_COLOR: "1" },
+      timeout: 600_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d) => (stdout += d.toString()));
+    proc.stderr.on("data", (d) => (stderr += d.toString()));
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        try {
+          const parsed = JSON.parse(stdout);
+          resolve(parsed.result || stdout);
+        } catch {
+          resolve(stdout);
+        }
+      } else {
+        reject(new Error(`claude exited ${code}: ${stderr.slice(0, 500)}`));
+      }
+    });
+
+    proc.on("error", (err) =>
+      reject(new Error(`Failed to start claude: ${err.message}`)),
+    );
+
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+  });
+}
+
+function runOpencode(prompt: string, cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Use stdin pipe: opencode reads from stdin when run without message args
+    const proc = spawn(cmd, ["run"], {
+      env: { ...process.env, NO_COLOR: "1", TERM: "dumb" },
+      timeout: 600_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d) => (stdout += d.toString()));
+    proc.stderr.on("data", (d) => (stderr += d.toString()));
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve(stripAnsi(stdout));
+      } else {
+        reject(
+          new Error(`opencode exited ${code}: ${stripAnsi(stderr).slice(0, 500)}`),
+        );
+      }
+    });
+
+    proc.on("error", (err) =>
+      reject(new Error(`Failed to start opencode: ${err.message}`)),
+    );
+
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parsing & validation
+// ---------------------------------------------------------------------------
+
+function parseFeedbackResponse(
+  output: string,
+  session: ReplaySession,
+): FeedbackResult | null {
+  const json = extractJson(output);
+  if (!json) return null;
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+
+  // Validate top-level shape
+  if (!parsed || typeof parsed !== "object") return null;
+  if (typeof parsed.summary !== "string" || !parsed.summary) return null;
+  if (typeof parsed.score !== "number") return null;
+  parsed.score = Math.max(1, Math.min(10, Math.round(parsed.score)));
+  if (!Array.isArray(parsed.strengths)) parsed.strengths = [];
+  if (!Array.isArray(parsed.improvements)) parsed.improvements = [];
+  if (!Array.isArray(parsed.feedbackItems)) parsed.feedbackItems = [];
+
+  // Valid user-prompt scene indices
+  const validIndices = new Set(
+    session.scenes
+      .map((s, i) => (s.type === "user-prompt" ? i : -1))
+      .filter((i) => i !== -1),
+  );
+  const validCategories = new Set([
+    "clarity",
+    "specificity",
+    "context",
+    "efficiency",
+    "iteration",
+    "tool-usage",
+  ]);
+
+  const items: FeedbackItem[] = [];
+  for (const raw of parsed.feedbackItems) {
+    if (!raw || typeof raw !== "object") continue;
+    if (typeof raw.sceneIndex !== "number") continue;
+    if (!validIndices.has(raw.sceneIndex)) continue;
+    if (typeof raw.title !== "string" || !raw.title) continue;
+    if (typeof raw.feedback !== "string" || !raw.feedback) continue;
+
+    items.push({
+      sceneIndex: raw.sceneIndex,
+      title: raw.title,
+      feedback: raw.feedback,
+      category: validCategories.has(raw.category) ? raw.category : "clarity",
+      improvedPrompt:
+        typeof raw.improvedPrompt === "string" && raw.improvedPrompt
+          ? raw.improvedPrompt
+          : undefined,
+    });
+  }
+
+  return {
+    summary: parsed.summary,
+    score: parsed.score,
+    strengths: parsed.strengths.filter((s: any) => typeof s === "string"),
+    improvements: parsed.improvements.filter((s: any) => typeof s === "string"),
+    feedbackItems: items,
+  };
+}
+
+/** Best-effort JSON extraction from potentially noisy output. */
+function extractJson(raw: string): string | null {
+  const str = raw.trim();
+
+  // 0. Pre-process: fix common model errors
+  //    - Missing { before "sceneIndex" in feedbackItems array
+  const preFixed = str.replace(
+    /},\s*"sceneIndex"\s*:/g,
+    '},{"sceneIndex":',
+  );
+
+  // 1. Try raw parse (with pre-fix applied)
+  for (const candidate of [preFixed, str]) {
+    try {
+      JSON.parse(candidate);
+      return candidate;
+    } catch {
+      /* continue */
+    }
+  }
+
+  // 2. Try removing markdown fences
+  const fenceMatch = str.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    try {
+      JSON.parse(fenceMatch[1].trim());
+      return fenceMatch[1].trim();
+    } catch {
+      /* continue */
+    }
+  }
+
+  // 3. Find balanced top-level { ... } (try pre-fixed first)
+  const candidates = preFixed !== str ? [preFixed, str] : [str];
+  for (const s of candidates) {
+    const found = findBalancedJson(s);
+    if (found) return found;
+  }
+
+  // 4. Handle truncated JSON — try to repair by closing open brackets
+  for (const s of candidates) {
+    const firstBrace = s.indexOf("{");
+    if (firstBrace !== -1) {
+      const repaired = repairTruncatedJson(s.slice(firstBrace));
+      if (repaired) return repaired;
+    }
+  }
+
+  return null;
+}
+
+function findBalancedJson(str: string): string | null {
+  let depth = 0;
+  let start = -1;
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === "{") {
+      if (start === -1) start = i;
+      depth++;
+    } else if (str[i] === "}") {
+      depth--;
+      if (depth === 0 && start !== -1) {
+        const candidate = str.slice(start, i + 1);
+        try {
+          JSON.parse(candidate);
+          return candidate;
+        } catch {
+          start = -1;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/** Attempt to repair truncated JSON by closing brackets and trimming bad tails. */
+function repairTruncatedJson(str: string): string | null {
+  // Strip trailing partial string/value by finding last valid JSON structure point
+  // Look backwards for the last complete value boundary (, } ] or complete string)
+  let candidate = str;
+
+  // If we're mid-string, truncate to last complete key-value or array item
+  const lastGoodPoints = [
+    candidate.lastIndexOf("},"),
+    candidate.lastIndexOf("}]"),
+    candidate.lastIndexOf('"]'),
+    candidate.lastIndexOf('",'),
+    candidate.lastIndexOf("null,"),
+    candidate.lastIndexOf("null}"),
+  ];
+  const lastGood = Math.max(...lastGoodPoints);
+
+  if (lastGood > candidate.length * 0.5) {
+    // Check what comes after the last good point
+    const afterChar = candidate[lastGood];
+    if (afterChar === "}") {
+      candidate = candidate.slice(0, lastGood + 1);
+    } else {
+      candidate = candidate.slice(0, lastGood + 1);
+    }
+  }
+
+  // Count unclosed brackets and add closing ones
+  let braces = 0;
+  let brackets = 0;
+  let inString = false;
+  let escaped = false;
+  for (const ch of candidate) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") braces++;
+    else if (ch === "}") braces--;
+    else if (ch === "[") brackets++;
+    else if (ch === "]") brackets--;
+  }
+
+  // Close what's open
+  let suffix = "";
+  while (brackets > 0) {
+    suffix += "]";
+    brackets--;
+  }
+  while (braces > 0) {
+    suffix += "}";
+    braces--;
+  }
+
+  if (!suffix) return null;
+
+  const repaired = candidate + suffix;
+  try {
+    JSON.parse(repaired);
+    return repaired;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Annotation conversion
+// ---------------------------------------------------------------------------
+
+function feedbackToAnnotations(feedback: FeedbackResult): Annotation[] {
+  const now = new Date().toISOString();
+  const annotations: Annotation[] = [];
+
+  // Overall summary (attached to first scene)
+  const summaryBody = [
+    `## Prompting Score: ${feedback.score}/10\n`,
+    feedback.summary,
+    "",
+    "**Strengths**",
+    ...feedback.strengths.map((s) => `- ${s}`),
+    "",
+    "**Areas for Improvement**",
+    ...feedback.improvements.map((s) => `- ${s}`),
+  ].join("\n");
+
+  annotations.push({
+    id: randomUUID(),
+    sceneIndex: 0,
+    body: summaryBody,
+    author: "vibe-feedback",
+    createdAt: now,
+    updatedAt: now,
+    resolved: false,
+  });
+
+  // Per-prompt feedback
+  for (const item of feedback.feedbackItems) {
+    const categoryLabel: Record<string, string> = {
+      clarity: "Clarity",
+      specificity: "Specificity",
+      context: "Context",
+      efficiency: "Efficiency",
+      iteration: "Iteration",
+      "tool-usage": "Tool Usage",
+    };
+    const label = categoryLabel[item.category] || item.category;
+
+    let body = `**${item.title}** \`${label}\`\n\n${item.feedback}`;
+    if (item.improvedPrompt) {
+      body += `\n\n**Suggested prompt:**\n> ${item.improvedPrompt.replace(/\n/g, "\n> ")}`;
+    }
+
+    annotations.push({
+      id: randomUUID(),
+      sceneIndex: item.sceneIndex,
+      body,
+      author: "vibe-feedback",
+      createdAt: now,
+      updatedAt: now,
+      resolved: false,
+    });
+  }
+
+  return annotations;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate AI feedback for a replay session.
+ * Returns annotations + parsed result, or null on failure.
+ * Set debug=true to write raw output to /tmp for troubleshooting.
+ */
+export async function generateFeedback(
+  session: ReplaySession,
+  tool: FeedbackTool,
+  { debug = false }: { debug?: boolean } = {},
+): Promise<{ annotations: Annotation[]; result: FeedbackResult } | null> {
+  if (session.meta.stats.userPrompts === 0) {
+    return null;
+  }
+
+  const digest = buildSessionDigest(session);
+  const prompt = buildFeedbackPrompt(digest, session);
+
+  if (debug) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync("/tmp/vibe-feedback-prompt.txt", prompt);
+  }
+
+  const output = await executeFeedback(prompt, tool);
+
+  if (debug) {
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync("/tmp/vibe-feedback-raw-output.txt", output);
+  }
+
+  const result = parseFeedbackResponse(output, session);
+
+  if (!result || result.feedbackItems.length === 0) {
+    return null;
+  }
+
+  return { annotations: feedbackToAnnotations(result), result };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str
+    .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "")
+    .replace(/\x1B\][^\x07]*\x07/g, "");
+}
+
+function shell(cmd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("sh", ["-c", cmd], { timeout: 5000 });
+    let out = "";
+    proc.stdout.on("data", (d) => (out += d.toString()));
+    proc.on("close", (code) => {
+      if (code === 0) resolve(out);
+      else reject(new Error(`${cmd} failed`));
+    });
+    proc.on("error", reject);
+  });
+}

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -471,11 +471,27 @@ function extractJson(raw: string): string | null {
 function findBalancedJson(str: string): string | null {
   let depth = 0;
   let start = -1;
+  let inString = false;
+  let escaped = false;
   for (let i = 0; i < str.length; i++) {
-    if (str[i] === "{") {
+    const ch = str[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") {
       if (start === -1) start = i;
       depth++;
-    } else if (str[i] === "}") {
+    } else if (ch === "}") {
       depth--;
       if (depth === 0 && start !== -1) {
         const candidate = str.slice(start, i + 1);
@@ -510,13 +526,7 @@ function repairTruncatedJson(str: string): string | null {
   const lastGood = Math.max(...lastGoodPoints);
 
   if (lastGood > candidate.length * 0.5) {
-    // Check what comes after the last good point
-    const afterChar = candidate[lastGood];
-    if (afterChar === "}") {
-      candidate = candidate.slice(0, lastGood + 1);
-    } else {
-      candidate = candidate.slice(0, lastGood + 1);
-    }
+    candidate = candidate.slice(0, lastGood + 1);
   }
 
   // Count unclosed brackets and add closing ones

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,6 @@ import { publishLocal } from "./publishers/local.js";
 import { publishGist, checkGhStatus, loadSavedGistInfo } from "./publishers/gist.js";
 import { startEditor } from "./server.js";
 import { scanForSecrets } from "./scan.js";
-import { detectFeedbackTools, generateFeedback } from "./feedback.js";
 import type { SessionInfo, ReplaySession } from "./types.js";
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
@@ -156,48 +155,6 @@ program
       console.log(chalk.dim("  Continuing — user confirmed findings are safe.\n"));
     }
 
-    // AI Feedback (experimental) — detect CLI tools and offer analysis
-    const feedbackTool = await detectFeedbackTools();
-    if (feedbackTool) {
-      console.log();
-      console.log(
-        chalk.dim("  [experimental]") +
-          ` AI Coding Coach available ${chalk.dim(`(${feedbackTool.name} detected)`)}`,
-      );
-
-      const { confirm } = await import("@inquirer/prompts");
-      const wantFeedback = await confirm({
-        message:
-          "Get AI feedback on your prompting? (may take a few minutes)",
-        default: false,
-      });
-
-      if (wantFeedback) {
-        const fbSpinner = ora(
-          "Analyzing your prompting patterns...",
-        ).start();
-        try {
-          const fb = await generateFeedback(replay, feedbackTool);
-          if (fb) {
-            replay.annotations = [
-              ...(replay.annotations || []),
-              ...fb.annotations,
-            ];
-            // Re-generate output with feedback annotations baked in
-            await generateOutput(replay, outputDir);
-
-            fbSpinner.succeed(
-              `Score: ${fb.result.score}/10 — ${fb.result.feedbackItems.length} feedback item(s) added as annotations`,
-            );
-          } else {
-            fbSpinner.warn("Could not parse AI feedback (invalid output)");
-          }
-        } catch (err: any) {
-          fbSpinner.fail(`Feedback failed: ${err.message}`);
-        }
-      }
-    }
-
     // Check gh availability for gist option
     const ghStatus = await checkGhStatus();
     const gistLabel = ghStatus.available
@@ -216,7 +173,7 @@ program
           }]
         : []),
       { name: `${chalk.magenta("✎")} Open in Editor ${chalk.dim("(annotate, publish, export)")}`, value: "editor" as const },
-      { name: `${chalk.green("▶")} Quick preview ${chalk.dim("(open HTML in browser, no editing)")}`, value: "local" as const },
+      { name: `${chalk.green("●")} Quick preview ${chalk.dim("(open HTML in browser, no editing)")}`, value: "local" as const },
       { name: gistLabel, value: "gist" as const },
       { name: `${chalk.dim("✕")} Exit`, value: "exit" as const },
     ];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { publishLocal } from "./publishers/local.js";
 import { publishGist, checkGhStatus, loadSavedGistInfo } from "./publishers/gist.js";
 import { startEditor } from "./server.js";
 import { scanForSecrets } from "./scan.js";
+import { detectFeedbackTools, generateFeedback } from "./feedback.js";
 import type { SessionInfo, ReplaySession } from "./types.js";
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
@@ -153,6 +154,48 @@ program
         process.exit(1);
       }
       console.log(chalk.dim("  Continuing — user confirmed findings are safe.\n"));
+    }
+
+    // AI Feedback (experimental) — detect CLI tools and offer analysis
+    const feedbackTool = await detectFeedbackTools();
+    if (feedbackTool) {
+      console.log();
+      console.log(
+        chalk.dim("  [experimental]") +
+          ` AI Coding Coach available ${chalk.dim(`(${feedbackTool.name} detected)`)}`,
+      );
+
+      const { confirm } = await import("@inquirer/prompts");
+      const wantFeedback = await confirm({
+        message:
+          "Get AI feedback on your prompting? (may take a few minutes)",
+        default: false,
+      });
+
+      if (wantFeedback) {
+        const fbSpinner = ora(
+          "Analyzing your prompting patterns...",
+        ).start();
+        try {
+          const fb = await generateFeedback(replay, feedbackTool);
+          if (fb) {
+            replay.annotations = [
+              ...(replay.annotations || []),
+              ...fb.annotations,
+            ];
+            // Re-generate output with feedback annotations baked in
+            await generateOutput(replay, outputDir);
+
+            fbSpinner.succeed(
+              `Score: ${fb.result.score}/10 — ${fb.result.feedbackItems.length} feedback item(s) added as annotations`,
+            );
+          } else {
+            fbSpinner.warn("Could not parse AI feedback (invalid output)");
+          }
+        } catch (err: any) {
+          fbSpinner.fail(`Feedback failed: ${err.message}`);
+        }
+      }
     }
 
     // Check gh availability for gist option

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -9,6 +9,7 @@ import chalk from "chalk";
 import type { ReplaySession, Annotation } from "./types.js";
 import { generateOutput } from "./generator.js";
 import { checkGhStatus, publishGist, loadSavedGistInfo } from "./publishers/gist.js";
+import { detectFeedbackTools, generateFeedback } from "./feedback.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -132,10 +133,53 @@ export async function startEditor(
     }
   });
 
+  // AI Feedback — detect available CLI tools
+  app.get("/api/feedback/detect", async (c) => {
+    try {
+      const tool = await detectFeedbackTools();
+      if (tool) {
+        return c.json({ available: true, tool: { name: tool.name } });
+      }
+      return c.json({ available: false });
+    } catch {
+      return c.json({ available: false });
+    }
+  });
+
+  // AI Feedback — generate feedback annotations
+  app.post("/api/feedback/generate", async (c) => {
+    try {
+      const tool = await detectFeedbackTools();
+      if (!tool) {
+        return c.json({ error: "No AI CLI tool available (claude or opencode)" }, 400);
+      }
+      const fb = await generateFeedback({ ...session, annotations }, tool);
+      if (!fb) {
+        return c.json({ error: "Could not generate feedback (invalid AI output)" }, 500);
+      }
+      // Replace any previous vibe-feedback annotations and merge new ones
+      annotations = [
+        ...annotations.filter((a) => a.author !== "vibe-feedback"),
+        ...fb.annotations,
+      ];
+      // Persist to disk
+      try {
+        await writeFile(annotationsPath, JSON.stringify(annotations, null, 2), "utf-8");
+      } catch { /* ignore write errors */ }
+      return c.json({
+        annotations,
+        score: fb.result.score,
+        itemCount: fb.result.feedbackItems.length,
+      });
+    } catch (err: any) {
+      return c.json({ error: err.message || "Feedback generation failed" }, 500);
+    }
+  });
+
   const port = await findFreePort(3456, 3466);
   const url = `http://localhost:${port}`;
 
-  serve({ fetch: app.fetch, port }, () => {
+  serve({ fetch: app.fetch, port, hostname: "127.0.0.1" }, () => {
     console.log(
       chalk.bold.cyan("\n  Editor running at ") +
         chalk.white(url) +

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -60,11 +60,12 @@ export default function AnnotationPanel({
   onClearAddingTarget,
   readOnly = false,
 }: Props) {
-  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting } = actions;
+  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting, aiCoachTool, runAiCoach, aiCoachRunning } = actions;
   const [internalAdding, setInternalAdding] = useState<number | null>(null);
   const [newBody, setNewBody] = useState("");
   const [statusMsg, setStatusMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [ghAvailable, setGhAvailable] = useState<boolean | null>(null);
+  const [showAiCoachConfirm, setShowAiCoachConfirm] = useState(false);
 
   // Check gh status in editor mode
   useEffect(() => {
@@ -277,8 +278,8 @@ export default function AnnotationPanel({
         )}
       </div>
 
-      {/* Footer: Save/export/publish buttons */}
-      {!readOnly && annotations.length > 0 && (
+      {/* Footer: Save/export/publish buttons + AI Coach */}
+      {!readOnly && (annotations.length > 0 || runAiCoach) && (
         <div className="shrink-0 border-t border-terminal-border/50 px-3 py-2 space-y-1.5">
           {hasUnsaved && !publishGist && (
             <div className="text-[9px] font-mono text-terminal-orange text-center mb-1">
@@ -292,6 +293,55 @@ export default function AnnotationPanel({
                   {statusMsg.text}
                 </a>
               ) : statusMsg.text}
+            </div>
+          )}
+
+          {/* AI Coach (editor mode only) */}
+          {runAiCoach && !showAiCoachConfirm && !aiCoachRunning && (
+            <button
+              onClick={() => setShowAiCoachConfirm(true)}
+              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-purple/15 text-terminal-purple rounded hover:bg-terminal-purple/25 transition-colors text-center border border-terminal-purple/30"
+            >
+              AI Coach (beta)
+            </button>
+          )}
+          {showAiCoachConfirm && !aiCoachRunning && (
+            <div className="space-y-1.5 p-2 rounded border border-terminal-purple/30 bg-terminal-purple/5">
+              <div className="text-[10px] font-mono text-terminal-purple font-semibold">
+                AI Coach (beta)
+              </div>
+              <div className="text-[9px] font-mono text-terminal-dim leading-relaxed">
+                Uses <span className="text-terminal-text">{aiCoachTool?.name}</span> CLI to analyze your prompting technique.
+                This will make API calls using your configured credentials and may use tokens/cost money.
+                Typically takes 1-3 minutes.
+              </div>
+              <div className="flex gap-1.5 justify-end">
+                <button
+                  onClick={() => setShowAiCoachConfirm(false)}
+                  className="px-2 py-1 text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={async () => {
+                    setShowAiCoachConfirm(false);
+                    try {
+                      const result = await runAiCoach!();
+                      setStatusMsg({ type: "success", text: `Score: ${result.score}/10 — ${result.itemCount} comment(s) added` });
+                    } catch (e: any) {
+                      setStatusMsg({ type: "error", text: e.message });
+                    }
+                  }}
+                  className="px-2 py-1 text-[10px] font-mono bg-terminal-purple/20 text-terminal-purple rounded hover:bg-terminal-purple/30 transition-colors"
+                >
+                  Run
+                </button>
+              </div>
+            </div>
+          )}
+          {aiCoachRunning && (
+            <div className="text-[10px] font-mono text-terminal-purple text-center py-2 animate-pulse">
+              Analyzing your prompting patterns...
             </div>
           )}
 

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -60,7 +60,7 @@ export default function AnnotationPanel({
   onClearAddingTarget,
   readOnly = false,
 }: Props) {
-  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting, aiCoachTool, runAiCoach, aiCoachRunning } = actions;
+  const { annotations, add, update, remove, hasUnsaved, canSaveHtml, downloadHtml, downloadJson, publishGist, exportHtml, gistPublishing, htmlExporting, aiCoachTool, runAiCoach, cancelAiCoach, aiCoachRunning } = actions;
   const [internalAdding, setInternalAdding] = useState<number | null>(null);
   const [newBody, setNewBody] = useState("");
   const [statusMsg, setStatusMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
@@ -297,51 +297,73 @@ export default function AnnotationPanel({
           )}
 
           {/* AI Coach (editor mode only) */}
-          {runAiCoach && !showAiCoachConfirm && !aiCoachRunning && (
-            <button
-              onClick={() => setShowAiCoachConfirm(true)}
-              className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-purple/15 text-terminal-purple rounded hover:bg-terminal-purple/25 transition-colors text-center border border-terminal-purple/30"
-            >
-              AI Coach (beta)
-            </button>
-          )}
-          {showAiCoachConfirm && !aiCoachRunning && (
-            <div className="space-y-1.5 p-2 rounded border border-terminal-purple/30 bg-terminal-purple/5">
-              <div className="text-[10px] font-mono text-terminal-purple font-semibold">
-                AI Coach (beta)
+          {runAiCoach && !showAiCoachConfirm && !aiCoachRunning && (() => {
+            const hasExisting = annotations.some((a) => a.author === "vibe-feedback");
+            return (
+              <button
+                onClick={() => setShowAiCoachConfirm(true)}
+                className="w-full px-2 py-1.5 text-[10px] font-mono bg-terminal-purple/15 text-terminal-purple rounded hover:bg-terminal-purple/25 transition-colors text-center border border-terminal-purple/30"
+              >
+                {hasExisting ? "Re-run AI Coach (beta)" : "AI Coach (beta)"}
+              </button>
+            );
+          })()}
+          {showAiCoachConfirm && !aiCoachRunning && (() => {
+            const hasExisting = annotations.some((a) => a.author === "vibe-feedback");
+            return (
+              <div className="space-y-1.5 p-2 rounded border border-terminal-purple/30 bg-terminal-purple/5">
+                <div className="text-[10px] font-mono text-terminal-purple font-semibold">
+                  AI Coach (beta)
+                </div>
+                <div className="text-[9px] font-mono text-terminal-dim leading-relaxed">
+                  Uses <span className="text-terminal-text">{aiCoachTool?.name}</span> CLI to analyze your prompting technique.
+                  This will make API calls using your configured credentials and may use tokens/cost money.
+                  Typically takes 1-3 minutes.
+                  {hasExisting && (
+                    <span className="block mt-1 text-terminal-orange">
+                      This will replace existing AI Coach comments.
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-1.5 justify-end">
+                  <button
+                    onClick={() => setShowAiCoachConfirm(false)}
+                    className="px-2 py-1 text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={async () => {
+                      setShowAiCoachConfirm(false);
+                      try {
+                        const result = await runAiCoach!();
+                        setStatusMsg({ type: "success", text: `Score: ${result.score}/10 — ${result.itemCount} comment(s) added` });
+                      } catch (e: any) {
+                        if (e.name === "AbortError") return;
+                        setStatusMsg({ type: "error", text: e.message });
+                      }
+                    }}
+                    className="px-2 py-1 text-[10px] font-mono bg-terminal-purple/20 text-terminal-purple rounded hover:bg-terminal-purple/30 transition-colors"
+                  >
+                    Run
+                  </button>
+                </div>
               </div>
-              <div className="text-[9px] font-mono text-terminal-dim leading-relaxed">
-                Uses <span className="text-terminal-text">{aiCoachTool?.name}</span> CLI to analyze your prompting technique.
-                This will make API calls using your configured credentials and may use tokens/cost money.
-                Typically takes 1-3 minutes.
-              </div>
-              <div className="flex gap-1.5 justify-end">
+            );
+          })()}
+          {aiCoachRunning && (
+            <div className="flex items-center justify-center gap-2 py-2">
+              <span className="text-[10px] font-mono text-terminal-purple animate-pulse">
+                Analyzing your prompting patterns...
+              </span>
+              {cancelAiCoach && (
                 <button
-                  onClick={() => setShowAiCoachConfirm(false)}
-                  className="px-2 py-1 text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+                  onClick={cancelAiCoach}
+                  className="px-1.5 py-0.5 text-[9px] font-mono text-terminal-dim hover:text-terminal-red border border-terminal-border/40 rounded transition-colors"
                 >
                   Cancel
                 </button>
-                <button
-                  onClick={async () => {
-                    setShowAiCoachConfirm(false);
-                    try {
-                      const result = await runAiCoach!();
-                      setStatusMsg({ type: "success", text: `Score: ${result.score}/10 — ${result.itemCount} comment(s) added` });
-                    } catch (e: any) {
-                      setStatusMsg({ type: "error", text: e.message });
-                    }
-                  }}
-                  className="px-2 py-1 text-[10px] font-mono bg-terminal-purple/20 text-terminal-purple rounded hover:bg-terminal-purple/30 transition-colors"
-                >
-                  Run
-                </button>
-              </div>
-            </div>
-          )}
-          {aiCoachRunning && (
-            <div className="text-[10px] font-mono text-terminal-purple text-center py-2 animate-pulse">
-              Analyzing your prompting patterns...
+              )}
             </div>
           )}
 

--- a/packages/viewer/src/components/AnnotationPanel.tsx
+++ b/packages/viewer/src/components/AnnotationPanel.tsx
@@ -415,17 +415,32 @@ const AnnotationCard = memo(function AnnotationCard({
     }
   }, [annotation.createdAt]);
 
+  const isAiFeedback = annotation.author === "vibe-feedback";
+
   return (
     <div
       data-annotation-scene={annotation.sceneIndex}
       className={`px-3 py-2 border-b border-terminal-border/30 transition-colors ${
-        isCurrent
-          ? "bg-terminal-blue/10 border-l-2 border-l-terminal-blue"
-          : "hover:bg-terminal-surface/50"
+        isAiFeedback
+          ? isCurrent
+            ? "bg-terminal-purple/10 border-l-2 border-l-terminal-purple"
+            : "bg-terminal-purple/[0.03] hover:bg-terminal-purple/[0.06]"
+          : isCurrent
+            ? "bg-terminal-blue/10 border-l-2 border-l-terminal-blue"
+            : "hover:bg-terminal-surface/50"
       }`}
       onMouseEnter={() => setShowActions(true)}
       onMouseLeave={() => setShowActions(false)}
     >
+      {/* AI Feedback badge */}
+      {isAiFeedback && (
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className="text-[9px] font-mono font-semibold uppercase tracking-wider text-terminal-purple px-1.5 py-0.5 rounded border border-terminal-purple/30 bg-terminal-purple/10">
+            AI Coach
+          </span>
+        </div>
+      )}
+
       {/* Scene reference — click to navigate */}
       <button
         onClick={onSeek}

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -23,6 +23,8 @@ export interface AnnotationActions {
   aiCoachTool: { name: string } | null;
   /** Editor mode: run AI Coach to generate feedback annotations */
   runAiCoach: (() => Promise<{ score: number; itemCount: number }>) | null;
+  /** Editor mode: cancel a running AI Coach operation */
+  cancelAiCoach: (() => void) | null;
   aiCoachRunning: boolean;
 }
 
@@ -221,6 +223,7 @@ export function useAnnotations(
   // AI Coach (editor mode)
   const [aiCoachTool, setAiCoachTool] = useState<{ name: string } | null>(null);
   const [aiCoachRunning, setAiCoachRunning] = useState(false);
+  const aiCoachAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     if (!isEditor) return;
@@ -234,16 +237,37 @@ export function useAnnotations(
 
   const runAiCoach = isEditor && aiCoachTool
     ? async () => {
+        const controller = new AbortController();
+        aiCoachAbortRef.current = controller;
         setAiCoachRunning(true);
         try {
-          const resp = await fetch("/api/feedback/generate", { method: "POST" });
+          // Flush current annotations to server first (debounce may not have fired yet)
+          await fetch("/api/annotations", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(annotations),
+            signal: controller.signal,
+          });
+          const resp = await fetch("/api/feedback/generate", {
+            method: "POST",
+            signal: controller.signal,
+          });
           const data = await resp.json();
           if (!resp.ok) throw new Error(data.error || "AI Coach failed");
           setAnnotations(data.annotations);
           setSavedSnapshot(JSON.stringify(data.annotations));
           return { score: data.score as number, itemCount: data.itemCount as number };
         } finally {
+          aiCoachAbortRef.current = null;
           setAiCoachRunning(false);
+        }
+      }
+    : null;
+
+  const cancelAiCoach = isEditor
+    ? () => {
+        if (aiCoachAbortRef.current) {
+          aiCoachAbortRef.current.abort();
         }
       }
     : null;
@@ -277,6 +301,6 @@ export function useAnnotations(
     downloadHtml, downloadJson,
     publishGist, exportHtml,
     gistPublishing, htmlExporting,
-    aiCoachTool, runAiCoach, aiCoachRunning,
+    aiCoachTool, runAiCoach, cancelAiCoach, aiCoachRunning,
   };
 }

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -19,6 +19,11 @@ export interface AnnotationActions {
   exportHtml: (() => Promise<string>) | null;
   gistPublishing: boolean;
   htmlExporting: boolean;
+  /** Editor mode: detected AI Coach tool info (null if unavailable) */
+  aiCoachTool: { name: string } | null;
+  /** Editor mode: run AI Coach to generate feedback annotations */
+  runAiCoach: (() => Promise<{ score: number; itemCount: number }>) | null;
+  aiCoachRunning: boolean;
 }
 
 const LS_PREFIX = "vibe-replay-annotations-";
@@ -213,6 +218,36 @@ export function useAnnotations(
       }
     : null;
 
+  // AI Coach (editor mode)
+  const [aiCoachTool, setAiCoachTool] = useState<{ name: string } | null>(null);
+  const [aiCoachRunning, setAiCoachRunning] = useState(false);
+
+  useEffect(() => {
+    if (!isEditor) return;
+    fetch("/api/feedback/detect")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.available && data.tool) setAiCoachTool(data.tool);
+      })
+      .catch(() => {});
+  }, [isEditor]);
+
+  const runAiCoach = isEditor && aiCoachTool
+    ? async () => {
+        setAiCoachRunning(true);
+        try {
+          const resp = await fetch("/api/feedback/generate", { method: "POST" });
+          const data = await resp.json();
+          if (!resp.ok) throw new Error(data.error || "AI Coach failed");
+          setAnnotations(data.annotations);
+          setSavedSnapshot(JSON.stringify(data.annotations));
+          return { score: data.score as number, itemCount: data.itemCount as number };
+        } finally {
+          setAiCoachRunning(false);
+        }
+      }
+    : null;
+
   // Editor mode: server-side HTML export
   const [htmlExporting, setHtmlExporting] = useState(false);
   const exportHtml = isEditor
@@ -242,5 +277,6 @@ export function useAnnotations(
     downloadHtml, downloadJson,
     publishGist, exportHtml,
     gistPublishing, htmlExporting,
+    aiCoachTool, runAiCoach, aiCoachRunning,
   };
 }


### PR DESCRIPTION

<img width="1316" height="1319" alt="image" src="https://github.com/user-attachments/assets/d57fa92a-f67a-4890-8bf4-2ac3394bf644" />

## Summary

Adds an experimental **AI Coach** feature that analyzes your prompting technique in recorded coding sessions and gives structured feedback as annotations.

**Demo replay:** https://vibe-replay.com/view/?gist=2509b6fbcc8fa138cac53164dfac63a4

### What it does

- Detects available AI CLI tools (`claude` or `opencode`) on your machine
- Sends a condensed session digest to the AI for analysis
- Gets back a structured score (1-10), strengths, areas for improvement, and per-prompt feedback
- Feedback appears as purple "AI Coach" annotations attached to specific prompts in the replay viewer

### How it works (user flow)

1. Run `vibe-replay`, pick a session, choose **Open in Editor**
2. In the editor's Comments panel, click **AI Coach (beta)**
3. A confirmation card shows which tool will be used (`claude`/`opencode`), warns about API cost, and estimates 1-3 minutes
4. Click **Run** → feedback annotations appear in the panel
5. User can edit, delete, or add their own comments on top — then export/publish as usual

### Changes across 2 commits

**Commit 1** (`b43dfe9`): Core implementation
- `packages/cli/src/feedback.ts` — new module: tool detection, session digest builder, prompt construction, CLI execution (claude/opencode via stdin pipe), robust JSON parsing (handles truncation, ANSI noise, structural errors), annotation conversion
- Viewer: purple "AI Coach" badge on feedback annotations in AnnotationPanel

**Commit 2** (`34b0924`): UX fixes from feedback
- **Moved AI Coach out of CLI critical path** — was blocking the main flow with a confirm prompt before the share menu. Now lives inside editor mode where it belongs (same level as manual editing, export, publish)
- **Added API routes** in `server.ts`: `GET /api/feedback/detect` and `POST /api/feedback/generate` — editor's Hono server handles the long-running AI call
- **Viewer integration** — "AI Coach (beta)" button in AnnotationPanel footer with inline confirmation card showing tool name, beta status, and cost warning
- **Fixed EADDRINUSE crash** — `findFreePort()` checked `127.0.0.1` but `serve()` bound to `::` (all interfaces). Now both use `127.0.0.1`
- **Fixed confusing menu emoji** — replaced `▶` (looks like selection cursor) with `●` on "Quick preview"

### Files changed

| File | What |
|------|------|
| `packages/cli/src/feedback.ts` | New — core feedback engine (detection, digest, prompt, execution, parsing) |
| `packages/cli/src/server.ts` | Added feedback API routes, fixed EADDRINUSE hostname mismatch |
| `packages/cli/src/index.ts` | Removed feedback from critical path, fixed menu emoji |
| `packages/viewer/src/hooks/useAnnotations.ts` | Added `aiCoachTool`, `runAiCoach`, `aiCoachRunning` to hook |
| `packages/viewer/src/components/AnnotationPanel.tsx` | Added AI Coach button + confirmation card + running state in footer |

## Test plan

- [x] `pnpm build` succeeds (viewer 438KB, CLI compiles clean)
- [x] `pnpm test` — all 93 tests pass
- [x] Security scan — no secrets/credentials in diff
- [x] EADDRINUSE fix verified — `findFreePort` and `serve` both bind `127.0.0.1`
- [ ] Manual: run `pnpm start` → confirm no feedback prompt in CLI flow
- [ ] Manual: choose "Open in Editor" → confirm AI Coach button appears in Comments panel
- [ ] Manual: click AI Coach → confirm beta/cost warning shows correct tool name
- [ ] Manual: run AI Coach → confirm feedback annotations appear with purple badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)