### PR TITLE
chore: bump version to 0.0.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `vibe-replay` CLI package version from 0.0.4 → 0.0.5

## What's in 0.0.5 (since 0.0.4)
- **Cursor global state support**: Ingest sessions from `state.vscdb` (devcontainer/SSH-remote scenarios)
- **AI Coach (beta)**: Editor-mode AI prompting feedback via `claude`, `agent`, or `opencode` CLI
- **Replay metadata**: Generator info (name, version, timestamp), `dataSourceInfo` for debugging
- **JSONL supplements**: Merge thinking blocks + user images from JSONL into SQLite-backed sessions
- **Security tests**: 38 new tests for path/secret/email redaction

## Test plan
- [x] 102 tests pass
- [x] Build clean (viewer 442KB, CLI 111KB)
- [ ] `npm publish` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)