### PR TITLE
chore: bump version to 0.0.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.0.6 for release

## Changes since 0.0.5
- feat: explore page metadata from gist, dashboard improvements, GitHub App auth
- fix: path traversal protection, content hash sync detection, UI consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)