### PR TITLE
fix: allow same version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           cd packages/cli
-          npm version "$VERSION" --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - run: pnpm build
 


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` flag to `npm version` in release workflow
- Fixes failure when package.json already has the target version (e.g. from a version bump PR merged before release)

## Context
The v0.0.6 release failed because the bump PR had already set the version to 0.0.6, so `npm version 0.0.6` errored with "Version not changed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)