### PR TITLE
fix: use Node 22 for OIDC tokenless npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Summary
- Upgrade Node from 20 to 22 in release workflow
- Node 20 ships npm ~10.2 which doesn't support OIDC tokenless publishing
- Node 22 ships npm 10.9+ which enables publishing via trusted publishers without an npm access token

## Context
v0.0.6 release failed with `404 Not Found` on `npm publish` because npm was too old to use the configured OIDC trusted publisher for authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)