### PR TITLE
fix: remove registry-url for OIDC tokenless npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` in release workflow
- `setup-node` with `registry-url` auto-sets `NODE_AUTH_TOKEN` to `GITHUB_TOKEN`, which npm sends to the npm registry causing 404
- Without `registry-url`, npm handles auth purely via OIDC trusted publisher flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)