### PR TITLE
chore: bump version to 0.0.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Version bump to 0.0.7 for release

## Changes since v0.0.6
- feat: Local UI as first-class citizen (Phase 1 & 2) (#25)
  - Multi-prompt display on session cards
  - GitHub icon for git repo projects
  - Directory-based archive (hide/show sessions)
  - "Local" environment badge
  - Rename replays from Sessions tab
  - Shared `cleanPromptText` utility with test coverage
  - Discover multi-prompt extraction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)