### PR TITLE
fix: add track_progress to Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Add `track_progress: true` to `claude-code-review.yml` to fix Claude not posting review comments on PRs
- The `code-review` plugin enters agent mode on `pull_request` events, which skips comment-posting logic. `track_progress: true` forces tag mode so results appear as PR comments.

## References
- https://github.com/anthropics/claude-code/issues/26227
- https://github.com/anthropics/claude-code-action/issues/944

## Test plan
- [ ] This PR itself should trigger the Claude Code Review workflow
- [ ] Verify a review comment appears on this PR after the workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)