### PR TITLE
refactor: extract playback engine into framework-agnostic modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:dashboard": "sh -c 'pnpm viewer:dev >/tmp/vibe-replay-viewer.log 2>&1 & VITE_PID=$!; cleanup(){ kill $VITE_PID 2>/dev/null; }; trap \"cleanup; exit 130\" INT TERM; echo \"[vibe-replay] viewer: http://localhost:5173  logs: /tmp/vibe-replay-viewer.log\"; pnpm cli:dev -- -d; cleanup'",
     "viewer:dev": "pnpm --filter @vibe-replay/viewer dev",
     "cli:dev": "VIBE_REPLAY_DEV_MENU=1 npx tsx packages/cli/src/index.ts",
-    "test": "pnpm --filter vibe-replay test",
+    "test": "pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
     "lint": "biome check --write packages/ website/src cloudflare/src",
     "lint:check": "biome check packages/ website/src cloudflare/src",
     "prepare": "lefthook install"

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -517,9 +517,16 @@ function bubbleTypeToRole(type: unknown): "user" | "assistant" {
 }
 
 function parseThinking(value: unknown): string {
-  if (typeof value !== "string") return "";
-  const trimmed = value.trim();
-  return trimmed;
+  if (typeof value === "string") return value.trim();
+  if (
+    value &&
+    typeof value === "object" &&
+    "text" in value &&
+    typeof (value as { text: unknown }).text === "string"
+  ) {
+    return (value as { text: string }).text.trim();
+  }
+  return "";
 }
 
 function normalizeTurnText(raw: unknown): string {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@vibe-replay/types": "workspace:*",
@@ -26,6 +27,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
-    "vite-plugin-singlefile": "^2.0.3"
+    "vite-plugin-singlefile": "^2.0.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/viewer/src/engine/__tests__/annotation-store.test.ts
+++ b/packages/viewer/src/engine/__tests__/annotation-store.test.ts
@@ -152,24 +152,24 @@ describe("computeAnnotationCounts", () => {
 // -- hasUnsavedChanges --
 
 describe("hasUnsavedChanges", () => {
-  it("returns false when annotations match snapshot", () => {
+  it("returns false when annotations match saved", () => {
     const list = [makeAnnotation()];
-    const snapshot = JSON.stringify(list);
-    expect(hasUnsavedChanges(list, snapshot)).toBe(false);
+    const saved = [makeAnnotation()];
+    expect(hasUnsavedChanges(list, saved)).toBe(false);
   });
 
-  it("returns true when annotations differ from snapshot", () => {
+  it("returns true when annotations differ from saved", () => {
     const list = [makeAnnotation({ body: "changed" })];
-    const snapshot = JSON.stringify([makeAnnotation({ body: "original" })]);
-    expect(hasUnsavedChanges(list, snapshot)).toBe(true);
+    const saved = [makeAnnotation({ body: "original" })];
+    expect(hasUnsavedChanges(list, saved)).toBe(true);
   });
 
-  it("returns false for empty list and empty snapshot", () => {
-    expect(hasUnsavedChanges([], "[]")).toBe(false);
+  it("returns false for empty list and empty saved", () => {
+    expect(hasUnsavedChanges([], [])).toBe(false);
   });
 
   it("returns true when annotation added", () => {
     const list = [makeAnnotation()];
-    expect(hasUnsavedChanges(list, "[]")).toBe(true);
+    expect(hasUnsavedChanges(list, [])).toBe(true);
   });
 });

--- a/packages/viewer/src/engine/__tests__/annotation-store.test.ts
+++ b/packages/viewer/src/engine/__tests__/annotation-store.test.ts
@@ -172,4 +172,10 @@ describe("hasUnsavedChanges", () => {
     const list = [makeAnnotation()];
     expect(hasUnsavedChanges(list, [])).toBe(true);
   });
+
+  it("returns true when annotations are in different order (order-sensitive)", () => {
+    const a = makeAnnotation({ id: "a", sceneIndex: 0 });
+    const b = makeAnnotation({ id: "b", sceneIndex: 1 });
+    expect(hasUnsavedChanges([a, b], [b, a])).toBe(true);
+  });
 });

--- a/packages/viewer/src/engine/__tests__/annotation-store.test.ts
+++ b/packages/viewer/src/engine/__tests__/annotation-store.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { Annotation } from "../../types";
+import {
+  addAnnotation,
+  computeAnnotatedScenes,
+  computeAnnotationCounts,
+  hasUnsavedChanges,
+  removeAnnotation,
+  updateAnnotation,
+} from "../annotation-store";
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "test-id",
+    sceneIndex: 0,
+    body: "test body",
+    author: "anonymous",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    resolved: false,
+    ...overrides,
+  };
+}
+
+// -- addAnnotation --
+
+describe("addAnnotation", () => {
+  it("adds annotation to empty list", () => {
+    const result = addAnnotation([], 5, "hello", "fixed-id");
+    expect(result).toHaveLength(1);
+    expect(result[0].sceneIndex).toBe(5);
+    expect(result[0].body).toBe("hello");
+    expect(result[0].id).toBe("fixed-id");
+    expect(result[0].author).toBe("anonymous");
+    expect(result[0].resolved).toBe(false);
+  });
+
+  it("appends to existing list without mutating", () => {
+    const existing = [makeAnnotation({ id: "a" })];
+    const result = addAnnotation(existing, 3, "new", "b");
+    expect(result).toHaveLength(2);
+    expect(existing).toHaveLength(1); // original unchanged
+  });
+
+  it("generates UUID if id not provided", () => {
+    const result = addAnnotation([], 0, "test");
+    expect(result[0].id).toBeTruthy();
+    expect(result[0].id).not.toBe("test-id");
+  });
+});
+
+// -- updateAnnotation --
+
+describe("updateAnnotation", () => {
+  it("updates body of matching annotation", () => {
+    const list = [
+      makeAnnotation({ id: "a", body: "old" }),
+      makeAnnotation({ id: "b", body: "keep" }),
+    ];
+    const result = updateAnnotation(list, "a", "new body");
+    expect(result[0].body).toBe("new body");
+    expect(result[1].body).toBe("keep");
+  });
+
+  it("updates updatedAt timestamp", () => {
+    const list = [makeAnnotation({ id: "a", updatedAt: "2024-01-01T00:00:00.000Z" })];
+    const result = updateAnnotation(list, "a", "changed");
+    expect(result[0].updatedAt).not.toBe("2024-01-01T00:00:00.000Z");
+  });
+
+  it("does not mutate original array", () => {
+    const list = [makeAnnotation({ id: "a", body: "old" })];
+    const result = updateAnnotation(list, "a", "new");
+    expect(list[0].body).toBe("old");
+    expect(result[0].body).toBe("new");
+  });
+
+  it("leaves list unchanged if id not found", () => {
+    const list = [makeAnnotation({ id: "a" })];
+    const result = updateAnnotation(list, "nonexistent", "new");
+    expect(result).toEqual(list);
+  });
+});
+
+// -- removeAnnotation --
+
+describe("removeAnnotation", () => {
+  it("removes annotation by id", () => {
+    const list = [
+      makeAnnotation({ id: "a" }),
+      makeAnnotation({ id: "b" }),
+      makeAnnotation({ id: "c" }),
+    ];
+    const result = removeAnnotation(list, "b");
+    expect(result).toHaveLength(2);
+    expect(result.map((a) => a.id)).toEqual(["a", "c"]);
+  });
+
+  it("does not mutate original array", () => {
+    const list = [makeAnnotation({ id: "a" })];
+    const result = removeAnnotation(list, "a");
+    expect(list).toHaveLength(1);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns same content if id not found", () => {
+    const list = [makeAnnotation({ id: "a" })];
+    const result = removeAnnotation(list, "nonexistent");
+    expect(result).toHaveLength(1);
+  });
+});
+
+// -- computeAnnotatedScenes --
+
+describe("computeAnnotatedScenes", () => {
+  it("returns empty set for empty list", () => {
+    expect(computeAnnotatedScenes([])).toEqual(new Set());
+  });
+
+  it("returns set of unique scene indices", () => {
+    const list = [
+      makeAnnotation({ sceneIndex: 1 }),
+      makeAnnotation({ sceneIndex: 3 }),
+      makeAnnotation({ sceneIndex: 1 }), // duplicate
+      makeAnnotation({ sceneIndex: 7 }),
+    ];
+    expect(computeAnnotatedScenes(list)).toEqual(new Set([1, 3, 7]));
+  });
+});
+
+// -- computeAnnotationCounts --
+
+describe("computeAnnotationCounts", () => {
+  it("returns empty map for empty list", () => {
+    expect(computeAnnotationCounts([])).toEqual(new Map());
+  });
+
+  it("counts annotations per scene", () => {
+    const list = [
+      makeAnnotation({ sceneIndex: 1 }),
+      makeAnnotation({ sceneIndex: 1 }),
+      makeAnnotation({ sceneIndex: 3 }),
+      makeAnnotation({ sceneIndex: 1 }),
+    ];
+    const counts = computeAnnotationCounts(list);
+    expect(counts.get(1)).toBe(3);
+    expect(counts.get(3)).toBe(1);
+    expect(counts.get(0)).toBeUndefined();
+  });
+});
+
+// -- hasUnsavedChanges --
+
+describe("hasUnsavedChanges", () => {
+  it("returns false when annotations match snapshot", () => {
+    const list = [makeAnnotation()];
+    const snapshot = JSON.stringify(list);
+    expect(hasUnsavedChanges(list, snapshot)).toBe(false);
+  });
+
+  it("returns true when annotations differ from snapshot", () => {
+    const list = [makeAnnotation({ body: "changed" })];
+    const snapshot = JSON.stringify([makeAnnotation({ body: "original" })]);
+    expect(hasUnsavedChanges(list, snapshot)).toBe(true);
+  });
+
+  it("returns false for empty list and empty snapshot", () => {
+    expect(hasUnsavedChanges([], "[]")).toBe(false);
+  });
+
+  it("returns true when annotation added", () => {
+    const list = [makeAnnotation()];
+    expect(hasUnsavedChanges(list, "[]")).toBe(true);
+  });
+});

--- a/packages/viewer/src/engine/__tests__/helpers.ts
+++ b/packages/viewer/src/engine/__tests__/helpers.ts
@@ -1,0 +1,27 @@
+import type { Scene } from "../../types";
+
+export function userPrompt(content = "hello"): Scene {
+  return { type: "user-prompt", content };
+}
+
+export function thinking(content = "hmm"): Scene {
+  return { type: "thinking", content };
+}
+
+export function textResponse(content = "hi"): Scene {
+  return { type: "text-response", content };
+}
+
+export function toolCall(
+  toolName = "Read",
+  opts: { diff?: boolean; bashOutput?: boolean } = {},
+): Scene {
+  return {
+    type: "tool-call",
+    toolName,
+    input: {},
+    result: "",
+    ...(opts.diff ? { diff: { filePath: "a.ts", oldContent: "", newContent: "x" } } : {}),
+    ...(opts.bashOutput ? { bashOutput: { command: "ls", stdout: "files" } } : {}),
+  };
+}

--- a/packages/viewer/src/engine/__tests__/scene-navigation.test.ts
+++ b/packages/viewer/src/engine/__tests__/scene-navigation.test.ts
@@ -1,29 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { Scene } from "../../types";
 import {
   computeNextIndex,
   computeUserPromptIndices,
   findNextUserPrompt,
   findPrevUserPrompt,
 } from "../scene-navigation";
-
-// -- Helpers --
-
-function userPrompt(content = "hello"): Scene {
-  return { type: "user-prompt", content };
-}
-
-function thinking(content = "hmm"): Scene {
-  return { type: "thinking", content };
-}
-
-function textResponse(content = "hi"): Scene {
-  return { type: "text-response", content };
-}
-
-function toolCall(toolName = "Read"): Scene {
-  return { type: "tool-call", toolName, input: {}, result: "" };
-}
+import { textResponse, thinking, toolCall, userPrompt } from "./helpers";
 
 // -- computeUserPromptIndices --
 

--- a/packages/viewer/src/engine/__tests__/scene-navigation.test.ts
+++ b/packages/viewer/src/engine/__tests__/scene-navigation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { Scene } from "../../types";
+import {
+  computeNextIndex,
+  computeUserPromptIndices,
+  findNextUserPrompt,
+  findPrevUserPrompt,
+} from "../scene-navigation";
+
+// -- Helpers --
+
+function userPrompt(content = "hello"): Scene {
+  return { type: "user-prompt", content };
+}
+
+function thinking(content = "hmm"): Scene {
+  return { type: "thinking", content };
+}
+
+function textResponse(content = "hi"): Scene {
+  return { type: "text-response", content };
+}
+
+function toolCall(toolName = "Read"): Scene {
+  return { type: "tool-call", toolName, input: {}, result: "" };
+}
+
+// -- computeUserPromptIndices --
+
+describe("computeUserPromptIndices", () => {
+  it("returns empty array for no scenes", () => {
+    expect(computeUserPromptIndices([])).toEqual([]);
+  });
+
+  it("returns empty array when no user prompts exist", () => {
+    expect(computeUserPromptIndices([thinking(), textResponse()])).toEqual([]);
+  });
+
+  it("finds all user-prompt indices", () => {
+    const scenes = [userPrompt(), thinking(), textResponse(), userPrompt(), toolCall()];
+    expect(computeUserPromptIndices(scenes)).toEqual([0, 3]);
+  });
+
+  it("works when all scenes are user prompts", () => {
+    const scenes = [userPrompt("a"), userPrompt("b"), userPrompt("c")];
+    expect(computeUserPromptIndices(scenes)).toEqual([0, 1, 2]);
+  });
+});
+
+// -- findNextUserPrompt --
+
+describe("findNextUserPrompt", () => {
+  const indices = [0, 5, 10, 20];
+
+  it("finds next prompt after current position", () => {
+    expect(findNextUserPrompt(indices, 0)).toBe(5);
+    expect(findNextUserPrompt(indices, 3)).toBe(5);
+    expect(findNextUserPrompt(indices, 5)).toBe(10);
+  });
+
+  it("returns undefined when no next prompt exists", () => {
+    expect(findNextUserPrompt(indices, 20)).toBeUndefined();
+    expect(findNextUserPrompt(indices, 25)).toBeUndefined();
+  });
+
+  it("returns undefined for empty indices", () => {
+    expect(findNextUserPrompt([], 0)).toBeUndefined();
+  });
+
+  it("finds first prompt when current is -1", () => {
+    expect(findNextUserPrompt(indices, -1)).toBe(0);
+  });
+});
+
+// -- findPrevUserPrompt --
+
+describe("findPrevUserPrompt", () => {
+  const indices = [0, 5, 10, 20];
+
+  it("finds previous prompt before current position", () => {
+    expect(findPrevUserPrompt(indices, 20)).toBe(10);
+    expect(findPrevUserPrompt(indices, 7)).toBe(5);
+    expect(findPrevUserPrompt(indices, 5)).toBe(0);
+  });
+
+  it("returns undefined when no previous prompt exists", () => {
+    expect(findPrevUserPrompt(indices, 0)).toBeUndefined();
+    expect(findPrevUserPrompt(indices, -1)).toBeUndefined();
+  });
+
+  it("returns undefined for empty indices", () => {
+    expect(findPrevUserPrompt([], 5)).toBeUndefined();
+  });
+});
+
+// -- computeNextIndex --
+
+describe("computeNextIndex", () => {
+  it("returns -1 when past end of scenes", () => {
+    const scenes = [userPrompt(), textResponse()];
+    expect(computeNextIndex(scenes, 1, false)).toBe(-1);
+  });
+
+  it("advances to next scene normally", () => {
+    const scenes = [userPrompt(), thinking(), textResponse()];
+    expect(computeNextIndex(scenes, 0, false)).toBe(1);
+  });
+
+  it("batches consecutive same-name tool calls", () => {
+    const scenes = [
+      userPrompt(),
+      toolCall("Read"),
+      toolCall("Read"),
+      toolCall("Read"),
+      textResponse(),
+    ];
+    expect(computeNextIndex(scenes, 0, false)).toBe(3);
+  });
+
+  it("in prompts-only mode, skips to next user-prompt", () => {
+    const scenes = [
+      userPrompt("first"),
+      thinking(),
+      textResponse(),
+      toolCall(),
+      userPrompt("second"),
+    ];
+    expect(computeNextIndex(scenes, 0, true)).toBe(4);
+  });
+
+  it("in prompts-only mode, returns -1 when no more prompts", () => {
+    const scenes = [userPrompt(), thinking(), textResponse()];
+    expect(computeNextIndex(scenes, 0, true)).toBe(-1);
+  });
+
+  it("in prompts-only mode from before first scene", () => {
+    const scenes = [thinking(), userPrompt()];
+    expect(computeNextIndex(scenes, -1, true)).toBe(1);
+  });
+});

--- a/packages/viewer/src/engine/__tests__/scene-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/scene-timing.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { Scene } from "../../types";
+import { findBatchEnd, isBatchable, sceneDuration } from "../scene-timing";
+
+// -- Helpers --
+
+function userPrompt(content = "hello"): Scene {
+  return { type: "user-prompt", content };
+}
+
+function thinking(content = "hmm"): Scene {
+  return { type: "thinking", content };
+}
+
+function textResponse(content = "hi"): Scene {
+  return { type: "text-response", content };
+}
+
+function toolCall(toolName = "Read", opts: { diff?: boolean; bashOutput?: boolean } = {}): Scene {
+  return {
+    type: "tool-call",
+    toolName,
+    input: {},
+    result: "",
+    ...(opts.diff ? { diff: { filePath: "a.ts", oldContent: "", newContent: "x" } } : {}),
+    ...(opts.bashOutput ? { bashOutput: { command: "ls", stdout: "files" } } : {}),
+  };
+}
+
+// -- isBatchable --
+
+describe("isBatchable", () => {
+  it("returns true for simple tool-call (no diff, no bashOutput)", () => {
+    expect(isBatchable(toolCall("Read"))).toBe(true);
+  });
+
+  it("returns false for tool-call with diff", () => {
+    expect(isBatchable(toolCall("Edit", { diff: true }))).toBe(false);
+  });
+
+  it("returns false for tool-call with bashOutput", () => {
+    expect(isBatchable(toolCall("Bash", { bashOutput: true }))).toBe(false);
+  });
+
+  it("returns false for non-tool-call scenes", () => {
+    expect(isBatchable(userPrompt())).toBe(false);
+    expect(isBatchable(thinking())).toBe(false);
+    expect(isBatchable(textResponse())).toBe(false);
+  });
+});
+
+// -- findBatchEnd --
+
+describe("findBatchEnd", () => {
+  it("returns same index for non-batchable scene", () => {
+    const scenes = [userPrompt(), toolCall("Read")];
+    expect(findBatchEnd(scenes, 0)).toBe(0);
+  });
+
+  it("returns same index for single batchable scene", () => {
+    const scenes = [toolCall("Read"), userPrompt()];
+    expect(findBatchEnd(scenes, 0)).toBe(0);
+  });
+
+  it("merges consecutive same-name batchable tool calls", () => {
+    const scenes = [toolCall("Read"), toolCall("Read"), toolCall("Read"), userPrompt()];
+    expect(findBatchEnd(scenes, 0)).toBe(2);
+  });
+
+  it("stops at different tool name", () => {
+    const scenes = [toolCall("Read"), toolCall("Read"), toolCall("Glob"), toolCall("Read")];
+    expect(findBatchEnd(scenes, 0)).toBe(1);
+  });
+
+  it("stops at tool-call with diff", () => {
+    const scenes = [toolCall("Edit"), toolCall("Edit", { diff: true }), toolCall("Edit")];
+    expect(findBatchEnd(scenes, 0)).toBe(0);
+  });
+
+  it("stops at tool-call with bashOutput", () => {
+    const scenes = [toolCall("Bash"), toolCall("Bash", { bashOutput: true })];
+    expect(findBatchEnd(scenes, 0)).toBe(0);
+  });
+
+  it("works starting from middle of array", () => {
+    const scenes = [userPrompt(), toolCall("Read"), toolCall("Read"), toolCall("Read")];
+    expect(findBatchEnd(scenes, 1)).toBe(3);
+  });
+
+  it("returns idx for last element in array", () => {
+    const scenes = [toolCall("Read")];
+    expect(findBatchEnd(scenes, 0)).toBe(0);
+  });
+});
+
+// -- sceneDuration --
+
+describe("sceneDuration", () => {
+  it("user-prompt is 1200ms at 1x", () => {
+    expect(sceneDuration(userPrompt(), 1)).toBe(1200);
+  });
+
+  it("user-prompt at 2x is half duration", () => {
+    expect(sceneDuration(userPrompt(), 2)).toBe(600);
+  });
+
+  it("thinking is 600ms at 1x", () => {
+    expect(sceneDuration(thinking(), 1)).toBe(600);
+  });
+
+  it("text-response minimum is 800ms", () => {
+    expect(sceneDuration(textResponse("hi"), 1)).toBe(800);
+  });
+
+  it("text-response scales with content length", () => {
+    const short = sceneDuration(textResponse("hi"), 1);
+    const long = sceneDuration(textResponse("x".repeat(1000)), 1);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it("text-response caps at 3000ms", () => {
+    const veryLong = sceneDuration(textResponse("x".repeat(10000)), 1);
+    expect(veryLong).toBe(3000);
+  });
+
+  it("tool-call with diff is 1200ms", () => {
+    expect(sceneDuration(toolCall("Edit", { diff: true }), 1)).toBe(1200);
+  });
+
+  it("tool-call with bashOutput is 900ms", () => {
+    expect(sceneDuration(toolCall("Bash", { bashOutput: true }), 1)).toBe(900);
+  });
+
+  it("simple tool-call is 400ms", () => {
+    expect(sceneDuration(toolCall("Read"), 1)).toBe(400);
+  });
+
+  it("respects speed multiplier for all types", () => {
+    const scenes: Scene[] = [
+      userPrompt(),
+      thinking(),
+      textResponse("hello world"),
+      toolCall("Read"),
+    ];
+    for (const scene of scenes) {
+      const at1x = sceneDuration(scene, 1);
+      const at4x = sceneDuration(scene, 4);
+      expect(at4x).toBe(at1x / 4);
+    }
+  });
+});

--- a/packages/viewer/src/engine/__tests__/scene-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/scene-timing.test.ts
@@ -1,31 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Scene } from "../../types";
 import { findBatchEnd, isBatchable, sceneDuration } from "../scene-timing";
-
-// -- Helpers --
-
-function userPrompt(content = "hello"): Scene {
-  return { type: "user-prompt", content };
-}
-
-function thinking(content = "hmm"): Scene {
-  return { type: "thinking", content };
-}
-
-function textResponse(content = "hi"): Scene {
-  return { type: "text-response", content };
-}
-
-function toolCall(toolName = "Read", opts: { diff?: boolean; bashOutput?: boolean } = {}): Scene {
-  return {
-    type: "tool-call",
-    toolName,
-    input: {},
-    result: "",
-    ...(opts.diff ? { diff: { filePath: "a.ts", oldContent: "", newContent: "x" } } : {}),
-    ...(opts.bashOutput ? { bashOutput: { command: "ls", stdout: "files" } } : {}),
-  };
-}
+import { textResponse, thinking, toolCall, userPrompt } from "./helpers";
 
 // -- isBatchable --
 

--- a/packages/viewer/src/engine/annotation-store.ts
+++ b/packages/viewer/src/engine/annotation-store.ts
@@ -50,7 +50,7 @@ export function computeAnnotationCounts(annotations: Annotation[]): Map<number, 
   return counts;
 }
 
-/** Check if current annotations differ from a saved snapshot */
-export function hasUnsavedChanges(current: Annotation[], savedSnapshot: string): boolean {
-  return JSON.stringify(current) !== savedSnapshot;
+/** Check if current annotations differ from a saved snapshot (order-sensitive comparison) */
+export function hasUnsavedChanges(current: Annotation[], saved: Annotation[]): boolean {
+  return JSON.stringify(current) !== JSON.stringify(saved);
 }

--- a/packages/viewer/src/engine/annotation-store.ts
+++ b/packages/viewer/src/engine/annotation-store.ts
@@ -1,0 +1,56 @@
+import type { Annotation } from "../types";
+
+/** Add a new annotation to the list (pure — returns new array) */
+export function addAnnotation(
+  annotations: Annotation[],
+  sceneIndex: number,
+  body: string,
+  id?: string,
+): Annotation[] {
+  const now = new Date().toISOString();
+  const annotation: Annotation = {
+    id: id ?? crypto.randomUUID(),
+    sceneIndex,
+    body,
+    author: "anonymous",
+    createdAt: now,
+    updatedAt: now,
+    resolved: false,
+  };
+  return [...annotations, annotation];
+}
+
+/** Update an annotation's body by id (pure — returns new array) */
+export function updateAnnotation(
+  annotations: Annotation[],
+  id: string,
+  body: string,
+): Annotation[] {
+  return annotations.map((a) =>
+    a.id === id ? { ...a, body, updatedAt: new Date().toISOString() } : a,
+  );
+}
+
+/** Remove an annotation by id (pure — returns new array) */
+export function removeAnnotation(annotations: Annotation[], id: string): Annotation[] {
+  return annotations.filter((a) => a.id !== id);
+}
+
+/** Compute the set of scene indices that have at least one annotation */
+export function computeAnnotatedScenes(annotations: Annotation[]): Set<number> {
+  return new Set(annotations.map((a) => a.sceneIndex));
+}
+
+/** Compute annotation count per scene index */
+export function computeAnnotationCounts(annotations: Annotation[]): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const a of annotations) {
+    counts.set(a.sceneIndex, (counts.get(a.sceneIndex) || 0) + 1);
+  }
+  return counts;
+}
+
+/** Check if current annotations differ from a saved snapshot */
+export function hasUnsavedChanges(current: Annotation[], savedSnapshot: string): boolean {
+  return JSON.stringify(current) !== savedSnapshot;
+}

--- a/packages/viewer/src/engine/index.ts
+++ b/packages/viewer/src/engine/index.ts
@@ -1,0 +1,20 @@
+export {
+  addAnnotation,
+  computeAnnotatedScenes,
+  computeAnnotationCounts,
+  hasUnsavedChanges,
+  removeAnnotation,
+  updateAnnotation,
+} from "./annotation-store";
+
+export {
+  computeNextIndex,
+  computeUserPromptIndices,
+  findNextUserPrompt,
+  findPrevUserPrompt,
+} from "./scene-navigation";
+export {
+  findBatchEnd,
+  isBatchable,
+  sceneDuration,
+} from "./scene-timing";

--- a/packages/viewer/src/engine/scene-navigation.ts
+++ b/packages/viewer/src/engine/scene-navigation.ts
@@ -1,0 +1,57 @@
+import type { Scene } from "../types";
+import { findBatchEnd } from "./scene-timing";
+
+/** Compute indices of all user-prompt scenes */
+export function computeUserPromptIndices(scenes: Scene[]): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < scenes.length; i++) {
+    if (scenes[i].type === "user-prompt") indices.push(i);
+  }
+  return indices;
+}
+
+/** Find the next user prompt index after `current`, or undefined */
+export function findNextUserPrompt(
+  userPromptIndices: number[],
+  current: number,
+): number | undefined {
+  return userPromptIndices.find((i) => i > current);
+}
+
+/** Find the previous user prompt index before `current`, or undefined */
+export function findPrevUserPrompt(
+  userPromptIndices: number[],
+  current: number,
+): number | undefined {
+  for (let i = userPromptIndices.length - 1; i >= 0; i--) {
+    if (userPromptIndices[i] < current) return userPromptIndices[i];
+  }
+  return undefined;
+}
+
+/**
+ * Compute the next scene index to display, accounting for:
+ * - prompts-only mode (skip non-user-prompt scenes)
+ * - batch grouping (consecutive same-name batchable tool calls)
+ *
+ * Returns the target index, or -1 if playback should end.
+ */
+export function computeNextIndex(
+  scenes: Scene[],
+  currentIndex: number,
+  promptsOnly: boolean,
+): number {
+  let nextIdx = currentIndex + 1;
+
+  if (nextIdx >= scenes.length) return -1;
+
+  if (promptsOnly) {
+    while (nextIdx < scenes.length && scenes[nextIdx].type !== "user-prompt") {
+      nextIdx++;
+    }
+    return nextIdx >= scenes.length ? -1 : nextIdx;
+  }
+
+  // For batchable tool calls, skip to the end of the batch
+  return findBatchEnd(scenes, nextIdx);
+}

--- a/packages/viewer/src/engine/scene-timing.ts
+++ b/packages/viewer/src/engine/scene-timing.ts
@@ -1,21 +1,20 @@
 import type { Scene } from "../types";
 
 /** Check if a tool-call scene is "simple" (batchable — no diff, no bash output) */
-export function isBatchable(scene: Scene): boolean {
+export function isBatchable(scene: Scene): scene is Extract<Scene, { type: "tool-call" }> {
   return scene.type === "tool-call" && !scene.diff && !scene.bashOutput;
 }
 
 /** Find the end of a consecutive batch of same-name batchable tool calls starting at idx */
 export function findBatchEnd(scenes: Scene[], idx: number): number {
   const scene = scenes[idx];
-  if (!isBatchable(scene) || scene.type !== "tool-call") return idx;
+  if (!isBatchable(scene)) return idx;
   const toolName = scene.toolName;
   let end = idx;
   while (
     end + 1 < scenes.length &&
-    scenes[end + 1].type === "tool-call" &&
     isBatchable(scenes[end + 1]) &&
-    (scenes[end + 1] as Extract<Scene, { type: "tool-call" }>).toolName === toolName
+    scenes[end + 1].toolName === toolName
   ) {
     end++;
   }

--- a/packages/viewer/src/engine/scene-timing.ts
+++ b/packages/viewer/src/engine/scene-timing.ts
@@ -1,0 +1,46 @@
+import type { Scene } from "../types";
+
+/** Check if a tool-call scene is "simple" (batchable — no diff, no bash output) */
+export function isBatchable(scene: Scene): boolean {
+  return scene.type === "tool-call" && !scene.diff && !scene.bashOutput;
+}
+
+/** Find the end of a consecutive batch of same-name batchable tool calls starting at idx */
+export function findBatchEnd(scenes: Scene[], idx: number): number {
+  const scene = scenes[idx];
+  if (!isBatchable(scene) || scene.type !== "tool-call") return idx;
+  const toolName = scene.toolName;
+  let end = idx;
+  while (
+    end + 1 < scenes.length &&
+    scenes[end + 1].type === "tool-call" &&
+    isBatchable(scenes[end + 1]) &&
+    (scenes[end + 1] as Extract<Scene, { type: "tool-call" }>).toolName === toolName
+  ) {
+    end++;
+  }
+  return end;
+}
+
+/** Calculate display duration for a scene at a given playback speed */
+export function sceneDuration(scene: Scene, speed: number): number {
+  const base = (() => {
+    switch (scene.type) {
+      case "user-prompt":
+        return 1200;
+      case "thinking":
+        return 600;
+      case "text-response": {
+        const chars = scene.content.length;
+        // Short text: 800ms, long text: up to 3s
+        return Math.max(800, Math.min(chars / 40, 5) * 600);
+      }
+      case "tool-call": {
+        if (scene.diff) return 1200;
+        if (scene.bashOutput) return 900;
+        return 400;
+      }
+    }
+  })();
+  return base / speed;
+}

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -102,7 +102,7 @@ export function useAnnotations(
           body: JSON.stringify(annotations),
         })
           .then(() => {
-            setSavedSnapshot([...annotations]);
+            setSavedSnapshot(annotations);
           })
           .catch(() => {
             /* silent */
@@ -175,7 +175,7 @@ export function useAnnotations(
       URL.revokeObjectURL(url);
     }
 
-    setSavedSnapshot([...annotations]);
+    setSavedSnapshot(annotations);
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch {
@@ -196,7 +196,7 @@ export function useAnnotations(
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    setSavedSnapshot([...annotations]);
+    setSavedSnapshot(annotations);
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch {
@@ -221,7 +221,7 @@ export function useAnnotations(
           if (!resp.ok) {
             throw new Error(result.error || `Server error: ${resp.status}`);
           }
-          setSavedSnapshot([...annotations]);
+          setSavedSnapshot(annotations);
           return result as { gistUrl: string; viewerUrl: string };
         } finally {
           setGistPublishing(false);
@@ -280,7 +280,7 @@ export function useAnnotations(
             const data = await resp.json();
             if (!resp.ok) throw new Error(data.error || "AI Coach failed");
             setAnnotations(data.annotations);
-            setSavedSnapshot([...data.annotations]);
+            setSavedSnapshot(data.annotations);
             return { score: data.score as number, itemCount: data.itemCount as number };
           } finally {
             aiCoachAbortRef.current = null;
@@ -318,7 +318,7 @@ export function useAnnotations(
           const data = await resp.json();
           if (!resp.ok) throw new Error(data.error || `Export failed: ${resp.status}`);
           const { path } = data;
-          setSavedSnapshot([...annotations]);
+          setSavedSnapshot(annotations);
           return path as string;
         } finally {
           setHtmlExporting(false);

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -1,4 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  addAnnotation,
+  computeAnnotatedScenes,
+  computeAnnotationCounts,
+  hasUnsavedChanges,
+  removeAnnotation,
+  updateAnnotation,
+} from "../engine";
 import type { Annotation, ReplaySession } from "../types";
 import type { ViewerMode } from "./useSessionLoader";
 
@@ -80,7 +88,7 @@ export function useAnnotations(
     JSON.stringify(session.annotations ?? []),
   );
 
-  const hasUnsaved = JSON.stringify(annotations) !== savedSnapshot;
+  const hasUnsaved = hasUnsavedChanges(annotations, savedSnapshot);
 
   // Autosave: localStorage for embedded/readonly, API for editor
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -114,41 +122,20 @@ export function useAnnotations(
     }
   }, [annotations, sessionId, isEditor]);
 
-  const annotatedScenes = useMemo(
-    () => new Set(annotations.map((a) => a.sceneIndex)),
-    [annotations],
-  );
+  const annotatedScenes = useMemo(() => computeAnnotatedScenes(annotations), [annotations]);
 
-  const annotationCounts = useMemo(() => {
-    const counts = new Map<number, number>();
-    for (const a of annotations) {
-      counts.set(a.sceneIndex, (counts.get(a.sceneIndex) || 0) + 1);
-    }
-    return counts;
-  }, [annotations]);
+  const annotationCounts = useMemo(() => computeAnnotationCounts(annotations), [annotations]);
 
   const add = useCallback((sceneIndex: number, body: string) => {
-    const now = new Date().toISOString();
-    const annotation: Annotation = {
-      id: crypto.randomUUID(),
-      sceneIndex,
-      body,
-      author: "anonymous",
-      createdAt: now,
-      updatedAt: now,
-      resolved: false,
-    };
-    setAnnotations((prev) => [...prev, annotation]);
+    setAnnotations((prev) => addAnnotation(prev, sceneIndex, body));
   }, []);
 
   const update = useCallback((id: string, body: string) => {
-    setAnnotations((prev) =>
-      prev.map((a) => (a.id === id ? { ...a, body, updatedAt: new Date().toISOString() } : a)),
-    );
+    setAnnotations((prev) => updateAnnotation(prev, id, body));
   }, []);
 
   const remove = useCallback((id: string) => {
-    setAnnotations((prev) => prev.filter((a) => a.id !== id));
+    setAnnotations((prev) => removeAnnotation(prev, id));
   }, []);
 
   const downloadHtml = useCallback(() => {

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -84,9 +84,7 @@ export function useAnnotations(
   });
 
   // Track whether we've diverged from embedded/server state
-  const [savedSnapshot, setSavedSnapshot] = useState(() =>
-    JSON.stringify(session.annotations ?? []),
-  );
+  const [savedSnapshot, setSavedSnapshot] = useState<Annotation[]>(() => session.annotations ?? []);
 
   const hasUnsaved = hasUnsavedChanges(annotations, savedSnapshot);
 
@@ -104,7 +102,7 @@ export function useAnnotations(
           body: JSON.stringify(annotations),
         })
           .then(() => {
-            setSavedSnapshot(JSON.stringify(annotations));
+            setSavedSnapshot([...annotations]);
           })
           .catch(() => {
             /* silent */
@@ -177,7 +175,7 @@ export function useAnnotations(
       URL.revokeObjectURL(url);
     }
 
-    setSavedSnapshot(JSON.stringify(annotations));
+    setSavedSnapshot([...annotations]);
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch {
@@ -198,7 +196,7 @@ export function useAnnotations(
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    setSavedSnapshot(JSON.stringify(annotations));
+    setSavedSnapshot([...annotations]);
     try {
       localStorage.removeItem(storageKey(sessionId));
     } catch {
@@ -223,7 +221,7 @@ export function useAnnotations(
           if (!resp.ok) {
             throw new Error(result.error || `Server error: ${resp.status}`);
           }
-          setSavedSnapshot(JSON.stringify(annotations));
+          setSavedSnapshot([...annotations]);
           return result as { gistUrl: string; viewerUrl: string };
         } finally {
           setGistPublishing(false);
@@ -282,7 +280,7 @@ export function useAnnotations(
             const data = await resp.json();
             if (!resp.ok) throw new Error(data.error || "AI Coach failed");
             setAnnotations(data.annotations);
-            setSavedSnapshot(JSON.stringify(data.annotations));
+            setSavedSnapshot([...data.annotations]);
             return { score: data.score as number, itemCount: data.itemCount as number };
           } finally {
             aiCoachAbortRef.current = null;
@@ -320,7 +318,7 @@ export function useAnnotations(
           const data = await resp.json();
           if (!resp.ok) throw new Error(data.error || `Export failed: ${resp.status}`);
           const { path } = data;
-          setSavedSnapshot(JSON.stringify(annotations));
+          setSavedSnapshot([...annotations]);
           return path as string;
         } finally {
           setHtmlExporting(false);

--- a/packages/viewer/src/hooks/usePlayback.ts
+++ b/packages/viewer/src/hooks/usePlayback.ts
@@ -1,4 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  computeNextIndex,
+  computeUserPromptIndices,
+  findBatchEnd,
+  findNextUserPrompt,
+  findPrevUserPrompt,
+  sceneDuration,
+} from "../engine";
 import type { Scene } from "../types";
 
 export type PlayState = "idle" | "playing" | "paused" | "ended";
@@ -11,51 +19,6 @@ function isEditableTarget(target: EventTarget | null): boolean {
   if (el.isContentEditable) return true;
   const role = el.getAttribute("role");
   return role === "textbox" || role === "combobox";
-}
-
-/** Check if a tool-call scene is "simple" (batchable — no diff, no bash output) */
-function isBatchable(scene: Scene): boolean {
-  return scene.type === "tool-call" && !scene.diff && !scene.bashOutput;
-}
-
-/** Find the end of a consecutive batch of same-name batchable tool calls starting at idx */
-function findBatchEnd(scenes: Scene[], idx: number): number {
-  const scene = scenes[idx];
-  if (!isBatchable(scene) || scene.type !== "tool-call") return idx;
-  const toolName = scene.toolName;
-  let end = idx;
-  while (
-    end + 1 < scenes.length &&
-    scenes[end + 1].type === "tool-call" &&
-    isBatchable(scenes[end + 1]) &&
-    (scenes[end + 1] as Extract<Scene, { type: "tool-call" }>).toolName === toolName
-  ) {
-    end++;
-  }
-  return end;
-}
-
-function sceneDuration(scene: Scene, speed: number): number {
-  // Base durations calibrated for 1x = smooth reading pace (no jumping feel)
-  const base = (() => {
-    switch (scene.type) {
-      case "user-prompt":
-        return 1200;
-      case "thinking":
-        return 600;
-      case "text-response": {
-        const chars = scene.content.length;
-        // Short text: 800ms, long text: up to 3s
-        return Math.max(800, Math.min(chars / 40, 5) * 600);
-      }
-      case "tool-call": {
-        if (scene.diff) return 1200;
-        if (scene.bashOutput) return 900;
-        return 400;
-      }
-    }
-  })();
-  return base / speed;
 }
 
 export function usePlayback(scenes: Scene[], promptsOnly = false, enabled = true) {
@@ -76,13 +39,7 @@ export function usePlayback(scenes: Scene[], promptsOnly = false, enabled = true
   promptsOnlyRef.current = promptsOnly;
 
   // Compute user prompt indices for jump navigation
-  const userPromptIndices = useMemo(() => {
-    const indices: number[] = [];
-    scenes.forEach((s, i) => {
-      if (s.type === "user-prompt") indices.push(i);
-    });
-    return indices;
-  }, [scenes]);
+  const userPromptIndices = useMemo(() => computeUserPromptIndices(scenes), [scenes]);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) {
@@ -94,39 +51,17 @@ export function usePlayback(scenes: Scene[], promptsOnly = false, enabled = true
   const advanceScene = useCallback(() => {
     if (stateRef.current !== "playing") return;
 
-    let nextIdx = indexRef.current + 1;
-    if (nextIdx >= scenes.length) {
+    const nextIdx = computeNextIndex(scenes, indexRef.current, promptsOnlyRef.current);
+    if (nextIdx === -1) {
       setState("ended");
       setCurrentIndex(scenes.length - 1);
       setVisibleCount(scenes.length);
       return;
     }
 
-    // In prompts-only mode, jump straight to the next user-prompt
-    if (promptsOnlyRef.current) {
-      while (nextIdx < scenes.length && scenes[nextIdx].type !== "user-prompt") {
-        nextIdx++;
-      }
-      if (nextIdx >= scenes.length) {
-        setState("ended");
-        setCurrentIndex(scenes.length - 1);
-        setVisibleCount(scenes.length);
-        return;
-      }
-      setCurrentIndex(nextIdx);
-      setVisibleCount(nextIdx + 1);
-      const duration = sceneDuration(scenes[nextIdx], speedRef.current);
-      timerRef.current = setTimeout(advanceScene, duration);
-      return;
-    }
-
-    // For batchable tool calls, skip to the end of the batch
-    const endIdx = findBatchEnd(scenes, nextIdx);
-
-    setCurrentIndex(endIdx);
-    setVisibleCount(endIdx + 1);
-
-    const duration = sceneDuration(scenes[endIdx], speedRef.current);
+    setCurrentIndex(nextIdx);
+    setVisibleCount(nextIdx + 1);
+    const duration = sceneDuration(scenes[nextIdx], speedRef.current);
     timerRef.current = setTimeout(advanceScene, duration);
   }, [scenes]);
 
@@ -190,14 +125,12 @@ export function usePlayback(scenes: Scene[], promptsOnly = false, enabled = true
   );
 
   const jumpToNextUserPrompt = useCallback(() => {
-    const current = indexRef.current;
-    const next = userPromptIndices.find((i) => i > current);
+    const next = findNextUserPrompt(userPromptIndices, indexRef.current);
     if (next !== undefined) seekTo(next);
   }, [userPromptIndices, seekTo]);
 
   const jumpToPrevUserPrompt = useCallback(() => {
-    const current = indexRef.current;
-    const prev = [...userPromptIndices].reverse().find((i) => i < current);
+    const prev = findPrevUserPrompt(userPromptIndices, indexRef.current);
     if (prev !== undefined) seekTo(prev);
   }, [userPromptIndices, seekTo]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       vite-plugin-singlefile:
         specifier: ^2.0.3
         version: 2.3.0(rollup@4.59.0)(vite@6.4.1(@types/node@22.19.13)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.13)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   website:
     dependencies:


### PR DESCRIPTION
## Summary

- Extract pure domain logic from React hooks (`usePlayback`, `useAnnotations`) into `packages/viewer/src/engine/` — three framework-agnostic TypeScript modules:
  - `scene-timing.ts`: `isBatchable`, `findBatchEnd`, `sceneDuration`
  - `scene-navigation.ts`: `computeUserPromptIndices`, `findNext/PrevUserPrompt`, `computeNextIndex`
  - `annotation-store.ts`: add/update/remove annotation, `computeAnnotatedScenes/Counts`, `hasUnsavedChanges`
- React hooks become thin wrappers: domain logic delegated to engine, hooks only manage timers, state, and DOM
- Added 57 unit tests for all extracted functions (vitest, viewer package)
- Net -113 lines from hooks, +683 lines total (engine + tests)

## Test plan

- [x] `pnpm test` — all 281 tests pass (224 CLI + 57 viewer engine)
- [x] `pnpm lint:check` — 0 errors
- [x] `pnpm build` — viewer 478KB < 500KB limit
- [ ] Manual: `pnpm dev` — verify playback, navigation, annotations behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)