### PR TITLE
ci: reduce Claude Code Review token usage

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,21 +2,17 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, ready_for_review, reopened]
+
+# Cancel in-progress reviews when a new one is triggered
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip draft PRs
+    if: ${{ !github.event.pull_request.draft }}
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Remove `synchronize` trigger from Claude Code Review workflow — reviews now only run automatically on PR open/reopen/ready_for_review, not on every push
- Add `concurrency` group with `cancel-in-progress: true` to prevent stacking reviews
- Skip draft PRs

## Why
The `synchronize` trigger was causing a full Claude (Opus) code review on **every single push** to a PR branch. One branch (`feat/local-ui-phase1`) alone triggered **24 reviews**. Total: **79 review runs** across the repo.

For subsequent reviews after the initial auto-review, use `@claude /code-review` in a PR comment.

## Test plan
- [ ] Open a new PR → should trigger Claude Code Review
- [ ] Push to an existing PR → should NOT trigger Claude Code Review
- [ ] Comment `@claude /code-review` on a PR → should trigger review via `claude.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)