### PR TITLE
fix: move @vibe-replay/types to devDependencies to fix npx install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,4 @@ jobs:
       - run: pnpm build
 
       - name: Publish to npm
-        run: |
-          cd packages/cli
-          npm publish --access public
+        run: pnpm --filter vibe-replay publish --access public --no-git-checks

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@vibe-replay/types": "workspace:*",
     "@hono/node-server": "^1.19.11",
     "@inquirer/prompts": "^7.2.0",
     "chalk": "^5.3.0",
@@ -52,6 +51,7 @@
     "sql.js": "^1.14.1"
   },
   "devDependencies": {
+    "@vibe-replay/types": "workspace:*",
     "@types/node": "^22.10.0",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@inquirer/prompts':
         specifier: ^7.2.0
         version: 7.10.1(@types/node@22.19.13)
-      '@vibe-replay/types':
-        specifier: workspace:*
-        version: link:../types
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -67,6 +64,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.13
+      '@vibe-replay/types':
+        specifier: workspace:*
+        version: link:../types
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## Summary
- Moved `@vibe-replay/types` from `dependencies` to `devDependencies` in `packages/cli/package.json` — it's only used as `import type` (erased at compile time by tsup), so it's not needed at runtime
- Switched release workflow from `npm publish` to `pnpm publish` which properly resolves `workspace:*` protocols as a safety net

## Problem
`npx vibe-replay@0.0.8` fails with:
```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

The `workspace:*` protocol (pnpm monorepo feature) leaked into the published package because `npm publish` doesn't resolve it.

## Test plan
- [x] `pnpm build` succeeds
- [x] All 339 tests pass
- [x] `npm pack --dry-run` shows no `workspace:*` in runtime dependencies

Made with [Cursor](https://cursor.com)