### PR TITLE
feat: show friendly notice when running on Windows

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ program
         chalk.dim("  → ") + chalk.white("https://github.com/tuo-lei/vibe-replay/issues/26"),
       );
       console.log(chalk.dim("  → ") + chalk.white("https://vibe-replay.com\n"));
-      process.exit(0);
+      process.exit(1);
     }
 
     // --dashboard: open Dashboard directly

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,17 @@ program
   .action(async (opts) => {
     console.log(chalk.bold.cyan("\n  vibe-replay") + chalk.dim(` v${CLI_VERSION}\n`));
 
+    // Windows is not supported yet (see https://github.com/tuo-lei/vibe-replay/issues/26)
+    if (process.platform === "win32") {
+      console.log(chalk.yellow("  ⚠ Windows is not supported yet.\n"));
+      console.log(chalk.dim("  We're working on it! Follow progress and updates:"));
+      console.log(
+        chalk.dim("  → ") + chalk.white("https://github.com/tuo-lei/vibe-replay/issues/26"),
+      );
+      console.log(chalk.dim("  → ") + chalk.white("https://vibe-replay.com\n"));
+      process.exit(0);
+    }
+
     // --dashboard: open Dashboard directly
     if (opts.dashboard) {
       const { join: pathJoin } = await import("node:path");


### PR DESCRIPTION
## Summary
- Detect `process.platform === "win32"` at CLI startup and show a friendly message explaining Windows isn't supported yet
- Links users to tracking issue (#26) and the website for updates
- WSL users are unaffected (`process.platform` returns `"linux"` inside WSL)

Closes #26 — partially (adds user-facing notice; full Windows support is a larger effort)

## Context
Windows support is blocked primarily by:
- `@inquirer/prompts` doesn't work in Git Bash/mintty (not a true TTY)
- Path handling differences (backslashes, drive letters)
- Unix-specific commands (`which`) in the codebase

This PR ensures Windows users get a clear message instead of a confusing crash.

## Test plan
- [ ] Verify on macOS/Linux: no change in behavior
- [ ] Verify message appears correctly when `process.platform` is `"win32"`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)