### PR TITLE
feat: cache session discovery and refresh UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ When to use which:
 - **Cursor tri-source**: Sessions come from SQLite `store.db` (primary), `globalStorage/state.vscdb`, or JSONL (fallback). Discovery merges all sources. DB data is source of truth; JSONL supplements missing thinking/images.
 - **Skip `progress` lines**: These are subagent streaming artifacts in JSONL.
 - **sql.js (WASM)**: Used instead of native SQLite bindings for portability — no C++ compiler needed.
+- **Session discovery cache**: CLI picker + local dashboard use file cache at `~/.vibe-replay/cache/*.json` (stale-while-refresh UX). Cache validity is tied to CLI release version (`CLI_VERSION`) plus envelope version, so caches auto-invalidate across releases. Keep cache writes best-effort and never block generation/parsing on cache failures.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ When to use which:
 - Test with both small (~30 scenes) and large (~500 scenes) sessions
 - **Test modification policy** — see `packages/cli/test/README.md` before changing any test
 
+## Release checklist (important)
+
+When creating a release for npm/GitHub, do this in order:
+
+1. Confirm with user first (no autonomous publish/version bump).
+2. Bump `packages/cli/package.json` `version` to the target release version.
+3. Build CLI: `pnpm --filter vibe-replay build`.
+4. Verify displayed CLI version matches package version:
+   - `node packages/cli/dist/index.js --version`
+   - Note: startup banner `vX.Y.Z` comes from `packages/cli/src/version.ts` reading `packages/cli/package.json`.
+5. Only then create tag/release/publish for that same version.
+
+If tag/release is updated but `packages/cli/package.json` is not, CLI will still show the old version.
+
 ## Key files
 
 | What | Where |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Pick a session, get a self-contained HTML file. Done.
 - **Share anywhere** — publish to [vibe-replay.com](https://vibe-replay.com) via GitHub Gist, or just send the HTML file
 - **Privacy first** — API keys, tokens, credentials, and paths are automatically redacted
 - **Light & dark themes** — with customizable view preferences
+- **Faster startup** — file-based stale cache shows sessions immediately while latest sessions refresh in background
 
 ## Supported Providers
 

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -1,0 +1,57 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { CLI_VERSION } from "./version.js";
+
+const CACHE_ENVELOPE_VERSION = 1;
+const CACHE_DIR = join(homedir(), ".vibe-replay", "cache");
+
+interface CacheEnvelope<T> {
+  envelopeVersion: number;
+  appVersion: string;
+  updatedAt: string;
+  data: T;
+}
+
+export interface FileCacheEntry<T> {
+  updatedAt: string;
+  data: T;
+}
+
+function toCachePath(key: string): string {
+  const safeKey = key.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return join(CACHE_DIR, `${safeKey}.json`);
+}
+
+export async function readFileCache<T>(key: string): Promise<FileCacheEntry<T> | null> {
+  try {
+    const raw = await readFile(toCachePath(key), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<CacheEnvelope<T>>;
+    if (
+      parsed.envelopeVersion !== CACHE_ENVELOPE_VERSION ||
+      parsed.appVersion !== CLI_VERSION ||
+      typeof parsed.updatedAt !== "string" ||
+      !("data" in parsed)
+    ) {
+      return null;
+    }
+    return { updatedAt: parsed.updatedAt, data: parsed.data as T };
+  } catch {
+    return null;
+  }
+}
+
+export async function writeFileCache<T>(key: string, data: T): Promise<void> {
+  try {
+    await mkdir(CACHE_DIR, { recursive: true });
+    const payload: CacheEnvelope<T> = {
+      envelopeVersion: CACHE_ENVELOPE_VERSION,
+      appVersion: CLI_VERSION,
+      updatedAt: new Date().toISOString(),
+      data,
+    };
+    await writeFile(toCachePath(key), JSON.stringify(payload), "utf-8");
+  } catch {
+    // Best-effort cache writes should never break core flows.
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { Separator, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import { program } from "commander";
 import ora from "ora";
+import { readFileCache, writeFileCache } from "./cache.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
@@ -14,6 +15,30 @@ import type { SessionInfo } from "./types.js";
 import { CLI_VERSION } from "./version.js";
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
+const SESSION_DISCOVERY_CACHE_KEY = "session-discovery-v1";
+
+function formatRelativeAge(iso: string): string {
+  const ageMs = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "just now";
+  const mins = Math.floor(ageMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+async function discoverAllSessions(): Promise<SessionInfo[]> {
+  const providers = getAllProviders();
+  const allSessions: SessionInfo[] = [];
+  for (const provider of providers) {
+    const sessions = await provider.discover();
+    allSessions.push(...sessions);
+  }
+  allSessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return allSessions;
+}
 
 program
   .name("vibe-replay")
@@ -60,80 +85,175 @@ program
       sessionPaths = opts.session;
       providerName = opts.provider;
     } else {
-      // Discover sessions from all providers
-      const spinner = ora("Scanning sessions...").start();
-      const providers = getAllProviders();
-      const allSessions: SessionInfo[] = [];
+      let displayedSessions: SessionInfo[] = [];
+      const cached = await readFileCache<SessionInfo[]>(SESSION_DISCOVERY_CACHE_KEY);
+      const hasStaleCache = !!(cached && cached.data.length > 0);
+      let showStaleLabel = hasStaleCache;
+      let refreshPromise: Promise<SessionInfo[] | null> | null = null;
 
-      for (const provider of providers) {
-        const sessions = await provider.discover();
-        allSessions.push(...sessions);
+      if (hasStaleCache && cached) {
+        displayedSessions = cached.data
+          .slice()
+          .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+        console.log(
+          chalk.cyan(
+            `  Quick start: loaded ${displayedSessions.length} sessions from local cache (${formatRelativeAge(cached.updatedAt)}).`,
+          ),
+        );
+        console.log(
+          chalk.dim("  Fetching latest sessions in background; this list will auto-refresh.\n"),
+        );
+
+        refreshPromise = discoverAllSessions()
+          .then(async (freshSessions) => {
+            await writeFileCache(SESSION_DISCOVERY_CACHE_KEY, freshSessions);
+            return freshSessions;
+          })
+          .catch(() => null);
+      } else {
+        const spinner = ora("Scanning latest sessions...").start();
+        try {
+          displayedSessions = await discoverAllSessions();
+          await writeFileCache(SESSION_DISCOVERY_CACHE_KEY, displayedSessions);
+        } finally {
+          spinner.stop();
+        }
       }
 
-      // Sort by timestamp descending
-      allSessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-      spinner.stop();
-
-      if (allSessions.length === 0) {
+      if (displayedSessions.length === 0) {
         console.log(chalk.red("  No AI coding sessions found."));
         process.exit(1);
       }
-
-      // Group by project for display
-      const choices = formatSessionChoices(allSessions);
 
       const { join: pathJoin } = await import("node:path");
       const { homedir } = await import("node:os");
       const replayBaseDir = pathJoin(homedir(), ".vibe-replay");
 
-      // Listen for 'd' keypress to open dashboard
-      const ac = new AbortController();
-      let dashboardRequested = false;
-      const { emitKeypressEvents } = await import("node:readline");
-      if (!process.stdin.listenerCount("keypress")) {
-        emitKeypressEvents(process.stdin);
-      }
-      const onKeypress = (_str: string, key: { name?: string }) => {
-        if (key?.name === "d") {
-          dashboardRequested = true;
-          ac.abort();
-        }
-      };
-      process.stdin.on("keypress", onKeypress);
-      ac.signal.addEventListener("abort", () => {
-        process.stdin.off("keypress", onKeypress);
-      });
-
       let chosen: string;
-      try {
-        chosen = await select<string>(
-          {
-            message: "Pick a session to replay:",
-            choices,
-            pageSize: 20,
-            theme: {
-              style: {
-                keysHelpTip: (keys: [string, string][]) =>
-                  [...keys, ["d", "dashboard"]]
-                    .map(([k, v]) => `${chalk.bold(k)} ${chalk.dim(v)}`)
-                    .join(chalk.dim(" \u00b7 ")),
+      let highlightedValue: string | undefined;
+      while (true) {
+        const choices = formatSessionChoices(displayedSessions);
+        const selectableValues = choices
+          .filter(
+            (choice): choice is { value: string } =>
+              !!choice &&
+              typeof choice === "object" &&
+              "value" in choice &&
+              typeof (choice as any).value === "string",
+          )
+          .map((choice) => choice.value);
+
+        let cursorIndex = 0;
+        if (highlightedValue) {
+          const idx = selectableValues.indexOf(highlightedValue);
+          if (idx >= 0) cursorIndex = idx;
+        }
+        highlightedValue = selectableValues[cursorIndex];
+
+        const ac = new AbortController();
+        let dashboardRequested = false;
+        let shouldSwitchToFresh = false;
+        let freshSessions: SessionInfo[] | null = null;
+        let promptSettled = false;
+
+        const { emitKeypressEvents } = await import("node:readline");
+        if (!process.stdin.listenerCount("keypress")) {
+          emitKeypressEvents(process.stdin);
+        }
+        const onKeypress = (_str: string, key: { name?: string }) => {
+          if (key?.name === "d") {
+            dashboardRequested = true;
+            ac.abort();
+            return;
+          }
+
+          if (selectableValues.length === 0) return;
+
+          if (key?.name === "down" || key?.name === "j") {
+            cursorIndex = Math.min(selectableValues.length - 1, cursorIndex + 1);
+            highlightedValue = selectableValues[cursorIndex];
+          } else if (key?.name === "up" || key?.name === "k") {
+            cursorIndex = Math.max(0, cursorIndex - 1);
+            highlightedValue = selectableValues[cursorIndex];
+          } else if (key?.name === "pageup") {
+            cursorIndex = Math.max(0, cursorIndex - 20);
+            highlightedValue = selectableValues[cursorIndex];
+          } else if (key?.name === "pagedown") {
+            cursorIndex = Math.min(selectableValues.length - 1, cursorIndex + 20);
+            highlightedValue = selectableValues[cursorIndex];
+          } else if (key?.name === "home") {
+            cursorIndex = 0;
+            highlightedValue = selectableValues[cursorIndex];
+          } else if (key?.name === "end") {
+            cursorIndex = selectableValues.length - 1;
+            highlightedValue = selectableValues[cursorIndex];
+          }
+        };
+        const cleanup = () => {
+          process.stdin.off("keypress", onKeypress);
+        };
+        process.stdin.on("keypress", onKeypress);
+        ac.signal.addEventListener("abort", () => {
+          cleanup();
+        });
+
+        if (showStaleLabel && refreshPromise) {
+          void refreshPromise.then((sessions) => {
+            if (promptSettled) return;
+            if (!sessions || sessions.length === 0) return;
+            freshSessions = sessions;
+            shouldSwitchToFresh = true;
+            ac.abort();
+          });
+        }
+
+        try {
+          chosen = await select<string>(
+            {
+              message: showStaleLabel
+                ? "Pick a session to replay (cached, auto-refreshing):"
+                : "Pick a session to replay:",
+              choices,
+              default: highlightedValue,
+              pageSize: 20,
+              theme: {
+                style: {
+                  keysHelpTip: (keys: [string, string][]) =>
+                    [...keys, ["d", "dashboard"]]
+                      .map(([k, v]) => `${chalk.bold(k)} ${chalk.dim(v)}`)
+                      .join(chalk.dim(" \u00b7 ")),
+                },
               },
             },
-          },
-          { signal: ac.signal },
-        );
-      } catch {
-        if (dashboardRequested) {
-          await startDashboard(
-            replayBaseDir,
-            DEV_MENU_ENABLED ? { externalViewerUrl: "http://localhost:5173" } : undefined,
+            { signal: ac.signal },
           );
-          return;
+          promptSettled = true;
+          highlightedValue = chosen;
+          cleanup();
+          break;
+        } catch {
+          promptSettled = true;
+          cleanup();
+          if (dashboardRequested) {
+            await startDashboard(
+              replayBaseDir,
+              DEV_MENU_ENABLED ? { externalViewerUrl: "http://localhost:5173" } : undefined,
+            );
+            return;
+          }
+          if (shouldSwitchToFresh && freshSessions) {
+            displayedSessions = freshSessions
+              .slice()
+              .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+            showStaleLabel = false;
+            console.log(chalk.green("\n  Latest sessions fetched. List refreshed.\n"));
+            continue;
+          }
+          process.exit(0);
         }
-        process.exit(0);
       }
 
-      const info = allSessions.find((s) => s.filePath === chosen);
+      const info = displayedSessions.find((s) => s.filePath === chosen);
       sessionInfo = info;
       sessionPaths = info ? [...info.filePaths, ...(info.toolPaths || [])] : [chosen];
       providerName = info?.provider || opts.provider;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -294,6 +294,14 @@ export async function startServer(
   const cacheKeySuffix = createHash("sha1").update(baseDir).digest("hex").slice(0, 12);
   const sourcesCacheKey = `dashboard-sources-v1-${cacheKeySuffix}`;
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
+  const refreshReplaysCache = async (): Promise<void> => {
+    try {
+      const sessions = await scanSessions(baseDir);
+      await writeFileCache(replaysCacheKey, sessions);
+    } catch {
+      // Best-effort cache refresh for dashboard listing.
+    }
+  };
 
   const app = new Hono();
 
@@ -348,6 +356,7 @@ export async function startServer(
       const targetDir = join(baseDir, slug);
       await writeFile(join(targetDir, "replay.json"), JSON.stringify(target), "utf-8");
       await generateOutput(target, targetDir);
+      await refreshReplaysCache();
 
       return c.json({ ok: true, title: target.meta.title });
     } catch (err: any) {
@@ -362,6 +371,7 @@ export async function startServer(
     try {
       const { rm } = await import("node:fs/promises");
       await rm(join(baseDir, slug), { recursive: true });
+      await refreshReplaysCache();
       return c.json({ ok: true });
     } catch (err: any) {
       return c.json({ error: err.message || "Delete failed" }, 500);
@@ -539,6 +549,7 @@ export async function startServer(
       const slug = rawSlug.replace(/[^a-zA-Z0-9_-]/g, "-");
       const outputDir = join(baseDir, slug);
       await generateOutput(replay, outputDir);
+      await refreshReplaysCache();
 
       // Secret scanning
       const findings = scanForSecrets(JSON.stringify(replay));

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -7,6 +7,7 @@ import { serve } from "@hono/node-server";
 import chalk from "chalk";
 import { Hono } from "hono";
 import open from "open";
+import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText } from "./clean-prompt.js";
 import { detectFeedbackTools, generateFeedback } from "./feedback.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
@@ -290,6 +291,9 @@ export async function startServer(
   await mkdir(baseDir, { recursive: true });
 
   const viewerHtml = await loadViewerHtml();
+  const cacheKeySuffix = createHash("sha1").update(baseDir).digest("hex").slice(0, 12);
+  const sourcesCacheKey = `dashboard-sources-v1-${cacheKeySuffix}`;
+  const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
 
   const app = new Hono();
 
@@ -314,8 +318,18 @@ export async function startServer(
   });
 
   // --- Dashboard: list all sessions ---
+  app.get("/api/sessions/cached", async (c) => {
+    const cached = await readFileCache<any[]>(replaysCacheKey);
+    return c.json({
+      sessions: cached?.data || [],
+      stale: !!cached,
+      cachedAt: cached?.updatedAt,
+    });
+  });
+
   app.get("/api/sessions", async (c) => {
     const sessions = await scanSessions(baseDir);
+    await writeFileCache(replaysCacheKey, sessions);
     return c.json(sessions);
   });
 
@@ -376,6 +390,15 @@ export async function startServer(
   });
 
   // --- Sources: discover AI coding sessions from all providers ---
+  app.get("/api/sources/cached", async (c) => {
+    const cached = await readFileCache<any[]>(sourcesCacheKey);
+    return c.json({
+      sessions: cached?.data || [],
+      stale: !!cached,
+      cachedAt: cached?.updatedAt,
+    });
+  });
+
   app.get("/api/sources", async (c) => {
     try {
       const providers = getAllProviders();
@@ -464,6 +487,7 @@ export async function startServer(
         };
       });
 
+      await writeFileCache(sourcesCacheKey, result);
       return c.json({ sessions: result });
     } catch (err: any) {
       return c.json({ error: err.message || "Source discovery failed" }, 500);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -322,7 +322,6 @@ export async function startServer(
     const cached = await readFileCache<any[]>(replaysCacheKey);
     return c.json({
       sessions: cached?.data || [],
-      stale: !!cached,
       cachedAt: cached?.updatedAt,
     });
   });
@@ -394,7 +393,6 @@ export async function startServer(
     const cached = await readFileCache<any[]>(sourcesCacheKey);
     return c.json({
       sessions: cached?.data || [],
-      stale: !!cached,
       cachedAt: cached?.updatedAt,
     });
   });

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -60,7 +60,12 @@ export default function App() {
   if (loadState.status === "loading") {
     return (
       <div className="h-screen bg-terminal-bg flex items-center justify-center">
-        <div className="text-terminal-dim font-mono text-sm animate-pulse">Loading session...</div>
+        <div className="text-center space-y-2">
+          <div className="text-terminal-green font-mono text-sm animate-pulse">
+            LOADING SESSION...
+          </div>
+          <div className="text-terminal-dimmer font-mono text-xs">Preparing replay data</div>
+        </div>
       </div>
     );
   }

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -987,7 +987,7 @@ function SessionsPanel() {
           </div>
         </div>
 
-        {(showInitialLoading || refreshing || staleCachedAt || refreshError) && (
+        {(showInitialLoading || refreshing || staleCachedAt) && (
           <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
             {showInitialLoading ? (
               <>

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -2,6 +2,52 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { SessionSummary, SourceSession } from "../types";
 
 type Tab = "sessions" | "replays";
+type CachedListResponse<T> = {
+  sessions: T[];
+  cachedAt?: string;
+};
+const CACHE_REFRESH_TTL_MS = 5 * 60 * 1000;
+
+function parseCachedList<T>(payload: unknown): CachedListResponse<T> | null {
+  if (!payload || typeof payload !== "object") return null;
+  const obj = payload as { sessions?: unknown; cachedAt?: unknown };
+  if (!Array.isArray(obj.sessions)) return null;
+  return {
+    sessions: obj.sessions as T[],
+    cachedAt: typeof obj.cachedAt === "string" ? obj.cachedAt : undefined,
+  };
+}
+
+function formatCacheAge(iso?: string): string {
+  if (!iso) return "just now";
+  const ageMs = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "just now";
+  const mins = Math.floor(ageMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatCompactAge(iso?: string, nowMs = Date.now()): string {
+  if (!iso) return "";
+  const ageMs = nowMs - new Date(iso).getTime();
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "0m";
+  const mins = Math.floor(ageMs / 60000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+function isCacheFresh(iso?: string, ttlMs = CACHE_REFRESH_TTL_MS): boolean {
+  if (!iso) return false;
+  const ageMs = Date.now() - new Date(iso).getTime();
+  return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < ttlMs;
+}
 
 function formatDuration(ms?: number): string {
   if (!ms) return "";
@@ -521,6 +567,11 @@ function SessionsPanel() {
   const [sources, setSources] = useState<SourceSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [staleCachedAt, setStaleCachedAt] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(null);
+  const [refreshClockMs, setRefreshClockMs] = useState(() => Date.now());
   const [selectedProject, setSelectedProject] = useState<string>(ALL_PROJECTS);
   const [filter, setFilter] = useState("");
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
@@ -531,22 +582,56 @@ function SessionsPanel() {
   const [archivedSlugs, setArchivedSlugs] = useState<Set<string>>(new Set());
   const [showArchived, setShowArchived] = useState(false);
 
-  const loadSources = useCallback(() => {
+  const loadSources = useCallback(async (opts?: { forceRefresh?: boolean }) => {
     setLoading(true);
     setError(null);
-    Promise.all([
-      fetch("/api/sources").then((r) => {
-        if (!r.ok) throw new Error("Failed to load sessions");
-        return r.json();
-      }),
-      fetch("/api/archived").then((r) => (r.ok ? r.json() : { slugs: [] })),
-    ])
-      .then(([data, archive]: [{ sessions: SourceSession[] }, { slugs: string[] }]) => {
-        setSources(data.sessions);
-        setArchivedSlugs(new Set(archive.slugs));
-      })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
+    setRefreshError(null);
+    setRefreshing(false);
+    setStaleCachedAt(null);
+
+    const archive = await fetch("/api/archived")
+      .then((r) => (r.ok ? r.json() : { slugs: [] }))
+      .catch(() => ({ slugs: [] as string[] }));
+    setArchivedSlugs(new Set(archive.slugs));
+
+    let servedFromCache = false;
+    const cached = await fetch("/api/sources/cached")
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+    const cachedData = parseCachedList<SourceSession>(cached);
+    const shouldSkipRefresh = !opts?.forceRefresh && isCacheFresh(cachedData?.cachedAt);
+    if (cachedData && cachedData.sessions.length > 0) {
+      servedFromCache = true;
+      setSources(cachedData.sessions);
+      setLastRefreshedAt(cachedData.cachedAt ?? null);
+      setStaleCachedAt(shouldSkipRefresh ? null : (cachedData.cachedAt ?? null));
+      setLoading(false);
+      setRefreshing(!shouldSkipRefresh);
+    }
+
+    if (shouldSkipRefresh) {
+      setRefreshing(false);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const freshResp = await fetch("/api/sources");
+      if (!freshResp.ok) throw new Error("Failed to load sessions");
+      const fresh = (await freshResp.json()) as { sessions: SourceSession[] };
+      setSources(fresh.sessions);
+      setLastRefreshedAt(new Date().toISOString());
+      setStaleCachedAt(null);
+    } catch (err: any) {
+      if (!servedFromCache) {
+        setError(err.message || "Failed to load sessions");
+      } else {
+        setRefreshError("Failed to refresh latest sessions. Showing cached data.");
+      }
+    } finally {
+      setRefreshing(false);
+      setLoading(false);
+    }
   }, []);
 
   const toggleArchive = async (slug: string) => {
@@ -560,8 +645,13 @@ function SessionsPanel() {
   };
 
   useEffect(() => {
-    loadSources();
+    void loadSources();
   }, [loadSources]);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setRefreshClockMs(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     if (titleInput) titleInputRef.current?.focus();
@@ -653,18 +743,11 @@ function SessionsPanel() {
           (s.gitBranch || "").toLowerCase().includes(filter.toLowerCase()),
       )
     : projectSessions;
+  const refreshAge = lastRefreshedAt ? formatCompactAge(lastRefreshedAt, refreshClockMs) : null;
 
-  if (loading) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-terminal-dim font-mono text-sm animate-pulse">
-          Scanning for AI sessions...
-        </div>
-      </div>
-    );
-  }
+  const showInitialLoading = loading && sources.length === 0;
 
-  if (error) {
+  if (error && sources.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center space-y-3">
@@ -680,7 +763,7 @@ function SessionsPanel() {
     );
   }
 
-  if (sources.length === 0) {
+  if (sources.length === 0 && !showInitialLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center space-y-2">
@@ -698,11 +781,20 @@ function SessionsPanel() {
       {/* ─── Left sidebar: project navigation (hidden on mobile) ─── */}
       <div className="hidden md:flex w-60 shrink-0 flex-col border-r border-terminal-border-subtle bg-terminal-surface/20">
         <div className="flex items-center justify-between px-4 py-3 border-b border-terminal-border-subtle">
-          <span className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold">
-            Projects
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold">
+              Projects
+            </span>
+            {refreshAge && (
+              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
+                {refreshAge}
+              </span>
+            )}
+          </div>
           <button
-            onClick={loadSources}
+            onClick={() => {
+              void loadSources({ forceRefresh: true });
+            }}
             className="p-1.5 rounded-md text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover transition-colors duration-200"
             title="Refresh"
           >
@@ -895,6 +987,42 @@ function SessionsPanel() {
           </div>
         </div>
 
+        {(showInitialLoading || refreshing || staleCachedAt || refreshError) && (
+          <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
+            {showInitialLoading ? (
+              <>
+                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+                <span>FETCHING SESSIONS...</span>
+              </>
+            ) : refreshing ? (
+              <>
+                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+                <span>SCANNING LATEST SESSIONS...</span>
+                {staleCachedAt && (
+                  <span className="text-terminal-dim">
+                    Showing stale cache ({formatCacheAge(staleCachedAt)})
+                  </span>
+                )}
+              </>
+            ) : staleCachedAt ? (
+              <span>Showing stale cache ({formatCacheAge(staleCachedAt)})</span>
+            ) : null}
+          </div>
+        )}
+
+        {/* Error toast */}
+        {refreshError && (
+          <div className="mx-4 mb-2 flex items-center gap-2 bg-terminal-orange-subtle rounded-lg px-3 py-2.5 text-xs font-mono text-terminal-orange shrink-0 shadow-layer-sm">
+            <span>{refreshError}</span>
+            <button
+              onClick={() => setRefreshError(null)}
+              className="ml-auto text-terminal-orange/60 hover:text-terminal-orange transition-colors"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+
         {/* Error toast */}
         {generateError && (
           <div className="mx-4 mb-2 flex items-center gap-2 bg-terminal-red-subtle rounded-lg px-3 py-2.5 text-xs font-mono text-terminal-red shrink-0 shadow-layer-sm">
@@ -950,7 +1078,11 @@ function SessionsPanel() {
 
         {/* Session list */}
         <div className="flex-1 overflow-y-auto">
-          {filtered.length === 0 ? (
+          {showInitialLoading ? (
+            <div className="text-center py-12 text-terminal-dim font-mono text-sm">
+              Fetching sessions...
+            </div>
+          ) : filtered.length === 0 ? (
             <div className="text-center py-12 text-terminal-dim font-mono text-sm">
               {filter ? "No sessions match your filter" : "No sessions in this project"}
             </div>
@@ -1096,6 +1228,10 @@ function ReplaysPanel() {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [serverAvailable, setServerAvailable] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [staleCachedAt, setStaleCachedAt] = useState<string | null>(null);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<string | null>(null);
+  const [refreshClockMs, setRefreshClockMs] = useState(() => Date.now());
   const [ghAvailable, setGhAvailable] = useState<boolean | null>(null);
   const [filter, setFilter] = useState("");
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -1105,27 +1241,80 @@ function ReplaysPanel() {
   const [selectedProject, setSelectedProject] = useState<string>(ALL_PROJECTS);
 
   useEffect(() => {
-    Promise.all([
-      fetch("/api/sessions").then((r) => {
-        if (!r.ok) throw new Error();
-        return r.json();
-      }),
-      fetch("/api/archived").then((r) => (r.ok ? r.json() : { slugs: [] })),
-    ])
-      .then(([data, archive]: [SessionSummary[], { slugs: string[] }]) => {
-        setSessions(data);
+    let mounted = true;
+    const loadReplays = async () => {
+      setLoading(true);
+      setRefreshing(false);
+      setStaleCachedAt(null);
+
+      const archive = await fetch("/api/archived")
+        .then((r) => (r.ok ? r.json() : { slugs: [] }))
+        .catch(() => ({ slugs: [] as string[] }));
+      if (mounted) {
         setArchivedSlugs(new Set(archive.slugs));
+      }
+
+      let servedFromCache = false;
+      const cached = await fetch("/api/sessions/cached")
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+      const cachedData = parseCachedList<SessionSummary>(cached);
+      const shouldSkipRefresh = isCacheFresh(cachedData?.cachedAt);
+      if (mounted && cachedData && cachedData.sessions.length > 0) {
+        servedFromCache = true;
+        setSessions(cachedData.sessions);
         setServerAvailable(true);
-      })
-      .catch(() => {
-        setServerAvailable(false);
-      })
-      .finally(() => setLoading(false));
+        setLastRefreshedAt(cachedData.cachedAt ?? null);
+        setStaleCachedAt(shouldSkipRefresh ? null : (cachedData.cachedAt ?? null));
+        setLoading(false);
+        setRefreshing(!shouldSkipRefresh);
+      }
+
+      if (shouldSkipRefresh) {
+        if (mounted) {
+          setRefreshing(false);
+          setLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const resp = await fetch("/api/sessions");
+        if (!resp.ok) throw new Error();
+        const data = (await resp.json()) as SessionSummary[];
+        if (!mounted) return;
+        setSessions(data);
+        setServerAvailable(true);
+        setLastRefreshedAt(new Date().toISOString());
+        setStaleCachedAt(null);
+      } catch {
+        if (!mounted) return;
+        if (!servedFromCache) {
+          setServerAvailable(false);
+        }
+      } finally {
+        if (mounted) {
+          setRefreshing(false);
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadReplays();
 
     fetch("/api/gh-status")
       .then((r) => r.json())
       .then((data: { available: boolean }) => setGhAvailable(data.available))
       .catch(() => setGhAvailable(false));
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setRefreshClockMs(Date.now()), 30_000);
+    return () => window.clearInterval(timer);
   }, []);
 
   const toggleArchive = async (slug: string) => {
@@ -1237,17 +1426,11 @@ function ReplaysPanel() {
           (s.firstMessage || "").toLowerCase().includes(filter.toLowerCase()),
       )
     : projectSessions;
-
-  if (loading) {
-    return (
-      <div className="flex-1 flex items-center justify-center py-12">
-        <div className="text-terminal-dim font-mono text-sm animate-pulse">Loading...</div>
-      </div>
-    );
-  }
+  const refreshAge = lastRefreshedAt ? formatCompactAge(lastRefreshedAt, refreshClockMs) : null;
+  const showInitialLoading = loading && sessions.length === 0;
 
   // Non-server or empty: show simple centered layout
-  if (!serverAvailable || sessions.length === 0) {
+  if (!showInitialLoading && (!serverAvailable || sessions.length === 0)) {
     return (
       <div className="flex-1 overflow-auto">
         <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
@@ -1278,9 +1461,16 @@ function ReplaysPanel() {
       {/* ─── Left sidebar: project navigation (hidden on mobile) ─── */}
       <div className="hidden md:flex w-60 shrink-0 flex-col border-r border-terminal-border-subtle bg-terminal-surface/20">
         <div className="flex items-center justify-between px-4 py-3 border-b border-terminal-border-subtle">
-          <span className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold">
-            Projects
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold">
+              Projects
+            </span>
+            {refreshAge && (
+              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
+                {refreshAge}
+              </span>
+            )}
+          </div>
         </div>
         <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
           {/* All projects */}
@@ -1442,6 +1632,29 @@ function ReplaysPanel() {
           </div>
         </div>
 
+        {(showInitialLoading || refreshing || staleCachedAt) && (
+          <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
+            {showInitialLoading ? (
+              <>
+                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+                <span>FETCHING REPLAYS...</span>
+              </>
+            ) : refreshing ? (
+              <>
+                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+                <span>SCANNING LATEST REPLAYS...</span>
+                {staleCachedAt && (
+                  <span className="text-terminal-dim">
+                    Showing stale cache ({formatCacheAge(staleCachedAt)})
+                  </span>
+                )}
+              </>
+            ) : staleCachedAt ? (
+              <span>Showing stale cache ({formatCacheAge(staleCachedAt)})</span>
+            ) : null}
+          </div>
+        )}
+
         {/* Error toast */}
         {deleteError && (
           <div className="mx-4 mb-2 flex items-center gap-2 bg-terminal-red-subtle rounded-lg px-3 py-2.5 text-xs font-mono text-terminal-red shrink-0 shadow-layer-sm">
@@ -1457,7 +1670,11 @@ function ReplaysPanel() {
 
         {/* Replay list */}
         <div className="flex-1 overflow-y-auto">
-          {filtered.length === 0 ? (
+          {showInitialLoading ? (
+            <div className="text-center py-12 text-terminal-dim font-mono text-sm">
+              Fetching replays...
+            </div>
+          ) : filtered.length === 0 ? (
             <div className="text-center py-12 text-terminal-dim font-mono text-sm">
               {filter ? "No replays match your filter" : "No replays in this project"}
             </div>

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1260,14 +1260,16 @@ function ReplaysPanel() {
         .catch(() => null);
       const cachedData = parseCachedList<SessionSummary>(cached);
       const shouldSkipRefresh = isCacheFresh(cachedData?.cachedAt);
-      if (mounted && cachedData && cachedData.sessions.length > 0) {
+      if (mounted && cachedData) {
         servedFromCache = true;
         setSessions(cachedData.sessions);
         setServerAvailable(true);
         setLastRefreshedAt(cachedData.cachedAt ?? null);
-        setStaleCachedAt(shouldSkipRefresh ? null : (cachedData.cachedAt ?? null));
-        setLoading(false);
-        setRefreshing(!shouldSkipRefresh);
+        if (cachedData.sessions.length > 0 || shouldSkipRefresh) {
+          setStaleCachedAt(shouldSkipRefresh ? null : (cachedData.cachedAt ?? null));
+          setLoading(false);
+          setRefreshing(!shouldSkipRefresh);
+        }
       }
 
       if (shouldSkipRefresh) {


### PR DESCRIPTION
## Summary
- add a file-based cache layer for session/source/replay discovery so CLI and local dashboard can render cached data immediately
- refresh latest sessions in background and auto-refresh CLI picker once fresh results arrive, while preserving current selection position during refresh
- improve dashboard loading UX to avoid blocking full-screen loading states and show clearer fetch/refresh status banners

## Test plan
- [x] Run `pnpm --filter vibe-replay build`
- [x] Run `pnpm build`
- [ ] Manually run `npx vibe-replay` and confirm cached picker auto-refreshes to latest list
- [ ] Manually verify Dashboard `Sessions` and `Replays` tabs show non-blocking loading and refresh banners

Made with [Cursor](https://cursor.com)