### PR TITLE
ci: add publish simulation to prevent broken npm releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,35 @@ jobs:
           mkdir -p website/public/view
           cp packages/viewer/dist/index.html website/public/view/index.html
           pnpm --filter @vibe-replay/website build
+
+      - name: Simulate npm install (catch broken releases before merge)
+        run: |
+          cd packages/cli
+          pnpm pack --pack-destination /tmp/vibe-replay-pack
+
+          # Check for workspace: protocol leaks
+          tar xzf /tmp/vibe-replay-pack/*.tgz -C /tmp/vibe-replay-pack
+          if grep -q 'workspace:' /tmp/vibe-replay-pack/package/package.json; then
+            echo "::error::workspace: protocol reference found in packed package.json"
+            cat /tmp/vibe-replay-pack/package/package.json
+            exit 1
+          fi
+
+          # Verify required files are in the tarball
+          for f in package.json dist/index.js assets/viewer.html; do
+            if [ ! -f "/tmp/vibe-replay-pack/package/$f" ]; then
+              echo "::error::Required file missing from package: $f"
+              ls -R /tmp/vibe-replay-pack/package/
+              exit 1
+            fi
+          done
+
+          # Install from tarball in a clean directory (like a real user)
+          mkdir -p /tmp/vibe-replay-smoke
+          cd /tmp/vibe-replay-smoke
+          npm init -y > /dev/null 2>&1
+          npm install /tmp/vibe-replay-pack/*.tgz
+
+          # Verify the CLI actually runs
+          npx vibe-replay --version
+          echo "Publish simulation passed — package installs and runs correctly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,32 @@ jobs:
 
       - run: pnpm build
 
+      - name: Validate package (no workspace protocol leaks)
+        run: |
+          cd packages/cli
+          pnpm pack --pack-destination /tmp/vibe-replay-pack
+          tar xzf /tmp/vibe-replay-pack/*.tgz -C /tmp/vibe-replay-pack
+          if grep -q 'workspace:' /tmp/vibe-replay-pack/package/package.json; then
+            echo "::error::workspace: protocol reference found in packed package.json — aborting publish"
+            cat /tmp/vibe-replay-pack/package/package.json
+            exit 1
+          fi
+          echo "Package validation passed"
+
       - name: Publish to npm
         run: pnpm --filter vibe-replay publish --access public --no-git-checks
+
+      - name: Smoke test published package
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          for i in 1 2 3; do
+            echo "Attempt $i: waiting for npm registry propagation..."
+            sleep 30
+            if npx --yes vibe-replay@${VERSION} --version 2>&1 | grep -q "${VERSION}"; then
+              echo "Smoke test passed: vibe-replay@${VERSION} is installable and reports correct version"
+              exit 0
+            fi
+            echo "Version not yet available, retrying..."
+          done
+          echo "::error::Smoke test failed after 3 attempts — vibe-replay@${VERSION} not installable or reports wrong version"
+          exit 1


### PR DESCRIPTION
## Summary

After 0.0.8 shipped with `workspace:*` protocol leak that made `npx vibe-replay` completely broken (`EUNSUPPORTEDPROTOCOL`), this adds CI gates to catch this class of issue **before merge**.

- **CI build job** (every PR): `pnpm pack` → check no `workspace:` refs → verify required files (`dist/index.js`, `assets/viewer.html`) → `npm install` from tarball in clean dir → `npx vibe-replay --version`
- **Release workflow**: pre-publish `workspace:` validation (last line of defense) + post-publish smoke test with retry (`npx vibe-replay@$VERSION --version`)

## What this catches

| Check | Catches |
|-------|---------|
| `grep workspace:` | Protocol leak (the 0.0.8 bug) |
| Required files check | Missing `dist/index.js` or `assets/viewer.html` |
| `npm install tarball` | Any dependency that breaks install |
| `npx --version` | Import failures, bundle corruption |

## Test plan

- [x] Verified locally: full pack → install → run cycle passes
- [ ] CI should pass on this PR (the new step itself validates the current package)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)