### PR TITLE
fix(cursor): harden parsing fallback and global-state discovery

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { program } from "commander";
 import ora from "ora";
 import { readFileCache, writeFileCache } from "./cache.js";
+import { cleanPromptText } from "./clean-prompt.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
@@ -16,6 +17,37 @@ import { CLI_VERSION } from "./version.js";
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
 const SESSION_DISCOVERY_CACHE_KEY = "session-discovery-v1";
+const TITLE_MAX_CHARS = 120;
+
+function normalizeTitle(value?: string): string {
+  return (value || "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX_CHARS);
+}
+
+function normalizePromptTitle(value?: string): string {
+  return normalizeTitle(cleanPromptText(value || ""));
+}
+
+function suggestedReplayTitle(
+  replayTitle: string | undefined,
+  replaySlug: string,
+  sessionInfo?: SessionInfo,
+): string {
+  const slug = normalizeTitle(replaySlug);
+  const replayCandidate = normalizeTitle(replayTitle);
+  if (replayCandidate && replayCandidate !== slug) return replayCandidate;
+
+  const sessionTitle = normalizeTitle(sessionInfo?.title);
+  if (sessionTitle && sessionTitle !== slug) return sessionTitle;
+
+  for (const prompt of sessionInfo?.prompts || []) {
+    const promptTitle = normalizePromptTitle(prompt);
+    if (promptTitle) return promptTitle;
+  }
+  const firstPromptTitle = normalizePromptTitle(sessionInfo?.firstPrompt);
+  if (firstPromptTitle) return firstPromptTitle;
+
+  return replayCandidate || slug;
+}
 
 function formatRelativeAge(iso: string): string {
   const ageMs = Date.now() - new Date(iso).getTime();
@@ -291,16 +323,18 @@ program
 
     // Title: CLI flag > interactive prompt > auto-detected > slug
     if (opts.title) {
-      replay.meta.title = opts.title;
+      const normalizedCliTitle = normalizeTitle(opts.title);
+      if (normalizedCliTitle) replay.meta.title = normalizedCliTitle;
     } else {
       const { input } = await import("@inquirer/prompts");
-      const defaultTitle = replay.meta.title || replay.meta.slug;
+      const defaultTitle = suggestedReplayTitle(replay.meta.title, replay.meta.slug, sessionInfo);
       const userTitle = await input({
         message: "Replay title (shown on landing page & shared links):",
         default: defaultTitle,
       });
-      if (userTitle.trim()) {
-        replay.meta.title = userTitle.trim();
+      const normalizedUserTitle = normalizeTitle(userTitle);
+      if (normalizedUserTitle) {
+        replay.meta.title = normalizedUserTitle;
       }
     }
 

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./sqlite-reader.js", () => ({
+  parseCursorSqlite: vi.fn(),
+}));
+
+import { parseCursorSession } from "./parser.js";
+import { parseCursorSqlite } from "./sqlite-reader.js";
+
+const mockedParseCursorSqlite = vi.mocked(parseCursorSqlite);
+
+describe("parseCursorSession", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    mockedParseCursorSqlite.mockReset();
+    for (const dir of tempDirs.splice(0)) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns sqlite result when available", async () => {
+    mockedParseCursorSqlite.mockResolvedValueOnce({
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      cwd: "/repo",
+      turns: [{ role: "user", blocks: [{ type: "text", text: "hello" }] }],
+      dataSource: "sqlite",
+      dataSourceInfo: {
+        primary: "sqlite",
+        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      },
+    });
+
+    const parsed = await parseCursorSession(["/tmp/fake.txt"], {
+      provider: "cursor",
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      project: "/repo",
+      cwd: "/repo",
+      version: "",
+      timestamp: new Date().toISOString(),
+      lineCount: 0,
+      fileSize: 0,
+      filePath: "/tmp/fake.txt",
+      filePaths: ["/tmp/fake.txt"],
+      firstPrompt: "hello",
+    });
+
+    expect(parsed.dataSource).toBe("sqlite");
+    expect(parsed.sessionId).toBe("sqlite-session");
+  });
+
+  it("falls back to JSONL when sqlite parsing throws", async () => {
+    mockedParseCursorSqlite.mockRejectedValueOnce(new Error("no such table: meta"));
+
+    const dir = await mkdtemp(join(tmpdir(), "cursor-parser-test-"));
+    tempDirs.push(dir);
+    const transcript = join(dir, "session.jsonl");
+
+    const lines = [
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "<user_query>build tests</user_query>" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: { content: [{ type: "text", text: "Working on it." }] },
+      }),
+    ].join("\n");
+    await writeFile(transcript, `${lines}\n`, "utf-8");
+
+    const parsed = await parseCursorSession([transcript], {
+      provider: "cursor",
+      sessionId: "session",
+      slug: "session",
+      project: dir,
+      cwd: dir,
+      version: "",
+      timestamp: new Date().toISOString(),
+      lineCount: 2,
+      fileSize: lines.length,
+      filePath: transcript,
+      filePaths: [transcript],
+      firstPrompt: "build tests",
+    });
+
+    expect(parsed.dataSource).toBe("jsonl");
+    expect(parsed.turns.length).toBeGreaterThan(0);
+    expect(parsed.turns[0]?.role).toBe("user");
+  });
+});

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -91,5 +91,28 @@ describe("parseCursorSession", () => {
     expect(parsed.dataSource).toBe("jsonl");
     expect(parsed.turns.length).toBeGreaterThan(0);
     expect(parsed.turns[0]?.role).toBe("user");
+    expect(parsed.dataSourceInfo?.notes?.[0]).toContain("SQLite parse failed");
+    expect(parsed.dataSourceInfo?.notes?.[0]).toContain("fell back to JSONL transcript");
+  });
+
+  it("surfaces sqlite error details when no transcript fallback exists", async () => {
+    mockedParseCursorSqlite.mockRejectedValueOnce(new Error("sql.js init failed"));
+
+    await expect(
+      parseCursorSession(["/tmp/fake.txt"], {
+        provider: "cursor",
+        sessionId: "session",
+        slug: "session",
+        project: "/tmp",
+        cwd: "/tmp",
+        version: "",
+        timestamp: new Date().toISOString(),
+        lineCount: 0,
+        fileSize: 0,
+        filePath: "/tmp/fake.txt",
+        filePaths: ["/tmp/fake.txt"],
+        firstPrompt: "x",
+      }),
+    ).rejects.toThrow(/sql\.js init failed/);
   });
 });

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -35,6 +35,7 @@ describe("parseCursorSession", () => {
       },
     });
 
+    // Use a non-.jsonl path so this test exercises the sqlite return path only.
     const parsed = await parseCursorSession(["/tmp/fake.txt"], {
       provider: "cursor",
       sessionId: "sqlite-session",

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -5,6 +5,17 @@ import type { ParsedTurn, SessionInfo } from "../../types.js";
 import type { DataSourceInfo, ProviderParseResult } from "../types.js";
 import { parseCursorSqlite } from "./sqlite-reader.js";
 
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  return String(err);
+}
+
+function compactErrorMessage(err: unknown, max = 180): string {
+  const cleaned = toErrorMessage(err).replace(/\s+/g, " ").trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, max)}...`;
+}
+
 export async function parseCursorSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
@@ -12,17 +23,21 @@ export async function parseCursorSession(
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
   const transcriptPaths = paths.filter((p) => p.endsWith(".jsonl"));
   const explicitToolPaths = paths.filter((p) => p.endsWith(".txt"));
+  let sqliteFallbackNote: string | undefined;
+  let sqliteAttempted = false;
 
   // Try SQLite first if session info is available
   if (sessionInfo?.sessionId) {
+    sqliteAttempted = true;
     let sqliteResult: ProviderParseResult | null = null;
     try {
       sqliteResult = await parseCursorSqlite(
         sessionInfo.workspacePath || "",
         sessionInfo.sessionId,
       );
-    } catch {
+    } catch (err) {
       // Cursor DB schemas can vary across versions/hosts; fall back to JSONL when available.
+      sqliteFallbackNote = `cursor SQLite parse failed (${compactErrorMessage(err)}); fell back to JSONL transcript`;
       sqliteResult = null;
     }
     if (sqliteResult) {
@@ -53,9 +68,28 @@ export async function parseCursorSession(
 
   // Fallback to JSONL parsing
   if (transcriptPaths.length === 0) {
+    if (sqliteFallbackNote) {
+      throw new Error(
+        `Cursor parse failed: ${sqliteFallbackNote.replace("; fell back to JSONL transcript", "")}. No transcript .jsonl fallback is available.`,
+      );
+    }
+    if (sqliteAttempted) {
+      throw new Error(
+        "Cursor parse failed: SQLite data unavailable for this session and no transcript .jsonl fallback is available.",
+      );
+    }
     throw new Error("Cursor parse requires at least one transcript .jsonl path");
   }
-  return parseCursorJsonl(transcriptPaths, explicitToolPaths, { inferToolPaths: true });
+  const jsonlResult = await parseCursorJsonl(transcriptPaths, explicitToolPaths, {
+    inferToolPaths: true,
+  });
+  if (sqliteFallbackNote) {
+    jsonlResult.dataSourceInfo = withNote(
+      jsonlResult.dataSourceInfo || defaultDataSourceInfo(jsonlResult.dataSource),
+      sqliteFallbackNote,
+    );
+  }
+  return jsonlResult;
 }
 
 interface ParseJsonlOptions {
@@ -80,6 +114,13 @@ function withSupplement(
   const supplements = [...(info.supplements || [])];
   if (!supplements.includes(supplement)) supplements.push(supplement);
   return { ...info, supplements };
+}
+
+function withNote(info: DataSourceInfo | undefined, note: string): DataSourceInfo | undefined {
+  if (!info) return undefined;
+  const notes = [...(info.notes || [])];
+  if (!notes.includes(note)) notes.push(note);
+  return { ...info, notes };
 }
 
 async function parseCursorJsonl(

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -15,10 +15,16 @@ export async function parseCursorSession(
 
   // Try SQLite first if session info is available
   if (sessionInfo?.sessionId) {
-    const sqliteResult = await parseCursorSqlite(
-      sessionInfo.workspacePath || "",
-      sessionInfo.sessionId,
-    );
+    let sqliteResult: ProviderParseResult | null = null;
+    try {
+      sqliteResult = await parseCursorSqlite(
+        sessionInfo.workspacePath || "",
+        sessionInfo.sessionId,
+      );
+    } catch {
+      // Cursor DB schemas can vary across versions/hosts; fall back to JSONL when available.
+      sqliteResult = null;
+    }
     if (sqliteResult) {
       // Keep SQLite/global-state as source of truth, but supplement missing
       // thinking markers and user images from JSONL when transcript files are available.

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -23,6 +23,7 @@ export async function parseCursorSession(
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
   const transcriptPaths = paths.filter((p) => p.endsWith(".jsonl"));
   const explicitToolPaths = paths.filter((p) => p.endsWith(".txt"));
+  let sqliteError: string | undefined;
   let sqliteFallbackNote: string | undefined;
   let sqliteAttempted = false;
 
@@ -37,7 +38,8 @@ export async function parseCursorSession(
       );
     } catch (err) {
       // Cursor DB schemas can vary across versions/hosts; fall back to JSONL when available.
-      sqliteFallbackNote = `cursor SQLite parse failed (${compactErrorMessage(err)}); fell back to JSONL transcript`;
+      sqliteError = compactErrorMessage(err);
+      sqliteFallbackNote = `cursor SQLite parse failed (${sqliteError}); fell back to JSONL transcript`;
       sqliteResult = null;
     }
     if (sqliteResult) {
@@ -68,9 +70,9 @@ export async function parseCursorSession(
 
   // Fallback to JSONL parsing
   if (transcriptPaths.length === 0) {
-    if (sqliteFallbackNote) {
+    if (sqliteError) {
       throw new Error(
-        `Cursor parse failed: ${sqliteFallbackNote.replace("; fell back to JSONL transcript", "")}. No transcript .jsonl fallback is available.`,
+        `Cursor parse failed: ${sqliteError}. No transcript .jsonl fallback is available.`,
       );
     }
     if (sqliteAttempted) {

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { countComposerConversationHeaders } from "./sqlite-reader.js";
+
+describe("countComposerConversationHeaders", () => {
+  it("returns zero when headers are missing", () => {
+    expect(countComposerConversationHeaders({})).toBe(0);
+  });
+
+  it("returns zero when headers are not an array", () => {
+    expect(countComposerConversationHeaders({ fullConversationHeadersOnly: "oops" })).toBe(0);
+  });
+
+  it("returns array length for replayable composer payloads", () => {
+    expect(
+      countComposerConversationHeaders({
+        fullConversationHeadersOnly: [{ bubbleId: "a" }, { bubbleId: "b" }, { bubbleId: "c" }],
+      }),
+    ).toBe(3);
+  });
+});

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -663,10 +663,8 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
     const composer = parseJson<Record<string, any>>(rawComposer);
     if (!composer) return null;
 
-    const headers = Array.isArray(composer.fullConversationHeadersOnly)
-      ? composer.fullConversationHeadersOnly
-      : [];
-    if (headers.length === 0) return null;
+    if (countComposerConversationHeaders(composer) === 0) return null;
+    const headers = composer.fullConversationHeadersOnly as any[];
 
     const turns: ParsedTurn[] = [];
     const bubbleStmt = db.prepare("SELECT value FROM cursorDiskKV WHERE key = ?");

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -311,12 +311,16 @@ export async function discoverGlobalStateOnlySessions(
       const sessionId = key.startsWith("composerData:") ? key.slice("composerData:".length) : "";
       if (!SESSION_ID_RE.test(sessionId)) continue;
 
-      sessionIds.add(sessionId);
-      if (knownSessionIds.has(sessionId)) continue;
-
       const rawComposer = valueToString(value);
       const composer = parseJson<Record<string, any>>(rawComposer);
       if (!composer) continue;
+      const headerCount = countComposerConversationHeaders(composer);
+      // Skip sessions without conversation headers: they cannot be replayed.
+      if (headerCount === 0) continue;
+
+      // Track only replayable global-state sessions for downstream hasSqlite marking.
+      sessionIds.add(sessionId);
+      if (knownSessionIds.has(sessionId)) continue;
 
       const timestamp =
         toIsoTimestamp(composer.lastUpdatedAt) ||
@@ -327,9 +331,6 @@ export async function discoverGlobalStateOnlySessions(
           ? composer.name.trim()
           : undefined;
       const firstPrompt = title || "(cursor global state session)";
-      const headerCount = countComposerConversationHeaders(composer);
-      // Skip sessions without conversation headers: they cannot be replayed.
-      if (headerCount === 0) continue;
       const projectPath = await inferProjectFromComposerData(rawComposer, decodedWorkspacePaths);
 
       const sessionInfo: SessionInfo = {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -267,6 +267,12 @@ export interface GlobalStateDiscoveryResult {
   sessionIds: Set<string>;
 }
 
+export function countComposerConversationHeaders(composer: Record<string, any>): number {
+  return Array.isArray(composer.fullConversationHeadersOnly)
+    ? composer.fullConversationHeadersOnly.length
+    : 0;
+}
+
 /**
  * Discover sessions from Cursor's globalStorage state.vscdb.
  * This is where devcontainer/remote sessions can keep rich `composerData:*`
@@ -321,9 +327,9 @@ export async function discoverGlobalStateOnlySessions(
           ? composer.name.trim()
           : undefined;
       const firstPrompt = title || "(cursor global state session)";
-      const headers = Array.isArray(composer.fullConversationHeadersOnly)
-        ? composer.fullConversationHeadersOnly
-        : [];
+      const headerCount = countComposerConversationHeaders(composer);
+      // Skip sessions without conversation headers: they cannot be replayed.
+      if (headerCount === 0) continue;
       const projectPath = await inferProjectFromComposerData(rawComposer, decodedWorkspacePaths);
 
       const sessionInfo: SessionInfo = {
@@ -335,7 +341,7 @@ export async function discoverGlobalStateOnlySessions(
         cwd: projectPath,
         version: "",
         timestamp,
-        lineCount: headers.length,
+        lineCount: headerCount,
         fileSize: Buffer.byteLength(rawComposer, "utf-8"),
         filePath: `${dbPath}#composerData:${sessionId}`,
         filePaths: [],

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -41,6 +41,13 @@ function requireSlug(raw: string | undefined): { slug: string } | { error: strin
   return { slug };
 }
 
+const MAX_TITLE_CHARS = 120;
+
+function normalizeTitle(title: string): string | undefined {
+  const cleaned = title.replace(/\s+/g, " ").trim().slice(0, MAX_TITLE_CHARS);
+  return cleaned || undefined;
+}
+
 // ─── Archive helpers (directory-based, one marker file per slug) ────
 
 const ARCHIVE_DIR = ".archive";
@@ -344,14 +351,14 @@ export async function startServer(
   app.patch("/api/sessions/:slug", async (c) => {
     const slug = safeSlug(c.req.param("slug"));
     if (!slug) return c.json({ error: "invalid slug" }, 400);
-    const body = await c.req.json<{ title: string }>();
-    if (!body.title && body.title !== "") {
+    const body = await c.req.json<{ title?: unknown }>();
+    if (typeof body.title !== "string") {
       return c.json({ error: "title field required" }, 400);
     }
 
     try {
       const target = await loadSessionFromDisk(baseDir, slug);
-      target.meta.title = body.title || undefined;
+      target.meta.title = normalizeTitle(body.title);
 
       const targetDir = join(baseDir, slug);
       await writeFile(join(targetDir, "replay.json"), JSON.stringify(target), "utf-8");
@@ -509,7 +516,7 @@ export async function startServer(
         provider: string;
         filePaths: string[];
         toolPaths?: string[];
-        title?: string;
+        title?: unknown;
         sessionSlug?: string;
         sessionProject?: string;
       }>();
@@ -522,6 +529,9 @@ export async function startServer(
       const paths = [...body.filePaths, ...(body.toolPaths || [])];
       if (paths.length === 0) {
         return c.json({ error: "filePaths is required" }, 400);
+      }
+      if (body.title !== undefined && typeof body.title !== "string") {
+        return c.json({ error: "title must be a string" }, 400);
       }
 
       const parsed = await provider.parse(paths);
@@ -540,8 +550,11 @@ export async function startServer(
         },
       });
 
-      if (body.title) {
-        replay.meta.title = body.title;
+      if (typeof body.title === "string") {
+        const normalizedCustomTitle = normalizeTitle(body.title);
+        if (normalizedCustomTitle) {
+          replay.meta.title = normalizedCustomTitle;
+        }
       }
 
       // Save replay

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -7,6 +7,11 @@ type CachedListResponse<T> = {
   cachedAt?: string;
 };
 const CACHE_REFRESH_TTL_MS = 5 * 60 * 1000;
+const TITLE_MAX_CHARS = 120;
+
+function normalizeTitleText(value?: string): string {
+  return (value || "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX_CHARS);
+}
 
 function parseCachedList<T>(payload: unknown): CachedListResponse<T> | null {
   if (!payload || typeof payload !== "object") return null;
@@ -100,20 +105,23 @@ function ProviderBadge({ provider }: { provider: string }) {
 function EditableTitle({
   slug,
   title,
+  fallbackTitle,
   onSave,
 }: {
   slug: string;
   title?: string;
+  fallbackTitle?: string;
   onSave: (slug: string, title: string) => Promise<void>;
 }) {
+  const suggestedTitle = normalizeTitleText(title || fallbackTitle || slug);
   const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(title || "");
+  const [value, setValue] = useState(suggestedTitle);
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setValue(title || "");
-  }, [title]);
+    setValue(suggestedTitle);
+  }, [suggestedTitle]);
 
   useEffect(() => {
     if (editing) inputRef.current?.focus();
@@ -123,7 +131,7 @@ function EditableTitle({
     if (saving) return;
     setSaving(true);
     try {
-      await onSave(slug, value.trim());
+      await onSave(slug, normalizeTitleText(value));
     } finally {
       setSaving(false);
       setEditing(false);
@@ -132,51 +140,64 @@ function EditableTitle({
 
   if (editing) {
     return (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          save();
-        }}
-        className="flex items-center gap-1.5 min-w-0"
-      >
-        <input
-          ref={inputRef}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onBlur={save}
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              setValue(title || "");
-              setEditing(false);
-            }
+      <div className="min-w-0">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            save();
           }}
-          className="bg-terminal-surface-2 rounded px-2 py-0.5 text-sm font-mono text-terminal-text w-full outline-none ring-1 ring-terminal-border-subtle focus:ring-terminal-green/50 transition-shadow duration-200"
-          placeholder={slug}
-          disabled={saving}
-        />
-      </form>
+          className="flex items-center gap-1.5 min-w-0"
+        >
+          <input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={save}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setValue(suggestedTitle);
+                setEditing(false);
+              }
+            }}
+            className="bg-terminal-surface-2 rounded px-2 py-0.5 text-sm font-mono text-terminal-text w-full outline-none ring-1 ring-terminal-border-subtle focus:ring-terminal-green/50 transition-shadow duration-200"
+            placeholder={suggestedTitle}
+            maxLength={TITLE_MAX_CHARS}
+            disabled={saving}
+          />
+        </form>
+        <div className="text-[11px] font-mono text-terminal-dimmer truncate mt-0.5">
+          slug: <span className="text-terminal-dim">{slug}</span>
+        </div>
+      </div>
     );
   }
 
   return (
-    <button
-      onClick={() => setEditing(true)}
-      className="group flex items-center gap-1 min-w-0 text-left"
-      title="Click to edit title"
-    >
-      <span className="text-sm font-mono text-terminal-text truncate">{title || slug}</span>
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        className="shrink-0 text-terminal-dim opacity-0 group-hover:opacity-100 transition-opacity"
+    <div className="min-w-0">
+      <button
+        onClick={() => setEditing(true)}
+        className="group flex items-center gap-1 min-w-0 text-left"
+        title="Click to edit title"
       >
-        <path d="M11.5 1.5l3 3-9 9H2.5v-3l9-9z" />
-      </svg>
-    </button>
+        <span className="text-sm font-mono text-terminal-text truncate">
+          {suggestedTitle || slug}
+        </span>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          className="shrink-0 text-terminal-dim opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          <path d="M11.5 1.5l3 3-9 9H2.5v-3l9-9z" />
+        </svg>
+      </button>
+      <div className="text-[11px] font-mono text-terminal-dimmer truncate mt-0.5">
+        slug: <span className="text-terminal-dim">{slug}</span>
+      </div>
+    </div>
   );
 }
 
@@ -216,13 +237,23 @@ function ReplayCard({
     >
       {/* Row 1: title + badges + actions */}
       <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-start gap-2 min-w-0">
           {onTitleSave ? (
-            <EditableTitle slug={s.slug} title={s.title} onSave={onTitleSave} />
+            <EditableTitle
+              slug={s.slug}
+              title={s.title}
+              fallbackTitle={replaySuggestedTitle(s)}
+              onSave={onTitleSave}
+            />
           ) : (
-            <span className="text-sm font-mono text-terminal-text truncate">
-              {s.title || s.slug}
-            </span>
+            <div className="min-w-0">
+              <span className="text-sm font-mono text-terminal-text truncate block">
+                {replaySuggestedTitle(s)}
+              </span>
+              <div className="text-[11px] font-mono text-terminal-dimmer truncate mt-0.5">
+                slug: <span className="text-terminal-dim">{s.slug}</span>
+              </div>
+            </div>
           )}
           {s.gist && !s.gist.outdated && (
             <a
@@ -532,16 +563,6 @@ function shortenPath(path: string): string {
   return `${first}/\u2026/${last}`;
 }
 
-/** Build a human-readable session label — slug is always the primary identifier */
-function sessionLabel(s: SourceSession): { primary: string; branch?: string } {
-  const branch =
-    s.gitBranch && s.gitBranch !== "main" && s.gitBranch !== "master" ? s.gitBranch : undefined;
-  if (s.title && s.title !== s.slug) {
-    return { primary: s.title, branch };
-  }
-  return { primary: s.slug, branch };
-}
-
 /** Strip system-injected noise from first prompt for display */
 function cleanPrompt(text: string): string {
   let cleaned = text;
@@ -558,6 +579,27 @@ function cleanPrompt(text: string): string {
   // Collapse whitespace
   cleaned = cleaned.replace(/\s+/g, " ").trim();
   return cleaned;
+}
+
+function sourceSuggestedTitle(s: SourceSession): string {
+  const explicitTitle = normalizeTitleText(s.title);
+  if (explicitTitle) return explicitTitle;
+  const promptCandidates = [...(s.prompts || []), s.firstPrompt];
+  for (const candidate of promptCandidates) {
+    const cleaned = normalizeTitleText(cleanPrompt(candidate || ""));
+    if (cleaned) return cleaned;
+  }
+  return s.slug;
+}
+
+function replaySuggestedTitle(s: SessionSummary): string {
+  const explicitTitle = normalizeTitleText(s.title);
+  if (explicitTitle) return explicitTitle;
+  const firstMessage = normalizeTitleText(s.firstMessage);
+  if (firstMessage) return firstMessage;
+  const firstFromMessages = normalizeTitleText(s.messages?.[0]);
+  if (firstFromMessages) return firstFromMessages;
+  return s.slug;
 }
 
 /** "All projects" sentinel */
@@ -675,8 +717,9 @@ function SessionsPanel() {
   };
 
   const handleGenerate = (source: SourceSession) => {
-    setTitleInput({ slug: source.slug, defaultTitle: source.title || source.slug });
-    setTitleValue(source.title || source.slug);
+    const suggested = sourceSuggestedTitle(source);
+    setTitleInput({ slug: source.slug, defaultTitle: suggested });
+    setTitleValue(suggested);
   };
 
   const submitGenerate = async () => {
@@ -696,7 +739,7 @@ function SessionsPanel() {
           provider: source.provider,
           filePaths: source.filePaths,
           toolPaths: source.toolPaths,
-          title: titleValue.trim() || undefined,
+          title: normalizeTitleText(titleValue) || undefined,
           sessionSlug: source.slug,
           sessionProject: source.project,
         }),
@@ -1055,6 +1098,7 @@ function SessionsPanel() {
                 onChange={(e) => setTitleValue(e.target.value)}
                 className="flex-1 bg-terminal-bg rounded-lg px-3 py-2.5 text-sm font-mono text-terminal-text placeholder:text-terminal-dimmer outline-none ring-1 ring-terminal-border-subtle focus:ring-terminal-green/40 transition-shadow duration-200"
                 placeholder={titleInput.defaultTitle}
+                maxLength={TITLE_MAX_CHARS}
                 onKeyDown={(e) => {
                   if (e.key === "Escape") setTitleInput(null);
                 }}
@@ -1106,7 +1150,6 @@ function SessionsPanel() {
                   );
                 }
                 // Sessions without replay: simpler card with Generate
-                const label = sessionLabel(s);
                 const prompts = (s.prompts || [])
                   .map((p) => cleanPrompt(p))
                   .filter((p) => p.length > 0);
@@ -1114,6 +1157,11 @@ function SessionsPanel() {
                   const cleaned = cleanPrompt(s.firstPrompt);
                   if (cleaned) prompts.push(cleaned);
                 }
+                const branch =
+                  s.gitBranch && s.gitBranch !== "main" && s.gitBranch !== "master"
+                    ? s.gitBranch
+                    : undefined;
+                const sessionTitle = sourceSuggestedTitle(s);
                 const isArchived = archivedSlugs.has(s.slug);
                 return (
                   <div
@@ -1122,10 +1170,15 @@ function SessionsPanel() {
                   >
                     {/* Row 1: slug + branch + time + action */}
                     <div className="flex items-center gap-2">
-                      <span className="text-sm font-mono text-terminal-text truncate">
-                        {label.primary}
-                      </span>
-                      {label.branch && (
+                      <div className="min-w-0">
+                        <span className="text-sm font-mono text-terminal-text truncate block">
+                          {sessionTitle}
+                        </span>
+                        <div className="text-[11px] font-mono text-terminal-dimmer truncate mt-0.5">
+                          slug: <span className="text-terminal-dim">{s.slug}</span>
+                        </div>
+                      </div>
+                      {branch && (
                         <span className="text-xs font-mono px-1.5 py-0.5 rounded bg-terminal-surface-2 text-terminal-dim shrink-0 flex items-center gap-0.5">
                           <svg
                             width="10"
@@ -1139,7 +1192,7 @@ function SessionsPanel() {
                             <circle cx="11" cy="12" r="2" />
                             <path d="M5 6v4c0 1.1.9 2 2 2h2" />
                           </svg>
-                          {label.branch}
+                          {branch}
                         </span>
                       )}
                       <div className="flex items-center gap-1.5 shrink-0 ml-auto">


### PR DESCRIPTION
## Summary
- make Cursor parsing resilient to `store.db` schema differences by falling back to JSONL when SQLite parsing throws
- skip global-state `composerData:*` sessions that have no conversation headers so the picker only lists replayable sessions
- add focused Cursor provider tests for SQLite-success, SQLite-throw fallback, and conversation-header counting

## Test plan
- [x] `pnpm --filter vibe-replay test`
- [x] `pnpm test`
- [x] sampled parse verification on local machine: recent 300 Cursor sessions parsed successfully after fix

Made with [Cursor](https://cursor.com)