### PR TITLE
fix: harden error handling and fix secret redaction at truncation boundary

### DIFF
--- a/packages/cli/src/generator.ts
+++ b/packages/cli/src/generator.ts
@@ -33,6 +33,9 @@ export async function generateOutput(session: ReplaySession, outputDir: string):
   // Use lastIndexOf to find the ACTUAL </head> HTML tag, not a "</head>" string
   // that may appear inside minified JS code within the viewer bundle.
   const headIdx = viewerHtml.lastIndexOf("</head>");
+  if (headIdx === -1) {
+    throw new Error("Could not find </head> tag in viewer.html — is the build corrupted?");
+  }
   const outputHtml = `${viewerHtml.slice(0, headIdx) + dataScript}\n${viewerHtml.slice(headIdx)}`;
 
   // Update title

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -299,27 +299,36 @@ program
     }
 
     const spinner = ora("Parsing session...").start();
-    const parsed = await provider.parse(sessionPaths, sessionInfo);
-    spinner.text = "Transforming to replay...";
-
-    const rawProject = sessionInfo?.project || parsed.cwd;
     const home = (await import("node:os")).homedir();
-    const project = rawProject.startsWith(home) ? `~${rawProject.slice(home.length)}` : rawProject;
-    const replay = transformToReplay(parsed, providerName, project, {
-      generator: {
-        name: "vibe-replay",
-        version: CLI_VERSION,
-        generatedAt: new Date().toISOString(),
-      },
-    });
+    let parsed: Awaited<ReturnType<typeof provider.parse>>;
+    let replay: ReturnType<typeof transformToReplay>;
+    try {
+      parsed = await provider.parse(sessionPaths, sessionInfo);
+      spinner.text = "Transforming to replay...";
 
-    const thinkingStr = replay.meta.stats.thinkingBlocks
-      ? `, ${replay.meta.stats.thinkingBlocks} thinking`
-      : "";
-    const sourceStr = replay.meta.dataSource ? chalk.dim(` [${replay.meta.dataSource}]`) : "";
-    spinner.succeed(
-      `${replay.scenes.length} scenes (${replay.meta.stats.userPrompts} prompts, ${replay.meta.stats.toolCalls} tool calls${thinkingStr})${sourceStr}`,
-    );
+      const rawProject = sessionInfo?.project || parsed.cwd;
+      const project = rawProject.startsWith(home)
+        ? `~${rawProject.slice(home.length)}`
+        : rawProject;
+      replay = transformToReplay(parsed, providerName, project, {
+        generator: {
+          name: "vibe-replay",
+          version: CLI_VERSION,
+          generatedAt: new Date().toISOString(),
+        },
+      });
+
+      const thinkingStr = replay.meta.stats.thinkingBlocks
+        ? `, ${replay.meta.stats.thinkingBlocks} thinking`
+        : "";
+      const sourceStr = replay.meta.dataSource ? chalk.dim(` [${replay.meta.dataSource}]`) : "";
+      spinner.succeed(
+        `${replay.scenes.length} scenes (${replay.meta.stats.userPrompts} prompts, ${replay.meta.stats.toolCalls} tool calls${thinkingStr})${sourceStr}`,
+      );
+    } catch (err) {
+      spinner.fail("Failed to parse session");
+      throw err;
+    }
 
     // Title: CLI flag > interactive prompt > auto-detected > slug
     if (opts.title) {
@@ -470,8 +479,8 @@ program
               gistSpinner.succeed(result.mode === "updated" ? "Gist updated!" : "Published!");
               console.log(chalk.dim("  Gist:   ") + chalk.white(result.gistUrl));
               console.log(chalk.dim("  Viewer: ") + chalk.cyan(result.viewerUrl));
-            } catch (err: any) {
-              gistSpinner.fail(err.message);
+            } catch (err: unknown) {
+              gistSpinner.fail(err instanceof Error ? err.message : String(err));
             }
           }
         }

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -468,6 +468,7 @@ async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResul
     const metaHex = metaRows[0].values[0][0] as string;
     const metaJson: ChatMeta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
     const rootId = metaJson.latestRootBlobId;
+    if (!rootId) return null;
 
     const rootRows = db.exec("SELECT data FROM blobs WHERE id = ?", [rootId]);
     if (!rootRows.length || !rootRows[0].values.length) return null;
@@ -675,16 +676,19 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
           : "";
       if (!bubbleId) continue;
 
-      bubbleStmt.bind([`bubbleId:${sessionId}:${bubbleId}`]);
-      if (bubbleStmt.step()) {
-        const rawBubble = valueToString(bubbleStmt.get()[0]);
-        const bubble = parseJson<Record<string, any>>(rawBubble);
-        if (bubble) {
-          const turn = bubbleToTurn(bubble);
-          if (turn) turns.push(turn);
+      try {
+        bubbleStmt.bind([`bubbleId:${sessionId}:${bubbleId}`]);
+        if (bubbleStmt.step()) {
+          const rawBubble = valueToString(bubbleStmt.get()[0]);
+          const bubble = parseJson<Record<string, any>>(rawBubble);
+          if (bubble) {
+            const turn = bubbleToTurn(bubble);
+            if (turn) turns.push(turn);
+          }
         }
+      } finally {
+        bubbleStmt.reset();
       }
-      bubbleStmt.reset();
     }
     bubbleStmt.free();
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -351,7 +351,13 @@ export async function startServer(
   app.patch("/api/sessions/:slug", async (c) => {
     const slug = safeSlug(c.req.param("slug"));
     if (!slug) return c.json({ error: "invalid slug" }, 400);
-    const body = await c.req.json<{ title?: unknown }>();
+
+    let body: { title?: unknown };
+    try {
+      body = await c.req.json<{ title?: unknown }>();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
     if (typeof body.title !== "string") {
       return c.json({ error: "title field required" }, 400);
     }
@@ -595,7 +601,12 @@ export async function startServer(
   app.post("/api/annotations", async (c) => {
     const result = requireSlug(c.req.query("slug"));
     if ("error" in result) return c.json({ error: result.error }, 400);
-    const body = await c.req.json<Annotation[]>();
+    let body: Annotation[];
+    try {
+      body = await c.req.json<Annotation[]>();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
     try {
       await saveAnnotations(baseDir, result.slug, body);
     } catch {

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -186,8 +186,9 @@ function sanitizeInput(input: Record<string, any>): Record<string, any> {
 }
 
 function truncate(s: string, max: number): string {
-  if (s.length <= max) return redactSecrets(s);
-  return redactSecrets(`${s.slice(0, max)}\n... (truncated, ${s.length} chars total)`);
+  const redacted = redactSecrets(s);
+  if (redacted.length <= max) return redacted;
+  return `${redacted.slice(0, max)}\n... (truncated, ${redacted.length} chars total)`;
 }
 
 // Redact common secret patterns from output

--- a/packages/cli/test/transform-security.test.ts
+++ b/packages/cli/test/transform-security.test.ts
@@ -632,6 +632,34 @@ describe("tool result truncation", () => {
     const scene = replay.scenes.find((s) => s.type === "tool-call")!;
     expect(scene.result).not.toContain(secretTail);
   });
+
+  it("redacts secrets that span the truncation boundary", () => {
+    // Place the secret so it straddles the 5000-char truncation limit.
+    // With redact-after-truncate, slice(0, 5000) would cut the token in half,
+    // leaving a partial prefix that no longer matches the regex → leak.
+    const prefix = "A".repeat(4990);
+    const secretTail = EXAMPLE_GH_PAT; // ~41 chars → total ~5031, exceeds 5000
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Read",
+            input: { file_path: "/f" },
+            _result: prefix + secretTail,
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const scene = replay.scenes.find((s) => s.type === "tool-call")!;
+    // The full token must not appear, and neither should a recognizable partial prefix.
+    // The [REDACTED] marker itself may be truncated, so we only assert no secret leaks.
+    expect(scene.result).not.toContain(secretTail);
+    expect(scene.result).not.toContain("ghp_ABCDEFGHIJ");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix secret redaction at truncation boundary to prevent partial key leakage
- Validate lastIndexOf result in generator to avoid silent HTML corruption
- Wrap c.req.json() in try-catch for malformed JSON requests
- Stop spinner on parse/transform failure with try-finally
- Handle non-Error thrown values in gist publish catch
- Guard latestRootBlobId against null/undefined in sqlite-reader
- Ensure prepared statement reset via try-finally