### PR TITLE
fix: allow generate for Cursor sqlite-only sessions

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -74,7 +74,8 @@ type GenerateInputResolution =
 function toStringArray(value: unknown): string[] | null {
   if (value === undefined) return [];
   if (!Array.isArray(value)) return null;
-  return value.filter((item): item is string => typeof item === "string");
+  if (value.some((item) => typeof item !== "string")) return null;
+  return value;
 }
 
 export function resolveGenerateInputs(

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -48,6 +48,89 @@ function normalizeTitle(title: string): string | undefined {
   return cleaned || undefined;
 }
 
+function normalizeProjectPath(project: string): string {
+  const home = homedir();
+  return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
+}
+
+interface GenerateRequestBody {
+  provider: string;
+  filePaths?: unknown;
+  toolPaths?: unknown;
+  title?: unknown;
+  sessionSlug?: string;
+  sessionProject?: string;
+}
+
+interface ResolvedGenerateInputs {
+  paths: string[];
+  sessionInfo?: SessionInfo;
+}
+
+type GenerateInputResolution =
+  | { ok: true; value: ResolvedGenerateInputs }
+  | { ok: false; error: string };
+
+function toStringArray(value: unknown): string[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return null;
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export function resolveGenerateInputs(
+  body: GenerateRequestBody,
+  discoveredSessions: SessionInfo[],
+): GenerateInputResolution {
+  const filePaths = toStringArray(body.filePaths);
+  if (!filePaths) {
+    return { ok: false, error: "filePaths must be an array of strings" };
+  }
+  const toolPaths = toStringArray(body.toolPaths);
+  if (!toolPaths) {
+    return { ok: false, error: "toolPaths must be an array of strings" };
+  }
+
+  const requestedSessionSlug =
+    typeof body.sessionSlug === "string" ? safeSlug(body.sessionSlug) : null;
+  const requestedSessionProject =
+    typeof body.sessionProject === "string" ? normalizeProjectPath(body.sessionProject) : undefined;
+
+  let sessionInfo: SessionInfo | undefined;
+  if (requestedSessionSlug) {
+    const slugMatches = discoveredSessions.filter((s) => s.slug === requestedSessionSlug);
+    if (requestedSessionProject) {
+      sessionInfo = slugMatches.find(
+        (s) => normalizeProjectPath(s.project) === requestedSessionProject,
+      );
+    }
+    sessionInfo = sessionInfo || slugMatches[0];
+  }
+
+  const fallbackFilePaths = sessionInfo?.filePaths || [];
+  const fallbackToolPaths = sessionInfo?.toolPaths || [];
+  const paths = [
+    ...(filePaths.length > 0 ? filePaths : fallbackFilePaths),
+    ...(toolPaths.length > 0 ? toolPaths : fallbackToolPaths),
+  ];
+
+  const hasCursorSessionFallback = body.provider === "cursor" && Boolean(sessionInfo?.sessionId);
+  if (paths.length === 0 && !hasCursorSessionFallback) {
+    return {
+      ok: false,
+      error:
+        "filePaths is required (or provide a resolvable Cursor sessionSlug for SQLite/global-state sessions)",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      paths,
+      sessionInfo,
+    },
+  };
+}
+
 // ─── Archive helpers (directory-based, one marker file per slug) ────
 
 const ARCHIVE_DIR = ".archive";
@@ -518,29 +601,27 @@ export async function startServer(
   // --- Generate: parse a source session into a replay ---
   app.post("/api/generate", async (c) => {
     try {
-      const body = await c.req.json<{
-        provider: string;
-        filePaths: string[];
-        toolPaths?: string[];
-        title?: unknown;
-        sessionSlug?: string;
-        sessionProject?: string;
-      }>();
+      const body = await c.req.json<GenerateRequestBody>();
 
       const provider = getProvider(body.provider);
       if (!provider) {
         return c.json({ error: `Unknown provider: ${body.provider}` }, 400);
       }
 
-      const paths = [...body.filePaths, ...(body.toolPaths || [])];
-      if (paths.length === 0) {
-        return c.json({ error: "filePaths is required" }, 400);
+      let discoveredSessions: SessionInfo[] = [];
+      if (typeof body.sessionSlug === "string" && safeSlug(body.sessionSlug)) {
+        discoveredSessions = mergeSameSessions(await provider.discover());
+      }
+
+      const resolved = resolveGenerateInputs(body, discoveredSessions);
+      if (!resolved.ok) {
+        return c.json({ error: resolved.error }, 400);
       }
       if (body.title !== undefined && typeof body.title !== "string") {
         return c.json({ error: "title must be a string" }, 400);
       }
 
-      const parsed = await provider.parse(paths);
+      const parsed = await provider.parse(resolved.value.paths, resolved.value.sessionInfo);
 
       const home = homedir();
       const rawProject = body.sessionProject || parsed.cwd;

--- a/packages/cli/test/server-generate.test.ts
+++ b/packages/cli/test/server-generate.test.ts
@@ -35,6 +35,31 @@ describe("resolveGenerateInputs", () => {
     expect(resolved.ok === false && resolved.error).toBe("filePaths must be an array of strings");
   });
 
+  it("rejects filePaths arrays with non-string entries", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: ["/tmp/session.jsonl", 42],
+      },
+      [],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toBe("filePaths must be an array of strings");
+  });
+
+  it("rejects non-array toolPaths payload", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: ["/tmp/session.jsonl"],
+        toolPaths: "not-an-array",
+      },
+      [],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toBe("toolPaths must be an array of strings");
+  });
+
   it("uses explicit file paths and falls back to discovered tool paths", () => {
     const resolved = resolveGenerateInputs(
       {
@@ -110,6 +135,32 @@ describe("resolveGenerateInputs", () => {
         sessionSlug: "aaaaaaaa",
       },
       [makeSession({ provider: "claude-code", filePaths: [], toolPaths: [] })],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toContain("filePaths is required");
+  });
+
+  it("rejects empty Cursor paths when session slug is unsafe", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "../../../etc/passwd",
+      },
+      [makeSession({ filePaths: [], toolPaths: [] })],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toContain("filePaths is required");
+  });
+
+  it("rejects empty Cursor paths when session slug does not resolve", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "missing01",
+      },
+      [makeSession({ slug: "different", filePaths: [], toolPaths: [] })],
     );
     expect(resolved.ok).toBe(false);
     expect(resolved.ok === false && resolved.error).toContain("filePaths is required");

--- a/packages/cli/test/server-generate.test.ts
+++ b/packages/cli/test/server-generate.test.ts
@@ -1,0 +1,117 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { resolveGenerateInputs } from "../src/server.js";
+import type { SessionInfo } from "../src/types.js";
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    provider: "cursor",
+    sessionId: "cursor-session-a",
+    slug: "aaaaaaaa",
+    project: "~/project-a",
+    cwd: "/tmp/project-a",
+    version: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    lineCount: 10,
+    fileSize: 1024,
+    filePath: "/tmp/session.jsonl",
+    filePaths: ["/tmp/session.jsonl"],
+    toolPaths: ["/tmp/tool.txt"],
+    firstPrompt: "test prompt",
+    ...overrides,
+  };
+}
+
+describe("resolveGenerateInputs", () => {
+  it("rejects non-array filePaths payload", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: "not-an-array",
+      },
+      [],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toBe("filePaths must be an array of strings");
+  });
+
+  it("uses explicit file paths and falls back to discovered tool paths", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: ["/explicit/session.jsonl"],
+        sessionSlug: "aaaaaaaa",
+      },
+      [makeSession()],
+    );
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.paths).toEqual(["/explicit/session.jsonl", "/tmp/tool.txt"]);
+    expect(resolved.value.sessionInfo?.slug).toBe("aaaaaaaa");
+  });
+
+  it("allows Cursor sqlite/global-state session with empty file paths", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "6d8dd9bc",
+      },
+      [
+        makeSession({
+          slug: "6d8dd9bc",
+          sessionId: "cursor-session-devspaces",
+          filePaths: [],
+          toolPaths: [],
+        }),
+      ],
+    );
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.paths).toHaveLength(0);
+    expect(resolved.value.sessionInfo?.sessionId).toBe("cursor-session-devspaces");
+  });
+
+  it("matches session by normalized project path when slug collides", () => {
+    const home = homedir();
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "aaaaaaaa",
+        sessionProject: `${home}/project-b`,
+      },
+      [
+        makeSession({
+          project: "~/project-a",
+          sessionId: "cursor-session-a",
+          filePaths: [],
+          toolPaths: [],
+        }),
+        makeSession({
+          project: "~/project-b",
+          sessionId: "cursor-session-b",
+          filePaths: [],
+          toolPaths: [],
+        }),
+      ],
+    );
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.sessionInfo?.project).toBe("~/project-b");
+    expect(resolved.value.sessionInfo?.sessionId).toBe("cursor-session-b");
+  });
+
+  it("still requires file paths for non-cursor providers", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "claude-code",
+        filePaths: [],
+        sessionSlug: "aaaaaaaa",
+      },
+      [makeSession({ provider: "claude-code", filePaths: [], toolPaths: [] })],
+    );
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toContain("filePaths is required");
+  });
+});


### PR DESCRIPTION
## Summary
- fix `/api/generate` to accept Cursor sessions with empty `filePaths` by resolving the selected session via `sessionSlug` and passing `sessionInfo` into provider parsing
- keep strict payload validation while allowing devcontainer/global-state Cursor sessions to parse via SQLite fallback
- add `server-generate.test.ts` to cover slug/project resolution, fallback path behavior, and non-Cursor guardrails

## Test plan
- [x] `pnpm --filter vibe-replay test -- test/server-generate.test.ts`
- [x] `pnpm lint:check`
- [x] Verified local Cursor devcontainer/global-state slug (`6d8dd9bc`) parses with `filePaths=[]`

Made with [Cursor](https://cursor.com)