### PR TITLE
chore(release): bump cli version to 0.0.11

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `packages/cli/package.json` version from `0.0.10` to `0.0.11`
- prepare `main` for CI-driven `v0.0.11` release publication

## Test plan
- [x] `pnpm --filter vibe-replay build`
- [x] `node packages/cli/dist/index.js --version` outputs `0.0.11`
- [x] `pnpm lint:check`


Made with [Cursor](https://cursor.com)