### PR TITLE
fix: improve error handling type safety and deduplicate utilities

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -469,7 +469,7 @@ export async function startServer(
 
       return c.json({ ok: true, title: target.meta.title });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Update failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -483,7 +483,7 @@ export async function startServer(
       await refreshReplaysCache();
       return c.json({ ok: true });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Delete failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -608,7 +608,7 @@ export async function startServer(
       await writeFileCache(sourcesCacheKey, result);
       return c.json({ sessions: result });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Source discovery failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -681,7 +681,7 @@ export async function startServer(
         warnings: warnings.length > 0 ? warnings : undefined,
       });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Generation failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -744,7 +744,7 @@ export async function startServer(
       });
       return c.json(gistResult);
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Gist publish failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -759,7 +759,7 @@ export async function startServer(
       const outputPath = await generateOutput(targetSession, targetDir);
       return c.json({ path: outputPath });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "HTML export failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -829,7 +829,7 @@ export async function startServer(
         warnings: warnings.length > 0 ? warnings : undefined,
       });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "GitHub export failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -899,7 +899,7 @@ export async function startServer(
         itemCount: fb.result.feedbackItems.length,
       });
     } catch (err) {
-      return c.json({ error: getErrorMessage(err) || "Feedback generation failed" }, 500);
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -41,6 +41,12 @@ function requireSlug(raw: string | undefined): { slug: string } | { error: strin
   return { slug };
 }
 
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown error";
+}
+
 const MAX_TITLE_CHARS = 120;
 
 function normalizeTitle(title: string): string | undefined {
@@ -462,8 +468,8 @@ export async function startServer(
       await refreshReplaysCache();
 
       return c.json({ ok: true, title: target.meta.title });
-    } catch (err: any) {
-      return c.json({ error: err.message || "Update failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Update failed" }, 500);
     }
   });
 
@@ -476,8 +482,8 @@ export async function startServer(
       await rm(join(baseDir, slug), { recursive: true });
       await refreshReplaysCache();
       return c.json({ ok: true });
-    } catch (err: any) {
-      return c.json({ error: err.message || "Delete failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Delete failed" }, 500);
     }
   });
 
@@ -601,8 +607,8 @@ export async function startServer(
 
       await writeFileCache(sourcesCacheKey, result);
       return c.json({ sessions: result });
-    } catch (err: any) {
-      return c.json({ error: err.message || "Source discovery failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Source discovery failed" }, 500);
     }
   });
 
@@ -674,8 +680,8 @@ export async function startServer(
         },
         warnings: warnings.length > 0 ? warnings : undefined,
       });
-    } catch (err: any) {
-      return c.json({ error: err.message || "Generation failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Generation failed" }, 500);
     }
   });
 
@@ -737,8 +743,8 @@ export async function startServer(
         overwrite: savedGist || undefined,
       });
       return c.json(gistResult);
-    } catch (err: any) {
-      return c.json({ error: err.message || "Gist publish failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Gist publish failed" }, 500);
     }
   });
 
@@ -752,8 +758,8 @@ export async function startServer(
       const targetSession = await loadSessionFromDisk(baseDir, result.slug);
       const outputPath = await generateOutput(targetSession, targetDir);
       return c.json({ path: outputPath });
-    } catch (err: any) {
-      return c.json({ error: err.message || "HTML export failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "HTML export failed" }, 500);
     }
   });
 
@@ -822,8 +828,8 @@ export async function startServer(
         replayUrl,
         warnings: warnings.length > 0 ? warnings : undefined,
       });
-    } catch (err: any) {
-      return c.json({ error: err.message || "GitHub export failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "GitHub export failed" }, 500);
     }
   });
 
@@ -892,8 +898,8 @@ export async function startServer(
         score: fb.result.score,
         itemCount: fb.result.feedbackItems.length,
       });
-    } catch (err: any) {
-      return c.json({ error: err.message || "Feedback generation failed" }, 500);
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) || "Feedback generation failed" }, 500);
     }
   });
 

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -819,7 +819,8 @@ function SessionsPanel() {
     try {
       const resp = await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
       if (!resp.ok) throw new Error("Archive toggle failed");
-    } catch {
+    } catch (err) {
+      console.error("Archive toggle failed:", getErrorMessage(err));
       setArchivedSlugs((prev) => {
         const next = new Set(prev);
         isArchived ? next.add(slug) : next.delete(slug);
@@ -1576,7 +1577,8 @@ function ReplaysPanel() {
     try {
       const resp = await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
       if (!resp.ok) throw new Error("Archive toggle failed");
-    } catch {
+    } catch (err) {
+      console.error("Archive toggle failed:", getErrorMessage(err));
       setArchivedSlugs((prev) => {
         const next = new Set(prev);
         isArchived ? next.add(slug) : next.delete(slug);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SessionSummary, SourceSession } from "../types";
+import { formatDuration } from "./StatsPanel";
 
 type Tab = "sessions" | "replays";
 type CachedListResponse<T> = {
   sessions: T[];
   cachedAt?: string;
 };
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown error";
+}
+
 const CACHE_REFRESH_TTL_MS = 5 * 60 * 1000;
 const TITLE_MAX_CHARS = 120;
 
@@ -60,16 +67,6 @@ function isCacheFresh(iso?: string, ttlMs = CACHE_REFRESH_TTL_MS): boolean {
   if (!iso) return false;
   const ageMs = Date.now() - new Date(iso).getTime();
   return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < ttlMs;
-}
-
-function formatDuration(ms?: number): string {
-  if (!ms) return "";
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ${secs % 60}s`;
-  const hrs = Math.floor(mins / 60);
-  return `${hrs}h ${mins % 60}m`;
 }
 
 function formatDate(iso: string): string {
@@ -800,9 +797,9 @@ function SessionsPanel() {
       setSources(fresh.sessions);
       setLastRefreshedAt(new Date().toISOString());
       setStaleCachedAt(null);
-    } catch (err: any) {
+    } catch (err) {
       if (!servedFromCache) {
-        setError(err.message || "Failed to load sessions");
+        setError(getErrorMessage(err) || "Failed to load sessions");
       } else {
         setRefreshError("Failed to refresh latest sessions. Showing cached data.");
       }
@@ -814,12 +811,21 @@ function SessionsPanel() {
 
   const toggleArchive = async (slug: string) => {
     const isArchived = archivedSlugs.has(slug);
-    await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
     setArchivedSlugs((prev) => {
       const next = new Set(prev);
       isArchived ? next.delete(slug) : next.add(slug);
       return next;
     });
+    try {
+      const resp = await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
+      if (!resp.ok) throw new Error("Archive toggle failed");
+    } catch {
+      setArchivedSlugs((prev) => {
+        const next = new Set(prev);
+        isArchived ? next.add(slug) : next.delete(slug);
+        return next;
+      });
+    }
   };
 
   useEffect(() => {
@@ -887,8 +893,8 @@ function SessionsPanel() {
       const data = await resp.json();
       if (!resp.ok) throw new Error(data.error || "Generation failed");
       navigateTo({ view: null, session: data.slug });
-    } catch (err: any) {
-      setGenerateError(err.message);
+    } catch (err) {
+      setGenerateError(getErrorMessage(err));
     } finally {
       setGeneratingSlug(null);
     }
@@ -923,8 +929,8 @@ function SessionsPanel() {
             : s,
         ),
       );
-    } catch (err: any) {
-      console.error("Gist publish error:", err.message);
+    } catch (err) {
+      console.error("Gist publish error:", getErrorMessage(err));
     } finally {
       setPublishingSlug(null);
     }
@@ -1523,7 +1529,7 @@ function ReplaysPanel() {
 
       try {
         const resp = await fetch("/api/sessions");
-        if (!resp.ok) throw new Error();
+        if (!resp.ok) throw new Error("Failed to load sessions");
         const data = (await resp.json()) as SessionSummary[];
         if (!mounted) return;
         setSessions(data);
@@ -1562,12 +1568,21 @@ function ReplaysPanel() {
 
   const toggleArchive = async (slug: string) => {
     const isArchived = archivedSlugs.has(slug);
-    await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
     setArchivedSlugs((prev) => {
       const next = new Set(prev);
       isArchived ? next.delete(slug) : next.add(slug);
       return next;
     });
+    try {
+      const resp = await fetch(`/api/archive/${slug}`, { method: isArchived ? "DELETE" : "POST" });
+      if (!resp.ok) throw new Error("Archive toggle failed");
+    } catch {
+      setArchivedSlugs((prev) => {
+        const next = new Set(prev);
+        isArchived ? next.add(slug) : next.delete(slug);
+        return next;
+      });
+    }
   };
 
   const handleTitleSave = async (slug: string, title: string) => {
@@ -1629,8 +1644,8 @@ function ReplaysPanel() {
             : s,
         ),
       );
-    } catch (err: any) {
-      console.error("Gist publish error:", err.message);
+    } catch (err) {
+      console.error("Gist publish error:", getErrorMessage(err));
     } finally {
       setPublishingSlug(null);
     }
@@ -1653,8 +1668,8 @@ function ReplaysPanel() {
       const data = await resp.json();
       if (!resp.ok) throw new Error(data.error || "Regeneration failed");
       navigateTo({ view: null, session: data.slug });
-    } catch (err: any) {
-      console.error("Regenerate error:", err.message);
+    } catch (err) {
+      console.error("Regenerate error:", getErrorMessage(err));
     } finally {
       setRegeneratingSlug(null);
     }

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -1,19 +1,10 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { ReplaySession } from "../types";
+import { formatDuration } from "./StatsPanel";
 
 interface Props {
   session: ReplaySession;
   onStart: (autoPlay?: boolean) => void;
-}
-
-function formatDuration(ms?: number): string {
-  if (!ms) return "";
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ${secs % 60}s`;
-  const hrs = Math.floor(mins / 60);
-  return `${hrs}h ${mins % 60}m`;
 }
 
 export default function LandingHero({ session, onStart }: Props) {

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -279,7 +279,8 @@ export function fmtNum(n: number): string {
   return n.toString();
 }
 
-export function formatDuration(ms: number): string {
+export function formatDuration(ms?: number): string {
+  if (!ms) return "";
   const secs = Math.floor(ms / 1000);
   if (secs < 60) return `${secs}s`;
   const mins = Math.floor(secs / 60);


### PR DESCRIPTION
## Summary
- Replace `catch (err: any)` antipattern with type-safe `getErrorMessage(err: unknown)` helper across server.ts (8 sites) and Dashboard.tsx (5 sites)
- Add optimistic-update-with-rollback to `toggleArchive` in both dashboard panels (previously fire-and-forget with no error handling)
- Fix empty `throw new Error()` missing descriptive message in ReplaysPanel
- Deduplicate `formatDuration()` — Dashboard.tsx and LandingHero.tsx now import from StatsPanel instead of maintaining local copies

## Test plan
- [x] `pnpm lint:check` passes
- [x] `pnpm build` succeeds (viewer 564KB, CLI 185KB)
- [x] All 361 tests pass (303 CLI + 58 viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)