### PR TITLE
feat: improve Cursor dashboard parity and stats backfill

### DIFF
--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -5,7 +5,7 @@ import type { SessionInfo } from "../../types.js";
 import {
   discoverGlobalStateOnlySessions,
   discoverSqliteOnlySessions,
-  storeDbExists,
+  listStoreDbSessionIds,
 } from "./sqlite-reader.js";
 
 const CURSOR_DIR = join(homedir(), ".cursor", "projects");
@@ -68,8 +68,9 @@ export async function discoverCursorSessions(): Promise<SessionInfo[]> {
   sessions.push(...globalState.sessions);
 
   // Mark transcript-discovered sessions that have any SQLite-backed rich data.
+  const storeDbSessionIds = await listStoreDbSessionIds();
   for (const session of transcriptSessions) {
-    const hasStoreDb = await storeDbExists(session.workspacePath || "", session.sessionId);
+    const hasStoreDb = storeDbSessionIds.has(session.sessionId);
     session.hasSqlite = hasStoreDb || globalState.sessionIds.has(session.sessionId);
   }
 
@@ -163,6 +164,9 @@ async function extractSessionInfo(
       const toolMatches = line.match(toolUseRe);
       if (toolMatches) toolCallCount += toolMatches.length;
     }
+    // Cursor transcript markers can be missing in some flows; tool artifacts are
+    // a better lower bound for real tool activity in the same time window.
+    toolCallCount = Math.max(toolCallCount, toolPaths.length);
 
     // Use file mtime as timestamp (Cursor doesn't store timestamps in JSONL)
     const timestamp = new Date(mtimeMs).toISOString();

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -20,6 +20,20 @@ describe("countComposerConversationHeaders", () => {
 });
 
 describe("cursor sqlite metrics helpers", () => {
+  it("retries async initializer after a failure", async () => {
+    let calls = 0;
+    const init = __testables.createRetryableInit(async () => {
+      calls++;
+      if (calls === 1) throw new Error("init failed");
+      return "ok";
+    });
+
+    await expect(init()).rejects.toThrow("init failed");
+    await expect(init()).resolves.toBe("ok");
+    await expect(init()).resolves.toBe("ok");
+    expect(calls).toBe(2);
+  });
+
   it("computes token increments from cumulative snapshots", () => {
     const first = __testables.estimateTokenIncrement(
       {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -11,6 +11,24 @@ const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]
 
 const MIN_STORE_DB_SIZE = 8192;
 
+function createRetryableInit<T>(factory: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | null = null;
+  return async () => {
+    if (!promise) {
+      promise = factory().catch((err) => {
+        promise = null;
+        throw err;
+      });
+    }
+    return promise;
+  };
+}
+
+const getSqlJs = createRetryableInit(async () => {
+  const mod = await import("sql.js");
+  return mod.default();
+});
+
 export function workspaceHash(absolutePath: string): string {
   return createHash("md5").update(absolutePath).digest("hex");
 }
@@ -70,6 +88,39 @@ async function findStoreDb(sessionId: string): Promise<string | null> {
 export async function storeDbExists(_workspacePath: string, sessionId: string): Promise<boolean> {
   const dbPath = await findStoreDb(sessionId);
   return dbPath !== null;
+}
+
+export async function listStoreDbSessionIds(): Promise<Set<string>> {
+  const sessionIds = new Set<string>();
+  let workspaceDirs: string[];
+  try {
+    workspaceDirs = await readdir(CURSOR_CHATS_DIR);
+  } catch {
+    return sessionIds;
+  }
+
+  for (const wsHash of workspaceDirs) {
+    const wsDir = join(CURSOR_CHATS_DIR, wsHash);
+    const wsStat = await stat(wsDir).catch(() => null);
+    if (!wsStat?.isDirectory()) continue;
+
+    let sessions: string[];
+    try {
+      sessions = await readdir(wsDir);
+    } catch {
+      continue;
+    }
+
+    for (const sessionId of sessions) {
+      if (!SESSION_ID_RE.test(sessionId)) continue;
+      const dbPath = join(wsDir, sessionId, "store.db");
+      const dbStat = await stat(dbPath).catch(() => null);
+      if (!dbStat?.isFile() || dbStat.size < MIN_STORE_DB_SIZE) continue;
+      sessionIds.add(sessionId);
+    }
+  }
+
+  return sessionIds;
 }
 
 function valueToString(value: unknown): string {
@@ -292,14 +343,13 @@ function buildHashToProjectMap(decodedWorkspacePaths: string[]): Map<string, str
  * Returns null if the DB is empty, corrupt, or has no meta table.
  */
 async function readStoreDbMeta(dbPath: string): Promise<ChatMeta | null> {
-  let initSqlJs: any;
+  let SQL: any;
   try {
-    initSqlJs = (await import("sql.js")).default;
+    SQL = await getSqlJs();
   } catch {
     return null;
   }
   const dbBuffer = await readFile(dbPath);
-  const SQL = await initSqlJs();
   const db = new SQL.Database(dbBuffer);
   try {
     const metaRows = db.exec("SELECT value FROM meta WHERE key = '0'");
@@ -410,9 +460,9 @@ export async function discoverGlobalStateOnlySessions(
   const dbPath = await findGlobalStateDb();
   if (!dbPath) return { sessions, sessionIds };
 
-  let initSqlJs: any;
+  let SQL: any;
   try {
-    initSqlJs = (await import("sql.js")).default;
+    SQL = await getSqlJs();
   } catch {
     return { sessions, sessionIds };
   }
@@ -420,7 +470,6 @@ export async function discoverGlobalStateOnlySessions(
   const dbBuffer = await readFile(dbPath).catch(() => null);
   if (!dbBuffer) return { sessions, sessionIds };
 
-  const SQL = await initSqlJs();
   const db = new SQL.Database(dbBuffer);
 
   try {
@@ -568,9 +617,9 @@ export async function parseCursorSqlite(
 }
 
 async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResult | null> {
-  let initSqlJs: any;
+  let SQL: any;
   try {
-    initSqlJs = (await import("sql.js")).default;
+    SQL = await getSqlJs();
   } catch {
     return null;
   }
@@ -579,7 +628,6 @@ async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResul
   if (!dbPath) return null;
 
   const dbBuffer = await readFile(dbPath);
-  const SQL = await initSqlJs();
   const db = new SQL.Database(dbBuffer);
 
   try {
@@ -950,9 +998,9 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
   const dbPath = await findGlobalStateDb();
   if (!dbPath) return null;
 
-  let initSqlJs: any;
+  let SQL: any;
   try {
-    initSqlJs = (await import("sql.js")).default;
+    SQL = await getSqlJs();
   } catch {
     return null;
   }
@@ -960,7 +1008,6 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
   const dbBuffer = await readFile(dbPath).catch(() => null);
   if (!dbBuffer) return null;
 
-  const SQL = await initSqlJs();
   const db = new SQL.Database(dbBuffer);
 
   try {
@@ -1342,5 +1389,6 @@ function extractModel(msg: CursorMessage): string | undefined {
 export const __testables = {
   buildGlobalStateMetrics,
   buildStoreTurnStats,
+  createRetryableInit,
   estimateTokenIncrement,
 };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -29,7 +29,13 @@ import {
 } from "./publishers/gist.js";
 import { scanForSecrets } from "./scan.js";
 import { transformToReplay } from "./transform.js";
-import type { Annotation, ReplaySession, SessionInfo, SessionOverlays } from "./types.js";
+import type {
+  Annotation,
+  ParsedTurn,
+  ReplaySession,
+  SessionInfo,
+  SessionOverlays,
+} from "./types.js";
 import { CLI_VERSION } from "./version.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -330,6 +336,105 @@ async function loadSessionFromDisk(baseDir: string, slug: string): Promise<Repla
   return session;
 }
 
+interface SourceSummaryRecord {
+  provider: string;
+  slug: string;
+  project: string;
+  sessionId?: string;
+  promptCount?: number;
+  toolCallCount?: number;
+  filePaths: string[];
+  toolPaths?: string[];
+  hasSqlite?: boolean;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+interface SourcesEnrichmentStatus {
+  running: boolean;
+  processed: number;
+  total: number;
+  updated: number;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+}
+
+function sourceSessionKey(provider: string, project: string, slug: string): string {
+  return `${provider}::${project}::${slug}`;
+}
+
+function pickSourceRecordForSession(
+  session: Pick<SessionInfo, "provider" | "sessionId" | "project" | "slug">,
+  bySessionId: Map<string, SourceSummaryRecord>,
+  byKey: Map<string, SourceSummaryRecord>,
+): SourceSummaryRecord | undefined {
+  const byIdMatch = bySessionId.get(session.sessionId);
+  return (
+    (byIdMatch?.provider === session.provider ? byIdMatch : undefined) ??
+    byKey.get(sourceSessionKey(session.provider, session.project, session.slug))
+  );
+}
+
+function selectCursorEnrichmentCandidates(
+  merged: SessionInfo[],
+  baseSources: SourceSummaryRecord[],
+  limit = 30,
+): SessionInfo[] {
+  const mergedBySessionId = new Map<string, SessionInfo>();
+  const mergedByKey = new Map<string, SessionInfo>();
+  for (const session of merged) {
+    mergedBySessionId.set(session.sessionId, session);
+    mergedByKey.set(sourceSessionKey(session.provider, session.project, session.slug), session);
+  }
+
+  return baseSources
+    .filter(
+      (s) =>
+        s.provider === "cursor" &&
+        (s.promptCount == null || s.toolCallCount == null) &&
+        (s.hasSqlite || s.filePaths.length > 0),
+    )
+    .map((s) => {
+      const byId = s.sessionId ? mergedBySessionId.get(s.sessionId) : undefined;
+      return byId || mergedByKey.get(sourceSessionKey(s.provider, s.project, s.slug));
+    })
+    .filter((s): s is SessionInfo => Boolean(s))
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    .slice(0, limit);
+}
+
+function countSessionStats(turns: ParsedTurn[]): {
+  promptCount: number;
+  toolCallCount: number;
+} {
+  let promptCount = 0;
+  let toolCallCount = 0;
+  for (const turn of turns) {
+    if (turn.role === "user" && turn.subtype !== "compaction-summary") {
+      const hasText = turn.blocks.some(
+        (block) =>
+          block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
+      );
+      const hasImages = turn.blocks.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          "type" in block &&
+          (block as { type?: unknown }).type === "_user_images" &&
+          "images" in block &&
+          Array.isArray((block as { images?: unknown }).images) &&
+          (block as { images: unknown[] }).images.length > 0,
+      );
+      if (hasText || hasImages) promptCount++;
+    }
+    for (const block of turn.blocks) {
+      if (block.type === "tool_use") toolCallCount++;
+    }
+  }
+  return { promptCount, toolCallCount };
+}
+
 /**
  * Merge multiple JSONL files that share the same slug + project into one entry.
  * Claude Code creates a new file per /resume, but they're the same logical session.
@@ -341,7 +446,8 @@ async function buildSourcesResult(
   merged: SessionInfo[],
   baseDir: string,
   home: string,
-): Promise<Record<string, unknown>[]> {
+  previousSources: SourceSummaryRecord[] = [],
+): Promise<SourceSummaryRecord[]> {
   // Normalize project paths: /Users/xxx/... → ~/...
   for (const s of merged) {
     if (s.project.startsWith(home)) {
@@ -378,18 +484,32 @@ async function buildSourcesResult(
     replayMap.set(r.slug as string, r);
   }
 
+  const previousBySessionId = new Map<string, SourceSummaryRecord>();
+  const previousByKey = new Map<string, SourceSummaryRecord>();
+  for (const prev of previousSources) {
+    const key = sourceSessionKey(prev.provider, prev.project, prev.slug);
+    previousByKey.set(key, prev);
+    if (typeof prev.sessionId === "string" && prev.sessionId) {
+      previousBySessionId.set(prev.sessionId, prev);
+    }
+  }
+
   return merged.map((s) => {
+    const previous = pickSourceRecordForSession(s, previousBySessionId, previousByKey);
     const replay = replayMap.get(s.slug);
+    const promptCount = s.promptCount ?? previous?.promptCount;
+    const toolCallCount = s.toolCallCount ?? previous?.toolCallCount;
     return {
       provider: s.provider,
+      sessionId: s.sessionId,
       slug: s.slug,
       title: s.title,
       project: s.project,
       timestamp: s.timestamp,
       fileSize: s.fileSize,
       lineCount: s.lineCount,
-      promptCount: s.promptCount,
-      toolCallCount: s.toolCallCount,
+      promptCount,
+      toolCallCount,
       firstPrompt: cleanPromptText(s.firstPrompt).slice(0, 200),
       prompts: s.prompts?.map((p) => cleanPromptText(p).slice(0, 200)),
       filePaths: s.filePaths,
@@ -538,6 +658,99 @@ export async function startServer(
       // Best-effort cache refresh for dashboard listing.
     }
   };
+  let sourcesEnrichmentStatus: SourcesEnrichmentStatus = {
+    running: false,
+    processed: 0,
+    total: 0,
+    updated: 0,
+  };
+
+  const enrichCursorStatsInBackground = (
+    merged: SessionInfo[],
+    baseSources: SourceSummaryRecord[],
+  ): void => {
+    if (sourcesEnrichmentStatus.running) return;
+    const cursorProvider = getProvider("cursor");
+    if (!cursorProvider) return;
+
+    const candidates = selectCursorEnrichmentCandidates(merged, baseSources);
+
+    sourcesEnrichmentStatus = {
+      running: true,
+      processed: 0,
+      total: candidates.length,
+      updated: 0,
+      startedAt: new Date().toISOString(),
+      message:
+        candidates.length > 0
+          ? "Computing detailed Cursor stats in background"
+          : "No Cursor stat backfill needed",
+    };
+
+    if (candidates.length === 0) {
+      sourcesEnrichmentStatus = {
+        ...sourcesEnrichmentStatus,
+        running: false,
+        finishedAt: new Date().toISOString(),
+      };
+      return;
+    }
+
+    void (async () => {
+      let changed = false;
+      const enrichedSources = baseSources.map((s) => ({ ...s }));
+      const bySessionId = new Map<string, SourceSummaryRecord>();
+      const byKey = new Map<string, SourceSummaryRecord>();
+      for (const source of enrichedSources) {
+        byKey.set(sourceSessionKey(source.provider, source.project, source.slug), source);
+        if (typeof source.sessionId === "string" && source.sessionId) {
+          bySessionId.set(source.sessionId, source);
+        }
+      }
+
+      for (const session of candidates) {
+        try {
+          const paths = [...session.filePaths, ...(session.toolPaths || [])];
+          const parsed = await cursorProvider.parse(paths, session);
+          const counts = countSessionStats(parsed.turns);
+          const target = pickSourceRecordForSession(session, bySessionId, byKey);
+          if (
+            target &&
+            (target.promptCount !== counts.promptCount ||
+              target.toolCallCount !== counts.toolCallCount)
+          ) {
+            target.promptCount = counts.promptCount;
+            target.toolCallCount = counts.toolCallCount;
+            changed = true;
+            sourcesEnrichmentStatus.updated += 1;
+          }
+        } catch {
+          // Best-effort enrichment only.
+        } finally {
+          sourcesEnrichmentStatus.processed += 1;
+          if (changed && sourcesEnrichmentStatus.processed % 5 === 0) {
+            await writeFileCache(sourcesCacheKey, enrichedSources);
+          }
+        }
+      }
+
+      if (changed) {
+        await writeFileCache(sourcesCacheKey, enrichedSources);
+      }
+      sourcesEnrichmentStatus = {
+        ...sourcesEnrichmentStatus,
+        running: false,
+        finishedAt: new Date().toISOString(),
+      };
+    })().catch(() => {
+      sourcesEnrichmentStatus = {
+        ...sourcesEnrichmentStatus,
+        running: false,
+        finishedAt: new Date().toISOString(),
+        message: "Cursor stat backfill failed",
+      };
+    });
+  };
 
   const app = new Hono();
 
@@ -649,6 +862,10 @@ export async function startServer(
     });
   });
 
+  app.get("/api/sources/enrichment-status", async (c) => {
+    return c.json(sourcesEnrichmentStatus);
+  });
+
   app.get("/api/sources", async (c) => {
     try {
       const providers = getAllProviders();
@@ -659,9 +876,11 @@ export async function startServer(
       }
 
       const merged = mergeSameSessions(allSessions);
-      const result = await buildSourcesResult(merged, baseDir, homedir());
+      const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
+      const result = await buildSourcesResult(merged, baseDir, homedir(), previous?.data || []);
 
       await writeFileCache(sourcesCacheKey, result);
+      enrichCursorStatsInBackground(merged, result);
       return c.json({ sessions: result });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
@@ -692,9 +911,11 @@ export async function startServer(
         }
 
         const merged = mergeSameSessions(allSessions);
-        const result = await buildSourcesResult(merged, baseDir, homedir());
+        const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
+        const result = await buildSourcesResult(merged, baseDir, homedir(), previous?.data || []);
 
         await writeFileCache(sourcesCacheKey, result);
+        enrichCursorStatsInBackground(merged, result);
         await stream.writeSSE({
           data: JSON.stringify({ type: "complete", sessions: result }),
         });
@@ -1353,3 +1574,10 @@ export async function startDashboard(
 ): Promise<void> {
   await startServer(baseDir, { openDashboard: true, externalViewerUrl: opts?.externalViewerUrl });
 }
+
+export const __testables = {
+  countSessionStats,
+  pickSourceRecordForSession,
+  selectCursorEnrichmentCandidates,
+  sourceSessionKey,
+};

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1035,6 +1035,8 @@ export async function startServer(
   app.get("/api/system-checks", async (c) => {
     const exec = promisify(execFile);
 
+    const TOOL_CHECK_TIMEOUT_MS = 3000;
+
     interface ToolCheck {
       name: string;
       label: string;
@@ -1044,83 +1046,121 @@ export async function startServer(
       detail?: string;
     }
 
+    interface CommandRunResult {
+      ok: boolean;
+      stdout: string;
+      timedOut: boolean;
+    }
+
+    type RunCommand = (cmd: string, args: string[]) => Promise<CommandRunResult>;
+
+    function isTimeoutError(err: unknown): boolean {
+      if (!(err instanceof Error)) return false;
+      const timeoutErr = err as Error & { code?: string; killed?: boolean; signal?: string };
+      return (
+        timeoutErr.code === "ETIMEDOUT" ||
+        timeoutErr.killed === true ||
+        timeoutErr.signal === "SIGTERM"
+      );
+    }
+
+    const runCommand: RunCommand = async (cmd, args) => {
+      try {
+        const { stdout } = await exec(cmd, args, {
+          timeout: TOOL_CHECK_TIMEOUT_MS,
+          maxBuffer: 1024 * 1024,
+        });
+        return { ok: true, stdout, timedOut: false };
+      } catch (err) {
+        return { ok: false, stdout: "", timedOut: isTimeoutError(err) };
+      }
+    };
+
     async function checkCli(
       name: string,
       label: string,
       purpose: string,
       cmd: string,
       versionArgs: string[] = ["--version"],
-      extraCheck?: () => Promise<string | undefined>,
-    ): Promise<ToolCheck> {
-      try {
-        await exec("which", [cmd]);
-      } catch {
+      extraCheck?: (run: RunCommand) => Promise<string | null | undefined>,
+    ): Promise<ToolCheck | null> {
+      const whichResult = await runCommand("which", [cmd]);
+      if (!whichResult.ok) {
+        if (whichResult.timedOut) return null;
         return { name, label, purpose, installed: false };
       }
+
       let version: string | undefined;
-      try {
-        const { stdout } = await exec(cmd, versionArgs);
-        version = stdout.trim().split("\n")[0];
-      } catch {
-        /* version check failed, still installed */
+      const versionResult = await runCommand(cmd, versionArgs);
+      if (versionResult.timedOut) return null;
+      if (versionResult.ok) {
+        version = versionResult.stdout.trim().split("\n")[0];
       }
-      const detail = extraCheck ? await extraCheck() : undefined;
+
+      const detail = extraCheck ? await extraCheck(runCommand) : undefined;
+      if (detail === null) return null;
+
       return { name, label, purpose, installed: true, version, detail };
     }
 
-    const checks = await Promise.all([
-      checkCli(
-        "gh",
-        "GitHub CLI",
-        "Publish replays as GitHub Gists",
-        "gh",
-        ["--version"],
-        async () => {
-          try {
-            await exec("gh", ["auth", "status"]);
-            return "authenticated";
-          } catch {
-            return "not authenticated";
-          }
-        },
-      ),
-      checkCli(
-        "claude",
-        "Claude Code",
-        "AI feedback via headless mode",
-        "claude",
-        ["--version"],
-        async () => {
-          try {
-            const { stdout } = await exec("claude", ["auth", "status"]);
-            const info = JSON.parse(stdout);
-            if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
+    const checks = (
+      await Promise.all([
+        checkCli(
+          "gh",
+          "GitHub CLI",
+          "Publish replays as GitHub Gists",
+          "gh",
+          ["--version"],
+          async (run) => {
+            const auth = await run("gh", ["auth", "status"]);
+            if (auth.timedOut) return null;
+            return auth.ok ? "authenticated" : "not authenticated";
+          },
+        ),
+        checkCli(
+          "claude",
+          "Claude Code",
+          "AI feedback via headless mode",
+          "claude",
+          ["--version"],
+          async (run) => {
+            const auth = await run("claude", ["auth", "status"]);
+            if (auth.timedOut) return null;
+            if (!auth.ok) return "not logged in";
+
+            try {
+              const info = JSON.parse(auth.stdout) as {
+                loggedIn?: boolean;
+                email?: string;
+                authMethod?: string;
+              };
+              if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
+            } catch {
+              // Non-JSON output still means command completed; keep non-blocking fallback detail.
+            }
+
             return "not logged in";
-          } catch {
-            return "not logged in";
-          }
-        },
-      ),
-      checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
-        "agent",
-        "--version",
-      ]),
-      checkCli(
-        "opencode",
-        "OpenCode",
-        "AI feedback via headless mode",
-        "opencode",
-        ["--version"],
-        async () => {
-          try {
-            const { stdout } = await exec("opencode", ["auth", "list"]);
-            return stdout.includes("0 credentials") ? "no credentials" : "configured";
-          } catch {
-            return undefined;
-          }
-        },
-      ),
-    ]);
+          },
+        ),
+        checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
+          "agent",
+          "--version",
+        ]),
+        checkCli(
+          "opencode",
+          "OpenCode",
+          "AI feedback via headless mode",
+          "opencode",
+          ["--version"],
+          async (run) => {
+            const auth = await run("opencode", ["auth", "list"]);
+            if (auth.timedOut) return null;
+            if (!auth.ok) return undefined;
+            return auth.stdout.includes("0 credentials") ? "no credentials" : "configured";
+          },
+        ),
+      ])
+    ).filter((check): check is ToolCheck => check !== null);
 
     return c.json({ checks });
   });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1112,62 +1112,76 @@ export async function startServer(
       return { name, label, purpose, installed: true, version, detail };
     }
 
-    const checks = await Promise.all([
-      checkCli(
-        "gh",
-        "GitHub CLI",
-        "Publish replays as GitHub Gists",
-        "gh",
-        ["--version"],
-        async (run) => {
-          const auth = await run("gh", ["auth", "status"]);
-          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
-          return auth.ok ? "authenticated" : "not authenticated";
-        },
-      ),
-      checkCli(
-        "claude",
-        "Claude Code",
-        "AI feedback via headless mode",
-        "claude",
-        ["--version"],
-        async (run) => {
-          const auth = await run("claude", ["auth", "status"]);
-          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
-          if (!auth.ok) return "not logged in";
+    const toolChecks: Record<string, () => Promise<ToolCheck>> = {
+      gh: () =>
+        checkCli(
+          "gh",
+          "GitHub CLI",
+          "Publish replays as GitHub Gists",
+          "gh",
+          ["--version"],
+          async (run) => {
+            const auth = await run("gh", ["auth", "status"]);
+            if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+            return auth.ok ? "authenticated" : "not authenticated";
+          },
+        ),
+      claude: () =>
+        checkCli(
+          "claude",
+          "Claude Code",
+          "AI feedback via headless mode",
+          "claude",
+          ["--version"],
+          async (run) => {
+            const auth = await run("claude", ["auth", "status"]);
+            if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+            if (!auth.ok) return "not logged in";
 
-          try {
-            const info = JSON.parse(auth.stdout) as {
-              loggedIn?: boolean;
-              email?: string;
-              authMethod?: string;
-            };
-            if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
-          } catch {
-            // Non-JSON output still means command completed; keep non-blocking fallback detail.
-          }
+            try {
+              const info = JSON.parse(auth.stdout) as {
+                loggedIn?: boolean;
+                email?: string;
+                authMethod?: string;
+              };
+              if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
+            } catch {
+              // Non-JSON output still means command completed; keep non-blocking fallback detail.
+            }
 
-          return "not logged in";
-        },
-      ),
-      checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
-        "agent",
-        "--version",
-      ]),
-      checkCli(
-        "opencode",
-        "OpenCode",
-        "AI feedback via headless mode",
-        "opencode",
-        ["--version"],
-        async (run) => {
-          const auth = await run("opencode", ["auth", "list"]);
-          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
-          if (!auth.ok) return undefined;
-          return auth.stdout.includes("0 credentials") ? "no credentials" : "configured";
-        },
-      ),
-    ]);
+            return "not logged in";
+          },
+        ),
+      cursor: () =>
+        checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
+          "agent",
+          "--version",
+        ]),
+      opencode: () =>
+        checkCli(
+          "opencode",
+          "OpenCode",
+          "AI feedback via headless mode",
+          "opencode",
+          ["--version"],
+          async (run) => {
+            const auth = await run("opencode", ["auth", "list"]);
+            if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+            if (!auth.ok) return undefined;
+            return auth.stdout.includes("0 credentials") ? "no credentials" : "configured";
+          },
+        ),
+    };
+
+    const requestedTool = c.req.query("tool");
+    if (requestedTool) {
+      const checker = toolChecks[requestedTool];
+      if (!checker) return c.json({ error: `Unknown tool: ${requestedTool}` }, 400);
+      const check = await checker();
+      return c.json({ checks: [check] });
+    }
+
+    const checks = await Promise.all(Object.values(toolChecks).map((check) => check()));
 
     return c.json({ checks });
   });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -722,12 +722,18 @@ export async function startServer(
             target.promptCount = counts.promptCount;
             target.toolCallCount = counts.toolCallCount;
             changed = true;
-            sourcesEnrichmentStatus.updated += 1;
+            sourcesEnrichmentStatus = {
+              ...sourcesEnrichmentStatus,
+              updated: sourcesEnrichmentStatus.updated + 1,
+            };
           }
         } catch {
           // Best-effort enrichment only.
         } finally {
-          sourcesEnrichmentStatus.processed += 1;
+          sourcesEnrichmentStatus = {
+            ...sourcesEnrichmentStatus,
+            processed: sourcesEnrichmentStatus.processed + 1,
+          };
           if (changed && sourcesEnrichmentStatus.processed % 5 === 0) {
             await writeFileCache(sourcesCacheKey, enrichedSources);
           }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1036,6 +1036,8 @@ export async function startServer(
     const exec = promisify(execFile);
 
     const TOOL_CHECK_TIMEOUT_MS = 3000;
+    const CHECK_TIMEOUT_MARKER = "__check_timeout__" as const;
+    const CHECK_TIMEOUT_DETAIL = "check timeout";
 
     interface ToolCheck {
       name: string;
@@ -1052,6 +1054,7 @@ export async function startServer(
       timedOut: boolean;
     }
 
+    type ExtraCheckResult = string | typeof CHECK_TIMEOUT_MARKER | undefined;
     type RunCommand = (cmd: string, args: string[]) => Promise<CommandRunResult>;
 
     function isTimeoutError(err: unknown): boolean {
@@ -1082,85 +1085,89 @@ export async function startServer(
       purpose: string,
       cmd: string,
       versionArgs: string[] = ["--version"],
-      extraCheck?: (run: RunCommand) => Promise<string | null | undefined>,
-    ): Promise<ToolCheck | null> {
+      extraCheck?: (run: RunCommand) => Promise<ExtraCheckResult>,
+    ): Promise<ToolCheck> {
       const whichResult = await runCommand("which", [cmd]);
       if (!whichResult.ok) {
-        if (whichResult.timedOut) return null;
+        if (whichResult.timedOut) {
+          return { name, label, purpose, installed: false, detail: CHECK_TIMEOUT_DETAIL };
+        }
         return { name, label, purpose, installed: false };
       }
 
       let version: string | undefined;
       const versionResult = await runCommand(cmd, versionArgs);
-      if (versionResult.timedOut) return null;
+      if (versionResult.timedOut) {
+        return { name, label, purpose, installed: false, detail: CHECK_TIMEOUT_DETAIL };
+      }
       if (versionResult.ok) {
         version = versionResult.stdout.trim().split("\n")[0];
       }
 
       const detail = extraCheck ? await extraCheck(runCommand) : undefined;
-      if (detail === null) return null;
+      if (detail === CHECK_TIMEOUT_MARKER) {
+        return { name, label, purpose, installed: false, version, detail: CHECK_TIMEOUT_DETAIL };
+      }
 
       return { name, label, purpose, installed: true, version, detail };
     }
 
-    const checks = (
-      await Promise.all([
-        checkCli(
-          "gh",
-          "GitHub CLI",
-          "Publish replays as GitHub Gists",
-          "gh",
-          ["--version"],
-          async (run) => {
-            const auth = await run("gh", ["auth", "status"]);
-            if (auth.timedOut) return null;
-            return auth.ok ? "authenticated" : "not authenticated";
-          },
-        ),
-        checkCli(
-          "claude",
-          "Claude Code",
-          "AI feedback via headless mode",
-          "claude",
-          ["--version"],
-          async (run) => {
-            const auth = await run("claude", ["auth", "status"]);
-            if (auth.timedOut) return null;
-            if (!auth.ok) return "not logged in";
+    const checks = await Promise.all([
+      checkCli(
+        "gh",
+        "GitHub CLI",
+        "Publish replays as GitHub Gists",
+        "gh",
+        ["--version"],
+        async (run) => {
+          const auth = await run("gh", ["auth", "status"]);
+          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+          return auth.ok ? "authenticated" : "not authenticated";
+        },
+      ),
+      checkCli(
+        "claude",
+        "Claude Code",
+        "AI feedback via headless mode",
+        "claude",
+        ["--version"],
+        async (run) => {
+          const auth = await run("claude", ["auth", "status"]);
+          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+          if (!auth.ok) return "not logged in";
 
-            try {
-              const info = JSON.parse(auth.stdout) as {
-                loggedIn?: boolean;
-                email?: string;
-                authMethod?: string;
-              };
-              if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
-            } catch {
-              // Non-JSON output still means command completed; keep non-blocking fallback detail.
-            }
+          try {
+            const info = JSON.parse(auth.stdout) as {
+              loggedIn?: boolean;
+              email?: string;
+              authMethod?: string;
+            };
+            if (info.loggedIn) return `${info.email || info.authMethod || "logged in"}`;
+          } catch {
+            // Non-JSON output still means command completed; keep non-blocking fallback detail.
+          }
 
-            return "not logged in";
-          },
-        ),
-        checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
-          "agent",
-          "--version",
-        ]),
-        checkCli(
-          "opencode",
-          "OpenCode",
-          "AI feedback via headless mode",
-          "opencode",
-          ["--version"],
-          async (run) => {
-            const auth = await run("opencode", ["auth", "list"]);
-            if (auth.timedOut) return null;
-            if (!auth.ok) return undefined;
-            return auth.stdout.includes("0 credentials") ? "no credentials" : "configured";
-          },
-        ),
-      ])
-    ).filter((check): check is ToolCheck => check !== null);
+          return "not logged in";
+        },
+      ),
+      checkCli("cursor", "Cursor CLI", "AI feedback via AI Studio", "cursor", [
+        "agent",
+        "--version",
+      ]),
+      checkCli(
+        "opencode",
+        "OpenCode",
+        "AI feedback via headless mode",
+        "opencode",
+        ["--version"],
+        async (run) => {
+          const auth = await run("opencode", ["auth", "list"]);
+          if (auth.timedOut) return CHECK_TIMEOUT_MARKER;
+          if (!auth.ok) return undefined;
+          return auth.stdout.includes("0 credentials") ? "no credentials" : "configured";
+        },
+      ),
+    ]);
 
     return c.json({ checks });
   });

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { __testables } from "../src/server.js";
+import type { SessionInfo } from "../src/types.js";
+
+function makeCursorSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    provider: "cursor",
+    sessionId: "cursor-session-a",
+    slug: "aaaaaaaa",
+    project: "~/project-a",
+    cwd: "/tmp/project-a",
+    version: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    lineCount: 10,
+    fileSize: 1024,
+    filePath: "/tmp/session-a.jsonl",
+    filePaths: ["/tmp/session-a.jsonl"],
+    toolPaths: ["/tmp/tool-a.txt"],
+    firstPrompt: "test prompt",
+    ...overrides,
+  };
+}
+
+describe("sources enrichment helpers", () => {
+  it("skips candidate sessions already enriched in cached sources", () => {
+    const merged = [
+      makeCursorSession({
+        promptCount: undefined,
+        toolCallCount: undefined,
+      }),
+    ];
+
+    const baseSources = [
+      {
+        provider: "cursor",
+        sessionId: "cursor-session-a",
+        slug: "aaaaaaaa",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/session-a.jsonl"],
+        hasSqlite: true,
+        promptCount: 12,
+        toolCallCount: 8,
+      },
+    ] as any[];
+
+    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("selects only missing-count cursor sessions and respects recency", () => {
+    const merged = [
+      makeCursorSession({
+        sessionId: "cursor-old",
+        slug: "oldold00",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+      makeCursorSession({
+        sessionId: "cursor-new",
+        slug: "newnew00",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      }),
+      makeCursorSession({
+        sessionId: "cursor-done",
+        slug: "done0000",
+        timestamp: "2026-01-03T00:00:00.000Z",
+      }),
+    ];
+
+    const baseSources = [
+      {
+        provider: "cursor",
+        sessionId: "cursor-old",
+        slug: "oldold00",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/session-old.jsonl"],
+        promptCount: undefined,
+        toolCallCount: undefined,
+      },
+      {
+        provider: "cursor",
+        sessionId: "cursor-new",
+        slug: "newnew00",
+        project: "~/project-a",
+        timestamp: "2026-01-02T00:00:00.000Z",
+        filePaths: ["/tmp/session-new.jsonl"],
+        promptCount: undefined,
+        toolCallCount: undefined,
+      },
+      {
+        provider: "cursor",
+        sessionId: "cursor-done",
+        slug: "done0000",
+        project: "~/project-a",
+        timestamp: "2026-01-03T00:00:00.000Z",
+        filePaths: ["/tmp/session-done.jsonl"],
+        promptCount: 4,
+        toolCallCount: 2,
+      },
+    ] as any[];
+
+    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources, 2);
+    expect(candidates.map((s) => s.sessionId)).toEqual(["cursor-new", "cursor-old"]);
+  });
+
+  it("does not cross-provider match by sessionId when picking cache records", () => {
+    const current = makeCursorSession({ sessionId: "shared-id", slug: "aaaaaaaa" });
+    const bySessionId = new Map<string, any>([
+      [
+        "shared-id",
+        {
+          provider: "claude-code",
+          sessionId: "shared-id",
+          slug: "claude01",
+          project: "~/project-a",
+          promptCount: 999,
+          toolCallCount: 999,
+        },
+      ],
+    ]);
+    const byKey = new Map<string, any>([
+      [
+        __testables.sourceSessionKey("cursor", "~/project-a", "aaaaaaaa"),
+        {
+          provider: "cursor",
+          sessionId: "cursor-real",
+          slug: "aaaaaaaa",
+          project: "~/project-a",
+          promptCount: 5,
+          toolCallCount: 3,
+        },
+      ],
+    ]);
+
+    const picked = __testables.pickSourceRecordForSession(current, bySessionId, byKey);
+    expect(picked?.provider).toBe("cursor");
+    expect(picked?.promptCount).toBe(5);
+  });
+
+  it("counts prompts/tools from parsed turns with compaction exclusion", () => {
+    const counts = __testables.countSessionStats([
+      {
+        role: "user",
+        subtype: "compaction-summary",
+        blocks: [{ type: "text", text: "ignored" }],
+      },
+      {
+        role: "user",
+        blocks: [{ type: "_user_images", images: ["data:image/png;base64,abc"] }],
+      },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use" }, { type: "tool_use" }],
+      },
+    ] as any);
+
+    expect(counts).toEqual({ promptCount: 1, toolCallCount: 2 });
+  });
+});

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -18,6 +18,7 @@ import {
   providerBadgeClass,
   providerBadgeLabel,
   replaySuggestedTitle,
+  type SourcesEnrichmentStatus,
   sourceSuggestedTitle,
   TITLE_MAX_CHARS,
   timeAgo,
@@ -25,12 +26,6 @@ import {
 import { formatDuration } from "./StatsPanel";
 
 type Tab = "home" | "sessions" | "replays";
-
-interface SourcesEnrichmentStatus {
-  running: boolean;
-  processed: number;
-  total: number;
-}
 
 const MoreDotsIcon = () => (
   <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -603,6 +598,7 @@ function SessionsPanel() {
   const [ghAvailable, setGhAvailable] = useState<boolean | null>(null);
   const [publishingSlug, setPublishingSlug] = useState<string | null>(null);
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
+  const hasCursorSources = sources.some((source) => source.provider === "cursor");
 
   const loadSources = useCallback(async (opts?: { forceRefresh?: boolean }) => {
     setLoading(true);
@@ -685,6 +681,8 @@ function SessionsPanel() {
   }, [loadSources]);
 
   useEffect(() => {
+    if (!loading && !hasCursorSources && !wasEnrichingRef.current) return;
+
     let cancelled = false;
     let timer: number | undefined;
     const refreshSourcesFromCache = async () => {
@@ -718,7 +716,7 @@ function SessionsPanel() {
       cancelled = true;
       if (timer) window.clearInterval(timer);
     };
-  }, []);
+  }, [hasCursorSources, loading]);
 
   useEffect(() => {
     const timer = window.setInterval(() => setRefreshClockMs(Date.now()), 30_000);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -26,6 +26,12 @@ import { formatDuration } from "./StatsPanel";
 
 type Tab = "home" | "sessions" | "replays";
 
+interface SourcesEnrichmentStatus {
+  running: boolean;
+  processed: number;
+  total: number;
+}
+
 const MoreDotsIcon = () => (
   <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
     <circle cx="8" cy="3" r="1.5" />
@@ -591,10 +597,12 @@ function SessionsPanel() {
   const [titleInput, setTitleInput] = useState<{ slug: string; defaultTitle: string } | null>(null);
   const [titleValue, setTitleValue] = useState("");
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const wasEnrichingRef = useRef(false);
   const [archivedSlugs, setArchivedSlugs] = useState<Set<string>>(new Set());
   const [showArchived, setShowArchived] = useState(false);
   const [ghAvailable, setGhAvailable] = useState<boolean | null>(null);
   const [publishingSlug, setPublishingSlug] = useState<string | null>(null);
+  const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
 
   const loadSources = useCallback(async (opts?: { forceRefresh?: boolean }) => {
     setLoading(true);
@@ -675,6 +683,42 @@ function SessionsPanel() {
       .then((data: { available: boolean }) => setGhAvailable(data.available))
       .catch(() => setGhAvailable(false));
   }, [loadSources]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+    const refreshSourcesFromCache = async () => {
+      const payload = await fetch("/api/sources/cached")
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+      const cached = parseCachedList<SourceSession>(payload);
+      if (!cancelled && cached?.sessions.length) {
+        setSources(cached.sessions);
+      }
+    };
+    const poll = async () => {
+      const status = await fetch("/api/sources/enrichment-status")
+        .then((r) => (r.ok ? (r.json() as Promise<SourcesEnrichmentStatus>) : null))
+        .catch(() => null);
+      if (!status || cancelled) return;
+      setEnrichmentStatus(status);
+      if (status.running) {
+        wasEnrichingRef.current = true;
+        await refreshSourcesFromCache();
+      } else if (wasEnrichingRef.current) {
+        wasEnrichingRef.current = false;
+        await refreshSourcesFromCache();
+      }
+    };
+    void poll();
+    timer = window.setInterval(() => {
+      void poll();
+    }, 2500);
+    return () => {
+      cancelled = true;
+      if (timer) window.clearInterval(timer);
+    };
+  }, []);
 
   useEffect(() => {
     const timer = window.setInterval(() => setRefreshClockMs(Date.now()), 30_000);
@@ -1087,6 +1131,15 @@ function SessionsPanel() {
             ) : staleCachedAt ? (
               <span>Showing stale cache ({formatCacheAge(staleCachedAt)})</span>
             ) : null}
+          </div>
+        )}
+
+        {enrichmentStatus?.running && enrichmentStatus.total > 0 && (
+          <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
+            <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+            <span>
+              BACKFILLING CURSOR STATS... {enrichmentStatus.processed}/{enrichmentStatus.total}
+            </span>
           </div>
         )}
 

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -724,7 +724,7 @@ function SystemChecksSection() {
         .then((r) => (r.ok ? r.json() : null))
         .then((d: { checks?: TC[] } | null) => {
           if (cancelled) return;
-          const resolved = d?.checks?.[0];
+          const resolved = d?.checks?.find((entry) => entry.name === tool.name) || d?.checks?.[0];
           if (!resolved) {
             setChecks((prev) =>
               prev.map((entry) =>
@@ -737,7 +737,15 @@ function SystemChecksSection() {
           }
           setChecks((prev) =>
             prev.map((entry) =>
-              entry.name === tool.name ? { ...resolved, loading: false } : entry,
+              entry.name === tool.name
+                ? {
+                    ...entry,
+                    installed: Boolean(resolved.installed),
+                    version: resolved.version,
+                    detail: resolved.detail,
+                    loading: false,
+                  }
+                : entry,
             ),
           );
         })

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { SessionSummary, SourceSession } from "../types";
 import {
   isCacheFresh,
@@ -35,6 +35,16 @@ interface InsightStats {
   replayConversionPct: number;
 }
 
+interface SourcesEnrichmentStatus {
+  running: boolean;
+  processed: number;
+  total: number;
+  updated: number;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────
 
 function formatCompactDuration(ms: number): string {
@@ -55,11 +65,17 @@ function useDashboardData() {
   const [sources, setSources] = useState<SourceSession[]>([]);
   const [replays, setReplays] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingSources, setLoadingSources] = useState(true);
+  const [loadingReplays, setLoadingReplays] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [scanProgress, setScanProgress] = useState<number | null>(null);
+  const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
+  const wasEnrichingRef = useRef(false);
 
   const loadData = useCallback(async () => {
     setLoading(true);
+    setLoadingSources(true);
+    setLoadingReplays(true);
     setError(null);
 
     try {
@@ -85,6 +101,9 @@ function useDashboardData() {
       const sourceFresh = isCacheFresh(cachedSources?.cachedAt);
       const replayFresh = isCacheFresh(cachedReplays?.cachedAt);
       const refreshPromises: Promise<void>[] = [];
+
+      if (sourceFresh) setLoadingSources(false);
+      if (replayFresh) setLoadingReplays(false);
 
       if (!sourceFresh) {
         // Use SSE stream for discovery with progress reporting
@@ -131,7 +150,7 @@ function useDashboardData() {
                 })
                 .finally(() => resolve());
             };
-          }),
+          }).finally(() => setLoadingSources(false)),
         );
       }
 
@@ -147,7 +166,8 @@ function useDashboardData() {
               if (!cachedReplays?.sessions.length) {
                 setError(err instanceof Error ? err.message : "Failed to load replays");
               }
-            }),
+            })
+            .finally(() => setLoadingReplays(false)),
         );
       }
 
@@ -163,7 +183,57 @@ function useDashboardData() {
     void loadData();
   }, [loadData]);
 
-  return { sources, replays, loading, error, scanProgress };
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const maybeRefreshSourcesFromCache = async () => {
+      const payload = await fetch("/api/sources/cached")
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+      const cached = parseCachedList<SourceSession>(payload);
+      if (!cancelled && cached?.sessions.length) {
+        setSources(cached.sessions);
+      }
+    };
+
+    const poll = async () => {
+      const status = await fetch("/api/sources/enrichment-status")
+        .then((r) => (r.ok ? (r.json() as Promise<SourcesEnrichmentStatus>) : null))
+        .catch(() => null);
+      if (!status || cancelled) return;
+      setEnrichmentStatus(status);
+
+      if (status.running) {
+        wasEnrichingRef.current = true;
+        await maybeRefreshSourcesFromCache();
+      } else if (wasEnrichingRef.current) {
+        wasEnrichingRef.current = false;
+        await maybeRefreshSourcesFromCache();
+      }
+    };
+
+    void poll();
+    timer = window.setInterval(() => {
+      void poll();
+    }, 2500);
+
+    return () => {
+      cancelled = true;
+      if (timer) window.clearInterval(timer);
+    };
+  }, []);
+
+  return {
+    sources,
+    replays,
+    loading,
+    loadingSources,
+    loadingReplays,
+    error,
+    scanProgress,
+    enrichmentStatus,
+  };
 }
 
 // ─── Compute Insights ────────────────────────────────────────────────
@@ -181,11 +251,15 @@ function computeInsights(sources: SourceSession[], replays: SessionSummary[]): I
   }
   for (const r of replays) {
     const src = srcBySlug.get(r.slug);
+    const replayToolCalls = r.stats.toolCalls || 0;
     if (!src) {
       totalPrompts += r.stats.userPrompts || 0;
-      totalToolCalls += r.stats.toolCalls || 0;
+      totalToolCalls += replayToolCalls;
     } else if (src.toolCallCount == null) {
-      totalToolCalls += r.stats.toolCalls || 0;
+      totalToolCalls += replayToolCalls;
+    } else if (replayToolCalls > src.toolCallCount) {
+      // Source discovery counts can under-report Cursor tool calls; trust replay stats when higher.
+      totalToolCalls += replayToolCalls - src.toolCallCount;
     }
     totalDuration += r.stats.durationMs || 0;
   }
@@ -438,6 +512,7 @@ function ProviderBadge({ provider }: { provider: string }) {
 
 function RecentSessionsList({
   sessions,
+  isLoading,
   onViewAll,
   onGenerate,
   onViewReplay,
@@ -445,6 +520,7 @@ function RecentSessionsList({
   generateErrorSlug,
 }: {
   sessions: SourceSession[];
+  isLoading: boolean;
   onViewAll: () => void;
   onGenerate: (source: SourceSession) => void;
   onViewReplay: (slug: string) => void;
@@ -454,7 +530,9 @@ function RecentSessionsList({
   if (sessions.length === 0) {
     return (
       <div className="text-center py-6 text-terminal-dimmer text-xs font-mono">
-        No sessions found. Start a coding session with Claude Code or Cursor.
+        {isLoading
+          ? "Loading sessions..."
+          : "No sessions found. Start a coding session with Claude Code or Cursor."}
       </div>
     );
   }
@@ -540,17 +618,19 @@ function RecentSessionsList({
 
 function RecentReplaysList({
   replays,
+  isLoading,
   onViewAll,
   onOpen,
 }: {
   replays: SessionSummary[];
+  isLoading: boolean;
   onViewAll: () => void;
   onOpen: (slug: string) => void;
 }) {
   if (replays.length === 0) {
     return (
       <div className="text-center py-6 text-terminal-dimmer text-xs font-mono">
-        No replays yet. Generate one from the Sessions tab.
+        {isLoading ? "Loading replays..." : "No replays yet. Generate one from the Sessions tab."}
       </div>
     );
   }
@@ -709,7 +789,16 @@ const ToolsIcon = () => (
 // ─── Main Component ──────────────────────────────────────────────────
 
 export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
-  const { sources, replays, loading, error, scanProgress } = useDashboardData();
+  const {
+    sources,
+    replays,
+    loading,
+    loadingSources,
+    loadingReplays,
+    error,
+    scanProgress,
+    enrichmentStatus,
+  } = useDashboardData();
   const insights = useMemo(() => computeInsights(sources, replays), [sources, replays]);
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateErrorSlug, setGenerateErrorSlug] = useState<string | null>(null);
@@ -755,6 +844,9 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="text-sm font-mono text-terminal-dim animate-pulse">
             Loading dashboard...
           </div>
+          <div className="text-xs font-mono text-terminal-dimmer">
+            Cursor history may take longer on large workspaces
+          </div>
         </div>
       </div>
     );
@@ -783,6 +875,15 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             <div className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
             <span className="text-xs font-mono text-terminal-dim">
               Scanning... {scanProgress} sessions
+            </span>
+          </div>
+        )}
+
+        {enrichmentStatus?.running && enrichmentStatus.total > 0 && (
+          <div className="flex items-center gap-2 px-1">
+            <div className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
+            <span className="text-xs font-mono text-terminal-dim">
+              Enriching Cursor stats... {enrichmentStatus.processed}/{enrichmentStatus.total}
             </span>
           </div>
         )}
@@ -878,6 +979,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             </div>
             <RecentSessionsList
               sessions={insights.recentSources}
+              isLoading={loadingSources}
               onViewAll={() => onNavigate("sessions")}
               onGenerate={handleGenerate}
               onViewReplay={handleOpenReplay}
@@ -897,6 +999,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             </div>
             <RecentReplaysList
               replays={insights.recentReplays}
+              isLoading={loadingReplays}
               onViewAll={() => onNavigate("replays")}
               onOpen={handleOpenReplay}
             />

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -697,17 +697,66 @@ interface TC {
   installed: boolean;
   version?: string;
   detail?: string;
+  loading?: boolean;
 }
 
+const SYSTEM_TOOLS: Array<Pick<TC, "name" | "label" | "purpose">> = [
+  { name: "gh", label: "GitHub CLI", purpose: "Publish replays as GitHub Gists" },
+  { name: "claude", label: "Claude Code", purpose: "AI feedback via headless mode" },
+  { name: "cursor", label: "Cursor CLI", purpose: "AI feedback via AI Studio" },
+  { name: "opencode", label: "OpenCode", purpose: "AI feedback via headless mode" },
+];
+
 function SystemChecksSection() {
-  const [checks, setChecks] = useState<TC[] | null>(null);
+  const [checks, setChecks] = useState<TC[]>(() =>
+    SYSTEM_TOOLS.map((tool) => ({
+      ...tool,
+      installed: false,
+      detail: "checking...",
+      loading: true,
+    })),
+  );
+
   useEffect(() => {
-    fetch("/api/system-checks")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d: { checks: TC[] } | null) => d?.checks && setChecks(d.checks))
-      .catch(() => {});
+    let cancelled = false;
+    for (const tool of SYSTEM_TOOLS) {
+      fetch(`/api/system-checks?tool=${encodeURIComponent(tool.name)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d: { checks?: TC[] } | null) => {
+          if (cancelled) return;
+          const resolved = d?.checks?.[0];
+          if (!resolved) {
+            setChecks((prev) =>
+              prev.map((entry) =>
+                entry.name === tool.name
+                  ? { ...entry, installed: false, detail: "check failed", loading: false }
+                  : entry,
+              ),
+            );
+            return;
+          }
+          setChecks((prev) =>
+            prev.map((entry) =>
+              entry.name === tool.name ? { ...resolved, loading: false } : entry,
+            ),
+          );
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setChecks((prev) =>
+            prev.map((entry) =>
+              entry.name === tool.name
+                ? { ...entry, installed: false, detail: "check failed", loading: false }
+                : entry,
+            ),
+          );
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
-  if (!checks) return null;
 
   return (
     <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
@@ -721,16 +770,32 @@ function SystemChecksSection() {
             className="flex items-start gap-2.5 px-3 py-2.5 rounded-lg bg-terminal-bg"
           >
             <div
-              className={`w-2 h-2 mt-1 rounded-full shrink-0 ${t.installed ? "bg-terminal-green" : "bg-terminal-dim opacity-40"}`}
+              className={`w-2 h-2 mt-1 rounded-full shrink-0 ${
+                t.loading
+                  ? "bg-terminal-blue animate-pulse"
+                  : t.installed
+                    ? "bg-terminal-green"
+                    : "bg-terminal-dim opacity-40"
+              }`}
             />
             <div className="min-w-0">
               <span
-                className={`text-xs font-sans font-medium ${t.installed ? "text-terminal-text" : "text-terminal-dimmer"}`}
+                className={`text-xs font-sans font-medium ${
+                  t.loading
+                    ? "text-terminal-dim"
+                    : t.installed
+                      ? "text-terminal-text"
+                      : "text-terminal-dimmer"
+                }`}
               >
                 {t.label}
               </span>
               <p className="text-[10px] font-mono text-terminal-dimmer truncate">{t.purpose}</p>
-              {t.installed ? (
+              {t.loading ? (
+                <p className="text-[10px] font-mono text-terminal-blue truncate animate-pulse">
+                  checking...
+                </p>
+              ) : t.installed ? (
                 <p className="text-[10px] font-mono text-terminal-green truncate">
                   {t.detail || t.version || "ready"}
                 </p>

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -9,6 +9,7 @@ import {
   providerBadgeClass,
   providerBadgeLabel,
   replaySuggestedTitle,
+  type SourcesEnrichmentStatus,
   sourceSuggestedTitle,
   timeAgo,
 } from "./dashboard-utils";
@@ -33,16 +34,6 @@ interface InsightStats {
   recentReplays: SessionSummary[];
   publishedCount: number;
   replayConversionPct: number;
-}
-
-interface SourcesEnrichmentStatus {
-  running: boolean;
-  processed: number;
-  total: number;
-  updated: number;
-  startedAt?: string;
-  finishedAt?: string;
-  message?: string;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -71,6 +62,10 @@ function useDashboardData() {
   const [scanProgress, setScanProgress] = useState<number | null>(null);
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const wasEnrichingRef = useRef(false);
+  const hasCursorSources = useMemo(
+    () => sources.some((source) => source.provider === "cursor"),
+    [sources],
+  );
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -184,6 +179,8 @@ function useDashboardData() {
   }, [loadData]);
 
   useEffect(() => {
+    if (!loadingSources && !hasCursorSources && !wasEnrichingRef.current) return;
+
     let cancelled = false;
     let timer: number | undefined;
 
@@ -222,7 +219,7 @@ function useDashboardData() {
       cancelled = true;
       if (timer) window.clearInterval(timer);
     };
-  }, []);
+  }, [hasCursorSources, loadingSources]);
 
   return {
     sources,
@@ -258,7 +255,8 @@ function computeInsights(sources: SourceSession[], replays: SessionSummary[]): I
     } else if (src.toolCallCount == null) {
       totalToolCalls += replayToolCalls;
     } else if (replayToolCalls > src.toolCallCount) {
-      // Source discovery counts can under-report Cursor tool calls; trust replay stats when higher.
+      // Invariant: source and replay represent the same session; replay stats can be more complete.
+      // We only add the delta here to avoid double-counting counts already included from sources.
       totalToolCalls += replayToolCalls - src.toolCallCount;
     }
     totalDuration += r.stats.durationMs || 0;

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -7,6 +7,16 @@ export type CachedListResponse<T> = {
   cachedAt?: string;
 };
 
+export interface SourcesEnrichmentStatus {
+  running: boolean;
+  processed: number;
+  total: number;
+  updated: number;
+  startedAt?: string;
+  finishedAt?: string;
+  message?: string;
+}
+
 // ─── Cache helpers ───────────────────────────────────────────────────
 
 export const CACHE_REFRESH_TTL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
## Summary
- Improve Cursor session discovery parity by counting tool calls with transcript markers plus tool artifact lower-bound and by replacing repeated `storeDbExists` checks with a single `listStoreDbSessionIds()` scan.
- Add background Cursor stat enrichment on dashboard sources (with cache-aware candidate selection and provider-safe cache matching), plus `/api/sources/enrichment-status` so UI can show progressive backfill state.
- Improve dashboard UX with granular loading states for sources/replays, explicit loading messaging, and live enrichment indicators in Home and Sessions; add targeted tests for enrichment helpers and retryable sql.js init.

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm --filter vibe-replay test`
- [x] `pnpm build`
- [ ] Manual check: open dashboard and confirm loading/backfill messaging on a Cursor-heavy workspace

Made with [Cursor](https://cursor.com)