### PR TITLE
feat: add Google Analytics to website

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -71,6 +71,15 @@ const ogImage = new URL("/og.png", siteBase).href;
     />
     <!-- GitHub buttons -->
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-DPXD4TGWYD"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-DPXD4TGWYD');
+    </script>
   </head>
   <body class="bg-surface text-text-primary font-sans antialiased">
     <slot />


### PR DESCRIPTION
## Summary
- Add Google Analytics (G-DPXD4TGWYD) to the website's base layout
- All pages (index, explore, 404) automatically inherit the tracking script
- Enables UTM-based traffic source tracking for marketing campaigns (e.g. `?utm_source=xiaohongshu`)

## Scope
- Website only — no GA in local dashboard or self-contained HTML outputs

## Test plan
- [x] `pnpm --filter @vibe-replay/website build` passes
- [x] Verified GA script present in all 3 built pages
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)