### PR TITLE
fix: address quality issues from PR #60 and #61

### DIFF
--- a/packages/cli/src/formatters/gif.ts
+++ b/packages/cli/src/formatters/gif.ts
@@ -7,7 +7,7 @@
  * Quality notes (from research):
  * - Render at exactly 1x (SVG native size) — non-integer scaling creates extra
  *   anti-aliasing shades that the 256-color quantizer can't preserve well
- * - Use prequantize() to consolidate near-identical dark shades before quantize()
+ * - snapColorsToPalette() pins exact theme colors after quantization
  * - 256 colors with snapColorsToPalette gives the best color accuracy — the
  *   extra palette entries let the quantizer preserve subtle shades while
  *   snapColorsToPalette pins our exact theme colors in the final palette
@@ -98,7 +98,7 @@ export async function generateGitHubGif(
     });
     const rendered = resvg.render();
     rasterizedFrames.push({
-      data: new Uint8Array(rendered.pixels.buffer),
+      data: new Uint8Array(rendered.pixels),
       width: rendered.width,
       height: rendered.height,
     });
@@ -111,7 +111,7 @@ export async function generateGitHubGif(
   const gif = gifenc.GIFEncoder();
 
   for (let i = 0; i < rasterizedFrames.length; i++) {
-    // Clone data — prequantize modifies in place
+    // Clone data — quantize reads via shared Uint32Array view
     const data = new Uint8Array(rasterizedFrames[i].data);
 
     // Quantize then snap palette to exact theme colors

--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ReplaySession, Scene } from "@vibe-replay/types";
+import { isSystemGeneratedMessage } from "../clean-prompt.js";
 
 // ─── Public API ────────────────────────────────────────────
 
@@ -249,6 +250,8 @@ export function extractPhases(scenes: Scene[]): Phase[] {
 
   for (const scene of scenes) {
     if (scene.type === "user-prompt") {
+      // Skip system-generated messages (e.g. <bash-stdout>, <task-notification>)
+      if (isSystemGeneratedMessage(scene.content)) continue;
       if (current) {
         phases.push({
           prompt: current.prompt,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -520,6 +520,7 @@ program
       svgSpinner2.succeed(`SVG: ${svgFilePath}`);
 
       // Generate animated GIF
+      let gifGenerated = false;
       const gifSpinner = ora("Generating animated GIF...").start();
       try {
         const gifBuffer = await generateGitHubGif(replay, { replayUrl });
@@ -527,6 +528,7 @@ program
         await writeFile(gifFilePath, gifBuffer);
         const gifSizeKB = Math.round(gifBuffer.length / 1024);
         gifSpinner.succeed(`GIF: ${gifFilePath} (${gifSizeKB} KB)`);
+        gifGenerated = true;
       } catch (err) {
         gifSpinner.fail(
           `GIF generation failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -538,7 +540,7 @@ program
       const markdown = generateGitHubMarkdown(replay, {
         replayUrl,
         svgPath: "./session-preview.svg",
-        gifPath: "./session-preview.gif",
+        gifPath: gifGenerated ? "./session-preview.gif" : undefined,
       });
       const mdFilePath = join(outputDir, "github-summary.md");
       await writeFile(mdFilePath, markdown, "utf-8");

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -114,7 +114,7 @@ export default function ConversationView({
   return (
     <div className="max-w-4xl mx-auto space-y-5 pb-6">
       {displayGroups.map((group, gi) => (
-        <LazyGroup key={gi} forceRender={gi <= currentGroupIdx + 5}>
+        <LazyGroup key={gi} forceRender={gi >= currentGroupIdx - 15 && gi <= currentGroupIdx + 5}>
           <GroupCard
             group={group}
             currentIndex={currentIndex}

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -2037,7 +2037,8 @@ export default function Dashboard() {
 
   const handleTabChange = (id: Tab) => {
     setTab(id);
-    navigateTo({ tab: id });
+    // Clear text filter when switching tabs to avoid cross-tab filter contamination
+    navigateTo({ tab: id, q: null });
   };
 
   const tabButton = (id: Tab, label: string) => (

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -216,7 +216,11 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   const renderedMarkdown = useMemo(() => {
     if (!ghExportResult?.markdown) return "";
     // Strip the image line — preview is shown separately (GIF or SVG)
-    const md = ghExportResult.markdown.replace(/!\[[^\]]*\]\([^)]*\.(?:svg|gif)\)\n*/g, "");
+    // Handles both plain images ![alt](path.gif) and clickable [![alt](path.gif)](url)
+    const md = ghExportResult.markdown.replace(
+      /\[?!\[[^\]]*\]\([^)]*\.(?:svg|gif)\)\]?(?:\([^)]*\))?\n*/g,
+      "",
+    );
     return sanitizeHtml(marked.parse(md) as string);
   }, [ghExportResult?.markdown]);
 

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -159,13 +159,20 @@ export default function Player({
     }
   }, [viewPrefs.displayMode, landed, seekTo, initialSeekIndex]);
 
+  // Check if URL has ?s= deep-link (used by multiple auto-land effects below)
+  const hasUrlScene = useMemo(
+    () => new URLSearchParams(window.location.search).get("s") !== null,
+    [],
+  );
+
   // Auto-land if we start on a non-replay view (e.g., direct link to insights)
+  // Skip if URL has ?s= deep-link — that effect handles its own auto-land
   useEffect(() => {
-    if (!landed && activeView !== "replay") {
+    if (!landed && activeView !== "replay" && !hasUrlScene) {
       setLanded(true);
       setTimeout(() => seekTo(initialSeekIndex), 100);
     }
-  }, [activeView, landed, initialSeekIndex, seekTo]);
+  }, [activeView, landed, initialSeekIndex, seekTo, hasUrlScene]);
 
   const seekFromNavigation = useCallback(
     (index: number) => {
@@ -184,10 +191,6 @@ export default function Player({
   );
 
   // Auto-land if URL has ?s= deep-link (skip landing hero, seek + scroll directly)
-  const hasUrlScene = useMemo(
-    () => new URLSearchParams(window.location.search).get("s") !== null,
-    [],
-  );
   useEffect(() => {
     if (!landed && hasUrlScene) {
       setLanded(true);

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -193,6 +193,8 @@ export function navigateTo(
     });
     if (Object.keys(dashboardState).length > 0) {
       sessionStorage.setItem("vibe_dashboard_state", JSON.stringify(dashboardState));
+    } else {
+      sessionStorage.removeItem("vibe_dashboard_state");
     }
   }
 


### PR DESCRIPTION
## Summary

Post-merge review of PR #60 (Dashboard UI/UX) and #61 (GIF export) found 8 bugs. All fixed with minimal, targeted changes.

### PR #60 fixes
- **LazyGroup perf regression**: was rendering ALL past groups on long sessions; now uses bounded window `[-15, +5]`
- **Double auto-land**: two effects both fired when URL has `?s=` + non-replay view, causing double seek
- **Cross-tab filter bleed**: `?q=` param shared between Sessions/Replays tabs; now cleared on tab switch
- **Stale sessionStorage**: dashboard state not cleared on return to defaults

### PR #61 fixes
- **gifPath bug**: CLI passed `gifPath` to markdown even when GIF generation failed → broken image ref
- **System messages in GIF**: `extractPhases` didn't filter `<bash-stdout>` etc. from user prompts
- **Buffer pooling**: `rendered.pixels.buffer` could share pooled ArrayBuffer; use `Uint8Array(pixels)` instead
- **Image regex**: only stripped `![](gif)` not `[![](gif)](url)`, leaving empty link remnants

## Test plan
- [x] 383 tests pass
- [x] Lint clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)