### PR TITLE
fix: reliable HMR for dev workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ pnpm dev:dashboard         # Dev mode with dashboard flag (-d)
 ```
 
 When to use which:
-- `pnpm start` — validate full user flow
-- `pnpm dev` — daily iteration (choose "Dump to demo.json", open `localhost:5173/?file=/demo.json`)
+- `pnpm start` — validate full user flow (build + run)
+- `pnpm dev` — daily iteration with full HMR: viewer auto-reloads via Vite, CLI auto-restarts via `tsx watch`
 - `pnpm viewer:dev` — UI-only changes
 - `pnpm cli:dev` — parser/CLI-only changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,18 +12,20 @@ pnpm monorepo: `packages/cli` (npm: `vibe-replay`), `packages/viewer` (React →
 pnpm install               # Install deps
 pnpm build                 # Full build: viewer → cli
 pnpm start                 # Build + run interactive picker
-pnpm dev                   # Viewer (Vite HMR) + CLI together
+pnpm dev                   # Viewer (Vite HMR) + CLI (tsx watch) together
+pnpm dev:dashboard         # Dev mode with dashboard flag (-d)
+pnpm dev:website           # Website (Astro HMR) + Viewer (Vite HMR) together
 pnpm viewer:dev            # Viewer only
 pnpm cli:dev               # CLI only (tsx)
 pnpm test                  # Run tests
 pnpm lint                  # Lint + format (auto-fix)
 pnpm lint:check            # Lint check (no fix, for CI)
-pnpm dev:dashboard         # Dev mode with dashboard flag (-d)
 ```
 
 When to use which:
 - `pnpm start` — validate full user flow (build + run)
 - `pnpm dev` — daily iteration with full HMR: viewer auto-reloads via Vite, CLI auto-restarts via `tsx watch`
+- `pnpm dev:website` — website + viewer iteration: Astro HMR + `/view/` redirects to Vite viewer
 - `pnpm viewer:dev` — UI-only changes
 - `pnpm cli:dev` — parser/CLI-only changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,6 @@ pnpm start                 # Build + run interactive picker
 pnpm dev                   # Viewer (Vite HMR) + CLI (tsx watch) together
 pnpm dev:dashboard         # Dev mode with dashboard flag (-d)
 pnpm dev:website           # Website (Astro HMR) + Viewer (Vite HMR) together
-pnpm viewer:dev            # Viewer only
-pnpm cli:dev               # CLI only (tsx)
 pnpm test                  # Run tests
 pnpm lint                  # Lint + format (auto-fix)
 pnpm lint:check            # Lint check (no fix, for CI)
@@ -26,8 +24,6 @@ When to use which:
 - `pnpm start` — validate full user flow (build + run)
 - `pnpm dev` — daily iteration with full HMR: viewer auto-reloads via Vite, CLI auto-restarts via `tsx watch`
 - `pnpm dev:website` — website + viewer iteration: Astro HMR + `/view/` redirects to Vite viewer
-- `pnpm viewer:dev` — UI-only changes
-- `pnpm cli:dev` — parser/CLI-only changes
 
 ## Gotchas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,14 @@ Requires Node.js >= 20 and pnpm.
 ## Development
 
 ```bash
-pnpm dev          # Full dev mode: viewer (Vite HMR) + CLI together
-pnpm viewer:dev   # Viewer only (http://localhost:5173)
-pnpm cli:dev      # CLI only (tsx, no build step)
-pnpm test         # Run tests
-pnpm start        # Full build + run (simulates real user flow)
+pnpm dev              # Viewer (Vite HMR) + CLI (tsx watch, auto-restart)
+pnpm dev:dashboard    # Same as above, opens dashboard directly
+pnpm dev:website      # Website (Astro HMR) + Viewer (Vite HMR)
+pnpm test             # Run tests
+pnpm start            # Full build + run (simulates real user flow)
 ```
 
-**Daily workflow**: Run `pnpm dev`, choose "Dump to demo.json" in the CLI menu, then open `http://localhost:5173/?file=/demo.json`. Viewer changes hot-reload instantly. CLI/parser changes require re-dumping.
+**Daily workflow**: Run `pnpm dev`, open `http://localhost:5173`. Viewer changes hot-reload instantly via Vite HMR. CLI/API changes auto-restart via `tsx watch`. No manual rebuild or restart needed.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ After generation:
 git clone https://github.com/tuo-lei/vibe-replay.git
 cd vibe-replay
 pnpm install
-pnpm dev          # Viewer (Vite HMR) + CLI together
+pnpm dev              # Viewer (Vite HMR) + CLI (auto-restart) — full HMR
+pnpm dev:website      # Website (Astro HMR) + Viewer (Vite HMR)
 ```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for architecture details and development workflow.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "dev": "node scripts/dev.mjs",
     "dev:dashboard": "node scripts/dev.mjs -d",
     "dev:website": "node scripts/dev-website.mjs",
-    "viewer:dev": "pnpm --filter @vibe-replay/viewer dev",
-    "cli:dev": "VIBE_REPLAY_DEV_MENU=1 npx tsx packages/cli/src/index.ts",
     "test": "pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
     "lint": "biome check --write packages/ website/src cloudflare/src",
     "lint:check": "biome check packages/ website/src cloudflare/src",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "pnpm build && node packages/cli/dist/index.js",
     "dev": "node scripts/dev.mjs",
     "dev:dashboard": "node scripts/dev.mjs -d",
+    "dev:website": "node scripts/dev-website.mjs",
     "viewer:dev": "pnpm --filter @vibe-replay/viewer dev",
     "cli:dev": "VIBE_REPLAY_DEV_MENU=1 npx tsx packages/cli/src/index.ts",
     "test": "pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -647,7 +647,9 @@ export async function startServer(
 ): Promise<void> {
   await mkdir(baseDir, { recursive: true });
 
-  const viewerHtml = await loadViewerHtml();
+  const isDevMode = !!opts?.externalViewerUrl;
+  // In dev mode, Vite serves the viewer with HMR — no need to load/cache viewer HTML
+  const viewerHtml = isDevMode ? "" : await loadViewerHtml();
   const cacheKeySuffix = createHash("sha1").update(baseDir).digest("hex").slice(0, 12);
   const sourcesCacheKey = `dashboard-sources-v1-${cacheKeySuffix}`;
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
@@ -761,8 +763,16 @@ export async function startServer(
 
   const app = new Hono();
 
-  // Serve viewer HTML with editor flag
+  // Serve viewer HTML with editor flag (prod) or redirect to Vite dev server (dev)
   app.get("/", (c) => {
+    if (isDevMode) {
+      // In dev mode, redirect to Vite dev server which has HMR
+      const viteUrl = new URL(opts!.externalViewerUrl!);
+      // Preserve query params (e.g. ?session=xxx, ?view=dashboard)
+      const incoming = new URL(c.req.url);
+      viteUrl.search = incoming.search;
+      return c.redirect(viteUrl.toString(), 302);
+    }
     const flag = `<script>window.__VIBE_REPLAY_EDITOR__ = true;</script>`;
     const headIdx = viewerHtml.lastIndexOf("</head>");
     const html = `${viewerHtml.slice(0, headIdx) + flag}\n${viewerHtml.slice(headIdx)}`;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -769,7 +769,7 @@ export async function startServer(
       // In dev mode, redirect to Vite dev server which has HMR
       const viteUrl = new URL(opts!.externalViewerUrl!);
       // Preserve query params (e.g. ?session=xxx, ?view=dashboard)
-      const incoming = new URL(c.req.url);
+      const incoming = new URL(c.req.url, "http://localhost");
       viteUrl.search = incoming.search;
       return c.redirect(viteUrl.toString(), 302);
     }

--- a/scripts/dev-utils.mjs
+++ b/scripts/dev-utils.mjs
@@ -1,0 +1,34 @@
+/**
+ * Shared utilities for dev launcher scripts.
+ */
+import { createServer } from "node:net";
+
+/**
+ * Check if a port is free on BOTH IPv4 and IPv6 (macOS Vite listens on ::1).
+ * Returns true if the port is available.
+ */
+export function isPortFree(port) {
+  return new Promise((resolve) => {
+    const s4 = createServer();
+    s4.unref();
+    s4.on("error", () => resolve(false));
+    s4.listen(port, "127.0.0.1", () => {
+      s4.close(() => {
+        const s6 = createServer();
+        s6.unref();
+        s6.on("error", () => resolve(false));
+        s6.listen(port, "::1", () => {
+          s6.close(() => resolve(true));
+        });
+      });
+    });
+  });
+}
+
+/** Find a free port starting from `preferred`, incrementing on conflict. */
+export async function findFreePort(preferred) {
+  for (let port = preferred; port < preferred + 100; port++) {
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error(`No free port found in range ${preferred}-${preferred + 99}`);
+}

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -9,35 +9,10 @@
  *   node scripts/dev-website.mjs
  */
 import { spawn } from "node:child_process";
-import { createServer } from "node:net";
+import { findFreePort } from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const ASTRO_PREFERRED = 4321;
-
-function isPortFree(port) {
-  return new Promise((resolve) => {
-    const s4 = createServer();
-    s4.unref();
-    s4.on("error", () => resolve(false));
-    s4.listen(port, "127.0.0.1", () => {
-      s4.close(() => {
-        const s6 = createServer();
-        s6.unref();
-        s6.on("error", () => resolve(false));
-        s6.listen(port, "::1", () => {
-          s6.close(() => resolve(true));
-        });
-      });
-    });
-  });
-}
-
-async function findFreePort(preferred) {
-  for (let port = preferred; port < preferred + 100; port++) {
-    if (await isPortFree(port)) return port;
-  }
-  throw new Error(`No free port found in range ${preferred}-${preferred + 99}`);
-}
 
 const vitePort = await findFreePort(VITE_PREFERRED);
 const astroPort = await findFreePort(ASTRO_PREFERRED);
@@ -67,12 +42,21 @@ vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
 console.log(`[vibe-replay] Viewer logs:  ${logPath}`);
 
+// If Vite crashes, tear down Astro too
+vite.on("exit", (code) => {
+  if (code !== 0 && code !== null) {
+    console.error(`[vibe-replay] Viewer process exited with code ${code}. Check ${logPath}`);
+  }
+  astro.kill("SIGTERM");
+  process.exit(code ?? 0);
+});
+
 // Start Astro website dev (foreground, inherits stdio)
 const astro = spawn("pnpm", ["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
   stdio: "inherit",
   env: {
     ...process.env,
-    VITE_VIEWER_URL: `http://localhost:${vitePort}`,
+    DEV_VIEWER_URL: `http://localhost:${vitePort}`,
   },
 });
 

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Website dev launcher — starts Vite viewer + Astro website with HMR wired up.
+ *
+ * - Vite viewer: serves the viewer app with HMR
+ * - Astro website: serves the marketing site; /view/ redirects to Vite viewer
+ *
+ * Usage:
+ *   node scripts/dev-website.mjs
+ */
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+
+const VITE_PREFERRED = 5173;
+const ASTRO_PREFERRED = 4321;
+
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const s4 = createServer();
+    s4.unref();
+    s4.on("error", () => resolve(false));
+    s4.listen(port, "127.0.0.1", () => {
+      s4.close(() => {
+        const s6 = createServer();
+        s6.unref();
+        s6.on("error", () => resolve(false));
+        s6.listen(port, "::1", () => {
+          s6.close(() => resolve(true));
+        });
+      });
+    });
+  });
+}
+
+async function findFreePort(preferred) {
+  for (let port = preferred; port < preferred + 100; port++) {
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error(`No free port found in range ${preferred}-${preferred + 99}`);
+}
+
+const vitePort = await findFreePort(VITE_PREFERRED);
+const astroPort = await findFreePort(ASTRO_PREFERRED);
+
+console.log();
+console.log(
+  `[vibe-replay] Viewer port:  ${vitePort}${vitePort !== VITE_PREFERRED ? ` (${VITE_PREFERRED} was busy)` : ""}`,
+);
+console.log(
+  `[vibe-replay] Website port: ${astroPort}${astroPort !== ASTRO_PREFERRED ? ` (${ASTRO_PREFERRED} was busy)` : ""}`,
+);
+console.log(`[vibe-replay] Website:      http://localhost:${astroPort}  (Astro HMR)`);
+console.log(`[vibe-replay] Viewer:       http://localhost:${vitePort}  (Vite HMR)`);
+console.log(`[vibe-replay] /view/  →     redirects to Vite viewer`);
+console.log();
+
+// Start Vite viewer dev (backgrounded, logs to file)
+const vite = spawn("pnpm", ["--filter", "@vibe-replay/viewer", "dev"], {
+  stdio: ["ignore", "pipe", "pipe"],
+  env: { ...process.env, VITE_PORT: String(vitePort) },
+});
+
+const { createWriteStream } = await import("node:fs");
+const logPath = `/tmp/vibe-replay-viewer-${vitePort}.log`;
+const logStream = createWriteStream(logPath);
+vite.stdout.pipe(logStream);
+vite.stderr.pipe(logStream);
+console.log(`[vibe-replay] Viewer logs:  ${logPath}`);
+
+// Start Astro website dev (foreground, inherits stdio)
+const astro = spawn("pnpm", ["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    VITE_VIEWER_URL: `http://localhost:${vitePort}`,
+  },
+});
+
+function cleanup() {
+  vite.kill("SIGTERM");
+}
+
+astro.on("exit", (code) => {
+  cleanup();
+  process.exit(code ?? 0);
+});
+
+process.on("SIGINT", () => {
+  astro.kill("SIGINT");
+  cleanup();
+  process.exit(130);
+});
+
+process.on("SIGTERM", () => {
+  astro.kill("SIGTERM");
+  cleanup();
+  process.exit(143);
+});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -51,13 +51,15 @@ const dashboardMode = process.argv.includes("-d");
 const apiPort = await findFreePort(API_PREFERRED);
 const vitePort = await findFreePort(VITE_PREFERRED);
 
+console.log();
 console.log(
   `[vibe-replay] API port:    ${apiPort}${apiPort !== API_PREFERRED ? ` (${API_PREFERRED} was busy)` : ""}`,
 );
 console.log(
   `[vibe-replay] Viewer port: ${vitePort}${vitePort !== VITE_PREFERRED ? ` (${VITE_PREFERRED} was busy)` : ""}`,
 );
-console.log(`[vibe-replay] Viewer:      http://localhost:${vitePort}`);
+console.log(`[vibe-replay] Viewer:      http://localhost:${vitePort}  (HMR enabled)`);
+console.log(`[vibe-replay] CLI watch:   auto-restarts on packages/cli/src changes`);
 console.log();
 
 // Start Vite dev server (backgrounded) — port + strictPort via env vars in vite.config.ts
@@ -74,8 +76,8 @@ vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
 console.log(`[vibe-replay] Viewer logs: ${logPath}`);
 
-// Start CLI with the chosen ports
-const cliArgs = ["tsx", "packages/cli/src/index.ts"];
+// Start CLI with tsx watch so it auto-restarts on source changes
+const cliArgs = ["tsx", "watch", "--clear-screen=false", "packages/cli/src/index.ts"];
 if (dashboardMode) cliArgs.push("-d");
 
 const cli = spawn("npx", cliArgs, {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -8,42 +8,10 @@
  *   node scripts/dev.mjs -d         # dashboard mode (passes -d to CLI)
  */
 import { spawn } from "node:child_process";
-import { createServer } from "node:net";
+import { findFreePort } from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const API_PREFERRED = 13456;
-
-/**
- * Check if a port is free on BOTH IPv4 and IPv6 (macOS Vite listens on ::1).
- * Returns true if the port is available.
- */
-function isPortFree(port) {
-  return new Promise((resolve) => {
-    // Check IPv4 first
-    const s4 = createServer();
-    s4.unref();
-    s4.on("error", () => resolve(false));
-    s4.listen(port, "127.0.0.1", () => {
-      s4.close(() => {
-        // Then check IPv6
-        const s6 = createServer();
-        s6.unref();
-        s6.on("error", () => resolve(false));
-        s6.listen(port, "::1", () => {
-          s6.close(() => resolve(true));
-        });
-      });
-    });
-  });
-}
-
-/** Find a free port starting from `preferred`, incrementing on conflict. */
-async function findFreePort(preferred) {
-  for (let port = preferred; port < preferred + 100; port++) {
-    if (await isPortFree(port)) return port;
-  }
-  throw new Error(`No free port found in range ${preferred}-${preferred + 99}`);
-}
 
 const dashboardMode = process.argv.includes("-d");
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,8 +2,8 @@ import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
-// When VITE_VIEWER_URL is set (e.g. http://localhost:5173), proxy /view/ to Vite dev server for HMR
-const viewerDevUrl = process.env.VITE_VIEWER_URL;
+// When DEV_VIEWER_URL is set (e.g. http://localhost:5173), proxy /view/ to Vite dev server for HMR
+const viewerDevUrl = process.env.DEV_VIEWER_URL;
 
 export default defineConfig({
   site: "https://vibe-replay.com",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,6 +2,9 @@ import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
+// When VITE_VIEWER_URL is set (e.g. http://localhost:5173), proxy /view/ to Vite dev server for HMR
+const viewerDevUrl = process.env.VITE_VIEWER_URL;
+
 export default defineConfig({
   site: "https://vibe-replay.com",
   integrations: [sitemap()],
@@ -11,10 +14,17 @@ export default defineConfig({
       {
         name: "public-dir-index",
         configureServer(server) {
-          // Cloudflare Pages serves /view/ → /view/index.html automatically.
-          // Astro dev server does not, so replicate that behavior here.
           server.middlewares.use((req, _res, next) => {
             if (req.url && /^\/view\/(\?|$)/.test(req.url)) {
+              if (viewerDevUrl) {
+                // Proxy to Vite dev server for live HMR
+                const query = req.url.includes("?") ? req.url.slice(req.url.indexOf("?")) : "";
+                _res.writeHead(302, { Location: `${viewerDevUrl}/${query}` });
+                _res.end();
+                return;
+              }
+              // Cloudflare Pages serves /view/ → /view/index.html automatically.
+              // Astro dev server does not, so replicate that behavior here.
               req.url = req.url.replace("/view/", "/view/index.html");
             }
             next();


### PR DESCRIPTION
## Summary

- **`tsx watch`** for CLI: source changes auto-restart the API server (~1s), no manual restart needed
- **Vite redirect** in dev mode: CLI server redirects `/` to Vite dev server instead of caching stale viewer HTML at startup — eliminates the #1 HMR pain point
- **`pnpm dev:website`** command: unified Astro + Vite viewer dev with `/view/` auto-redirecting to Vite HMR
- **Remove `viewer:dev` / `cli:dev`**: redundant now that `pnpm dev` covers both with better HMR

## Motivation

During development, changes to viewer, CLI, and website were often not picked up automatically, requiring manual restarts. This blocked coding agents from completing e2e development without human intervention.

Root causes fixed:
1. CLI ran with one-shot `tsx` (no file watching)
2. CLI server cached viewer HTML at startup and never reloaded
3. Website `/view/` served a static build artifact
4. No unified website dev command

## Test plan

All verified with Playwright E2E tests (7/7 passed):

- [x] `pnpm dev` → edit viewer component → Vite HMR updates in ~1s
- [x] `pnpm dev` → edit CLI server endpoint → tsx watch auto-restarts in ~1s
- [x] Access CLI server URL → 302 redirects to Vite with query params preserved
- [x] `pnpm dev:website` → `/view/` redirects to Vite viewer
- [x] `pnpm dev:website` → `/view/?session=xxx` preserves query params
- [x] `pnpm dev:website` → edit Astro component → auto-reload in ~1s
- [x] `pnpm dev:website` → edit viewer via `/view/` → Vite HMR in ~1s
- [x] `pnpm build` succeeds
- [x] All 383 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)