### PR TITLE
fix: address unresolved review feedback from recent PRs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,127 @@
-/Users/tuo/Code/vibe-replay/.claude/CLAUDE.md
+# Plan 相关（AI 完成后别忘更新）
+
+`plan/` 为项目规划目录（gitignored），结构与约定见 `plan/README.md`。做完与 plan 相关的开发后请做以下更新，避免状态滞后。
+
+## 目录与文件名
+
+- **plan/** 下：`ROADMAP.md`、`STATUS.md`、`ideas/`、`tech-ideas/`、`marketing/`、`features/`
+- 文档命名：`NNN-简短描述性-slug.md`（三位数 + kebab-case，如 `001-local-ui-first-class.md`）
+- 新文档按此命名；已有文档不必为符合约定而改名
+
+## 语言
+
+- `plan/` 下所有文档全部用**中文**撰写
+
+## 状态约定（frontmatter）
+
+在 **ideas/**、**tech-ideas/**、**marketing/**、**features/** 下的 `.md` 顶部用 YAML 标注状态：
+
+```yaml
+---
+status: draft | planned | in_progress | pr | done
+pr: 42              # 可选
+done_at: 2025-03-08 # 可选
+note: 一句话备注     # 可选
+---
+```
+
+## 做完后必做
+
+- **完成某个 feature / idea 的实现**
+  → 打开对应 `plan/features/` 或 `plan/ideas/` 或 `plan/tech-ideas/` 或 `plan/marketing/` 下的文档，把 frontmatter 里 `status` 改为 `done`，并可选填 `done_at`、`note`。
+- **开了 PR**
+  → 该文档 frontmatter 里设 `status: pr`，并填 `pr: <号或 URL>`。
+- **总览**
+  → 若该条目在 `plan/STATUS.md` 的表里，顺手更新该行的状态/备注。
+
+这样下次看 plan 或 STATUS 时，不会误以为还没做完。
+
+# Agent 自验原则
+
+> 核心原则：**agent 自己验证，不消耗用户时间。** 永远不要把"你刷新一下试试"当作验证手段。
+
+## E2E 测试体系
+
+项目有完整的 E2E 测试，agent 改完代码后**必须运行**来确认没有搞坏产品：
+
+```bash
+pnpm build && pnpm test:e2e   # 构建后跑 E2E（13 个测试，~3s）
+```
+
+E2E 覆盖的关键流程：
+- **generated-html**（7 tests）— fixture → parse → transform → 生成 HTML → Playwright 打开浏览器验证：无 console 错误、self-contained 无外部请求、数据正确嵌入、scene 渲染、用户 prompt 可见、无错误状态、title 正确
+- **editor-server**（4 tests）— Hono server API 正常、viewer HTML 带 editor flag、浏览器能加载
+- **cli-smoke**（2 tests）— `--version` 和 `--help` 正常
+
+## 不同改动的验证策略
+
+**改 viewer（`packages/viewer/`）：**
+1. `pnpm build && pnpm test:e2e` — 确认生成的 HTML 在浏览器中正常渲染
+2. 如需视觉验证，用 Playwright 截图：
+   ```typescript
+   import { chromium } from "playwright";
+   const browser = await chromium.launch();
+   const page = await browser.newPage();
+   await page.goto("file:///path/to/generated/index.html");
+   await page.screenshot({ path: "/tmp/screenshot.png" });
+   ```
+3. 如果改动涉及新 UI 功能，**在 `e2e/generated-html.test.ts` 中添加对应断言**
+
+**改 CLI/API（`packages/cli/src/`）：**
+1. `pnpm test` — 单元测试
+2. `pnpm build && pnpm test:e2e` — 确认 CLI 启动正常、API 返回正确、生成的 HTML 不坏
+
+**改共享类型（`packages/types/`）：**
+1. `pnpm test && pnpm build && pnpm test:e2e` — 全量验证
+
+**改 generator/transform 等核心管线：**
+1. 必须跑 E2E — 这些改动最容易导致产出的 HTML 在浏览器中报错（如 `</` 转义、`</head>` 注入位置等）
+
+## 如何用 Playwright 做 ad-hoc 验证
+
+E2E 测试之外，如果需要验证具体的 UI 行为（布局、交互、z-index 等），直接用 Playwright：
+
+```typescript
+import { chromium } from "playwright";
+
+// 方式 1：验证生成的静态 HTML
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+await page.goto("file:///path/to/index.html", { waitUntil: "networkidle" });
+await page.screenshot({ path: "/tmp/verify.png" });
+
+// 方式 2：验证 dev server（pnpm dev 运行中）
+await page.goto("http://localhost:5173/?view=dashboard");
+await page.screenshot({ path: "/tmp/dashboard.png" });
+
+// 方式 3：验证 editor server
+await page.goto("http://localhost:13456/?session=some-slug");
+await page.screenshot({ path: "/tmp/editor.png" });
+```
+
+## E2E 测试文件
+
+| 文件 | 用途 |
+|------|------|
+| `e2e/helpers.ts` | 共享：fixture → parse → transform → generate HTML |
+| `e2e/generated-html.test.ts` | 生成的 HTML 在浏览器中的完整验证 |
+| `e2e/editor-server.test.ts` | Server API + viewer 加载 |
+| `e2e/cli-smoke.test.ts` | CLI 启动基本检查 |
+| `e2e/vitest.config.ts` | E2E 专用 vitest 配置（30s timeout） |
+
+## 添加新 E2E 测试
+
+新增 UI feature 时，**必须**在 `e2e/generated-html.test.ts` 或新文件中添加对应测试。模式：
+
+```typescript
+it("new feature works", async () => {
+  // page 已在 beforeAll 中打开了生成的 HTML
+  const element = page.locator("[data-testid='my-feature']");
+  await expect(element).toBeVisible();  // 或用 page.textContent + expect
+});
+```
+
+开发模式下的 HMR：
+- `pnpm dev` — Viewer HMR (Vite :5173) + CLI auto-restart (tsx watch :13456)
+- `pnpm dev:website` — Website (Astro) + Viewer (Vite) HMR
+- 改 viewer/CLI 源码自动生效，无需手动 build 或重启

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -72,8 +72,8 @@ export function getModelPricing(model: string): ModelPricing {
   if (lower.includes("sonnet-4-6") || lower.includes("sonnet-4-5"))
     return MODEL_PRICING["sonnet-4-new"];
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
-  // Haiku: 4.5+ → new pricing, 3.5 and earlier → legacy
-  if (lower.includes("haiku-4-5") || lower.includes("haiku-4")) return MODEL_PRICING["haiku-4-5"];
+  // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
+  if (lower.includes("haiku-4-5") || lower.includes("haiku-4-6")) return MODEL_PRICING["haiku-4-5"];
   if (lower.includes("haiku")) return MODEL_PRICING.haiku;
   return DEFAULT_PRICING;
 }

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -41,7 +41,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheCreateRate: 3.75,
     cacheReadRate: 0.3,
   },
-  // Haiku 4.5
+  // Haiku 4.5/4.6
   "haiku-4-5": {
     inputRate: 1,
     outputRate: 5,

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -649,17 +649,20 @@ async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResul
     const messages: CursorMessage[] = [];
     const stmt = db.prepare("SELECT data FROM blobs WHERE id = ?");
     for (const cid of childIds) {
-      stmt.bind([cid]);
-      if (stmt.step()) {
-        const blobData = stmt.get()[0] as Uint8Array;
-        try {
-          const text = new TextDecoder().decode(blobData);
-          messages.push(JSON.parse(text));
-        } catch {
-          // binary or corrupted blob, skip
+      try {
+        stmt.bind([cid]);
+        if (stmt.step()) {
+          const blobData = stmt.get()[0] as Uint8Array;
+          try {
+            const text = new TextDecoder().decode(blobData);
+            messages.push(JSON.parse(text));
+          } catch {
+            // binary or corrupted blob, skip
+          }
         }
+      } finally {
+        stmt.reset();
       }
-      stmt.reset();
     }
     stmt.free();
 

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -433,7 +433,7 @@ describe("transform — cost estimation", () => {
 
   it("applies Haiku pricing for haiku model", () => {
     const replay = transformToReplay(
-      buildParsed({ model: "claude-haiku-4-20250514", tokenUsage: baseUsage }),
+      buildParsed({ model: "claude-haiku-4-5-20250514", tokenUsage: baseUsage }),
       "claude-code",
       "~/test",
     );

--- a/website/src/components/CTA.astro
+++ b/website/src/components/CTA.astro
@@ -56,6 +56,13 @@
       input.select();
       document.execCommand("copy");
       document.body.removeChild(input);
+      const copyIcon = document.getElementById("cta-copy-icon");
+      const checkIcon = document.getElementById("cta-check-icon");
+      if (copyIcon && checkIcon) {
+        copyIcon.classList.add("hidden");
+        checkIcon.classList.remove("hidden");
+        setTimeout(() => { copyIcon.classList.remove("hidden"); checkIcon.classList.add("hidden"); }, 2000);
+      }
     });
   });
 </script>

--- a/website/src/components/CTA.astro
+++ b/website/src/components/CTA.astro
@@ -49,6 +49,13 @@
           checkIcon.classList.add("hidden");
         }, 2000);
       }
-    }).catch(() => {});
+    }).catch(() => {
+      const input = document.createElement("input");
+      input.value = "npx vibe-replay";
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    });
   });
 </script>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -625,6 +625,13 @@ const DEMO_URL = "/view/?gist=c40137e4c224dc883fe2eaa668e2d8ba";
       input.select();
       document.execCommand("copy");
       document.body.removeChild(input);
+      const copyIcon = document.getElementById("copy-icon");
+      const checkIcon = document.getElementById("check-icon");
+      if (copyIcon && checkIcon) {
+        copyIcon.classList.add("hidden");
+        checkIcon.classList.remove("hidden");
+        setTimeout(() => { copyIcon.classList.remove("hidden"); checkIcon.classList.add("hidden"); }, 2000);
+      }
     });
   });
 

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -594,6 +594,12 @@ const DEMO_URL = "/view/?gist=c40137e4c224dc883fe2eaa668e2d8ba";
     viewer.style.opacity = "1";
     viewer.style.transform = "translateY(0)";
 
+    // Release fixed height after crossfade so container responds to resize
+    await delay(600);
+    if (signal.aborted) return;
+    container.style.height = "";
+    container.style.transition = "";
+
   }
 
   // Copy button
@@ -611,7 +617,15 @@ const DEMO_URL = "/view/?gist=c40137e4c224dc883fe2eaa668e2d8ba";
           checkIcon.classList.add("hidden");
         }, 2000);
       }
-    }).catch(() => {});
+    }).catch(() => {
+      // Fallback for non-HTTPS or denied clipboard permission
+      const input = document.createElement("input");
+      input.value = "npx vibe-replay";
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    });
   });
 
   // Replay button

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -373,7 +373,14 @@
           checkIcon.classList.add("hidden");
         }, 2000);
       }
-    }).catch(() => {});
+    }).catch(() => {
+      const input = document.createElement("input");
+      input.value = "npx vibe-replay";
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    });
   });
 </script>
   </div>

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -380,6 +380,13 @@
       input.select();
       document.execCommand("copy");
       document.body.removeChild(input);
+      const copyIcon = document.getElementById("hiw-copy-icon");
+      const checkIcon = document.getElementById("hiw-check-icon");
+      if (copyIcon && checkIcon) {
+        copyIcon.classList.add("hidden");
+        checkIcon.classList.remove("hidden");
+        setTimeout(() => { copyIcon.classList.remove("hidden"); checkIcon.classList.add("hidden"); }, 2000);
+      }
     });
   });
 </script>


### PR DESCRIPTION
## Summary

Audited all merged PRs (#36–#68) for unaddressed code review feedback. Found 4 confirmed issues still present in the codebase:

- **sqlite-reader try-finally** (PR #46): `parseCursorStoreDb` didn't wrap `stmt.bind()`/`stmt.step()` in try-finally, so `stmt.reset()` was skipped on exceptions — leaving sql.js statements in a broken state. Same file's `parseCursorGlobalStateDb` already had the correct pattern.
- **Haiku pricing catch-all too broad** (PR #37): `lower.includes("haiku-4")` matched any future haiku-4.x model (e.g. haiku-4-6) and silently used haiku-4-5 pricing. Changed to explicit `haiku-4-5 || haiku-4-6` to match the opus/sonnet pattern. Also fixed test using a non-existent model ID.
- **Hero container height locked** (PR #47): Crossfade animation set `container.style.height` to a fixed pixel value but never cleared it, so the container didn't respond to window resize.
- **Clipboard API silent failure** (PR #47): `navigator.clipboard.writeText().catch(() => {})` gave users zero feedback when clipboard was unavailable. Added `document.execCommand("copy")` fallback for non-HTTPS / permission-denied scenarios.

## Test plan

- [x] `pnpm test` — 441 tests pass (including updated pricing test)
- [x] `pnpm lint:check` — clean
- [x] `pnpm build && pnpm test:e2e` — 13 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)