### PR TITLE
fix: increase GIF/SVG export to 8 sequential turns

### DIFF
--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -535,7 +535,7 @@ export function buildSvgFrames(
 
   // ── Conversation turn frames (compact-view style) ──
   // Start directly with conversation turns — no abstract overview
-  const selected = selectKeyPhases(phases, 4);
+  const selected = selectKeyPhases(phases, 8);
   for (const phase of selected) {
     const phaseIdx = phases.indexOf(phase) + 1;
     const phaseStats = computeToolStats(phase.scenes);
@@ -572,6 +572,14 @@ export function buildSvgFrames(
   summaryLines.push({ text: statParts.join("  ·  "), color: C.green });
   if (toolParts.length > 0) summaryLines.push({ text: toolParts.join("  ·  "), color: C.dim });
   if (breakdown) summaryLines.push({ text: condenseLine(breakdown, 80), color: C.orange });
+  const hiddenTurns = phases.length - selected.length;
+  if (hiddenTurns > 0) {
+    summaryLines.push({ text: "", color: C.dim });
+    summaryLines.push({
+      text: `+ ${hiddenTurns} more turn${hiddenTurns === 1 ? "" : "s"} not shown`,
+      color: C.dim,
+    });
+  }
   summaryLines.push({ text: "", color: C.dim });
   if (opts.replayUrl) {
     summaryLines.push({ text: "View full replay  →", color: C.blue, bold: true });
@@ -616,29 +624,8 @@ function stripMarkdown(s: string): string {
 }
 
 function selectKeyPhases(phases: Phase[], max: number): Phase[] {
-  if (phases.length <= max) return [...phases];
-
-  // Always include first phase
-  const selected: Phase[] = [phases[0]];
-
-  // Score remaining phases
-  const scored = phases.slice(1).map((p, i) => {
-    let score = p.actions.length;
-    for (const a of p.actions) {
-      if (a.kind === "run" && a.passed === false) score += 5;
-      if (a.kind === "run" && a.passed === true) score += 3;
-      if (a.kind === "create") score += 2;
-    }
-    return { phase: p, score, origIdx: i + 1 };
-  });
-
-  scored.sort((a, b) => b.score - a.score);
-  for (const { phase } of scored.slice(0, max - 1)) {
-    selected.push(phase);
-  }
-
-  // Maintain original order
-  return selected.sort((a, b) => phases.indexOf(a) - phases.indexOf(b));
+  // Take the first N phases in order for narrative continuity
+  return phases.slice(0, max);
 }
 
 function renderSvg(

--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -478,6 +478,9 @@ const C = {
   dotGreen: "#3fb950",
 };
 
+/** Max conversation turns shown in GIF/SVG export. Sync with ExportView.tsx UI strings. */
+export const MAX_EXPORT_TURNS = 8;
+
 const SVG_W = 960;
 const SVG_H = 540;
 const HEADER_H = 40;
@@ -535,7 +538,7 @@ export function buildSvgFrames(
 
   // ── Conversation turn frames (compact-view style) ──
   // Start directly with conversation turns — no abstract overview
-  const selected = selectKeyPhases(phases, 8);
+  const selected = selectKeyPhases(phases, MAX_EXPORT_TURNS);
   for (const phase of selected) {
     const phaseIdx = phases.indexOf(phase) + 1;
     const phaseStats = computeToolStats(phase.scenes);

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -5,6 +5,9 @@ import type { ViewerMode } from "../hooks/useSessionLoader";
 import type { ReplaySession } from "../types";
 import { sanitizeHtml, sanitizeSvg } from "../utils/sanitize";
 
+// Sync with MAX_EXPORT_TURNS in packages/cli/src/formatters/github.ts
+const MAX_EXPORT_TURNS = 8;
+
 interface Props {
   actions: AnnotationActions;
   viewerMode: ViewerMode;
@@ -483,7 +486,8 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           Animated SVG
                         </div>
                         <p className="text-[10px] font-mono text-terminal-dim mt-0.5">
-                          Embed in READMEs, PRs, or anywhere that renders SVG. Shows up to 8 turns.
+                          Embed in READMEs, PRs, or anywhere that renders SVG. Shows up to{" "}
+                          {MAX_EXPORT_TURNS} turns.
                         </p>
                       </div>
                       <div className="flex items-center gap-2">

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -409,7 +409,8 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           Animated GIF
                         </div>
                         <p className="text-[10px] font-mono text-terminal-dim mt-0.5">
-                          Works everywhere: GitHub PRs, issues, READMEs, Slack, Discord.
+                          Works everywhere: GitHub PRs, issues, READMEs, Slack, Discord. Shows up to
+                          8 turns.
                         </p>
                       </div>
                       <div className="flex items-center gap-2">
@@ -482,7 +483,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           Animated SVG
                         </div>
                         <p className="text-[10px] font-mono text-terminal-dim mt-0.5">
-                          Embed in READMEs, PRs, or anywhere that renders SVG.
+                          Embed in READMEs, PRs, or anywhere that renders SVG. Shows up to 8 turns.
                         </p>
                       </div>
                       <div className="flex items-center gap-2">
@@ -652,7 +653,8 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                   )}
                   {!ghExportResult && (
                     <span className="text-[11px] font-mono text-terminal-dim">
-                      For GitHub PRs, READMEs, websites, email, Slack, and more
+                      For GitHub PRs, READMEs, websites, email, Slack, and more. Shows up to 8
+                      turns.
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- Increase GIF/SVG frame limit from 4 to 8 turns for better session coverage
- Switch from score-based to sequential phase selection for narrative continuity
- Add "+ N more turns not shown" indicator in summary frame when turns exceed 8
- Show "Shows up to 8 turns" hint in export UI (GIF card, SVG card, and generate button)

## Test plan
- [x] `pnpm test` passes (441 tests including gif-export tests)
- [ ] Manual: export GIF from a session with >8 turns, verify 8 turn frames + summary
- [ ] Manual: verify summary frame shows hidden turn count
- [ ] Manual: export from a session with <8 turns, verify all turns shown, no hidden message

🤖 Generated with [Claude Code](https://claude.com/claude-code)