### PR TITLE
fix: add tsx as explicit devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "hono": "^4.12.5",
     "lefthook": "^2.1.3",
     "playwright": "^1.58.2",
+    "tsx": "^4.21.0",
     "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
## Summary
- `tsx` was only available as an indirect peer dependency of `vite`, not guaranteed to be hoisted to `node_modules/.bin/` in all pnpm configs
- This caused `spawn node_modules/.bin/tsx ENOENT` when running `pnpm dev` on fresh clones
- CI never caught this because no CI job exercises the dev workflow (`pnpm dev`), only build/test/lint

## Test plan
- [ ] Fresh clone + `pnpm install` + `pnpm dev` should work without ENOENT error

🤖 Generated with [Claude Code](https://claude.com/claude-code)