### PR TITLE
fix: harden Cursor sqlite discovery and system-context filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:website": "pnpm --filter @vibe-replay/viewer build && mkdir -p website/public/view && cp packages/viewer/dist/index.html website/public/view/index.html && pnpm --filter @vibe-replay/website build",
     "start": "pnpm build && node packages/cli/dist/index.js",
     "dev": "node scripts/dev.mjs",
+    "dev:menu": "node scripts/dev.mjs --menu",
     "dev:dashboard": "node scripts/dev.mjs -d",
     "dev:website": "node scripts/dev-website.mjs",
     "test": "pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./sqlite-reader.js", () => ({
   CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
+  isSystemContextText: (text: string) =>
+    /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/.test(text.trim()),
   parseCursorSqlite: vi.fn(),
 }));
 

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./sqlite-reader.js", () => ({
+  CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
   parseCursorSqlite: vi.fn(),
 }));
 

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 import type { ParsedTurn, SessionInfo } from "../../types.js";
 import type { DataSourceInfo, ProviderParseResult } from "../types.js";
-import { parseCursorSqlite } from "./sqlite-reader.js";
+import { CURSOR_SYSTEM_CONTEXT_RE, parseCursorSqlite } from "./sqlite-reader.js";
 
 function toErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
@@ -98,11 +98,8 @@ interface ParseJsonlOptions {
   inferToolPaths: boolean;
 }
 
-const JSONL_SYSTEM_CONTEXT_RE =
-  /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
-
 function isSystemContextText(text: string): boolean {
-  return JSONL_SYSTEM_CONTEXT_RE.test(text.trim());
+  return CURSOR_SYSTEM_CONTEXT_RE.test(text.trim());
 }
 
 function defaultDataSourceInfo(

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 import type { ParsedTurn, SessionInfo } from "../../types.js";
 import type { DataSourceInfo, ProviderParseResult } from "../types.js";
-import { CURSOR_SYSTEM_CONTEXT_RE, parseCursorSqlite } from "./sqlite-reader.js";
+import { isSystemContextText, parseCursorSqlite } from "./sqlite-reader.js";
 
 function toErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
@@ -98,10 +98,6 @@ interface ParseJsonlOptions {
   inferToolPaths: boolean;
 }
 
-function isSystemContextText(text: string): boolean {
-  return CURSOR_SYSTEM_CONTEXT_RE.test(text.trim());
-}
-
 function defaultDataSourceInfo(
   dataSource?: ProviderParseResult["dataSource"],
 ): DataSourceInfo | undefined {
@@ -164,7 +160,6 @@ async function parseCursorJsonl(
           if (role === "user" && isSystemContextText(text)) continue;
           const extracted = extractImageFilePathsFromText(text);
           text = normalizeImagePlaceholderLines(extracted.cleanedText);
-          if (role === "user" && isSystemContextText(text)) continue;
           for (const imagePath of extracted.paths) imageFilePaths.add(imagePath);
           if (text) textParts.push(text);
         } else if (block.type === "image") {

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -98,6 +98,13 @@ interface ParseJsonlOptions {
   inferToolPaths: boolean;
 }
 
+const JSONL_SYSTEM_CONTEXT_RE =
+  /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
+
+function isSystemContextText(text: string): boolean {
+  return JSONL_SYSTEM_CONTEXT_RE.test(text.trim());
+}
+
 function defaultDataSourceInfo(
   dataSource?: ProviderParseResult["dataSource"],
 ): DataSourceInfo | undefined {
@@ -157,8 +164,10 @@ async function parseCursorJsonl(
       for (const block of contentBlocks) {
         if (block.type === "text" && block.text) {
           let text = stripUserQueryWrapper(block.text);
+          if (role === "user" && isSystemContextText(text)) continue;
           const extracted = extractImageFilePathsFromText(text);
           text = normalizeImagePlaceholderLines(extracted.cleanedText);
+          if (role === "user" && isSystemContextText(text)) continue;
           for (const imagePath of extracted.paths) imageFilePaths.add(imagePath);
           if (text) textParts.push(text);
         } else if (block.type === "image") {

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -145,4 +145,36 @@ describe("cursor sqlite metrics helpers", () => {
     expect(turnStats[1]).toMatchObject({ turnIndex: 1 });
     expect(turnStats[1].durationMs).toBeUndefined();
   });
+
+  it("treats empty store roots as non-replayable", () => {
+    expect(__testables.hasReplayableRootBlob(new Uint8Array())).toBe(false);
+    expect(__testables.hasReplayableRootBlob(new Uint8Array([0x00, 0x01, 0x02]))).toBe(false);
+  });
+
+  it("detects replayable store roots with linked child blob ids", () => {
+    const replayableRoot = new Uint8Array([
+      0xff,
+      0x0a,
+      0x20,
+      ...Array.from({ length: 32 }, (_, i) => i + 1),
+      0xee,
+    ]);
+    expect(__testables.hasReplayableRootBlob(replayableRoot)).toBe(true);
+  });
+
+  it("drops system context wrapped in user_query from sqlite user content", () => {
+    const blocks = __testables.parseUserContent(
+      "<user_query>\n<system_reminder>\ninternal only\n</system_reminder>\n</user_query>",
+    );
+    expect(blocks).toEqual([]);
+  });
+
+  it("keeps normal user_query content from sqlite user content", () => {
+    const blocks = __testables.parseUserContent(
+      "<user_query>\nShip this fix\n</user_query>",
+    ) as any[];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("text");
+    expect(blocks[0].text).toBe("Ship this fix");
+  });
 });

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -188,4 +188,122 @@ describe("cursor sqlite metrics helpers", () => {
       "Fix auth bug",
     );
   });
+
+  it("maps ApplyPatch into Edit with diff-like args", () => {
+    expect(__testables.mapCursorToolName("ApplyPatch")).toBe("Edit");
+    const mapped = __testables.mapToolArgs(
+      "ApplyPatch",
+      "*** Begin Patch\n*** Update File: /tmp/demo.ts\n@@\n-old line\n+new line\n*** End Patch",
+    ) as any;
+    expect(mapped.file_path).toBe("/tmp/demo.ts");
+    expect(mapped.old_string).toContain("old line");
+    expect(mapped.new_string).toContain("new line");
+  });
+
+  it("maps apply_patch object args with relativeWorkspacePath", () => {
+    const mapped = __testables.mapToolArgs(
+      "apply_patch",
+      { relativeWorkspacePath: "src/c.ts" },
+      JSON.stringify({
+        diff: {
+          chunks: [{ diffString: "@@\n-old c\n+new c" }],
+        },
+      }),
+    ) as any;
+    expect(mapped.file_path).toBe("src/c.ts");
+    expect(mapped.old_string).toContain("old c");
+    expect(mapped.new_string).toContain("new c");
+  });
+
+  it("maps global-state Cursor tool aliases to canonical names", () => {
+    expect(__testables.mapCursorToolName("run_terminal_cmd")).toBe("Bash");
+    expect(__testables.mapCursorToolName("read_file")).toBe("Read");
+    expect(__testables.mapCursorToolName("search_replace")).toBe("Edit");
+    expect(__testables.mapCursorToolName("edit_file")).toBe("Edit");
+    expect(__testables.mapCursorToolName("write")).toBe("Write");
+    expect(__testables.mapCursorToolName("list_dir")).toBe("Glob");
+    expect(__testables.mapCursorToolName("rg")).toBe("Grep");
+    expect(__testables.mapCursorToolName("grep_search")).toBe("Grep");
+    expect(__testables.mapCursorToolName("ripgrep")).toBe("Grep");
+    expect(__testables.mapCursorToolName("file_search")).toBe("Glob");
+    expect(__testables.mapCursorToolName("codebase_search")).toBe("SemanticSearch");
+  });
+
+  it("maps run_terminal_cmd and read_file args into normalized shape", () => {
+    const run = __testables.mapToolArgs("run_terminal_cmd", {
+      command: "git status",
+      requireUserApproval: true,
+    }) as any;
+    expect(run).toMatchObject({ command: "git status", requireUserApproval: true });
+
+    const read = __testables.mapToolArgs("read_file", {
+      targetFile: "/tmp/a.ts",
+    }) as any;
+    expect(read).toEqual({ file_path: "/tmp/a.ts" });
+  });
+
+  it("maps search_replace args and infers old/new snippets from result payload", () => {
+    const mapped = __testables.mapToolArgs(
+      "search_replace",
+      { relativeWorkspacePath: "/tmp/a.ts" },
+      JSON.stringify({
+        diff: {
+          chunks: [{ diffString: "@@\n-const a = 1;\n+const a = 2;" }],
+        },
+      }),
+    ) as any;
+    expect(mapped.file_path).toBe("/tmp/a.ts");
+    expect(mapped.old_string).toContain("const a = 1;");
+    expect(mapped.new_string).toContain("const a = 2;");
+  });
+
+  it("maps canonical Edit args when Cursor stores relativeWorkspacePath", () => {
+    const mapped = __testables.mapToolArgs(
+      "Edit",
+      { relativeWorkspacePath: "src/a.ts" },
+      JSON.stringify({
+        diff: {
+          chunks: [{ diffString: "@@\n-old value\n+new value" }],
+        },
+      }),
+    ) as any;
+    expect(mapped.file_path).toBe("src/a.ts");
+    expect(mapped.old_string).toContain("old value");
+    expect(mapped.new_string).toContain("new value");
+  });
+
+  it("maps EditFile args with relativeWorkspacePath", () => {
+    const mapped = __testables.mapToolArgs("EditFile", {
+      relativeWorkspacePath: "src/b.ts",
+      oldStr: "a",
+      newStr: "b",
+    }) as any;
+    expect(mapped).toEqual({ file_path: "src/b.ts", old_string: "a", new_string: "b" });
+  });
+
+  it("maps lowercase write and list_dir variants", () => {
+    const write = __testables.mapToolArgs("write", {
+      relativeWorkspacePath: "/tmp/doc.md",
+      code: { code: "# title" },
+    }) as any;
+    expect(write).toEqual({ file_path: "/tmp/doc.md", content: "# title" });
+
+    const ls = __testables.mapToolArgs("list_dir", {
+      targetDirectory: "/tmp",
+    }) as any;
+    expect(ls).toEqual({ path: "/tmp" });
+  });
+
+  it("maps canonical Write args when Cursor stores relativeWorkspacePath + code object", () => {
+    const mapped = __testables.mapToolArgs("Write", {
+      relativeWorkspacePath: "docs/readme.md",
+      code: { code: "hello" },
+    }) as any;
+    expect(mapped).toEqual({ file_path: "docs/readme.md", content: "hello" });
+  });
+
+  it("keeps string tool args as raw text for unknown tools", () => {
+    const mapped = __testables.mapToolArgs("CustomTool", "plain text payload") as any;
+    expect(mapped).toEqual({ raw: "plain text payload" });
+  });
 });

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -215,6 +215,17 @@ describe("cursor sqlite metrics helpers", () => {
     expect(mapped.new_string).toContain("new c");
   });
 
+  it("preserves context lines when parsing ApplyPatch diff text", () => {
+    const mapped = __testables.mapToolArgs(
+      "ApplyPatch",
+      "*** Begin Patch\n*** Update File: /tmp/ctx.ts\n@@\n shared before\n-old value\n+new value\n shared after\n*** End Patch",
+    ) as any;
+    expect(mapped.old_string).toContain("shared before");
+    expect(mapped.old_string).toContain("shared after");
+    expect(mapped.new_string).toContain("shared before");
+    expect(mapped.new_string).toContain("shared after");
+  });
+
   it("maps global-state Cursor tool aliases to canonical names", () => {
     expect(__testables.mapCursorToolName("run_terminal_cmd")).toBe("Bash");
     expect(__testables.mapCursorToolName("read_file")).toBe("Read");

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -177,4 +177,15 @@ describe("cursor sqlite metrics helpers", () => {
     expect(blocks[0].type).toBe("text");
     expect(blocks[0].text).toBe("Ship this fix");
   });
+
+  it("normalizes turn text and drops wrapped system context", () => {
+    expect(
+      __testables.normalizeTurnText(
+        "<user_query>\n<agent_transcripts>\ninternal block\n</agent_transcripts>\n</user_query>",
+      ),
+    ).toBe("");
+    expect(__testables.normalizeTurnText("<user_query>\nFix auth bug\n</user_query>")).toBe(
+      "Fix auth bug",
+    );
+  });
 });

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -354,7 +354,8 @@ async function readStoreDbMeta(dbPath: string): Promise<StoreDbMetaPreview | nul
   } catch {
     return null;
   }
-  const dbBuffer = await readFile(dbPath);
+  const dbBuffer = await readFile(dbPath).catch(() => null);
+  if (!dbBuffer) return null;
   const db = new SQL.Database(dbBuffer);
   try {
     const metaRows = db.exec("SELECT value FROM meta WHERE key = '0'");
@@ -743,7 +744,7 @@ function parseThinking(value: unknown): string {
 function normalizeTurnText(raw: unknown): string {
   if (typeof raw !== "string") return "";
   const cleaned = raw.replace(/<\/?user_query>/g, "").trim();
-  if (!cleaned || SYSTEM_CONTEXT_RE.test(cleaned)) return "";
+  if (!cleaned || CURSOR_SYSTEM_CONTEXT_RE.test(cleaned)) return "";
   return cleaned;
 }
 
@@ -1209,10 +1210,11 @@ function messagesToTurns(messages: CursorMessage[]): {
   return { turns, turnStats, totalDurationMs };
 }
 
-const SYSTEM_CONTEXT_RE = /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
+export const CURSOR_SYSTEM_CONTEXT_RE =
+  /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
 
 function isSystemContextText(text: string): boolean {
-  return SYSTEM_CONTEXT_RE.test(text.trim());
+  return CURSOR_SYSTEM_CONTEXT_RE.test(text.trim());
 }
 
 function parseUserContent(content: string | CursorBlock[] | undefined): ContentBlock[] {
@@ -1420,5 +1422,6 @@ export const __testables = {
   createRetryableInit,
   estimateTokenIncrement,
   hasReplayableRootBlob,
+  normalizeTurnText,
   parseUserContent,
 };

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -324,6 +324,11 @@ async function inferProjectFromComposerData(
   return "";
 }
 
+function hasReplayableRootBlob(data: unknown): boolean {
+  if (!(data instanceof Uint8Array) || data.length === 0) return false;
+  return extractChildBlobIds(data).length > 0;
+}
+
 /**
  * Build reverse map from workspace MD5 hash → decoded project path.
  * Accepts pre-decoded workspace paths from the JSONL discovery phase.
@@ -342,7 +347,7 @@ function buildHashToProjectMap(decodedWorkspacePaths: string[]): Map<string, str
  * Read lightweight metadata from a store.db without full parsing.
  * Returns null if the DB is empty, corrupt, or has no meta table.
  */
-async function readStoreDbMeta(dbPath: string): Promise<ChatMeta | null> {
+async function readStoreDbMeta(dbPath: string): Promise<StoreDbMetaPreview | null> {
   let SQL: any;
   try {
     SQL = await getSqlJs();
@@ -355,7 +360,15 @@ async function readStoreDbMeta(dbPath: string): Promise<ChatMeta | null> {
     const metaRows = db.exec("SELECT value FROM meta WHERE key = '0'");
     if (!metaRows.length || !metaRows[0].values.length) return null;
     const metaHex = metaRows[0].values[0][0] as string;
-    return JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
+    const meta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8")) as ChatMeta;
+    const rootId = meta.latestRootBlobId;
+    if (!rootId) return { meta, hasReplayableRoot: false };
+    const rootRows = db.exec("SELECT data FROM blobs WHERE id = ?", [rootId]);
+    if (!rootRows.length || !rootRows[0].values.length) {
+      return { meta, hasReplayableRoot: false };
+    }
+    const rootData = rootRows[0].values[0][0] as unknown;
+    return { meta, hasReplayableRoot: hasReplayableRootBlob(rootData) };
   } catch {
     return null;
   } finally {
@@ -401,8 +414,9 @@ export async function discoverSqliteOnlySessions(
       const dbStat = await stat(dbPath).catch(() => null);
       if (!dbStat?.isFile() || dbStat.size < MIN_STORE_DB_SIZE) continue;
 
-      const meta = await readStoreDbMeta(dbPath);
-      if (!meta) continue;
+      const metaPreview = await readStoreDbMeta(dbPath);
+      if (!metaPreview?.hasReplayableRoot) continue;
+      const meta = metaPreview.meta;
 
       const project = hashToProject.get(wsHash) || "";
       const firstPrompt = meta.name || "(sqlite-only session)";
@@ -572,6 +586,11 @@ interface ChatMeta {
   mode?: string;
   createdAt?: number;
   lastUsedModel?: string;
+}
+
+interface StoreDbMetaPreview {
+  meta: ChatMeta;
+  hasReplayableRoot: boolean;
 }
 
 interface CursorBlock {
@@ -1192,18 +1211,24 @@ function messagesToTurns(messages: CursorMessage[]): {
 
 const SYSTEM_CONTEXT_RE = /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
 
+function isSystemContextText(text: string): boolean {
+  return SYSTEM_CONTEXT_RE.test(text.trim());
+}
+
 function parseUserContent(content: string | CursorBlock[] | undefined): ContentBlock[] {
   if (!content) return [];
   if (typeof content === "string") {
-    if (SYSTEM_CONTEXT_RE.test(content.trim())) return [];
+    if (isSystemContextText(content)) return [];
     const cleaned = content.replace(/<\/?user_query>/g, "").trim();
+    if (isSystemContextText(cleaned)) return [];
     return cleaned ? [{ type: "text", text: cleaned }] : [];
   }
   const blocks: ContentBlock[] = [];
   for (const b of content) {
     if (b.type === "text" && b.text) {
-      if (SYSTEM_CONTEXT_RE.test(b.text.trim())) continue;
+      if (isSystemContextText(b.text)) continue;
       const cleaned = b.text.replace(/<\/?user_query>/g, "").trim();
+      if (isSystemContextText(cleaned)) continue;
       if (cleaned) blocks.push({ type: "text", text: cleaned });
     }
   }
@@ -1394,4 +1419,6 @@ export const __testables = {
   buildStoreTurnStats,
   createRetryableInit,
   estimateTokenIncrement,
+  hasReplayableRootBlob,
+  parseUserContent,
 };

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -850,7 +850,8 @@ function parseToolFormerBlock(
   const name = typeof toolFormerData.name === "string" ? toolFormerData.name : "";
   if (!name) return null;
 
-  const paramsRaw = parseJson<Record<string, any>>(toolFormerData.params) || {};
+  const parsedParams = parseJson<Record<string, any>>(toolFormerData.params);
+  const paramsRaw = parsedParams ?? toolFormerData.params ?? {};
   const result = extractToolResultText(toolFormerData.result);
 
   return {
@@ -859,7 +860,7 @@ function parseToolFormerBlock(
       (typeof toolFormerData.toolCallId === "string" && toolFormerData.toolCallId) ||
       `cursor-bubble-${bubbleId}`,
     name: mapCursorToolName(name),
-    input: mapToolArgs(name, paramsRaw),
+    input: mapToolArgs(name, paramsRaw, result),
     _result: result,
     ...(hasToolError(toolFormerData.result) ? { _isError: true } : {}),
   } as any;
@@ -1258,7 +1259,7 @@ function parseAssistantContent(
         type: "tool_use",
         id: b.toolCallId,
         name: mapCursorToolName(b.toolName),
-        input: mapToolArgs(b.toolName, b.args || {}),
+        input: mapToolArgs(b.toolName, b.args || {}, result?.result || ""),
         _result: result?.result || "",
         ...(result?.isError ? { _isError: true } : {}),
         ...(result?.executionTimeMs ? { _durationMs: result.executionTimeMs } : {}),
@@ -1300,19 +1301,34 @@ function mapCursorToolName(name: string): string {
   const mapping: Record<string, string> = {
     Shell: "Bash",
     run_terminal_command_v2: "Bash",
+    run_terminal_cmd: "Bash",
     Read: "Read",
     ReadFile: "Read",
     read_file_v2: "Read",
+    read_file: "Read",
     read_lints: "ReadLints",
     Grep: "Grep",
     ripgrep_raw_search: "Grep",
+    ripgrep: "Grep",
+    rg: "Grep",
+    grep: "Grep",
+    grep_search: "Grep",
     Glob: "Glob",
     glob_file_search: "Glob",
+    file_search: "Glob",
+    list_dir: "Glob",
+    list_dir_v2: "Glob",
+    LS: "Glob",
     StrReplace: "Edit",
     EditFile: "Edit",
     edit_file_v2: "Edit",
+    edit_file: "Edit",
+    search_replace: "Edit",
+    ApplyPatch: "Edit",
+    apply_patch: "Edit",
     Write: "Write",
     WriteFile: "Write",
+    write: "Write",
     Delete: "Delete",
     delete_file: "Delete",
     Task: "Task",
@@ -1320,6 +1336,7 @@ function mapCursorToolName(name: string): string {
     todo_write: "TodoWrite",
     ask_question: "AskQuestion",
     semantic_search_full: "SemanticSearch",
+    codebase_search: "SemanticSearch",
     web_search: "WebSearch",
     WebFetch: "WebFetch",
     web_fetch: "WebFetch",
@@ -1327,73 +1344,279 @@ function mapCursorToolName(name: string): string {
   return mapping[name] || name;
 }
 
-function mapToolArgs(toolName: string, args: Record<string, any>): Record<string, any> {
-  if (toolName === "Shell" && args.command) {
+function parseDiffStringSnippet(diffString: string): { oldText: string; newText: string } {
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+  for (const line of diffString.split("\n")) {
+    if (
+      line.startsWith("@@") ||
+      line.startsWith("*** ") ||
+      line.startsWith("---") ||
+      line.startsWith("+++")
+    ) {
+      continue;
+    }
+    if (line.startsWith("-")) {
+      oldLines.push(line.slice(1));
+    } else if (line.startsWith("+")) {
+      newLines.push(line.slice(1));
+    } else if (line.startsWith(" ")) {
+      const shared = line.slice(1);
+      oldLines.push(shared);
+      newLines.push(shared);
+    }
+  }
+  return { oldText: oldLines.join("\n"), newText: newLines.join("\n") };
+}
+
+function inferEditStringsFromResult(resultText: string): {
+  old_string?: string;
+  new_string?: string;
+} {
+  if (!resultText.trim()) return {};
+  const parsed = parseJson<Record<string, any>>(resultText);
+  if (!parsed || typeof parsed !== "object") return {};
+
+  const out: { old_string?: string; new_string?: string } = {};
+  if (typeof parsed.contentsAfterEdit === "string" && parsed.contentsAfterEdit.trim()) {
+    out.new_string = parsed.contentsAfterEdit;
+  }
+
+  const chunks =
+    parsed.diff &&
+    typeof parsed.diff === "object" &&
+    Array.isArray((parsed.diff as Record<string, any>).chunks)
+      ? ((parsed.diff as Record<string, any>).chunks as any[])
+      : [];
+  const oldParts: string[] = [];
+  const newParts: string[] = [];
+  for (const chunk of chunks) {
+    if (!chunk || typeof chunk !== "object") continue;
+    if (typeof chunk.diffString !== "string" || !chunk.diffString.trim()) continue;
+    const parsedSnippet = parseDiffStringSnippet(chunk.diffString);
+    if (parsedSnippet.oldText) oldParts.push(parsedSnippet.oldText);
+    if (parsedSnippet.newText) newParts.push(parsedSnippet.newText);
+  }
+  if (oldParts.length > 0) out.old_string = oldParts.join("\n");
+  if (!out.new_string && newParts.length > 0) out.new_string = newParts.join("\n");
+  return out;
+}
+
+function parseApplyPatchArgs(rawPatch: string): Record<string, any> {
+  const fileMatch = rawPatch.match(/^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s+(.+)$/m);
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+  for (const line of rawPatch.split("\n")) {
+    if (
+      line.startsWith("*** ") ||
+      line.startsWith("@@") ||
+      line.startsWith("---") ||
+      line.startsWith("+++")
+    ) {
+      continue;
+    }
+    if (line.startsWith("-")) {
+      oldLines.push(line.slice(1));
+    } else if (line.startsWith("+")) {
+      newLines.push(line.slice(1));
+    }
+  }
+  return {
+    ...(fileMatch?.[1] ? { file_path: fileMatch[1].trim() } : {}),
+    old_string: oldLines.join("\n"),
+    new_string: newLines.join("\n"),
+    patch: rawPatch,
+  };
+}
+
+function mapEditLikeArgs(argsObj: Record<string, any>, resultText: string): Record<string, any> {
+  const mapped: Record<string, any> = {
+    file_path: argsObj.file_path ?? argsObj.path ?? argsObj.relativeWorkspacePath ?? "",
+    old_string: argsObj.old_string ?? argsObj.oldStr ?? "",
+    new_string:
+      argsObj.new_string ?? argsObj.newStr ?? argsObj.streamingContent ?? argsObj.content ?? "",
+  };
+  if (!mapped.old_string || !mapped.new_string) {
+    const inferred = inferEditStringsFromResult(resultText);
+    if (!mapped.old_string && inferred.old_string) mapped.old_string = inferred.old_string;
+    if (!mapped.new_string && inferred.new_string) mapped.new_string = inferred.new_string;
+  }
+  return mapped;
+}
+
+function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<string, any> {
+  const argsObj =
+    args && typeof args === "object" && !Array.isArray(args) ? (args as Record<string, any>) : null;
+  if (toolName === "ApplyPatch" || toolName === "apply_patch") {
+    const rawPatch =
+      typeof args === "string"
+        ? args
+        : typeof argsObj?.patch === "string"
+          ? argsObj.patch
+          : typeof argsObj?.input === "string"
+            ? argsObj.input
+            : typeof argsObj?.content === "string"
+              ? argsObj.content
+              : typeof argsObj?.contents === "string"
+                ? argsObj.contents
+                : "";
+    if (rawPatch) return parseApplyPatchArgs(rawPatch);
+    if (argsObj && (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)) {
+      return mapEditLikeArgs(argsObj, resultText);
+    }
+    return argsObj || {};
+  }
+  if (typeof args === "string") {
+    return { raw: args };
+  }
+  if (!argsObj) return {};
+  if (toolName === "Shell" && argsObj.command) {
     return {
-      command: args.command,
-      ...(args.description ? { description: args.description } : {}),
+      command: argsObj.command,
+      ...(argsObj.description ? { description: argsObj.description } : {}),
     };
   }
-  if (toolName === "StrReplace" && args.path) {
+  if (
+    toolName === "StrReplace" &&
+    (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)
+  ) {
+    return mapEditLikeArgs(argsObj, resultText);
+  }
+  if (
+    toolName === "EditFile" &&
+    (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)
+  ) {
+    return mapEditLikeArgs(argsObj, resultText);
+  }
+  if (toolName === "Edit" && (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)) {
+    return mapEditLikeArgs(argsObj, resultText);
+  }
+  if (
+    (toolName === "Write" || toolName === "WriteFile") &&
+    (argsObj.path || argsObj.relativeWorkspacePath || argsObj.targetFile || argsObj.file_path)
+  ) {
+    const codeValue =
+      typeof argsObj.code === "string"
+        ? argsObj.code
+        : argsObj.code && typeof argsObj.code === "object" && typeof argsObj.code.code === "string"
+          ? argsObj.code.code
+          : "";
     return {
-      file_path: args.path,
-      old_string: args.old_string ?? "",
-      new_string: args.new_string ?? "",
+      file_path:
+        argsObj.file_path ?? argsObj.path ?? argsObj.relativeWorkspacePath ?? argsObj.targetFile,
+      content: argsObj.contents ?? argsObj.content ?? codeValue,
     };
   }
-  if ((toolName === "Write" || toolName === "WriteFile") && args.path) {
-    return { file_path: args.path, content: args.contents ?? args.content ?? "" };
+  if ((toolName === "Read" || toolName === "ReadFile") && argsObj.path) {
+    return { file_path: argsObj.path };
   }
-  if ((toolName === "Read" || toolName === "ReadFile") && args.path) {
-    return { file_path: args.path };
-  }
-  if (toolName === "run_terminal_command_v2" && args.command) {
+  if (toolName === "run_terminal_command_v2" && argsObj.command) {
     return {
-      command: args.command,
-      ...(args.commandDescription ? { description: args.commandDescription } : {}),
-      ...(args.cwd ? { cwd: args.cwd } : {}),
+      command: argsObj.command,
+      ...(argsObj.commandDescription ? { description: argsObj.commandDescription } : {}),
+      ...(argsObj.cwd ? { cwd: argsObj.cwd } : {}),
     };
   }
-  if (toolName === "read_file_v2" && args.targetFile) {
-    return { file_path: args.targetFile };
-  }
-  if (toolName === "edit_file_v2" && args.relativeWorkspacePath) {
+  if (toolName === "run_terminal_cmd" && argsObj.command) {
     return {
-      file_path: args.relativeWorkspacePath,
-      new_string: args.streamingContent ?? "",
+      command: argsObj.command,
+      ...(argsObj.cwd ? { cwd: argsObj.cwd } : {}),
+      ...(argsObj.requireUserApproval !== undefined
+        ? { requireUserApproval: Boolean(argsObj.requireUserApproval) }
+        : {}),
     };
   }
-  if (toolName === "delete_file" && args.relativeWorkspacePath) {
-    return { file_path: args.relativeWorkspacePath };
+  if (toolName === "read_file_v2" && argsObj.targetFile) {
+    return { file_path: argsObj.targetFile };
+  }
+  if (toolName === "read_file" && argsObj.targetFile) {
+    return { file_path: argsObj.targetFile };
+  }
+  if (toolName === "edit_file_v2" && argsObj.relativeWorkspacePath) {
+    return {
+      file_path: argsObj.relativeWorkspacePath,
+      new_string: argsObj.streamingContent ?? "",
+    };
+  }
+  if (toolName === "edit_file" || toolName === "search_replace") {
+    return mapEditLikeArgs(argsObj, resultText);
+  }
+  if (
+    toolName === "write" &&
+    (argsObj.relativeWorkspacePath || argsObj.path || argsObj.targetFile)
+  ) {
+    const codeValue =
+      typeof argsObj.code === "string"
+        ? argsObj.code
+        : argsObj.code && typeof argsObj.code === "object" && typeof argsObj.code.code === "string"
+          ? argsObj.code.code
+          : "";
+    return {
+      file_path: argsObj.relativeWorkspacePath ?? argsObj.path ?? argsObj.targetFile,
+      content: argsObj.content ?? argsObj.contents ?? codeValue,
+    };
+  }
+  if (toolName === "delete_file" && argsObj.relativeWorkspacePath) {
+    return { file_path: argsObj.relativeWorkspacePath };
+  }
+  if (toolName === "list_dir" || toolName === "list_dir_v2" || toolName === "LS") {
+    return {
+      path: argsObj.targetDirectory ?? argsObj.target_directory ?? "",
+    };
   }
   if (toolName === "glob_file_search") {
     return {
-      pattern: args.globPattern ?? "",
-      path: args.targetDirectory ?? "",
+      pattern: argsObj.globPattern ?? "",
+      path: argsObj.targetDirectory ?? "",
+    };
+  }
+  if (toolName === "file_search") {
+    return {
+      pattern: argsObj.pattern ?? argsObj.query ?? argsObj.searchTerm ?? "",
+      path: argsObj.path ?? argsObj.targetDirectory ?? "",
     };
   }
   if (toolName === "ripgrep_raw_search") {
     return {
-      pattern: args.pattern ?? "",
-      path: args.path ?? "",
-      ...(args.glob ? { glob: args.glob } : {}),
-      ...(args.caseInsensitive !== undefined
-        ? { case_insensitive: Boolean(args.caseInsensitive) }
+      pattern: argsObj.pattern ?? "",
+      path: argsObj.path ?? "",
+      ...(argsObj.glob ? { glob: argsObj.glob } : {}),
+      ...(argsObj.caseInsensitive !== undefined
+        ? { case_insensitive: Boolean(argsObj.caseInsensitive) }
         : {}),
     };
   }
-  if (toolName === "web_search" && args.searchTerm) {
-    return { search_term: args.searchTerm };
+  if (toolName === "ripgrep") {
+    return {
+      pattern: argsObj.pattern ?? argsObj.query ?? "",
+      path: argsObj.path ?? argsObj.targetDirectory ?? "",
+      ...(argsObj.glob ? { glob: argsObj.glob } : {}),
+    };
+  }
+  if (toolName === "web_search" && argsObj.searchTerm) {
+    return { search_term: argsObj.searchTerm };
+  }
+  if (toolName === "codebase_search") {
+    return {
+      query: argsObj.query ?? "",
+      path:
+        argsObj.repositoryInfo &&
+        typeof argsObj.repositoryInfo === "object" &&
+        typeof (argsObj.repositoryInfo as Record<string, any>).relativeWorkspacePath === "string"
+          ? (argsObj.repositoryInfo as Record<string, any>).relativeWorkspacePath
+          : "",
+      ...(argsObj.includePattern ? { includePattern: argsObj.includePattern } : {}),
+    };
   }
   if (toolName === "task_v2") {
     return {
-      ...(args.description ? { description: args.description } : {}),
-      ...(args.prompt ? { prompt: args.prompt } : {}),
-      ...(args.subagentType ? { subagent_type: args.subagentType } : {}),
+      ...(argsObj.description ? { description: argsObj.description } : {}),
+      ...(argsObj.prompt ? { prompt: argsObj.prompt } : {}),
+      ...(argsObj.subagentType ? { subagent_type: argsObj.subagentType } : {}),
     };
   }
-  if (toolName.startsWith("mcp-") && Array.isArray(args.tools) && args.tools.length > 0) {
-    const first = args.tools[0] || {};
+  if (toolName.startsWith("mcp-") && Array.isArray(argsObj.tools) && argsObj.tools.length > 0) {
+    const first = argsObj.tools[0] || {};
     const parsedParameters =
       typeof first.parameters === "string"
         ? (parseJson(first.parameters) ?? first.parameters)
@@ -1404,7 +1627,7 @@ function mapToolArgs(toolName: string, args: Record<string, any>): Record<string
       ...(parsedParameters !== undefined ? { arguments: parsedParameters } : {}),
     };
   }
-  return args;
+  return argsObj;
 }
 
 function extractModel(msg: CursorMessage): string | undefined {
@@ -1422,6 +1645,8 @@ export const __testables = {
   createRetryableInit,
   estimateTokenIncrement,
   hasReplayableRootBlob,
+  mapCursorToolName,
+  mapToolArgs,
   normalizeTurnText,
   parseUserContent,
 };

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1213,7 +1213,7 @@ function messagesToTurns(messages: CursorMessage[]): {
 export const CURSOR_SYSTEM_CONTEXT_RE =
   /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/;
 
-function isSystemContextText(text: string): boolean {
+export function isSystemContextText(text: string): boolean {
   return CURSOR_SYSTEM_CONTEXT_RE.test(text.trim());
 }
 

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1419,6 +1419,10 @@ function parseApplyPatchArgs(rawPatch: string): Record<string, any> {
       oldLines.push(line.slice(1));
     } else if (line.startsWith("+")) {
       newLines.push(line.slice(1));
+    } else if (line.startsWith(" ")) {
+      const shared = line.slice(1);
+      oldLines.push(shared);
+      newLines.push(shared);
     }
   }
   return {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1671,7 +1671,9 @@ export async function startServer(
             chalk.dim("\n  Press Ctrl+C to stop\n"),
         );
       }
-      open(browseUrl);
+      if (process.env.VIBE_REPLAY_NO_AUTO_OPEN !== "1") {
+        open(browseUrl);
+      }
     },
   );
 

--- a/packages/cli/test/cursor-parser-comprehensive.test.ts
+++ b/packages/cli/test/cursor-parser-comprehensive.test.ts
@@ -160,6 +160,30 @@ describe("Cursor parser — inline JSONL fixtures", () => {
     expect(text).toBe("Describe what you see");
   });
 
+  it("drops system context wrapped in user_query for JSONL user messages", async () => {
+    const path = await writeJsonl(tempDir, "wrapped-system-context.jsonl", [
+      {
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "<user_query>\n<agent_transcripts>\ninternal block\n</agent_transcripts>\n</user_query>",
+            },
+          ],
+        },
+      },
+      {
+        role: "assistant",
+        message: { content: [{ type: "text", text: "Ignored context." }] },
+      },
+    ]);
+
+    const result = await parseCursorSession(path);
+    const userTurns = result.turns.filter((turn) => turn.role === "user");
+    expect(userTurns).toHaveLength(0);
+  });
+
   it("extracts title from first user prompt limited to 80 chars", async () => {
     const longPrompt = "A".repeat(120);
     const path = await writeJsonl(tempDir, "long-title.jsonl", [

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -9,6 +9,7 @@ const { mockParseCursorSqlite } = vi.hoisted(() => ({
 }));
 
 vi.mock("../src/providers/cursor/sqlite-reader.js", () => ({
+  CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
   parseCursorSqlite: mockParseCursorSqlite,
 }));
 

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -10,6 +10,8 @@ const { mockParseCursorSqlite } = vi.hoisted(() => ({
 
 vi.mock("../src/providers/cursor/sqlite-reader.js", () => ({
   CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
+  isSystemContextText: (text: string) =>
+    /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/.test(text.trim()),
   parseCursorSqlite: mockParseCursorSqlite,
 }));
 

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -2043,8 +2043,8 @@ export default function Dashboard() {
 
   const handleTabChange = (id: Tab) => {
     setTab(id);
-    // Clear text filter when switching tabs to avoid cross-tab filter contamination
-    navigateTo({ tab: id, q: null });
+    // Reset cross-tab list state to avoid landing on empty views due to stale project/filter params.
+    navigateTo({ tab: id, project: null, q: null, archived: null });
   };
 
   const tabButton = (id: Tab, label: string) => (

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -69,14 +69,21 @@ const cliExtraArgs = dashboardMode ? ["-d"] : [];
 let cli;
 let restarting = false;
 let shuttingDown = false;
+let hasOpenedBrowser = false;
 
 function startCli() {
   // Use node_modules/.bin/tsx directly instead of npx to avoid an extra
   // wrapper process that swallows signals (making Ctrl+C unreliable).
+  const cliEnvForRun = {
+    ...cliEnv,
+    // Open browser only once per dev launcher process to avoid tab spam on restarts.
+    VIBE_REPLAY_NO_AUTO_OPEN: hasOpenedBrowser ? "1" : "0",
+  };
   cli = spawn("node_modules/.bin/tsx", [cliScript, ...cliExtraArgs], {
     stdio: "inherit",
-    env: cliEnv,
+    env: cliEnvForRun,
   });
+  hasOpenedBrowser = true;
 
   cli.on("exit", (code, signal) => {
     if (restarting) return; // will be respawned by the watcher

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -4,8 +4,9 @@
  * so multiple `pnpm dev` sessions can run simultaneously without conflicts.
  *
  * Usage:
- *   node scripts/dev.mjs            # normal dev
- *   node scripts/dev.mjs -d         # dashboard mode (passes -d to CLI)
+ *   node scripts/dev.mjs            # dashboard-first dev (default)
+ *   node scripts/dev.mjs -d         # explicit dashboard mode (same as default)
+ *   node scripts/dev.mjs --menu     # interactive CLI menu mode
  */
 import { spawn } from "node:child_process";
 import { watch } from "node:fs";
@@ -14,7 +15,9 @@ import { findFreePort } from "./dev-utils.mjs";
 const VITE_PREFERRED = 5173;
 const API_PREFERRED = 13456;
 
-const dashboardMode = process.argv.includes("-d");
+const forceDashboard = process.argv.includes("-d");
+const menuMode = process.argv.includes("--menu");
+const dashboardMode = forceDashboard || !menuMode;
 
 // Find two non-colliding free ports
 const apiPort = await findFreePort(API_PREFERRED);
@@ -29,6 +32,9 @@ console.log(
 );
 console.log(`[vibe-replay] Viewer:      http://localhost:${vitePort}  (HMR enabled)`);
 console.log(`[vibe-replay] CLI watch:   auto-restarts on packages/cli/src changes`);
+console.log(
+  `[vibe-replay] Mode:        ${dashboardMode ? "dashboard-first (auto-open dashboard)" : "interactive menu"}`,
+);
 console.log();
 
 // Start Vite dev server (backgrounded) — port + strictPort via env vars in vite.config.ts


### PR DESCRIPTION
## Summary
- Filter out non-replayable Cursor `sqlite-only` sessions during discovery by validating the root blob has child message references, so picker entries do not point to guaranteed parse failures.
- Prevent wrapped system context payloads (for example `<system_reminder>` and `<agent_transcripts>`) from being treated as user prompts in both SQLite and JSONL parsing paths.
- Add focused tests for the new edge cases without removing existing Cursor coverage.

## Test plan
- [x] `pnpm --filter vibe-replay test -- src/providers/cursor/sqlite-reader.test.ts test/cursor-parser-comprehensive.test.ts src/providers/cursor/parser.test.ts`
- [x] `pnpm lint:check`
- [x] Local real-data validation on this machine: parse + transform all discovered Cursor sessions (`381/381` parse success, `0` leaked system-context user blocks)
- [ ] Manual: open CLI session picker and confirm no entries that fail immediately from empty `store.db` roots
- [ ] Manual: generate replay from (a) sqlite-backed session, (b) global-state session, (c) jsonl-only session and verify user prompts exclude system reminder/transcript blocks
- [ ] Manual: sanity-check turn stats, tool calls, and thinking blocks for one large Cursor session


Made with [Cursor](https://cursor.com)