### PR TITLE
release: v0.0.14

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -272,7 +272,7 @@ function ReplayCard({
       <div className="flex items-center justify-between gap-3">
         <div className="flex-1 flex items-center gap-2 min-w-0">
           {onTitleSave ? (
-            <div onClick={(e) => e.stopPropagation()}>
+            <div className="flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
               <EditableTitle
                 slug={s.slug}
                 title={s.title}


### PR DESCRIPTION
## Summary
- Bump CLI version to `0.0.14`
- Fix dashboard ReplayCard title overflow: long session titles no longer bleed into Upload/Redo/View action buttons (added `flex-1 min-w-0` to EditableTitle wrapper)

## Test plan
- [x] `pnpm build` — viewer 624KB, CLI 234KB
- [x] `pnpm test` — 545 passed
- [x] `pnpm test:e2e` — 13 passed
- [x] `pnpm lint:check` — clean
- [x] `--version` outputs `0.0.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)