### PR TITLE
feat: improve website SEO foundations

### DIFF
--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -40,7 +40,7 @@ const features = [
   <div class="max-w-5xl mx-auto">
     <!-- Section header -->
     <div class="text-center mb-10 md:mb-20">
-      <p class="text-accent/70 font-mono text-sm font-medium tracking-wider uppercase mb-3">Why vibe-replay</p>
+      <span class="block text-accent/70 font-mono text-sm font-medium tracking-wider uppercase mb-3">Why vibe-replay</span>
       <h2 class="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight">
         Built for how developers actually work
       </h2>

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -5,7 +5,7 @@
   <div class="max-w-5xl mx-auto">
     <!-- Section header -->
     <div class="text-center mb-10 md:mb-20">
-      <p class="text-accent/70 font-mono text-sm font-medium tracking-wider uppercase mb-3">How it works</p>
+      <span class="block text-accent/70 font-mono text-sm font-medium tracking-wider uppercase mb-3">How it works</span>
       <h2 class="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight">
         One command, full context
       </h2>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -40,11 +40,14 @@ const ogImage = new URL("/og.png", siteBase).href;
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:alt" content="vibe-replay — AI coding session replays" />
     <meta property="og:site_name" content="vibe-replay" />
+    <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content="vibe-replay — AI coding session replays" />
 
     <!-- Structured Data -->
     <script type="application/ld+json" set:html={JSON.stringify({
@@ -79,6 +82,7 @@ const ogImage = new URL("/og.png", siteBase).href;
 
     <!-- Google Analytics -->
     <link rel="preconnect" href="https://www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="https://www.google-analytics.com" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-DPXD4TGWYD"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -26,6 +26,7 @@ const ogImage = new URL("/og.png", siteBase).href;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="theme-color" content="#00e5a0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
     <title>{title}</title>
@@ -36,6 +37,9 @@ const ogImage = new URL("/og.png", siteBase).href;
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
     <meta property="og:site_name" content="vibe-replay" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
@@ -58,7 +62,8 @@ const ogImage = new URL("/og.png", siteBase).href;
       },
       "creator": {
         "@type": "Organization",
-        "name": "vibe-replay"
+        "name": "vibe-replay",
+        "url": siteBase
       }
     })} />
 
@@ -73,6 +78,7 @@ const ogImage = new URL("/og.png", siteBase).href;
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 
     <!-- Google Analytics -->
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-DPXD4TGWYD"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="404 - vibe-replay">
+<Layout title="Page not found - vibe-replay" description="The page you're looking for doesn't exist. Head back to vibe-replay to explore AI coding session replays.">
   <div class="min-h-screen flex items-center justify-center px-6">
     <div class="text-center max-w-md">
       <!-- Terminal-style 404 -->

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,7 +7,7 @@ import HowItWorks from "../components/HowItWorks.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="vibe-replay - Turn AI coding sessions into shareable replays">
+<Layout title="vibe-replay - Turn AI coding sessions into shareable replays" description="Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays. One command, one self-contained HTML file. Free and open source.">
   <main>
     <Hero />
     <HowItWorks />


### PR DESCRIPTION
## Summary
- Add keyword-optimized meta descriptions for home page ("Replay, analyze, and share your Claude Code and Cursor AI coding sessions...") and 404 page
- Add `og:image:width`, `og:image:height`, `og:image:type` for better social preview rendering
- Add `theme-color` meta tag (#00e5a0 accent color) for mobile browsers
- Fix heading hierarchy: section labels ("Why vibe-replay", "How it works") changed from `<p>` to `<span>` to avoid broken h2→p→h2 chain
- Add `preconnect` for Google Analytics domain
- Add `creator.url` to JSON-LD structured data

## Test plan
- [x] `pnpm lint:check` passes
- [x] `pnpm build` succeeds (viewer 633KB, CLI 234KB)
- [x] `pnpm test:e2e` — all 13 tests pass
- [x] Verified generated `dist/index.html` contains all new meta tags
- [x] Website Astro build succeeds with sitemap generation

🤖 Generated with [Claude Code](https://claude.ai/code)