### PR TITLE
fix: search input focus loss + dashboard auth in CLI mode

### DIFF
--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -236,12 +236,17 @@ export function navigateTo(
     if (value === null) url.searchParams.delete(key);
     else url.searchParams.set(key, value);
   }
+  const changed = url.toString() !== window.location.href;
   if (options.replace) {
     window.history.replaceState({}, "", url.toString());
   } else {
     window.history.pushState({}, "", url.toString());
   }
-  window.dispatchEvent(new PopStateEvent("popstate"));
+  // Only dispatch popstate for actual navigation (not filter typing).
+  // replace + no view/session change = filter update, skip popstate to avoid re-mount.
+  if (!options.replace && changed) {
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
 }
 
 // ─── Shared UI components ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Search input focus:**
- `navigateTo()` dispatched `popstate` on every call, including `replace:true` filter updates
- `useSessionLoader` listens to `popstate` and re-runs `loadSession()`, causing the entire Dashboard to re-mount per keystroke
- Fix: skip `popstate` dispatch for `replace:true` calls (filter typing only)

**Dashboard auth in CLI mode:**
- `VITE_CLOUD_API_URL` was empty in production builds (`pnpm build` / `npx vibe-replay`)
- Auth calls went to CLI server (`localhost:13456`) which has no auth endpoints → login broken
- Fix: `vite.config.ts` define defaults to `https://vibe-replay.com` when env var not set
- `pnpm dev` still uses `localhost:8787` via `scripts/dev.mjs`

## Test plan

- [x] E2E: 42 tests pass
- [x] Type in search box — focus maintained
- [x] `pnpm build` → viewer has `vibe-replay.com` baked in
- [ ] `pnpm start` → dashboard login works via production API

🤖 Generated with [Claude Code](https://claude.com/claude-code)