### PR TITLE
fix: CORS blocks dashboard auth from CLI (random localhost ports)

### DIFF
--- a/cloudflare/src/auth.ts
+++ b/cloudflare/src/auth.ts
@@ -25,7 +25,11 @@ export type AuthEnv = {
  */
 export function createAuth(env: AuthEnv) {
   const isDev = env.BETTER_AUTH_URL.startsWith("http://localhost");
+  // Trust production origins. In production, also trust localhost for CLI dashboard
+  // (CLI uses random ports, CORS middleware handles the actual origin validation)
   const trustedOrigins = [...PROD_ORIGINS];
+  // Always trust localhost — CLI dashboard runs on random ports
+  trustedOrigins.push("http://localhost");
   if (isDev) {
     trustedOrigins.push(...DEV_ORIGINS);
   }

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -34,9 +34,17 @@ const app = new Hono<HonoEnv>();
 
 app.use("/api/*", async (c, next) => {
   const isDev = c.env.BETTER_AUTH_URL?.startsWith("http://localhost");
-  const allowed = isDev ? [...PROD_ORIGINS, ...DEV_ORIGINS] : [...PROD_ORIGINS];
   const mw = cors({
-    origin: allowed,
+    origin: (origin) => {
+      if (!origin) return PROD_ORIGINS[0];
+      // Allow production origins
+      if (PROD_ORIGINS.includes(origin)) return origin;
+      // Allow any localhost origin (CLI dashboard uses random ports)
+      if (origin.match(/^http:\/\/localhost(:\d+)?$/)) return origin;
+      // In dev mode, allow additional dev origins
+      if (isDev && DEV_ORIGINS.includes(origin)) return origin;
+      return null;
+    },
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
     credentials: true,


### PR DESCRIPTION
## Summary

CLI dashboard (`pnpm start` / `npx vibe-replay`) runs on random ports (e.g. `localhost:63953`). Auth requests to `vibe-replay.com` were blocked by CORS because only fixed ports (8787, 5173, 4321) were allowed.

**Fix:** CORS origin handler now accepts any `http://localhost:*` origin pattern. Better Auth `trustedOrigins` also includes localhost.

## Test plan

- [x] E2E: 42 tests pass
- [ ] `pnpm start` → dashboard login works
- [ ] Production: non-localhost origins still restricted

🤖 Generated with [Claude Code](https://claude.com/claude-code)