### PR TITLE
fix: cloud API URL not baked in production viewer build

### DIFF
--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -14,7 +14,7 @@ function getActiveViewFromUrl(): ActiveView {
   return "replay";
 }
 
-const CLOUD_API = import.meta.env.VITE_CLOUD_API_URL || "";
+const CLOUD_API = __CLOUD_API_URL__;
 
 function DashboardAuthStatus() {
   const [auth, setAuth] = useState<{
@@ -269,7 +269,7 @@ export default function App() {
               <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
               Local
               <span className="instant-tooltip-text">
-                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${import.meta.env.VITE_CLOUD_API_URL ? `\nCloud ${import.meta.env.VITE_CLOUD_API_URL}` : ""}`}
+                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
               </span>
             </span>
             <span className="text-terminal-border/40 text-sm select-none">|</span>
@@ -322,7 +322,7 @@ export default function App() {
               <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
               Local
               <span className="instant-tooltip-text">
-                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${import.meta.env.VITE_CLOUD_API_URL ? `\nCloud ${import.meta.env.VITE_CLOUD_API_URL}` : ""}`}
+                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
               </span>
             </span>
           )}

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -142,7 +142,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   const [storageUsed, setStorageUsed] = useState<number | null>(null);
   const [storageLimit, setStorageLimit] = useState<number | null>(null);
 
-  const cloudApiUrl = import.meta.env.VITE_CLOUD_API_URL || "";
+  const cloudApiUrl = __CLOUD_API_URL__;
 
   // Compute replay JSON size
   const replaySize = useMemo(

--- a/packages/viewer/src/globals.d.ts
+++ b/packages/viewer/src/globals.d.ts
@@ -1,0 +1,2 @@
+/** Cloud API URL, baked at build time via vite.config.ts define */
+declare const __CLOUD_API_URL__: string;

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -72,7 +72,7 @@ async function loadSession(): Promise<LoadResult | "dashboard"> {
     if (!/^[a-zA-Z0-9_-]{10,16}$/.test(cloudId)) {
       throw new Error("Invalid cloud replay ID");
     }
-    const cloudApiUrl = import.meta.env.VITE_CLOUD_API_URL || "";
+    const cloudApiUrl = __CLOUD_API_URL__;
     const resp = await fetch(`${cloudApiUrl}/api/cloud-replays/${cloudId}`, {
       credentials: "include",
     });
@@ -99,7 +99,7 @@ async function loadSession(): Promise<LoadResult | "dashboard"> {
     const { rawUrl, owner } = await resolveGistUrl(gistId);
     const session = await fetchJson(rawUrl);
     // Track view count in cloud_replays (fire-and-forget)
-    const api = import.meta.env.VITE_CLOUD_API_URL || "";
+    const api = __CLOUD_API_URL__;
     fetch(`${api}/api/cloud-replays/view-gist/${gistId}`, { method: "POST" }).catch(() => {});
     return { session, mode: "readonly", gistOwner: owner };
   }

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -16,6 +16,11 @@ function editorFlagPlugin(): Plugin {
 
 export default defineConfig({
   plugins: [react(), viteSingleFile(), editorFlagPlugin()],
+  define: {
+    // Bake cloud API URL at build time. Vite's import.meta.env.VITE_* replacement
+    // runs before define, so we use a custom global instead.
+    __CLOUD_API_URL__: JSON.stringify(process.env.VITE_CLOUD_API_URL || "https://vibe-replay.com"),
+  },
   build: {
     outDir: "dist",
     target: "es2022",


### PR DESCRIPTION
## Summary

Two issues preventing login in `pnpm start` / `npx vibe-replay` (v0.0.15 used `gh` CLI auth which worked, PR #80 switched to OAuth which breaks):

**1. Cloud API URL not baked in build**
- Vite's `import.meta.env.VITE_*` replacement runs before `define`, resolving to `undefined`
- Auth calls went to CLI server (same-origin) which has no auth endpoints
- Fix: `__CLOUD_API_URL__` custom global via vite `define`, defaults to `https://vibe-replay.com`

**2. OAuth state_mismatch**
- Cross-origin fetch from localhost to vibe-replay.com to initiate OAuth
- Browser blocks third-party state cookie → `state_mismatch` error on callback
- Fix: `GET /auth/login` endpoint redirects to GitHub OAuth directly (same-origin navigation)
- Sign-in buttons use `window.open(url)` instead of cross-origin fetch + parse + open

## Test plan
- [x] 42 E2E tests pass
- [x] `pnpm build` → viewer has `vibe-replay.com` baked (4 occurrences)
- [x] `VITE_CLOUD_API_URL=localhost:8787 vite build` → uses localhost
- [ ] `pnpm start` → dashboard login works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)