### PR TITLE
fix: OAuth state_mismatch when logging in from CLI dashboard

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -124,6 +124,24 @@ app.on(["GET", "POST"], "/api/auth/*", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// Browser login — same-origin redirect to avoid third-party cookie issues
+// ---------------------------------------------------------------------------
+
+app.get("/auth/login", async (c) => {
+  const callbackURL = c.req.query("callback") || "/auth/success";
+  if (callbackURL.startsWith("//") || /^https?:/.test(callbackURL)) {
+    return c.text("Invalid callback URL", 400);
+  }
+  const auth = createAuth(c.env);
+  const res = await auth.api.signInSocial({
+    headers: c.req.raw.headers,
+    body: { provider: "github", callbackURL },
+  });
+  if (res?.url) return c.redirect(res.url);
+  return c.text("Failed to initiate login", 500);
+});
+
+// ---------------------------------------------------------------------------
 // Login success page — shown after OAuth callback, auto-closes tab
 // ---------------------------------------------------------------------------
 

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -61,33 +61,21 @@ function DashboardAuthStatus() {
     return (
       <button
         type="button"
-        onClick={async () => {
-          try {
-            const res = await fetch(`${CLOUD_API}/api/auth/sign-in/social`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              credentials: "include",
-              body: JSON.stringify({ provider: "github", callbackURL: "/auth/success" }),
-            });
-            const data = await res.json();
-            if (data.url) {
-              window.open(data.url, "_blank");
-              // Poll for login completion
-              const poll = setInterval(async () => {
-                try {
-                  const r = await fetch(`${CLOUD_API}/api/auth/get-session`, {
-                    credentials: "include",
-                  });
-                  const s = await r.json();
-                  if (s?.session) {
-                    clearInterval(poll);
-                    setAuth({ authenticated: true, user: s.user || null });
-                  }
-                } catch {}
-              }, 2000);
-              setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
-            }
-          } catch {}
+        onClick={() => {
+          window.open(`${CLOUD_API}/auth/login?callback=/auth/success`, "_blank");
+          const poll = setInterval(async () => {
+            try {
+              const r = await fetch(`${CLOUD_API}/api/auth/get-session`, {
+                credentials: "include",
+              });
+              const s = await r.json();
+              if (s?.session) {
+                clearInterval(poll);
+                setAuth({ authenticated: true, user: s.user || null });
+              }
+            } catch {}
+          }, 2000);
+          setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
         }}
         className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10"
       >

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -547,35 +547,21 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
 
                     <button
                       type="button"
-                      onClick={async () => {
-                        try {
-                          const res = await fetch(`${cloudApiUrl}/api/auth/sign-in/social`, {
-                            method: "POST",
-                            headers: { "Content-Type": "application/json" },
-                            credentials: "include",
-                            body: JSON.stringify({
-                              provider: "github",
-                              callbackURL: "/auth/success",
-                            }),
-                          });
-                          const data = await res.json();
-                          if (data.url) {
-                            window.open(data.url, "_blank");
-                            const poll = setInterval(async () => {
-                              try {
-                                const r = await fetch(`${cloudApiUrl}/api/auth/get-session`, {
-                                  credentials: "include",
-                                });
-                                const s = await r.json();
-                                if (s?.session) {
-                                  clearInterval(poll);
-                                  setGhAvailable(true);
-                                }
-                              } catch {}
-                            }, 2000);
-                            setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
-                          }
-                        } catch {}
+                      onClick={() => {
+                        window.open(`${cloudApiUrl}/auth/login?callback=/auth/success`, "_blank");
+                        const poll = setInterval(async () => {
+                          try {
+                            const r = await fetch(`${cloudApiUrl}/api/auth/get-session`, {
+                              credentials: "include",
+                            });
+                            const s = await r.json();
+                            if (s?.session) {
+                              clearInterval(poll);
+                              setGhAvailable(true);
+                            }
+                          } catch {}
+                        }, 2000);
+                        setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
                       }}
                       className="group inline-flex items-center gap-2.5 px-6 py-3 rounded-xl bg-terminal-green-subtle hover:bg-terminal-green-emphasis text-terminal-green text-sm font-sans font-semibold transition-all duration-200 ease-material shadow-layer-sm hover:shadow-layer-md hover:-translate-y-0.5"
                     >


### PR DESCRIPTION
## Summary

Cross-origin fetch from localhost to vibe-replay.com to initiate OAuth caused third-party cookie blocking — state cookie not saved, callback fails with `state_mismatch`.

**Fix:**
- Add `GET /auth/login` endpoint that redirects to GitHub OAuth directly (same-origin navigation, cookies work)
- Sign-in buttons use `window.open(url)` instead of cross-origin fetch + parse + open

## Test plan

- [x] 42 E2E tests pass
- [ ] `pnpm start` → Sign in → OAuth completes without state_mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)