### PR TITLE
fix: use postMessage for cross-origin OAuth session handoff

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -157,7 +157,18 @@ app.get("/auth/login", async (c) => {
 // Login success page — shown after OAuth callback, auto-closes tab
 // ---------------------------------------------------------------------------
 
-app.get("/auth/success", (c) => {
+app.get("/auth/success", async (c) => {
+  // Fetch session info (same-origin, cookies work here)
+  const auth = createAuth(c.env);
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const userJson = session?.user
+    ? JSON.stringify({ name: session.user.name, image: (session.user as any).image })
+    : "null";
+  // Get session token from cookie to pass back to opener
+  const cookies = c.req.raw.headers.get("cookie") || "";
+  const tokenMatch = cookies.match(/(?:__Secure-)?better-auth\.session_token=([^;]+)/);
+  const token = tokenMatch ? tokenMatch[1] : "";
+
   return c.html(`<!DOCTYPE html>
 <html><head><title>vibe-replay - Logged in</title>
 <style>
@@ -178,7 +189,9 @@ body{background:#0a0a0f;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFo
 <p class="countdown" id="cd"></p>
 </div>
 <script>
-var s=5;
+// Post auth result to opener (CLI dashboard on localhost)
+if(window.opener){try{window.opener.postMessage({type:'vibe-replay-auth',user:${userJson},token:'${token}'},'*');}catch(e){}}
+var s=3;
 var cd=document.getElementById('cd');
 cd.textContent='Auto-closing in '+s+'s...';
 var t=setInterval(function(){s--;if(s<=0){clearInterval(t);window.close();}else{cd.textContent='Auto-closing in '+s+'s...';}},1000);

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -38,9 +38,18 @@ function DashboardAuthStatus() {
         .catch(() => setAuth({ authenticated: false, user: null }));
     };
     check();
-    // Re-check when user returns to tab (e.g. after OAuth in another tab)
+    // Listen for postMessage from OAuth success page (cross-origin safe)
+    const onMessage = (e: MessageEvent) => {
+      if (e.data?.type === "vibe-replay-auth" && e.data.user) {
+        setAuth({ authenticated: true, user: e.data.user });
+      }
+    };
+    window.addEventListener("message", onMessage);
     window.addEventListener("focus", check);
-    return () => window.removeEventListener("focus", check);
+    return () => {
+      window.removeEventListener("message", onMessage);
+      window.removeEventListener("focus", check);
+    };
   }, []);
 
   // Close dropdown on outside click

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -549,19 +549,18 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                       type="button"
                       onClick={() => {
                         window.open(`${cloudApiUrl}/auth/login?callback=/auth/success`, "_blank");
-                        const poll = setInterval(async () => {
-                          try {
-                            const r = await fetch(`${cloudApiUrl}/api/auth/get-session`, {
-                              credentials: "include",
-                            });
-                            const s = await r.json();
-                            if (s?.session) {
-                              clearInterval(poll);
-                              setGhAvailable(true);
-                            }
-                          } catch {}
-                        }, 2000);
-                        setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
+                        // Listen for postMessage from success page
+                        const onMsg = (e: MessageEvent) => {
+                          if (e.data?.type === "vibe-replay-auth" && e.data.user) {
+                            window.removeEventListener("message", onMsg);
+                            setGhAvailable(true);
+                          }
+                        };
+                        window.addEventListener("message", onMsg);
+                        setTimeout(
+                          () => window.removeEventListener("message", onMsg),
+                          5 * 60 * 1000,
+                        );
                       }}
                       className="group inline-flex items-center gap-2.5 px-6 py-3 rounded-xl bg-terminal-green-subtle hover:bg-terminal-green-emphasis text-terminal-green text-sm font-sans font-semibold transition-all duration-200 ease-material shadow-layer-sm hover:shadow-layer-md hover:-translate-y-0.5"
                     >


### PR DESCRIPTION
Cross-origin fetch can't read session cookies. Success page now posts user info via postMessage.