### PR TITLE
fix: route editor auth/share through local BFF for parity

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -22,7 +22,7 @@ import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
-import { loadSavedCloudInfo, publishCloud } from "./publishers/cloud.js";
+import { getApiUrl, loadAuthToken, loadSavedCloudInfo, publishCloud } from "./publishers/cloud.js";
 import {
   checkPublishStatus,
   loadSavedGistInfo,
@@ -1063,22 +1063,61 @@ export async function startServer(
 
   // Auth — read local auth.json
   const authFilePath = join(homedir(), ".config", "vibe-replay", "auth.json");
+  const cloudApiBaseUrl = getApiUrl().replace(/\/$/, "");
 
-  app.get("/api/auth/status", async (c) => {
-    try {
-      const data = JSON.parse(await readFile(authFilePath, "utf-8"));
-      return c.json({ authenticated: true, user: data.user || null });
-    } catch {
-      return c.json({ authenticated: false, user: null });
-    }
-  });
+  function readLocalAuthSession(): {
+    token: string;
+    user: { id: string; name: string; email?: string; image?: string };
+  } | null {
+    const auth = loadAuthToken();
+    if (!auth) return null;
+    return {
+      token: auth.token,
+      user: auth.user as { id: string; name: string; email?: string; image?: string },
+    };
+  }
 
-  app.post("/api/auth/logout", async (c) => {
+  async function clearLocalAuthSession() {
     try {
       await unlink(authFilePath);
     } catch {
       // Already gone
     }
+  }
+
+  async function fetchCloudApiWithLocalAuth(path: string, init: RequestInit = {}) {
+    const auth = readLocalAuthSession();
+    if (!auth) return { unauthorized: true as const };
+    const headers = new Headers(init.headers);
+    headers.set("Cookie", `better-auth.session_token=${auth.token}`);
+    const response = await fetch(`${cloudApiBaseUrl}${path}`, { ...init, headers });
+    return { unauthorized: false as const, response };
+  }
+
+  app.get("/api/auth/status", async (c) => {
+    const auth = readLocalAuthSession();
+    if (!auth) return c.json({ authenticated: false, user: null });
+    return c.json({ authenticated: true, user: auth.user || null });
+  });
+
+  // Better Auth-shaped local session endpoint for editor mode parity
+  app.get("/api/auth/get-session", async (c) => {
+    const auth = readLocalAuthSession();
+    if (!auth) return c.json({ session: null, user: null });
+    return c.json({
+      session: { token: auth.token },
+      user: auth.user,
+    });
+  });
+
+  app.post("/api/auth/logout", async (c) => {
+    await clearLocalAuthSession();
+    return c.json({ success: true });
+  });
+
+  // Alias for cloud worker parity; keep /api/auth/logout for backward compatibility
+  app.post("/api/auth/sign-out", async (c) => {
+    await clearLocalAuthSession();
     return c.json({ success: true });
   });
 
@@ -1087,10 +1126,7 @@ export async function startServer(
     const { randomUUID } = await import("node:crypto");
     const http = await import("node:http");
 
-    const apiUrl = (process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com").replace(
-      /\/$/,
-      "",
-    );
+    const apiUrl = cloudApiBaseUrl;
     const nonce = randomUUID();
 
     // Start a temporary localhost server to receive the OAuth callback
@@ -1161,6 +1197,123 @@ export async function startServer(
         5 * 60 * 1000,
       );
     });
+  });
+
+  // Proxy cloud APIs via local auth session (BFF mode for editor)
+  // This keeps pnpm dev/start/npx behavior consistent and avoids cross-site cookie issues.
+  app.get("/api/cloud-replays", async (c) => {
+    try {
+      const proxied = await fetchCloudApiWithLocalAuth("/api/cloud-replays");
+      if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
+      const contentType = proxied.response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await proxied.response.text();
+        return c.body(text, proxied.response.status as any, {
+          "Content-Type": contentType || "text/plain",
+        });
+      }
+      const data = await proxied.response.json().catch(() => ({}));
+      return c.json(data, proxied.response.status as any);
+    } catch (err) {
+      return c.json({ error: `Cloud API unavailable: ${getErrorMessage(err)}` }, 502);
+    }
+  });
+
+  app.post("/api/cloud-replays", async (c) => {
+    try {
+      const body = await c.req.text();
+      const proxied = await fetchCloudApiWithLocalAuth("/api/cloud-replays", {
+        method: "POST",
+        headers: { "Content-Type": c.req.header("content-type") || "application/json" },
+        body,
+      });
+      if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
+      const contentType = proxied.response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await proxied.response.text();
+        return c.body(text, proxied.response.status as any, {
+          "Content-Type": contentType || "text/plain",
+        });
+      }
+      const data = await proxied.response.json().catch(() => ({}));
+      return c.json(data, proxied.response.status as any);
+    } catch (err) {
+      return c.json({ error: `Cloud upload failed: ${getErrorMessage(err)}` }, 502);
+    }
+  });
+
+  app.delete("/api/cloud-replays/:id", async (c) => {
+    const id = c.req.param("id");
+    if (!/^[a-zA-Z0-9_-]{10,16}$/.test(id)) {
+      return c.json({ error: "Invalid replay ID" }, 400);
+    }
+    try {
+      const proxied = await fetchCloudApiWithLocalAuth(`/api/cloud-replays/${id}`, {
+        method: "DELETE",
+      });
+      if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
+      const contentType = proxied.response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await proxied.response.text();
+        return c.body(text, proxied.response.status as any, {
+          "Content-Type": contentType || "text/plain",
+        });
+      }
+      const data = await proxied.response.json().catch(() => ({}));
+      return c.json(data, proxied.response.status as any);
+    } catch (err) {
+      return c.json({ error: `Cloud delete failed: ${getErrorMessage(err)}` }, 502);
+    }
+  });
+
+  app.post("/api/gists", async (c) => {
+    try {
+      const body = await c.req.text();
+      const proxied = await fetchCloudApiWithLocalAuth("/api/gists", {
+        method: "POST",
+        headers: { "Content-Type": c.req.header("content-type") || "application/json" },
+        body,
+      });
+      if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
+      const contentType = proxied.response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await proxied.response.text();
+        return c.body(text, proxied.response.status as any, {
+          "Content-Type": contentType || "text/plain",
+        });
+      }
+      const data = await proxied.response.json().catch(() => ({}));
+      return c.json(data, proxied.response.status as any);
+    } catch (err) {
+      return c.json({ error: `Gist publish failed: ${getErrorMessage(err)}` }, 502);
+    }
+  });
+
+  app.patch("/api/gists/:gistId", async (c) => {
+    const gistId = c.req.param("gistId");
+    if (!/^[a-f0-9]{20,40}$/.test(gistId)) {
+      return c.json({ error: "Invalid gist ID" }, 400);
+    }
+    try {
+      const body = await c.req.text();
+      const proxied = await fetchCloudApiWithLocalAuth(`/api/gists/${gistId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": c.req.header("content-type") || "application/json" },
+        body,
+      });
+      if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
+      const contentType = proxied.response.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        const text = await proxied.response.text();
+        return c.body(text, proxied.response.status as any, {
+          "Content-Type": contentType || "text/plain",
+        });
+      }
+      const data = await proxied.response.json().catch(() => ({}));
+      return c.json(data, proxied.response.status as any);
+    } catch (err) {
+      return c.json({ error: `Gist update failed: ${getErrorMessage(err)}` }, 502);
+    }
   });
 
   // System checks — detect available tools for publishing & AI feedback

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -16,7 +16,7 @@ function getActiveViewFromUrl(): ActiveView {
 
 const CLOUD_API = __CLOUD_API_URL__;
 
-function DashboardAuthStatus() {
+function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
   const [auth, setAuth] = useState<{
     authenticated: boolean;
     user: { name?: string; image?: string } | null;
@@ -25,8 +25,11 @@ function DashboardAuthStatus() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const sessionUrl = isEditor ? "/api/auth/get-session" : `${CLOUD_API}/api/auth/get-session`;
+    const signInOrigin = !isEditor ? new URL(CLOUD_API).origin : "";
+    const authFetchInit = isEditor ? {} : { credentials: "include" as const };
     const check = () => {
-      fetch(`${CLOUD_API}/api/auth/get-session`, { credentials: "include" })
+      fetch(sessionUrl, authFetchInit)
         .then((r) => r.json())
         .then((data: any) => {
           if (data?.session) {
@@ -38,9 +41,14 @@ function DashboardAuthStatus() {
         .catch(() => setAuth({ authenticated: false, user: null }));
     };
     check();
-    // Listen for postMessage from OAuth success page (cross-origin safe)
+    // Listen for postMessage from OAuth success page (cloud auth flow only)
     const onMessage = (e: MessageEvent) => {
-      if (e.data?.type === "vibe-replay-auth" && e.data.user) {
+      if (
+        !isEditor &&
+        e.origin === signInOrigin &&
+        e.data?.type === "vibe-replay-auth" &&
+        e.data.user
+      ) {
         setAuth({ authenticated: true, user: e.data.user });
       }
     };
@@ -50,7 +58,7 @@ function DashboardAuthStatus() {
       window.removeEventListener("message", onMessage);
       window.removeEventListener("focus", check);
     };
-  }, []);
+  }, [isEditor]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -70,13 +78,28 @@ function DashboardAuthStatus() {
     return (
       <button
         type="button"
-        onClick={() => {
-          window.open(`${CLOUD_API}/auth/login?callback=/auth/success`, "_blank");
+        onClick={async () => {
+          if (isEditor) {
+            try {
+              const res = await fetch("/api/auth/login", { method: "POST" });
+              const data = await res.json().catch(() => null);
+              if (res.ok && data?.url) {
+                window.open(data.url, "_blank");
+              }
+            } catch {
+              // Keep UI unchanged; poll below may still recover.
+            }
+          } else {
+            window.open(`${CLOUD_API}/auth/login?callback=/auth/success`, "_blank");
+          }
+
+          const sessionUrl = isEditor
+            ? "/api/auth/get-session"
+            : `${CLOUD_API}/api/auth/get-session`;
+          const authFetchInit = isEditor ? {} : { credentials: "include" as const };
           const poll = setInterval(async () => {
             try {
-              const r = await fetch(`${CLOUD_API}/api/auth/get-session`, {
-                credentials: "include",
-              });
+              const r = await fetch(sessionUrl, authFetchInit);
               const s = await r.json();
               if (s?.session) {
                 clearInterval(poll);
@@ -117,11 +140,10 @@ function DashboardAuthStatus() {
           <button
             type="button"
             onClick={async () => {
-              await fetch(`${CLOUD_API}/api/auth/sign-out`, {
+              const signOutUrl = isEditor ? "/api/auth/sign-out" : `${CLOUD_API}/api/auth/sign-out`;
+              await fetch(signOutUrl, {
                 method: "POST",
-                credentials: "include",
-                headers: { "Content-Type": "application/json" },
-                body: "{}",
+                ...(isEditor ? {} : { credentials: "include" }),
               });
               window.location.reload();
             }}
@@ -280,7 +302,7 @@ export default function App() {
             >
               {theme === "dark" ? "\u263E" : "\u2600"}
             </button>
-            <DashboardAuthStatus />
+            <DashboardAuthStatus isEditor={true} />
           </div>
         </header>
         <Dashboard />
@@ -509,7 +531,7 @@ export default function App() {
               {theme === "dark" ? "\u263E" : "\u2600"}
             </button>
 
-            {isEditor && <DashboardAuthStatus />}
+            {isEditor && <DashboardAuthStatus isEditor={isEditor} />}
           </div>
 
           {/* Mobile menu button */}

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -23,10 +23,19 @@ function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
   } | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const authPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const authPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const sessionUrl = isEditor ? "/api/auth/get-session" : `${CLOUD_API}/api/auth/get-session`;
-    const signInOrigin = !isEditor ? new URL(CLOUD_API).origin : "";
+    let signInOrigin = "";
+    if (!isEditor) {
+      try {
+        signInOrigin = new URL(CLOUD_API).origin;
+      } catch {
+        signInOrigin = "";
+      }
+    }
     const authFetchInit = isEditor ? {} : { credentials: "include" as const };
     const check = () => {
       fetch(sessionUrl, authFetchInit)
@@ -55,6 +64,14 @@ function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
     window.addEventListener("message", onMessage);
     window.addEventListener("focus", check);
     return () => {
+      if (authPollIntervalRef.current) {
+        clearInterval(authPollIntervalRef.current);
+        authPollIntervalRef.current = null;
+      }
+      if (authPollTimeoutRef.current) {
+        clearTimeout(authPollTimeoutRef.current);
+        authPollTimeoutRef.current = null;
+      }
       window.removeEventListener("message", onMessage);
       window.removeEventListener("focus", check);
     };
@@ -93,21 +110,46 @@ function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
             window.open(`${CLOUD_API}/auth/login?callback=/auth/success`, "_blank");
           }
 
+          if (authPollIntervalRef.current) {
+            clearInterval(authPollIntervalRef.current);
+            authPollIntervalRef.current = null;
+          }
+          if (authPollTimeoutRef.current) {
+            clearTimeout(authPollTimeoutRef.current);
+            authPollTimeoutRef.current = null;
+          }
+
           const sessionUrl = isEditor
             ? "/api/auth/get-session"
             : `${CLOUD_API}/api/auth/get-session`;
           const authFetchInit = isEditor ? {} : { credentials: "include" as const };
-          const poll = setInterval(async () => {
+          authPollIntervalRef.current = setInterval(async () => {
             try {
               const r = await fetch(sessionUrl, authFetchInit);
               const s = await r.json();
               if (s?.session) {
-                clearInterval(poll);
+                if (authPollIntervalRef.current) {
+                  clearInterval(authPollIntervalRef.current);
+                  authPollIntervalRef.current = null;
+                }
+                if (authPollTimeoutRef.current) {
+                  clearTimeout(authPollTimeoutRef.current);
+                  authPollTimeoutRef.current = null;
+                }
                 setAuth({ authenticated: true, user: s.user || null });
               }
             } catch {}
           }, 2000);
-          setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
+          authPollTimeoutRef.current = setTimeout(
+            () => {
+              if (authPollIntervalRef.current) {
+                clearInterval(authPollIntervalRef.current);
+                authPollIntervalRef.current = null;
+              }
+              authPollTimeoutRef.current = null;
+            },
+            5 * 60 * 1000,
+          );
         }}
         className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10"
       >

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AnnotationActions } from "../hooks/useAnnotations";
 import type { ViewerMode } from "../hooks/useSessionLoader";
 import type { ReplaySession } from "../types";
@@ -141,6 +141,10 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   } | null>(null);
   const [storageUsed, setStorageUsed] = useState<number | null>(null);
   const [storageLimit, setStorageLimit] = useState<number | null>(null);
+  const authPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const authPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const authMessageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const authMessageListenerRef = useRef<((e: MessageEvent) => void) | null>(null);
 
   const cloudApiUrl = __CLOUD_API_URL__;
   const cloudApiBase = isEditor ? "" : cloudApiUrl;
@@ -163,6 +167,27 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
     },
     [cloudApiBase, isEditor],
   );
+
+  useEffect(() => {
+    return () => {
+      if (authPollIntervalRef.current) {
+        clearInterval(authPollIntervalRef.current);
+        authPollIntervalRef.current = null;
+      }
+      if (authPollTimeoutRef.current) {
+        clearTimeout(authPollTimeoutRef.current);
+        authPollTimeoutRef.current = null;
+      }
+      if (authMessageTimeoutRef.current) {
+        clearTimeout(authMessageTimeoutRef.current);
+        authMessageTimeoutRef.current = null;
+      }
+      if (authMessageListenerRef.current) {
+        window.removeEventListener("message", authMessageListenerRef.current);
+        authMessageListenerRef.current = null;
+      }
+    };
+  }, []);
 
   // Compute replay JSON size
   const replaySize = useMemo(
@@ -560,6 +585,23 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                     <button
                       type="button"
                       onClick={async () => {
+                        if (authPollIntervalRef.current) {
+                          clearInterval(authPollIntervalRef.current);
+                          authPollIntervalRef.current = null;
+                        }
+                        if (authPollTimeoutRef.current) {
+                          clearTimeout(authPollTimeoutRef.current);
+                          authPollTimeoutRef.current = null;
+                        }
+                        if (authMessageTimeoutRef.current) {
+                          clearTimeout(authMessageTimeoutRef.current);
+                          authMessageTimeoutRef.current = null;
+                        }
+                        if (authMessageListenerRef.current) {
+                          window.removeEventListener("message", authMessageListenerRef.current);
+                          authMessageListenerRef.current = null;
+                        }
+
                         if (isEditor) {
                           try {
                             const res = await fetch("/api/auth/login", { method: "POST" });
@@ -570,17 +612,33 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           } catch {
                             // Keep CTA silent; polling below handles eventual consistency.
                           }
-                          const poll = setInterval(async () => {
+                          authPollIntervalRef.current = setInterval(async () => {
                             try {
                               const r = await fetch("/api/auth/get-session");
                               const s = await r.json();
                               if (s?.session) {
-                                clearInterval(poll);
+                                if (authPollIntervalRef.current) {
+                                  clearInterval(authPollIntervalRef.current);
+                                  authPollIntervalRef.current = null;
+                                }
+                                if (authPollTimeoutRef.current) {
+                                  clearTimeout(authPollTimeoutRef.current);
+                                  authPollTimeoutRef.current = null;
+                                }
                                 setGhAvailable(true);
                               }
                             } catch {}
                           }, 2000);
-                          setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
+                          authPollTimeoutRef.current = setTimeout(
+                            () => {
+                              if (authPollIntervalRef.current) {
+                                clearInterval(authPollIntervalRef.current);
+                                authPollIntervalRef.current = null;
+                              }
+                              authPollTimeoutRef.current = null;
+                            },
+                            5 * 60 * 1000,
+                          );
                           return;
                         }
 
@@ -593,12 +651,24 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                             e.data.user
                           ) {
                             window.removeEventListener("message", onMsg);
+                            authMessageListenerRef.current = null;
+                            if (authMessageTimeoutRef.current) {
+                              clearTimeout(authMessageTimeoutRef.current);
+                              authMessageTimeoutRef.current = null;
+                            }
                             setGhAvailable(true);
                           }
                         };
+                        authMessageListenerRef.current = onMsg;
                         window.addEventListener("message", onMsg);
-                        setTimeout(
-                          () => window.removeEventListener("message", onMsg),
+                        authMessageTimeoutRef.current = setTimeout(
+                          () => {
+                            window.removeEventListener("message", onMsg);
+                            authMessageTimeoutRef.current = null;
+                            if (authMessageListenerRef.current === onMsg) {
+                              authMessageListenerRef.current = null;
+                            }
+                          },
                           5 * 60 * 1000,
                         );
                       }}

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -143,6 +143,26 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   const [storageLimit, setStorageLimit] = useState<number | null>(null);
 
   const cloudApiUrl = __CLOUD_API_URL__;
+  const cloudApiBase = isEditor ? "" : cloudApiUrl;
+  const cloudAuthFetchInit = isEditor ? {} : { credentials: "include" as const };
+  const cloudAuthOrigin = useMemo(() => {
+    if (isEditor) return "";
+    try {
+      return new URL(cloudApiUrl).origin;
+    } catch {
+      return "";
+    }
+  }, [isEditor]);
+  const cloudFetch = useCallback(
+    (path: string, init: RequestInit = {}) => {
+      const url = `${cloudApiBase}${path}`;
+      return fetch(url, {
+        ...init,
+        ...(isEditor ? {} : { credentials: "include" }),
+      });
+    },
+    [cloudApiBase, isEditor],
+  );
 
   // Compute replay JSON size
   const replaySize = useMemo(
@@ -159,15 +179,15 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   useEffect(() => {
     if (!isEditor) return;
     if (publishGist) {
-      // Check auth against Worker directly (browser cookie)
-      fetch(`${cloudApiUrl}/api/auth/get-session`, { credentials: "include" })
+      // Editor mode uses local BFF auth for parity with pnpm start / npx.
+      cloudFetch("/api/auth/get-session", cloudAuthFetchInit)
         .then((r) => r.json())
         .then((data: any) => {
           const loggedIn = !!data?.session;
           setGhAvailable(loggedIn);
           // Fetch storage usage + cloud replays list (source of truth for visibility)
           if (loggedIn) {
-            fetch(`${cloudApiUrl}/api/cloud-replays`, { credentials: "include" })
+            cloudFetch("/api/cloud-replays", cloudAuthFetchInit)
               .then((r2) => r2.json())
               .then((d: any) => {
                 setStorageUsed(d.storage?.used ?? null);
@@ -247,7 +267,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
         })
         .catch(() => {});
     }
-  }, [isEditor, publishGist, exportGithub]);
+  }, [isEditor, publishGist, exportGithub, cloudFetch]);
 
   const handlePublishGist = useCallback(async () => {
     if (!session) return;
@@ -260,13 +280,10 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
         .replace(/[^a-zA-Z0-9_-]/g, "-")
         .replace(/-+/g, "-")
         .slice(0, 60)}.json`;
-      const endpoint = gistInfo
-        ? `${cloudApiUrl}/api/gists/${gistInfo.gistId}`
-        : `${cloudApiUrl}/api/gists`;
-      const resp = await fetch(endpoint, {
+      const endpoint = gistInfo ? `/api/gists/${gistInfo.gistId}` : "/api/gists";
+      const resp = await cloudFetch(endpoint, {
         method: gistInfo ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
-        credentials: "include",
         body: JSON.stringify({
           filename,
           content,
@@ -307,7 +324,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
     } finally {
       setGistPublishingLocal(false);
     }
-  }, [session, gistInfo]);
+  }, [session, gistInfo, cloudFetch]);
 
   const handleCloudShare = useCallback(async () => {
     if (!session) return;
@@ -316,10 +333,9 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
     try {
       // Upload new replay first, then delete old one on success
       const oldCloudId = cloudInfo?.id;
-      const resp = await fetch(`${cloudApiUrl}/api/cloud-replays`, {
+      const resp = await cloudFetch("/api/cloud-replays", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        credentials: "include",
         body: JSON.stringify({ replay: session, visibility: cloudVisibility }),
       });
       if (!resp.ok) {
@@ -330,9 +346,8 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
       // Delete old one after successful upload
       // Delete old replay first (await to ensure storage is accurate after)
       if (oldCloudId && oldCloudId !== result.id) {
-        await fetch(`${cloudApiUrl}/api/cloud-replays/${oldCloudId}`, {
+        await cloudFetch(`/api/cloud-replays/${oldCloudId}`, {
           method: "DELETE",
-          credentials: "include",
         }).catch(() => {});
       }
       setCloudInfo(result);
@@ -344,9 +359,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
         body: JSON.stringify({ ...result, visibility: cloudVisibility }),
       }).catch(() => {});
       // Refresh storage usage (after delete completed)
-      const storageResp = await fetch(`${cloudApiUrl}/api/cloud-replays`, {
-        credentials: "include",
-      }).catch(() => null);
+      const storageResp = await cloudFetch("/api/cloud-replays").catch(() => null);
       if (storageResp) {
         const storageData = (await storageResp.json().catch(() => null)) as any;
         if (storageData?.storage) {
@@ -359,16 +372,15 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
     } finally {
       setCloudSharing(false);
     }
-  }, [session, cloudVisibility, cloudInfo]);
+  }, [session, cloudVisibility, cloudInfo, cloudFetch]);
 
   const handleCloudDelete = useCallback(async () => {
     if (!cloudInfo?.id) return;
     setCloudSharing(true);
     setCloudStatus(null);
     try {
-      const resp = await fetch(`${cloudApiUrl}/api/cloud-replays/${cloudInfo.id}`, {
+      const resp = await cloudFetch(`/api/cloud-replays/${cloudInfo.id}`, {
         method: "DELETE",
-        credentials: "include",
       });
       if (!resp.ok) {
         const data = await resp.json().catch(() => ({}));
@@ -381,7 +393,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
         method: "DELETE",
       }).catch(() => {});
       // Refresh storage
-      fetch(`${cloudApiUrl}/api/cloud-replays`, { credentials: "include" })
+      cloudFetch("/api/cloud-replays")
         .then((r) => r.json())
         .then((d: any) => {
           setStorageUsed(d.storage?.used ?? null);
@@ -393,7 +405,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
     } finally {
       setCloudSharing(false);
     }
-  }, [cloudInfo]);
+  }, [cloudInfo, cloudFetch]);
 
   const handleExportGithub = useCallback(async () => {
     if (!exportGithub) return;
@@ -547,11 +559,39 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
 
                     <button
                       type="button"
-                      onClick={() => {
+                      onClick={async () => {
+                        if (isEditor) {
+                          try {
+                            const res = await fetch("/api/auth/login", { method: "POST" });
+                            const data = await res.json().catch(() => null);
+                            if (res.ok && data?.url) {
+                              window.open(data.url, "_blank");
+                            }
+                          } catch {
+                            // Keep CTA silent; polling below handles eventual consistency.
+                          }
+                          const poll = setInterval(async () => {
+                            try {
+                              const r = await fetch("/api/auth/get-session");
+                              const s = await r.json();
+                              if (s?.session) {
+                                clearInterval(poll);
+                                setGhAvailable(true);
+                              }
+                            } catch {}
+                          }, 2000);
+                          setTimeout(() => clearInterval(poll), 5 * 60 * 1000);
+                          return;
+                        }
+
                         window.open(`${cloudApiUrl}/auth/login?callback=/auth/success`, "_blank");
                         // Listen for postMessage from success page
                         const onMsg = (e: MessageEvent) => {
-                          if (e.data?.type === "vibe-replay-auth" && e.data.user) {
+                          if (
+                            e.origin === cloudAuthOrigin &&
+                            e.data?.type === "vibe-replay-auth" &&
+                            e.data.user
+                          ) {
                             window.removeEventListener("message", onMsg);
                             setGhAvailable(true);
                           }


### PR DESCRIPTION
## Summary
- route editor-mode auth/session checks to the local CLI server (`/api/auth/get-session`) and keep cloud direct-auth behavior for non-editor surfaces
- add local BFF proxy endpoints for cloud replay and gist APIs so `pnpm dev`, `pnpm start`, and `npx vibe-replay` share the same auth/share path without cross-site cookie instability
- preserve backward compatibility by keeping existing local auth endpoints (`/api/auth/status`, `/api/auth/logout`) while adding parity aliases (`/api/auth/sign-out`)

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] local API smoke checks for `/api/auth/get-session`, `/api/auth/login`, `/api/cloud-replays`, and `/api/gists`
- [ ] manual browser flow: Dashboard login + Cloud Share upload/update/delete

Made with [Cursor](https://cursor.com)