### PR TITLE
chore: release v0.0.16

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `vibe-replay` CLI version from `0.0.15` to `0.0.16`
- package this patch release for the editor auth/share BFF parity fixes merged in #88

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm --filter vibe-replay build`
- [x] `node packages/cli/dist/index.js --version` reports `0.0.16`

Made with [Cursor](https://cursor.com)