### PR TITLE
fix: cloud auth — per-environment storage, BFF cascade, signed token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ cloudflare/.dev.vars
 # Environment
 .env
 .env.*
+test-results/

--- a/cloudflare/src/auth.ts
+++ b/cloudflare/src/auth.ts
@@ -49,6 +49,10 @@ export function createAuth(env: AuthEnv) {
         scope: ["read:user", "user:email", "gist"],
       },
     },
+    session: {
+      expiresIn: 60 * 60 * 24 * 30, // 30 days
+      updateAge: 60 * 60 * 24, // refresh if accessed after 1 day
+    },
     emailAndPassword: { enabled: false },
     account: {
       encryptOAuthTokens: true,

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -272,6 +272,17 @@ body{background:#0a0a0f;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFo
 <p class="msg">Please close this window and try again.</p>
 </div></body></html>`);
   }
+  // Read the signed session cookie — Better Auth cookies are in `token.signature`
+  // format. The session API returns only the raw token, but the BFF must send the
+  // full signed cookie for auth to work.
+  const isDev = c.env.BETTER_AUTH_URL.startsWith("http://localhost");
+  const cookieName = isDev ? "better-auth.session_token" : "__Secure-better-auth.session_token";
+  const cookies = (c.req.raw.headers.get("cookie") || "").split(";").map((s) => s.trim());
+  const sessionCookie = cookies.find((ck) => ck.startsWith(`${cookieName}=`));
+  const signedToken = sessionCookie
+    ? decodeURIComponent(sessionCookie.slice(cookieName.length + 1))
+    : session.session.token;
+
   const payload = {
     nonce,
     user: {
@@ -280,7 +291,7 @@ body{background:#0a0a0f;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFo
       email: session.user.email,
       image: session.user.image,
     },
-    token: session.session.token,
+    token: signedToken,
   };
   const payloadJson = JSON.stringify(payload);
   // Escape for embedding in <script> — browsers close <script> on </

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -66,13 +66,16 @@ app.post("/api/auth/sign-out", async (c) => {
   } catch {
     // Session may already be gone — still clear cookies
   }
-  // Clear all Better Auth cookies
-  const cookieNames = [
+  // Clear all Better Auth cookies (both prefixed and non-prefixed variants)
+  const baseCookieNames = [
     "better-auth.session_token",
     "better-auth.session_data",
     "better-auth.dont_remember",
   ];
   const isDev = c.env.BETTER_AUTH_URL?.startsWith("http://localhost");
+  const cookieNames = isDev
+    ? baseCookieNames
+    : [...baseCookieNames, ...baseCookieNames.map((n) => `__Secure-${n}`)];
   const setCookies = cookieNames.map(
     (name) => `${name}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${isDev ? "" : "; Secure"}`,
   );

--- a/e2e/cloud-auth.test.ts
+++ b/e2e/cloud-auth.test.ts
@@ -1,0 +1,233 @@
+/**
+ * E2E tests for cloud auth + share flow.
+ * Requires a valid auth.json at ~/.config/vibe-replay/auth.json
+ * (created by scripts/vibe-login.mjs with a persistent browser profile).
+ */
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { type Browser, chromium } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const AUTH_PATH = join(homedir(), ".config", "vibe-replay", "auth.json");
+
+function loadAuth(): { token: string; user: { name: string } } | null {
+  try {
+    if (!existsSync(AUTH_PATH)) return null;
+    return JSON.parse(readFileSync(AUTH_PATH, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+// Determine cloud API URL (same logic as CLI)
+const CLOUD_API = process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com";
+const isSecure = CLOUD_API.startsWith("https://");
+const cookieName = isSecure ? "__Secure-better-auth.session_token" : "better-auth.session_token";
+
+describe("cloud auth", () => {
+  const auth = loadAuth();
+  const skip = !auth;
+
+  it.skipIf(skip)("auth.json exists with token and user", () => {
+    expect(auth).toBeTruthy();
+    expect(auth!.token).toBeTruthy();
+    expect(auth!.user?.name).toBeTruthy();
+  });
+
+  it.skipIf(skip)("token is valid against cloud API with correct cookie name", async () => {
+    const resp = await fetch(`${CLOUD_API}/api/auth/get-session`, {
+      headers: { Cookie: `${cookieName}=${auth!.token}` },
+    });
+    const data = (await resp.json()) as { session?: unknown; user?: { name?: string } };
+    expect(data.session).toBeTruthy();
+    expect(data.user?.name).toBeTruthy();
+  });
+
+  it.skipIf(skip)("cloud-replays API works with correct cookie name", async () => {
+    const resp = await fetch(`${CLOUD_API}/api/cloud-replays`, {
+      headers: { Cookie: `${cookieName}=${auth!.token}` },
+    });
+    expect(resp.status).toBe(200);
+    const data = (await resp.json()) as { replays?: unknown[]; storage?: unknown };
+    expect(data).toHaveProperty("replays");
+    expect(data).toHaveProperty("storage");
+  });
+
+  it.skipIf(skip)("WRONG cookie name gets rejected (proves prefix matters)", async () => {
+    const wrongName = isSecure ? "better-auth.session_token" : "__Secure-better-auth.session_token";
+    const resp = await fetch(`${CLOUD_API}/api/cloud-replays`, {
+      headers: { Cookie: `${wrongName}=${auth!.token}` },
+    });
+    // Should be 401 with wrong cookie name
+    expect(resp.status).toBe(401);
+  });
+});
+
+describe("editor BFF auth proxy", () => {
+  const auth = loadAuth();
+  const skip = !auth;
+
+  let serverProcess: ChildProcess | null = null;
+  let serverPort: number;
+
+  beforeAll(async () => {
+    if (skip) return;
+
+    const baseDir = join(homedir(), ".vibe-replay");
+    await mkdir(baseDir, { recursive: true });
+
+    serverProcess = spawn("node", ["packages/cli/dist/index.js", "-d"], {
+      env: {
+        ...process.env,
+        VIBE_REPLAY_NO_AUTO_OPEN: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Read port from server stdout (e.g. "Dashboard running at http://localhost:XXXX")
+    serverPort = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Server start timeout")), 15000);
+      let output = "";
+      serverProcess!.stdout!.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+        const match = output.match(/localhost:(\d+)/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(Number(match[1]));
+        }
+      });
+      serverProcess!.stderr!.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+      serverProcess!.on("exit", (code) => {
+        clearTimeout(timeout);
+        reject(new Error(`Server exited with code ${code}. Output: ${output}`));
+      });
+    });
+  }, 20000);
+
+  afterAll(() => {
+    serverProcess?.kill("SIGTERM");
+  });
+
+  it.skipIf(skip)("BFF /api/auth/get-session returns session from auth.json", async () => {
+    const resp = await fetch(`http://localhost:${serverPort}/api/auth/get-session`);
+    const data = (await resp.json()) as { session?: unknown; user?: { name?: string } };
+    expect(data.session).toBeTruthy();
+    expect(data.user?.name).toBe(auth!.user.name);
+  });
+
+  it.skipIf(skip)("BFF /api/cloud-replays proxies with correct cookie name (no 401)", async () => {
+    const resp = await fetch(`http://localhost:${serverPort}/api/cloud-replays`);
+    expect(resp.status).toBe(200);
+    const data = (await resp.json()) as { replays?: unknown[]; storage?: unknown; error?: string };
+    // Must NOT be "Unauthorized" — this was the original bug
+    expect(data.error).toBeUndefined();
+    expect(data).toHaveProperty("replays");
+    expect(data).toHaveProperty("storage");
+  });
+
+  it.skipIf(skip)("BFF /api/auth/status shows authenticated", async () => {
+    const resp = await fetch(`http://localhost:${serverPort}/api/auth/status`);
+    const data = (await resp.json()) as { authenticated: boolean };
+    expect(data.authenticated).toBe(true);
+  });
+});
+
+describe("viewer auth consistency", () => {
+  const auth = loadAuth();
+  const skip = !auth;
+
+  let serverProcess: ChildProcess | null = null;
+  let serverPort: number;
+  let browser: Browser;
+
+  beforeAll(async () => {
+    if (skip) return;
+
+    const baseDir = join(homedir(), ".vibe-replay");
+    await mkdir(baseDir, { recursive: true });
+
+    serverProcess = spawn("node", ["packages/cli/dist/index.js", "-d"], {
+      env: {
+        ...process.env,
+        VIBE_REPLAY_NO_AUTO_OPEN: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    serverPort = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Server start timeout")), 15000);
+      let output = "";
+      serverProcess!.stdout!.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+        const match = output.match(/localhost:(\d+)/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(Number(match[1]));
+        }
+      });
+      serverProcess!.stderr!.on("data", (chunk: Buffer) => {
+        output += chunk.toString();
+      });
+      serverProcess!.on("exit", (code) => {
+        clearTimeout(timeout);
+        reject(new Error(`Server exited with code ${code}. Output: ${output}`));
+      });
+    });
+
+    browser = await chromium.launch();
+  }, 20000);
+
+  afterAll(async () => {
+    await browser?.close();
+    serverProcess?.kill("SIGTERM");
+  });
+
+  it.skipIf(skip)("header and share section both show logged-in state", async () => {
+    // Get list of existing replays to find a session to test with
+    const sessionsResp = await fetch(`http://localhost:${serverPort}/api/sessions`);
+    const sessions = (await sessionsResp.json()) as { slug: string }[];
+
+    if (sessions.length === 0) {
+      // No sessions to test viewer — just verify API consistency
+      return;
+    }
+
+    const page = await browser.newPage();
+    const slug = sessions[0].slug;
+    await page.goto(`http://localhost:${serverPort}/?session=${slug}`, {
+      waitUntil: "networkidle",
+    });
+
+    // Wait for auth checks
+    await page.waitForTimeout(3000);
+
+    // Click SHARE & EXPORT tab if visible
+    const shareTab = page.locator("button", { hasText: /share/i }).first();
+    if (await shareTab.isVisible().catch(() => false)) {
+      await shareTab.click();
+      await page.waitForTimeout(2000);
+    }
+
+    // Header should NOT show "Sign in" button (user is logged in)
+    const headerSignInBtn = page.locator("header button", { hasText: "Sign in" });
+    const headerShowsSignIn = await headerSignInBtn.isVisible().catch(() => false);
+
+    // Share section should NOT show "Sign in with GitHub" CTA
+    const shareSignInCta = page.locator("button", { hasText: "Sign in with GitHub" });
+    const shareShowsCta = await shareSignInCta.isVisible().catch(() => false);
+
+    // CONSISTENCY: both must agree
+    expect(headerShowsSignIn).toBe(shareShowsCta);
+
+    // Since we have valid auth, neither should show sign-in
+    expect(headerShowsSignIn).toBe(false);
+    expect(shareShowsCta).toBe(false);
+
+    await page.close();
+  });
+});

--- a/e2e/cloud-auth.test.ts
+++ b/e2e/cloud-auth.test.ts
@@ -213,14 +213,18 @@ describe("viewer auth consistency", () => {
       waitUntil: "networkidle",
     });
 
-    // Wait for auth checks
-    await page.waitForTimeout(3000);
+    // Wait for auth check to complete (avatar or sign-in button appears)
+    await page
+      .locator("header img[alt], header button:has-text('Sign in')")
+      .first()
+      .waitFor({ timeout: 10000 })
+      .catch(() => {});
 
     // Click SHARE & EXPORT tab if visible
     const shareTab = page.locator("button", { hasText: /share/i }).first();
     if (await shareTab.isVisible().catch(() => false)) {
       await shareTab.click();
-      await page.waitForTimeout(2000);
+      await page.waitForLoadState("networkidle").catch(() => {});
     }
 
     // Header should NOT show "Sign in" button (user is logged in)

--- a/e2e/cloud-auth.test.ts
+++ b/e2e/cloud-auth.test.ts
@@ -13,17 +13,27 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const AUTH_PATH = join(homedir(), ".config", "vibe-replay", "auth.json");
 
+// Determine cloud API URL (same logic as CLI)
+const CLOUD_API = process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com";
+
 function loadAuth(): { token: string; user: { name: string } } | null {
   try {
     if (!existsSync(AUTH_PATH)) return null;
-    return JSON.parse(readFileSync(AUTH_PATH, "utf-8"));
+    const data = JSON.parse(readFileSync(AUTH_PATH, "utf-8"));
+    // New per-environment format: { accounts: { origin: { token, user } } }
+    if (data.accounts && typeof data.accounts === "object") {
+      const origin = new URL(CLOUD_API).origin;
+      const entry = data.accounts[origin];
+      if (entry?.token && entry?.user) return entry;
+      return null;
+    }
+    // Legacy flat format
+    if (data.token && data.user) return data;
+    return null;
   } catch {
     return null;
   }
 }
-
-// Determine cloud API URL (same logic as CLI)
-const CLOUD_API = process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com";
 const isSecure = CLOUD_API.startsWith("https://");
 const cookieName = isSecure ? "__Secure-better-auth.session_token" : "better-auth.session_token";
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,4 @@
-import fs from "node:fs";
 import http from "node:http";
-import os from "node:os";
-import nodePath from "node:path";
 import { Separator, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import { program } from "commander";
@@ -12,6 +9,12 @@ import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
+import {
+  getAuthFilePath,
+  loadAuthToken,
+  removeAuthTokenSync,
+  saveAuthTokenSync,
+} from "./publishers/cloud.js";
 import { checkPublishStatus, loadSavedGistInfo, publishGist } from "./publishers/gist.js";
 import { publishLocal } from "./publishers/local.js";
 import { scanForSecrets } from "./scan.js";
@@ -570,8 +573,6 @@ program
 // Auth command group — login, logout, status
 // ---------------------------------------------------------------------------
 
-const AUTH_PATH = nodePath.join(os.homedir(), ".config", "vibe-replay", "auth.json");
-
 const authCmd = program.command("auth").description("Manage authentication");
 
 authCmd
@@ -641,17 +642,12 @@ authCmd
 
           try {
             const data = JSON.parse(body);
-            const configDir = nodePath.join(os.homedir(), ".config", "vibe-replay");
-            fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
-            const authPath = nodePath.join(configDir, "auth.json");
-            fs.writeFileSync(authPath, JSON.stringify(data, null, 2), {
-              mode: 0o600,
-            });
+            saveAuthTokenSync({ token: data.token, user: data.user }, apiUrl);
             console.log(
               chalk.bold.green("\n  ✓ Logged in as ") +
                 chalk.white(data.user?.name || data.user?.email),
             );
-            console.log(chalk.dim(`  Token saved to ${authPath}\n`));
+            console.log(chalk.dim(`  Token saved to ${getAuthFilePath()} [${apiUrl}]\n`));
           } catch (err) {
             console.error(chalk.red("\n  ✗ Failed to save auth token"));
             console.error(chalk.dim(`  Body received: ${body.slice(0, 200)}`));
@@ -695,25 +691,28 @@ authCmd
 authCmd
   .command("logout")
   .description("Log out of vibe-replay")
-  .action(async () => {
-    const authPath = AUTH_PATH;
-
-    if (!fs.existsSync(authPath)) {
+  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .action(async (opts) => {
+    const apiUrl = opts.apiUrl.replace(/\/$/, "");
+    const auth = loadAuthToken(apiUrl);
+    if (!auth) {
       console.log(chalk.dim("\n  Not logged in.\n"));
       return;
     }
 
-    fs.rmSync(authPath);
+    removeAuthTokenSync(apiUrl);
     console.log(chalk.bold.green("\n  ✓ Logged out successfully\n"));
   });
 
 authCmd
   .command("status")
   .description("Show current authentication status")
-  .action(async () => {
-    const authPath = AUTH_PATH;
+  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .action(async (opts) => {
+    const apiUrl = opts.apiUrl.replace(/\/$/, "");
+    const auth = loadAuthToken(apiUrl);
 
-    if (!fs.existsSync(authPath)) {
+    if (!auth) {
       console.log(chalk.dim("\n  Not logged in."));
       console.log(
         chalk.dim("  Run ") +
@@ -723,22 +722,16 @@ authCmd
       return;
     }
 
-    try {
-      const data = JSON.parse(fs.readFileSync(authPath, "utf-8"));
-      console.log(chalk.bold.cyan("\n  vibe-replay auth status\n"));
-      console.log(
-        chalk.dim("  Logged in as ") +
-          chalk.white(data.user?.name || data.user?.email || "unknown"),
-      );
-      if (data.user?.image) {
-        console.log(chalk.dim("  Avatar:    ") + chalk.white(data.user.image));
-      }
-      console.log(chalk.dim("  Auth file: ") + chalk.white(authPath));
-      console.log();
-    } catch {
-      console.error(chalk.red("\n  ✗ Failed to read auth file"));
-      console.error(chalk.dim(`  Path: ${authPath}\n`));
+    console.log(chalk.bold.cyan("\n  vibe-replay auth status\n"));
+    console.log(
+      chalk.dim("  Logged in as ") + chalk.white(auth.user?.name || auth.user?.email || "unknown"),
+    );
+    if (auth.user?.image) {
+      console.log(chalk.dim("  Avatar:    ") + chalk.white(auth.user.image));
     }
+    console.log(chalk.dim("  API:       ") + chalk.white(apiUrl));
+    console.log(chalk.dim("  Auth file: ") + chalk.white(getAuthFilePath()));
+    console.log();
   });
 
 // Keep backwards-compatible hidden alias

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -90,6 +90,12 @@ export function loadAnyAuthToken(): (AuthData & { origin: string }) | null {
   return null;
 }
 
+/** Load all stored auth tokens with their origins. Used by logout to clear everything. */
+export function loadAllAuthTokens(): { origin: string }[] {
+  const store = readAuthStore();
+  return Object.keys(store.accounts).map((origin) => ({ origin }));
+}
+
 /** Save auth token keyed by API URL origin (sync, for CLI callback handlers) */
 export function saveAuthTokenSync(data: AuthData, apiUrl?: string): void {
   const store = readAuthStore();

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -41,6 +41,14 @@ export function getApiUrl(): string {
   return process.env.VIBE_REPLAY_API_URL || DEFAULT_API_URL;
 }
 
+/** HTTPS targets use __Secure- prefixed cookie names (Better Auth convention) */
+export function getSessionCookieName(apiUrl?: string): string {
+  const url = apiUrl || getApiUrl();
+  return url.startsWith("https://")
+    ? "__Secure-better-auth.session_token"
+    : "better-auth.session_token";
+}
+
 export async function publishCloud(
   outputDir: string,
   opts?: { visibility?: "public" | "unlisted" | "private" },
@@ -67,7 +75,7 @@ export async function publishCloud(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Cookie: `better-auth.session_token=${auth.token}`,
+      Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
     },
     body: JSON.stringify({
       replay,

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -1,10 +1,12 @@
-import { existsSync, readFileSync } from "node:fs";
-import { readFile, writeFile } from "node:fs/promises";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const CLOUD_META_FILE = ".vibe-replay-cloud.json";
 const DEFAULT_API_URL = "https://vibe-replay.com";
+const AUTH_DIR = join(homedir(), ".config", "vibe-replay");
+const AUTH_FILE = join(AUTH_DIR, "auth.json");
 
 export interface CloudResult {
   id: string;
@@ -19,22 +21,122 @@ export interface SavedCloudInfo {
   updatedAt: string;
 }
 
-interface AuthData {
+export interface AuthData {
   token: string;
-  user: { id: string; name: string; email?: string };
+  user: { id: string; name: string; email?: string; image?: string };
 }
 
-export function loadAuthToken(): AuthData | null {
+/** Normalize URL to origin (protocol + host) for use as auth store key */
+function authOrigin(url: string): string {
   try {
-    const authPath = join(homedir(), ".config", "vibe-replay", "auth.json");
-    if (!existsSync(authPath)) return null;
-    const raw = readFileSync(authPath, "utf-8");
-    const data = JSON.parse(raw);
-    if (data.token && data.user) return data;
-    return null;
+    return new URL(url).origin;
   } catch {
-    return null;
+    return url;
   }
+}
+
+interface AuthStore {
+  accounts: Record<string, AuthData>;
+}
+
+/** Read the auth store, migrating from legacy flat format if needed */
+function readAuthStore(): AuthStore {
+  try {
+    if (!existsSync(AUTH_FILE)) return { accounts: {} };
+    const raw = readFileSync(AUTH_FILE, "utf-8");
+    const data = JSON.parse(raw);
+    // Legacy flat format: { token, user } → migrate under default production origin
+    if (data.token && data.user && !data.accounts) {
+      return {
+        accounts: { [authOrigin(DEFAULT_API_URL)]: { token: data.token, user: data.user } },
+      };
+    }
+    if (data.accounts && typeof data.accounts === "object") return data as AuthStore;
+    return { accounts: {} };
+  } catch {
+    return { accounts: {} };
+  }
+}
+
+function writeAuthStoreSync(store: AuthStore): void {
+  mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
+  writeFileSync(AUTH_FILE, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+async function writeAuthStoreAsync(store: AuthStore): Promise<void> {
+  await mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
+  await writeFile(AUTH_FILE, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+/** Load auth token for the given API URL (defaults to current VIBE_REPLAY_API_URL) */
+export function loadAuthToken(apiUrl?: string): AuthData | null {
+  const store = readAuthStore();
+  const origin = authOrigin(apiUrl || getApiUrl());
+  const entry = store.accounts[origin];
+  if (!entry?.token || !entry?.user) return null;
+  return entry;
+}
+
+/** Load any available auth token, returning which origin it belongs to.
+ *  Used by BFF proxy: if no token for the current env, use whatever we have
+ *  and proxy to THAT origin instead. */
+export function loadAnyAuthToken(): (AuthData & { origin: string }) | null {
+  const store = readAuthStore();
+  for (const [origin, entry] of Object.entries(store.accounts)) {
+    if (entry?.token && entry?.user) {
+      return { ...entry, origin };
+    }
+  }
+  return null;
+}
+
+/** Save auth token keyed by API URL origin (sync, for CLI callback handlers) */
+export function saveAuthTokenSync(data: AuthData, apiUrl?: string): void {
+  const store = readAuthStore();
+  store.accounts[authOrigin(apiUrl || getApiUrl())] = data;
+  writeAuthStoreSync(store);
+}
+
+/** Save auth token keyed by API URL origin (async) */
+export async function saveAuthToken(data: AuthData, apiUrl?: string): Promise<void> {
+  const store = readAuthStore();
+  store.accounts[authOrigin(apiUrl || getApiUrl())] = data;
+  await writeAuthStoreAsync(store);
+}
+
+/** Remove auth token for the given API URL origin. Deletes file if no accounts remain. */
+export async function removeAuthToken(apiUrl?: string): Promise<void> {
+  const store = readAuthStore();
+  delete store.accounts[authOrigin(apiUrl || getApiUrl())];
+  if (Object.keys(store.accounts).length === 0) {
+    try {
+      await unlink(AUTH_FILE);
+    } catch {
+      // Already gone
+    }
+  } else {
+    await writeAuthStoreAsync(store);
+  }
+}
+
+/** Remove auth token (sync). Deletes file if no accounts remain. */
+export function removeAuthTokenSync(apiUrl?: string): void {
+  const store = readAuthStore();
+  delete store.accounts[authOrigin(apiUrl || getApiUrl())];
+  if (Object.keys(store.accounts).length === 0) {
+    try {
+      rmSync(AUTH_FILE);
+    } catch {
+      // Already gone
+    }
+  } else {
+    writeAuthStoreSync(store);
+  }
+}
+
+/** Get the auth file path (for display purposes) */
+export function getAuthFilePath(): string {
+  return AUTH_FILE;
 }
 
 export function getApiUrl(): string {

--- a/packages/cli/src/publishers/gist.ts
+++ b/packages/cli/src/publishers/gist.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getApiUrl, loadAuthToken } from "./cloud.js";
+import { getApiUrl, getSessionCookieName, loadAuthToken } from "./cloud.js";
 
 const GIST_META_FILE = ".vibe-replay-gist.json";
 
@@ -61,7 +61,7 @@ export async function publishGist(
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        Cookie: `better-auth.session_token=${auth.token}`,
+        Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
       },
       body: JSON.stringify({ filename, content, description }),
     });
@@ -82,7 +82,7 @@ export async function publishGist(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Cookie: `better-auth.session_token=${auth.token}`,
+        Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
       },
       body: JSON.stringify({ filename, content, description, public: true }),
     });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -25,6 +25,7 @@ import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
   getSessionCookieName,
+  loadAllAuthTokens,
   loadAnyAuthToken,
   loadAuthToken,
   loadSavedCloudInfo,
@@ -1105,12 +1106,9 @@ export async function startServer(
 
   async function clearLocalAuthSession() {
     // Remove ALL tokens — user expects a full logout, not per-env
-    const candidates = getAuthCandidates();
-    for (const c of candidates) {
-      await removeAuthToken(c.apiUrl);
+    for (const entry of loadAllAuthTokens()) {
+      await removeAuthToken(entry.origin);
     }
-    // Also remove for current env in case it wasn't in candidates
-    await removeAuthToken(cloudApiBaseUrl);
   }
 
   /** Build an ordered list of (token, apiUrl) pairs to try.

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -22,7 +22,13 @@ import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
-import { getApiUrl, loadAuthToken, loadSavedCloudInfo, publishCloud } from "./publishers/cloud.js";
+import {
+  getApiUrl,
+  getSessionCookieName,
+  loadAuthToken,
+  loadSavedCloudInfo,
+  publishCloud,
+} from "./publishers/cloud.js";
 import {
   checkPublishStatus,
   loadSavedGistInfo,
@@ -1085,11 +1091,13 @@ export async function startServer(
     }
   }
 
+  const sessionCookieName = getSessionCookieName(cloudApiBaseUrl);
+
   async function fetchCloudApiWithLocalAuth(path: string, init: RequestInit = {}) {
     const auth = readLocalAuthSession();
     if (!auth) return { unauthorized: true as const };
     const headers = new Headers(init.headers);
-    headers.set("Cookie", `better-auth.session_token=${auth.token}`);
+    headers.set("Cookie", `${sessionCookieName}=${auth.token}`);
     const response = await fetch(`${cloudApiBaseUrl}${path}`, { ...init, headers });
     return { unauthorized: false as const, response };
   }
@@ -1100,7 +1108,9 @@ export async function startServer(
     return c.json({ authenticated: true, user: auth.user || null });
   });
 
-  // Better Auth-shaped local session endpoint for editor mode parity
+  // Better Auth-shaped local session endpoint for editor mode parity.
+  // Trusts local auth.json — actual token validation happens lazily when
+  // BFF-proxied cloud calls return 401 (which clears stale auth).
   app.get("/api/auth/get-session", async (c) => {
     const auth = readLocalAuthSession();
     if (!auth) return c.json({ session: null, user: null });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -25,9 +25,12 @@ import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
   getSessionCookieName,
+  loadAnyAuthToken,
   loadAuthToken,
   loadSavedCloudInfo,
   publishCloud,
+  removeAuthToken,
+  saveAuthToken,
 } from "./publishers/cloud.js";
 import {
   checkPublishStatus,
@@ -1067,39 +1070,78 @@ export async function startServer(
     return c.json(checkPublishStatus());
   });
 
-  // Auth — read local auth.json
-  const authFilePath = join(homedir(), ".config", "vibe-replay", "auth.json");
+  // Auth — read local auth.json (per-environment, keyed by API origin)
+  // The BFF proxy follows the TOKEN, not the env var: if no token for the
+  // current VIBE_REPLAY_API_URL, it uses whatever token is available and
+  // proxies to that token's origin (e.g. production) instead.
   const cloudApiBaseUrl = getApiUrl().replace(/\/$/, "");
 
   function readLocalAuthSession(): {
     token: string;
     user: { id: string; name: string; email?: string; image?: string };
+    /** The actual API origin this token authenticates against */
+    targetApi: string;
   } | null {
-    const auth = loadAuthToken();
-    if (!auth) return null;
-    return {
-      token: auth.token,
-      user: auth.user as { id: string; name: string; email?: string; image?: string },
-    };
+    // 1. Try exact match for current environment
+    const exact = loadAuthToken(cloudApiBaseUrl);
+    if (exact) {
+      return {
+        token: exact.token,
+        user: exact.user as { id: string; name: string; email?: string; image?: string },
+        targetApi: cloudApiBaseUrl,
+      };
+    }
+    // 2. Fallback: use any available token and proxy to its origin
+    const fallback = loadAnyAuthToken();
+    if (fallback) {
+      return {
+        token: fallback.token,
+        user: fallback.user as { id: string; name: string; email?: string; image?: string },
+        targetApi: fallback.origin.replace(/\/$/, ""),
+      };
+    }
+    return null;
   }
 
   async function clearLocalAuthSession() {
-    try {
-      await unlink(authFilePath);
-    } catch {
-      // Already gone
+    // Remove ALL tokens — user expects a full logout, not per-env
+    const candidates = getAuthCandidates();
+    for (const c of candidates) {
+      await removeAuthToken(c.apiUrl);
     }
+    // Also remove for current env in case it wasn't in candidates
+    await removeAuthToken(cloudApiBaseUrl);
   }
 
-  const sessionCookieName = getSessionCookieName(cloudApiBaseUrl);
+  /** Build an ordered list of (token, apiUrl) pairs to try.
+   *  Exact match for current env first, then any other available token. */
+  function getAuthCandidates(): { token: string; apiUrl: string }[] {
+    const candidates: { token: string; apiUrl: string }[] = [];
+    const exact = loadAuthToken(cloudApiBaseUrl);
+    if (exact) candidates.push({ token: exact.token, apiUrl: cloudApiBaseUrl });
+    const fallback = loadAnyAuthToken();
+    if (fallback) {
+      const fallbackApi = fallback.origin.replace(/\/$/, "");
+      if (fallbackApi !== cloudApiBaseUrl) {
+        candidates.push({ token: fallback.token, apiUrl: fallbackApi });
+      }
+    }
+    return candidates;
+  }
 
   async function fetchCloudApiWithLocalAuth(path: string, init: RequestInit = {}) {
-    const auth = readLocalAuthSession();
-    if (!auth) return { unauthorized: true as const };
-    const headers = new Headers(init.headers);
-    headers.set("Cookie", `${sessionCookieName}=${auth.token}`);
-    const response = await fetch(`${cloudApiBaseUrl}${path}`, { ...init, headers });
-    return { unauthorized: false as const, response };
+    const candidates = getAuthCandidates();
+    if (candidates.length === 0) return { unauthorized: true as const };
+
+    // Try each candidate; on 401, cascade to the next one
+    for (const candidate of candidates) {
+      const headers = new Headers(init.headers);
+      const cookieName = getSessionCookieName(candidate.apiUrl);
+      headers.set("Cookie", `${cookieName}=${candidate.token}`);
+      const response = await fetch(`${candidate.apiUrl}${path}`, { ...init, headers });
+      if (response.status !== 401) return { unauthorized: false as const, response };
+    }
+    return { unauthorized: true as const };
   }
 
   app.get("/api/auth/status", async (c) => {
@@ -1175,12 +1217,8 @@ export async function startServer(
               });
               res.end("OK");
 
-              // Save auth
-              const configDir = join(homedir(), ".config", "vibe-replay");
-              await mkdir(configDir, { recursive: true, mode: 0o700 });
-              await writeFile(authFilePath, JSON.stringify(data, null, 2), {
-                mode: 0o600,
-              });
+              // Save auth keyed by current API environment
+              await saveAuthToken({ token: data.token, user: data.user }, cloudApiBaseUrl);
             } catch {
               res.writeHead(400);
               res.end("Bad Request");

--- a/packages/cli/test/cloud-publisher.test.ts
+++ b/packages/cli/test/cloud-publisher.test.ts
@@ -22,19 +22,80 @@ describe("cloud publisher", () => {
   });
 
   describe("loadAuthToken", () => {
-    it("returns auth data when valid auth.json exists", () => {
+    it("returns auth data when valid auth.json exists (new format)", () => {
       const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
       writeFileSync(
         authPath,
         JSON.stringify({
-          token: "session-token-123",
-          user: { id: "u1", name: "Test User", email: "test@example.com" },
+          accounts: {
+            "https://vibe-replay.com": {
+              token: "session-token-123",
+              user: { id: "u1", name: "Test User", email: "test@example.com" },
+            },
+          },
         }),
       );
-      const auth = loadAuthToken();
+      const auth = loadAuthToken("https://vibe-replay.com");
       expect(auth).toBeDefined();
       expect(auth?.token).toBe("session-token-123");
       expect(auth?.user.name).toBe("Test User");
+    });
+
+    it("migrates legacy flat format under default production origin", () => {
+      const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          token: "legacy-token",
+          user: { id: "u1", name: "Legacy User", email: "legacy@example.com" },
+        }),
+      );
+      // Legacy format should be accessible under the default production URL
+      const auth = loadAuthToken("https://vibe-replay.com");
+      expect(auth).toBeDefined();
+      expect(auth?.token).toBe("legacy-token");
+      expect(auth?.user.name).toBe("Legacy User");
+    });
+
+    it("returns null for non-matching environment", () => {
+      const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          accounts: {
+            "https://vibe-replay.com": {
+              token: "prod-token",
+              user: { id: "u1", name: "Prod User" },
+            },
+          },
+        }),
+      );
+      // Requesting local dev token should return null
+      const auth = loadAuthToken("http://localhost:8787");
+      expect(auth).toBeNull();
+    });
+
+    it("supports multiple environments", () => {
+      const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          accounts: {
+            "https://vibe-replay.com": {
+              token: "prod-token",
+              user: { id: "u1", name: "Prod User" },
+            },
+            "http://localhost:8787": {
+              token: "dev-token",
+              user: { id: "u2", name: "Dev User" },
+            },
+          },
+        }),
+      );
+      const prod = loadAuthToken("https://vibe-replay.com");
+      expect(prod?.token).toBe("prod-token");
+      const dev = loadAuthToken("http://localhost:8787");
+      expect(dev?.token).toBe("dev-token");
     });
 
     it("returns null when auth.json is missing", () => {
@@ -42,17 +103,27 @@ describe("cloud publisher", () => {
       expect(auth).toBeNull();
     });
 
-    it("returns null when auth.json has no token", () => {
+    it("returns null when account has no token", () => {
       const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
-      writeFileSync(authPath, JSON.stringify({ user: { id: "u1" } }));
-      const auth = loadAuthToken();
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          accounts: { "https://vibe-replay.com": { user: { id: "u1" } } },
+        }),
+      );
+      const auth = loadAuthToken("https://vibe-replay.com");
       expect(auth).toBeNull();
     });
 
-    it("returns null when auth.json has no user", () => {
+    it("returns null when account has no user", () => {
       const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
-      writeFileSync(authPath, JSON.stringify({ token: "abc" }));
-      const auth = loadAuthToken();
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          accounts: { "https://vibe-replay.com": { token: "abc" } },
+        }),
+      );
+      const auth = loadAuthToken("https://vibe-replay.com");
       expect(auth).toBeNull();
     });
   });

--- a/packages/cli/test/gist-publisher.test.ts
+++ b/packages/cli/test/gist-publisher.test.ts
@@ -27,6 +27,23 @@ describe("gist publisher", () => {
       writeFileSync(
         authPath,
         JSON.stringify({
+          accounts: {
+            "https://vibe-replay.com": {
+              token: "test-token",
+              user: { id: "u1", name: "Test" },
+            },
+          },
+        }),
+      );
+      const status = checkPublishStatus();
+      expect(status.available).toBe(true);
+    });
+
+    it("returns available with legacy flat format (backward compat)", () => {
+      const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
+      writeFileSync(
+        authPath,
+        JSON.stringify({
           token: "test-token",
           user: { id: "u1", name: "Test" },
         }),
@@ -43,7 +60,12 @@ describe("gist publisher", () => {
 
     it("returns unavailable when auth.json has no token", () => {
       const authPath = join(mockAuthDir, ".config", "vibe-replay", "auth.json");
-      writeFileSync(authPath, JSON.stringify({ user: { id: "u1" } }));
+      writeFileSync(
+        authPath,
+        JSON.stringify({
+          accounts: { "https://vibe-replay.com": { user: { id: "u1" } } },
+        }),
+      );
       const status = checkPublishStatus();
       expect(status.available).toBe(false);
     });

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -59,6 +59,7 @@ function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
         e.data.user
       ) {
         setAuth({ authenticated: true, user: e.data.user });
+        window.dispatchEvent(new Event("vibe-auth-change"));
       }
     };
     window.addEventListener("message", onMessage);
@@ -137,6 +138,7 @@ function DashboardAuthStatus({ isEditor }: { isEditor: boolean }) {
                   authPollTimeoutRef.current = null;
                 }
                 setAuth({ authenticated: true, user: s.user || null });
+                window.dispatchEvent(new Event("vibe-auth-change"));
               }
             } catch {}
           }, 2000);

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -148,7 +148,6 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
 
   const cloudApiUrl = __CLOUD_API_URL__;
   const cloudApiBase = isEditor ? "" : cloudApiUrl;
-  const cloudAuthFetchInit = isEditor ? {} : { credentials: "include" as const };
   const cloudAuthOrigin = useMemo(() => {
     if (isEditor) return "";
     try {
@@ -199,66 +198,69 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
   const cloudTooBig = replaySize > CLOUD_MAX;
   const gistTooBig = replaySize > GIST_MAX;
 
+  // Auth + cloud data check — extracted so it can re-run on login events
+  // biome-ignore lint/correctness/useExhaustiveDependencies: session is stable after initial load; including it would cause infinite re-fetches
+  const refreshAuthAndCloudData = useCallback(() => {
+    if (!isEditor) return;
+    cloudFetch("/api/auth/get-session")
+      .then((r) => r.json())
+      .then((data: any) => {
+        const loggedIn = !!data?.session;
+        setGhAvailable(loggedIn);
+        if (loggedIn) {
+          cloudFetch("/api/cloud-replays")
+            .then((r2) => r2.json())
+            .then((d: any) => {
+              setStorageUsed(d.storage?.used ?? null);
+              setStorageLimit(d.storage?.limit ?? null);
+              if (session) {
+                fetch(apiUrl("/api/cloud-info"))
+                  .then((lr) => lr.json())
+                  .then((ld: any) => {
+                    const localId = ld?.cloud?.id;
+                    const verify = localId
+                      ? (d.replays || []).find((r: any) => r.id === localId)
+                      : null;
+                    const match =
+                      verify ||
+                      (d.replays || []).find(
+                        (r: any) =>
+                          r.storageType === "r2" &&
+                          r.title === (session.meta.title || session.meta.slug),
+                      );
+                    if (match) {
+                      const info = {
+                        id: match.id,
+                        url: `${cloudApiUrl}/r/${match.id}`,
+                        expiresAt: match.expiresAt || "",
+                        visibility: match.visibility,
+                      };
+                      setCloudInfo(info);
+                      if (match.visibility) setCloudVisibility(match.visibility);
+                      if (!verify) {
+                        fetch(apiUrl("/api/cloud-info"), {
+                          method: "POST",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify(info),
+                        }).catch(() => {});
+                      }
+                    }
+                  })
+                  .catch(() => {});
+              }
+            })
+            .catch(() => {});
+        }
+      })
+      .catch(() => setGhAvailable(false));
+  }, [isEditor, cloudFetch]);
+
   // Fetch publish status, gist info, and existing export files
   // biome-ignore lint/correctness/useExhaustiveDependencies: session is stable after initial load; including it would cause infinite re-fetches
   useEffect(() => {
     if (!isEditor) return;
     if (publishGist) {
-      // Editor mode uses local BFF auth for parity with pnpm start / npx.
-      cloudFetch("/api/auth/get-session", cloudAuthFetchInit)
-        .then((r) => r.json())
-        .then((data: any) => {
-          const loggedIn = !!data?.session;
-          setGhAvailable(loggedIn);
-          // Fetch storage usage + cloud replays list (source of truth for visibility)
-          if (loggedIn) {
-            cloudFetch("/api/cloud-replays", cloudAuthFetchInit)
-              .then((r2) => r2.json())
-              .then((d: any) => {
-                setStorageUsed(d.storage?.used ?? null);
-                setStorageLimit(d.storage?.limit ?? null);
-                // Find existing cloud share for this session
-                if (session) {
-                  // Try local cloud-info first (has exact ID), then fall back to title match
-                  fetch(apiUrl("/api/cloud-info"))
-                    .then((lr) => lr.json())
-                    .then((ld: any) => {
-                      const localId = ld?.cloud?.id;
-                      const verify = localId
-                        ? (d.replays || []).find((r: any) => r.id === localId)
-                        : null;
-                      const match =
-                        verify ||
-                        (d.replays || []).find(
-                          (r: any) =>
-                            r.storageType === "r2" &&
-                            r.title === (session.meta.title || session.meta.slug),
-                        );
-                      if (match) {
-                        const info = {
-                          id: match.id,
-                          url: `${cloudApiUrl}/r/${match.id}`,
-                          expiresAt: match.expiresAt || "",
-                          visibility: match.visibility,
-                        };
-                        setCloudInfo(info);
-                        if (match.visibility) setCloudVisibility(match.visibility);
-                        if (!verify) {
-                          fetch(apiUrl("/api/cloud-info"), {
-                            method: "POST",
-                            headers: { "Content-Type": "application/json" },
-                            body: JSON.stringify(info),
-                          }).catch(() => {});
-                        }
-                      }
-                    })
-                    .catch(() => {});
-                }
-              })
-              .catch(() => {});
-          }
-        })
-        .catch(() => setGhAvailable(false));
+      refreshAuthAndCloudData();
 
       setGistInfoLoading(true);
       fetch(apiUrl("/api/gist-info"))
@@ -292,7 +294,15 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
         })
         .catch(() => {});
     }
-  }, [isEditor, publishGist, exportGithub, cloudFetch]);
+  }, [isEditor, publishGist, exportGithub, cloudFetch, refreshAuthAndCloudData]);
+
+  // Re-check auth when login happens elsewhere (e.g. DashboardAuthStatus header)
+  useEffect(() => {
+    if (!isEditor) return;
+    const onAuthChange = () => refreshAuthAndCloudData();
+    window.addEventListener("vibe-auth-change", onAuthChange);
+    return () => window.removeEventListener("vibe-auth-change", onAuthChange);
+  }, [isEditor, refreshAuthAndCloudData]);
 
   const handlePublishGist = useCallback(async () => {
     if (!session) return;
@@ -319,6 +329,10 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
       if (!resp.ok) {
         const data = await resp.json().catch(() => ({}));
         const errMsg = (data as any).error || "Gist publish failed";
+        if (resp.status === 401) {
+          setGhAvailable(false);
+          throw new Error(errMsg);
+        }
         // If gist was deleted on GitHub, clear stale local info + state
         if (gistInfo && (resp.status === 404 || errMsg.includes("not found"))) {
           setGistInfo(null);
@@ -365,6 +379,9 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
       });
       if (!resp.ok) {
         const data = await resp.json().catch(() => ({}));
+        if (resp.status === 401) {
+          setGhAvailable(false);
+        }
         throw new Error((data as any).error || "Upload failed");
       }
       const result = (await resp.json()) as { id: string; url: string; expiresAt: string };
@@ -626,6 +643,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                                   authPollTimeoutRef.current = null;
                                 }
                                 setGhAvailable(true);
+                                window.dispatchEvent(new Event("vibe-auth-change"));
                               }
                             } catch {}
                           }, 2000);
@@ -657,6 +675,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                               authMessageTimeoutRef.current = null;
                             }
                             setGhAvailable(true);
+                            window.dispatchEvent(new Event("vibe-auth-change"));
                           }
                         };
                         authMessageListenerRef.current = onMsg;

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,11 +4,25 @@ import { defineConfig } from "astro/config";
 
 // When DEV_VIEWER_URL is set (e.g. http://localhost:5173), proxy /view/ to Vite dev server for HMR
 const viewerDevUrl = process.env.DEV_VIEWER_URL;
+// In dev, proxy /api/* to the local Cloudflare Worker so auth + cloud APIs work
+const workerDevUrl = process.env.DEV_WORKER_URL || "http://localhost:8787";
 
 export default defineConfig({
   site: "https://vibe-replay.com",
   integrations: [sitemap()],
   vite: {
+    server: {
+      proxy: {
+        "/api": {
+          target: workerDevUrl,
+          changeOrigin: true,
+        },
+        "/auth": {
+          target: workerDevUrl,
+          changeOrigin: true,
+        },
+      },
+    },
     plugins: [
       tailwindcss(),
       {


### PR DESCRIPTION
## Summary

Fixes cloud auth across all dev/local/prod modes. Three root causes addressed:

- **Per-environment auth storage**: `auth.json` keyed by API origin so production and local wrangler tokens don't conflict. Auto-migrates legacy flat format.
- **BFF proxy cascade**: When local token returns 401, automatically falls back to production token (or any other valid token). Cookie name (`__Secure-` prefix) determined per-candidate.
- **Signed token in CLI login**: Worker's `/auth/cli-complete` was sending raw DB token, but Better Auth requires `token.signature` (HMAC-signed) format. Now reads the actual signed cookie from request headers.
- **Website dev proxy**: Astro config proxies `/api/*` and `/auth/*` to local worker so website dev login works.

## Test plan

See `plan/test-plan-cloud-auth.md` for full 8-scenario test plan covering:

- [ ] Local wrangler login (signed token fix)
- [ ] Production login (no regression)
- [ ] Per-environment isolation (two tokens coexist)
- [ ] Cascade fallback (dev mode with only prod token)
- [ ] Cascade fallback (stale local + valid prod)
- [ ] Legacy auth.json migration
- [ ] Website dev login (Astro proxy)
- [ ] No auth graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)