### PR TITLE
chore: bump version to 0.0.17

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.0.17 for release

Includes fixes from #91 (cloud auth — per-environment storage, BFF cascade, signed token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)