### PR TITLE
fix: improve Cursor data quality insights

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -232,12 +232,32 @@ describe("cursor sqlite metrics helpers", () => {
     expect(__testables.mapCursorToolName("search_replace")).toBe("Edit");
     expect(__testables.mapCursorToolName("edit_file")).toBe("Edit");
     expect(__testables.mapCursorToolName("write")).toBe("Write");
+    expect(__testables.mapCursorToolName("Task")).toBe("Agent");
+    expect(__testables.mapCursorToolName("task_v2")).toBe("Agent");
+    expect(__testables.mapCursorToolName("create_plan")).toBe("Plan");
+    expect(
+      __testables.mapCursorToolName("mcp-cursor-ide-browser-cursor-ide-browser-browser_navigate"),
+    ).toBe("Browser");
+    expect(__testables.mapCursorToolName("chrome-devtools-new_page")).toBe("Browser");
     expect(__testables.mapCursorToolName("list_dir")).toBe("Glob");
     expect(__testables.mapCursorToolName("rg")).toBe("Grep");
     expect(__testables.mapCursorToolName("grep_search")).toBe("Grep");
     expect(__testables.mapCursorToolName("ripgrep")).toBe("Grep");
     expect(__testables.mapCursorToolName("file_search")).toBe("Glob");
     expect(__testables.mapCursorToolName("codebase_search")).toBe("SemanticSearch");
+  });
+
+  it("maps Cursor task args into Agent-style subagent metadata", () => {
+    const mapped = __testables.mapToolArgs("task_v2", {
+      description: "Search auth patterns",
+      prompt: "Search auth patterns in the repo",
+      subagentType: "Explore",
+    }) as any;
+    expect(mapped).toEqual({
+      description: "Search auth patterns",
+      prompt: "Search auth patterns in the repo",
+      subagent_type: "Explore",
+    });
   });
 
   it("maps run_terminal_cmd and read_file args into normalized shape", () => {
@@ -311,6 +331,18 @@ describe("cursor sqlite metrics helpers", () => {
       code: { code: "hello" },
     }) as any;
     expect(mapped).toEqual({ file_path: "docs/readme.md", content: "hello" });
+  });
+
+  it("maps Delete args across Cursor variants", () => {
+    const canonical = __testables.mapToolArgs("Delete", {
+      path: "docs/old.md",
+    }) as any;
+    expect(canonical).toEqual({ file_path: "docs/old.md" });
+
+    const legacy = __testables.mapToolArgs("delete_file", {
+      relativeWorkspacePath: "src/obsolete.ts",
+    }) as any;
+    expect(legacy).toEqual({ file_path: "src/obsolete.ts" });
   });
 
   it("keeps string tool args as raw text for unknown tools", () => {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -264,14 +264,6 @@ function tokenUsageFromCursorTokenCount(value: unknown): TokenUsage | undefined 
   return hasAnyTokens(usage) ? usage : undefined;
 }
 
-function computeDurationFromIsoRange(start?: string, end?: string): number | undefined {
-  if (!start || !end) return undefined;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
-  return Math.round(endMs - startMs);
-}
-
 async function resolveProjectRootFromPath(rawPath: string): Promise<string | null> {
   const candidate = rawPath
     .replaceAll("\\\\", "/")
@@ -1089,8 +1081,6 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
     const endTime = toIsoTimestamp(composer.lastUpdatedAt);
     const sessionTokenUsage = tokenUsageFromCursorTokenCount(composer.tokenCount);
     const metrics = buildGlobalStateMetrics(entries, modelName, sessionTokenUsage);
-    const totalDurationMs =
-      metrics.totalDurationMs ?? computeDurationFromIsoRange(startTime, endTime);
 
     const notes = ["cursorDiskKV keys: composerData:* + bubbleId:*"];
     if (!metrics.tokenUsage) {
@@ -1103,8 +1093,8 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
     }
     if (metrics.totalDurationMs !== undefined) {
       notes.push("Duration is estimated from Cursor thinking and tool execution timing.");
-    } else if (totalDurationMs !== undefined) {
-      notes.push("Duration is estimated from session start/end timestamps.");
+    } else {
+      notes.push("Duration is unavailable for this Cursor global-state session.");
     }
     const hasDetailedTurnStats = Boolean(
       metrics.turnStats?.some(
@@ -1125,7 +1115,9 @@ async function parseCursorGlobalStateDb(sessionId: string): Promise<ProviderPars
       model: modelName,
       startTime,
       endTime,
-      ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
+      ...(metrics.totalDurationMs !== undefined
+        ? { totalDurationMs: metrics.totalDurationMs }
+        : {}),
       ...(metrics.tokenUsage ? { tokenUsage: metrics.tokenUsage } : {}),
       ...(metrics.tokenUsageByModel ? { tokenUsageByModel: metrics.tokenUsageByModel } : {}),
       ...(metrics.turnStats ? { turnStats: metrics.turnStats } : {}),
@@ -1331,8 +1323,8 @@ function mapCursorToolName(name: string): string {
     write: "Write",
     Delete: "Delete",
     delete_file: "Delete",
-    Task: "Task",
-    task_v2: "Task",
+    Task: "Agent",
+    task_v2: "Agent",
     todo_write: "TodoWrite",
     ask_question: "AskQuestion",
     semantic_search_full: "SemanticSearch",
@@ -1340,8 +1332,12 @@ function mapCursorToolName(name: string): string {
     web_search: "WebSearch",
     WebFetch: "WebFetch",
     web_fetch: "WebFetch",
+    create_plan: "Plan",
   };
-  return mapping[name] || name;
+  if (mapping[name]) return mapping[name];
+  if (name.startsWith("mcp-cursor-ide-browser-cursor-ide-browser-browser_")) return "Browser";
+  if (name.startsWith("chrome-devtools-")) return "Browser";
+  return name;
 }
 
 function parseDiffStringSnippet(diffString: string): { oldText: string; newText: string } {
@@ -1560,8 +1556,14 @@ function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<s
       content: argsObj.content ?? argsObj.contents ?? codeValue,
     };
   }
-  if (toolName === "delete_file" && argsObj.relativeWorkspacePath) {
-    return { file_path: argsObj.relativeWorkspacePath };
+  if (
+    (toolName === "Delete" || toolName === "delete_file") &&
+    (argsObj.relativeWorkspacePath || argsObj.path || argsObj.file_path || argsObj.targetFile)
+  ) {
+    return {
+      file_path:
+        argsObj.file_path ?? argsObj.path ?? argsObj.relativeWorkspacePath ?? argsObj.targetFile,
+    };
   }
   if (toolName === "list_dir" || toolName === "list_dir_v2" || toolName === "LS") {
     return {
@@ -1612,7 +1614,7 @@ function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<s
       ...(argsObj.includePattern ? { includePattern: argsObj.includePattern } : {}),
     };
   }
-  if (toolName === "task_v2") {
+  if (toolName === "task_v2" || toolName === "Task") {
     return {
       ...(argsObj.description ? { description: argsObj.description } : {}),
       ...(argsObj.prompt ? { prompt: argsObj.prompt } : {}),

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -14,10 +14,12 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { estimateCost, estimateCostSimple } from "./pricing.js";
-import type { PrLink, TokenUsage } from "./types.js";
+import { parseCursorSession } from "./providers/cursor/parser.js";
+import type { ProviderParseResult } from "./providers/types.js";
+import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
-const SCANNER_VERSION = 2;
+const SCANNER_VERSION = 5;
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -64,6 +66,9 @@ export interface SessionScanResult {
   entrypoint?: string;
   permissionMode?: string;
   compactionCount: number;
+  dataSource?: DataSource;
+  dataQualityNotes?: string[];
+  turnStatCount?: number;
 }
 
 export interface ScanCacheEntry {
@@ -95,6 +100,9 @@ export interface ProjectInsights {
   sessionsPerDay: Record<string, number>; // YYYY-MM-DD → count
   avgSessionDurationMs: number;
   memory?: ProjectMemory;
+  dataQuality?: {
+    notes: string[];
+  };
 }
 
 export interface BranchInfo {
@@ -142,16 +150,23 @@ export interface UserInsights {
   subAgentTotal: number;
   apiErrorTotal: number;
   avgSessionDurationMs: number;
+  dataQuality?: {
+    notes: string[];
+  };
 }
 
 // ─── Scanner ────────────────────────────────────────────────────────
 
-interface ScanInput {
+export interface ScanInput {
   sessionId: string;
   provider: string;
   project: string;
   slug: string;
   filePaths: string[];
+  toolPaths?: string[];
+  workspacePath?: string;
+  hasSqlite?: boolean;
+  timestamp?: string;
   title?: string;
   firstPrompt?: string;
 }
@@ -169,6 +184,15 @@ export interface ScanProgress {
  * subagent JSONL reading, no transform step.
  */
 export async function scanSession(input: ScanInput): Promise<SessionScanResult> {
+  if (input.provider === "cursor") {
+    try {
+      return await scanCursorSession(input);
+    } catch {
+      // Fall back to the legacy lightweight scanner below so Cursor sessions
+      // still show up even if richer parsing fails for one host/schema.
+    }
+  }
+
   let startTime: string | undefined;
   let endTime: string | undefined;
   let model: string | undefined;
@@ -313,7 +337,12 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
           if (block.type === "tool_use") {
             toolCallCount++;
             // Track file modifications
-            if (block.name === "Edit" || block.name === "Write" || block.name === "NotebookEdit") {
+            if (
+              block.name === "Edit" ||
+              block.name === "Write" ||
+              block.name === "NotebookEdit" ||
+              block.name === "Delete"
+            ) {
               const fp = block.input?.file_path || block.input?.filePath;
               if (fp) {
                 editCount++;
@@ -421,6 +450,152 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     entrypoint,
     permissionMode,
   };
+}
+
+async function scanCursorSession(input: ScanInput): Promise<SessionScanResult> {
+  const sessionInfo: SessionInfo = {
+    provider: "cursor",
+    sessionId: input.sessionId,
+    slug: input.slug,
+    title: input.title,
+    project: input.project,
+    cwd: input.workspacePath || input.project,
+    version: "",
+    timestamp: input.timestamp || new Date().toISOString(),
+    lineCount: 0,
+    fileSize: 0,
+    filePath: input.filePaths[0] || "",
+    filePaths: input.filePaths,
+    ...(input.toolPaths?.length ? { toolPaths: input.toolPaths } : {}),
+    ...(input.workspacePath ? { workspacePath: input.workspacePath } : {}),
+    ...(input.hasSqlite !== undefined ? { hasSqlite: input.hasSqlite } : {}),
+    firstPrompt: input.firstPrompt || input.title || "(cursor session)",
+  };
+
+  const parsed = await parseCursorSession(
+    [...input.filePaths, ...(input.toolPaths || [])],
+    sessionInfo,
+  );
+  return buildScanResultFromParsed(input, parsed);
+}
+
+function buildScanResultFromParsed(
+  input: ScanInput,
+  parsed: ProviderParseResult,
+): SessionScanResult {
+  let promptCount = 0;
+  let toolCallCount = 0;
+  let editCount = 0;
+  let subAgentCount = parsed.subAgentSummary?.length || 0;
+  const fileEditCounts = new Map<string, number>();
+
+  for (const turn of parsed.turns) {
+    if (turn.role === "user" && turn.subtype !== "compaction-summary") {
+      const hasText = turn.blocks.some(
+        (block) =>
+          block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
+      );
+      const hasImages = turn.blocks.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          "type" in block &&
+          (block as { type?: unknown }).type === "_user_images" &&
+          "images" in block &&
+          Array.isArray((block as { images?: unknown }).images) &&
+          (block as { images: unknown[] }).images.length > 0,
+      );
+      if (hasText || hasImages) promptCount++;
+    }
+
+    for (const block of turn.blocks as any[]) {
+      if (block?.type !== "tool_use") continue;
+      toolCallCount++;
+
+      if (
+        subAgentCount === 0 &&
+        block.name === "Agent" &&
+        block.input &&
+        typeof block.input.subagent_type === "string"
+      ) {
+        subAgentCount++;
+      }
+
+      if (
+        block.name !== "Edit" &&
+        block.name !== "Write" &&
+        block.name !== "NotebookEdit" &&
+        block.name !== "Delete"
+      ) {
+        continue;
+      }
+
+      const rawPath =
+        block.input?.file_path ??
+        block.input?.filePath ??
+        block.input?.path ??
+        block.input?.relativeWorkspacePath;
+      if (typeof rawPath !== "string" || !rawPath.trim()) continue;
+      editCount++;
+      const short = shortenPath(rawPath);
+      fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
+    }
+  }
+
+  const costEstimate = estimateParsedCost(parsed);
+  const fallbackStart = parsed.startTime || input.timestamp;
+  const fallbackEnd = parsed.endTime || input.timestamp;
+  const durationMs =
+    input.provider === "cursor"
+      ? parsed.totalDurationMs
+      : parsed.totalDurationMs || deriveDurationFromRange(fallbackStart, fallbackEnd);
+
+  return {
+    sessionId: input.sessionId,
+    provider: input.provider,
+    project: input.project,
+    slug: input.slug,
+    title: parsed.title || input.title,
+    firstPrompt: parsed.title || input.firstPrompt,
+    startTime: fallbackStart,
+    endTime: parsed.endTime,
+    durationMs,
+    gitBranch: parsed.gitBranch,
+    gitBranches: parsed.gitBranches,
+    prLinks: parsed.prLinks,
+    model: parsed.model,
+    promptCount,
+    toolCallCount,
+    editCount,
+    filesModified: [...fileEditCounts.entries()]
+      .map(([file, count]) => ({ file, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 100),
+    tokenUsage: parsed.tokenUsage,
+    costEstimate,
+    subAgentCount,
+    apiErrorCount: parsed.apiErrors?.length || 0,
+    compactionCount: parsed.compactions?.length || 0,
+    entrypoint: parsed.entrypoint,
+    permissionMode: parsed.permissionMode,
+    dataSource: parsed.dataSource,
+    dataQualityNotes: parsed.dataSourceInfo?.notes,
+    turnStatCount: parsed.turnStats?.length,
+  };
+}
+
+function estimateParsedCost(parsed: ProviderParseResult): number | undefined {
+  if (parsed.tokenUsageByModel) return estimateCost(parsed.tokenUsageByModel);
+  if (parsed.tokenUsage && parsed.model) return estimateCostSimple(parsed.tokenUsage, parsed.model);
+  return undefined;
+}
+
+function deriveDurationFromRange(start?: string, end?: string): number | undefined {
+  if (!start || !end) return undefined;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
+  return Math.round(endMs - startMs);
 }
 
 // ─── Cache management ───────────────────────────────────────────────
@@ -657,6 +832,7 @@ export function aggregateProjectInsights(
     avgSessionDurationMs:
       sessionsWithDuration > 0 ? Math.round(totalDurationMs / sessionsWithDuration) : 0,
     memory,
+    dataQuality: buildAggregateDataQuality(projectScans),
   };
 }
 
@@ -777,7 +953,43 @@ export function aggregateUserInsights(scans: SessionScanResult[]): UserInsights 
     apiErrorTotal,
     avgSessionDurationMs:
       sessionsWithDuration > 0 ? Math.round(totalDurationMs / sessionsWithDuration) : 0,
+    dataQuality: buildAggregateDataQuality(scans),
   };
+}
+
+function buildAggregateDataQuality(scans: SessionScanResult[]): { notes: string[] } | undefined {
+  const cursorScans = scans.filter((s) => s.provider === "cursor");
+  if (cursorScans.length === 0) return undefined;
+
+  const total = cursorScans.length;
+  const estimatedDurationCount = cursorScans.filter((s) =>
+    s.dataQualityNotes?.some((note) => /duration.*estimated|estimated.*duration/i.test(note)),
+  ).length;
+  const missingDurationCount = cursorScans.filter((s) => !s.durationMs).length;
+  const missingTokenCount = cursorScans.filter((s) => !s.tokenUsage).length;
+  const missingTurnStatsCount = cursorScans.filter((s) => !s.turnStatCount).length;
+
+  const notes: string[] = [];
+  if (estimatedDurationCount > 0) {
+    notes.push(
+      `${estimatedDurationCount}/${total} Cursor sessions use best-effort duration estimates.`,
+    );
+  }
+  if (missingDurationCount > 0) {
+    notes.push(
+      `${missingDurationCount}/${total} Cursor sessions do not have enough timing data to compute duration.`,
+    );
+  }
+  if (missingTokenCount > 0) {
+    notes.push(
+      `${missingTokenCount}/${total} Cursor sessions do not include token snapshots, so token and cost totals are partial.`,
+    );
+  }
+  if (missingTurnStatsCount > 0) {
+    notes.push(`${missingTurnStatsCount}/${total} Cursor sessions do not include per-turn stats.`);
+  }
+
+  return notes.length > 0 ? { notes } : undefined;
 }
 
 // ─── Memory reader ──────────────────────────────────────────────────

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -19,7 +19,7 @@ import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
-const SCANNER_VERSION = 5;
+const SCANNER_VERSION = 3;
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -486,7 +486,8 @@ function buildScanResultFromParsed(
   let promptCount = 0;
   let toolCallCount = 0;
   let editCount = 0;
-  let subAgentCount = parsed.subAgentSummary?.length || 0;
+  const parsedSubAgentCount = parsed.subAgentSummary?.length || 0;
+  let derivedSubAgentCount = 0;
   const fileEditCounts = new Map<string, number>();
 
   for (const turn of parsed.turns) {
@@ -496,14 +497,7 @@ function buildScanResultFromParsed(
           block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
       );
       const hasImages = turn.blocks.some(
-        (block) =>
-          typeof block === "object" &&
-          block !== null &&
-          "type" in block &&
-          (block as { type?: unknown }).type === "_user_images" &&
-          "images" in block &&
-          Array.isArray((block as { images?: unknown }).images) &&
-          (block as { images: unknown[] }).images.length > 0,
+        (block) => (block as any).type === "_user_images" && (block as any).images?.length > 0,
       );
       if (hasText || hasImages) promptCount++;
     }
@@ -513,12 +507,12 @@ function buildScanResultFromParsed(
       toolCallCount++;
 
       if (
-        subAgentCount === 0 &&
+        parsedSubAgentCount === 0 &&
         block.name === "Agent" &&
         block.input &&
         typeof block.input.subagent_type === "string"
       ) {
-        subAgentCount++;
+        derivedSubAgentCount++;
       }
 
       if (
@@ -544,11 +538,7 @@ function buildScanResultFromParsed(
 
   const costEstimate = estimateParsedCost(parsed);
   const fallbackStart = parsed.startTime || input.timestamp;
-  const fallbackEnd = parsed.endTime || input.timestamp;
-  const durationMs =
-    input.provider === "cursor"
-      ? parsed.totalDurationMs
-      : parsed.totalDurationMs || deriveDurationFromRange(fallbackStart, fallbackEnd);
+  const durationMs = parsed.totalDurationMs;
 
   return {
     sessionId: input.sessionId,
@@ -573,7 +563,7 @@ function buildScanResultFromParsed(
       .slice(0, 100),
     tokenUsage: parsed.tokenUsage,
     costEstimate,
-    subAgentCount,
+    subAgentCount: parsedSubAgentCount || derivedSubAgentCount,
     apiErrorCount: parsed.apiErrors?.length || 0,
     compactionCount: parsed.compactions?.length || 0,
     entrypoint: parsed.entrypoint,
@@ -588,14 +578,6 @@ function estimateParsedCost(parsed: ProviderParseResult): number | undefined {
   if (parsed.tokenUsageByModel) return estimateCost(parsed.tokenUsageByModel);
   if (parsed.tokenUsage && parsed.model) return estimateCostSimple(parsed.tokenUsage, parsed.model);
   return undefined;
-}
-
-function deriveDurationFromRange(start?: string, end?: string): number | undefined {
-  if (!start || !end) return undefined;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
-  return Math.round(endMs - startMs);
 }
 
 // ─── Cache management ───────────────────────────────────────────────

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -891,6 +891,10 @@ export async function startServer(
           project: s.project,
           slug: s.slug,
           filePaths: s.filePaths,
+          toolPaths: s.toolPaths,
+          workspacePath: s.workspacePath,
+          hasSqlite: s.hasSqlite,
+          timestamp: s.timestamp,
           title: s.title,
           firstPrompt: s.firstPrompt,
         }));

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -23,6 +23,7 @@ export function transformToReplay(
   let userPrompts = 0;
   let toolCalls = 0;
   let thinkingBlocks = 0;
+  const syntheticSubAgentSummary: NonNullable<ReplaySession["meta"]["subAgentSummary"]> = [];
 
   for (const turn of parsed.turns) {
     if (turn.role === "user") {
@@ -96,6 +97,18 @@ export function transformToReplay(
             model: sa.model,
             scenes: (sa.scenes || []).map((s: any) => redactSubAgentScene(s)),
           } satisfies SubAgent;
+        } else if (provider === "cursor" && toolBlock.name === "Agent") {
+          const minimal = buildMinimalCursorSubAgent(toolBlock);
+          if (minimal) {
+            (scene as any).subAgent = minimal;
+            syntheticSubAgentSummary.push({
+              agentId: minimal.agentId,
+              agentType: minimal.agentType,
+              description: minimal.description,
+              toolCalls: minimal.toolCalls,
+              model: minimal.model,
+            });
+          }
         }
         scenes.push(scene);
         toolCalls++;
@@ -116,7 +129,9 @@ export function transformToReplay(
   const durationMs =
     parsed.totalDurationMs && parsed.totalDurationMs > 0
       ? parsed.totalDurationMs
-      : derivedDurationMs;
+      : provider === "cursor" && parsed.dataSource
+        ? undefined
+        : derivedDurationMs;
 
   return {
     meta: {
@@ -148,7 +163,9 @@ export function transformToReplay(
       compactions: parsed.compactions,
       ...(parsed.subAgentSummary && parsed.subAgentSummary.length > 0
         ? { subAgentSummary: parsed.subAgentSummary }
-        : {}),
+        : syntheticSubAgentSummary.length > 0
+          ? { subAgentSummary: syntheticSubAgentSummary }
+          : {}),
       ...(parsed.gitBranch ? { gitBranch: parsed.gitBranch } : {}),
       ...(parsed.gitBranches ? { gitBranches: parsed.gitBranches } : {}),
       ...(parsed.entrypoint ? { entrypoint: parsed.entrypoint } : {}),
@@ -196,6 +213,12 @@ function buildToolScene(
       oldContent: "",
       newContent: truncate(input.content || "", 3000),
     };
+  } else if (toolName === "Delete" && input.file_path) {
+    (scene as any).diff = {
+      filePath: redactPath(input.file_path),
+      oldContent: input.old_string ?? "(file deleted)",
+      newContent: "",
+    };
   } else if (toolName === "Bash" && input.command) {
     (scene as any).bashOutput = {
       command: redactSecrets(redactPath(input.command)),
@@ -236,6 +259,42 @@ function truncate(s: string, max: number): string {
   const redacted = redactSecrets(s);
   if (redacted.length <= max) return redacted;
   return `${redacted.slice(0, max)}\n... (truncated, ${redacted.length} chars total)`;
+}
+
+function buildMinimalCursorSubAgent(toolBlock: any): SubAgent | null {
+  const input = toolBlock?.input;
+  if (!input || typeof input !== "object") return null;
+  const rawAgentType =
+    typeof input.subagent_type === "string" && input.subagent_type.trim()
+      ? input.subagent_type.trim()
+      : undefined;
+  if (!rawAgentType) return null;
+  const agentType = normalizeCursorAgentType(rawAgentType);
+  return {
+    agentId:
+      typeof toolBlock.id === "string" && toolBlock.id.trim()
+        ? toolBlock.id
+        : `cursor-agent-${agentType}`,
+    agentType,
+    ...(typeof input.description === "string" && input.description.trim()
+      ? { description: input.description.trim() }
+      : {}),
+    prompt: typeof input.prompt === "string" ? redactSecrets(redactPath(input.prompt)) : "",
+    toolCalls: 0,
+    thinkingBlocks: 0,
+    textResponses: 0,
+    model: typeof toolBlock.model === "string" ? toolBlock.model : undefined,
+    scenes: [],
+  };
+}
+
+function normalizeCursorAgentType(agentType: string): string {
+  const normalized = agentType.trim().toLowerCase();
+  if (normalized === "explore") return "Explore";
+  if (normalized === "plan") return "Plan";
+  if (normalized === "generalpurpose") return "general-purpose";
+  if (normalized === "shell") return "Shell";
+  return agentType;
 }
 
 // Redact common secret patterns from output

--- a/packages/cli/test/cursor-parser-comprehensive.test.ts
+++ b/packages/cli/test/cursor-parser-comprehensive.test.ts
@@ -405,6 +405,96 @@ describe("Cursor → transform — comprehensive", () => {
     expect(replay.meta.stats.toolCalls).toBe(1);
     expect(replay.meta.stats.sceneCount).toBe(replay.scenes.length);
   });
+
+  it("creates minimal sub-agent metadata for Cursor agent tasks", () => {
+    const replay = transformToReplay(
+      {
+        sessionId: "cursor-agent-session",
+        slug: "cursor-a",
+        cwd: "",
+        turns: [
+          {
+            role: "user",
+            blocks: [{ type: "text", text: "Search the repo for auth code" }],
+          },
+          {
+            role: "assistant",
+            blocks: [
+              {
+                type: "tool_use",
+                id: "task-1",
+                name: "Agent",
+                input: {
+                  subagent_type: "Explore",
+                  description: "Search auth patterns",
+                  prompt: "Search auth patterns in the repo",
+                },
+              } as any,
+            ],
+          },
+        ],
+      },
+      "cursor",
+      "~/test",
+    );
+
+    const agentScene = replay.scenes.find(
+      (scene) => scene.type === "tool-call" && scene.toolName === "Agent",
+    );
+    expect(agentScene).toBeDefined();
+    expect(agentScene?.type === "tool-call" && agentScene.subAgent?.agentType).toBe("Explore");
+    expect(agentScene?.type === "tool-call" && agentScene.subAgent?.description).toBe(
+      "Search auth patterns",
+    );
+    expect(replay.meta.subAgentSummary).toEqual([
+      {
+        agentId: "task-1",
+        agentType: "Explore",
+        description: "Search auth patterns",
+        toolCalls: 0,
+        model: undefined,
+      },
+    ]);
+  });
+
+  it("normalizes lowercase Cursor subagent types for viewer parity", () => {
+    const replay = transformToReplay(
+      {
+        sessionId: "cursor-agent-lowercase",
+        slug: "cursor-l",
+        cwd: "",
+        turns: [
+          {
+            role: "user",
+            blocks: [{ type: "text", text: "Investigate infra state" }],
+          },
+          {
+            role: "assistant",
+            blocks: [
+              {
+                type: "tool_use",
+                id: "task-2",
+                name: "Agent",
+                input: {
+                  subagent_type: "shell",
+                  description: "Run infra diagnostics",
+                  prompt: "Run shell checks",
+                },
+              } as any,
+            ],
+          },
+        ],
+      },
+      "cursor",
+      "~/test",
+    );
+
+    const agentScene = replay.scenes.find(
+      (scene) => scene.type === "tool-call" && scene.toolName === "Agent",
+    );
+    expect(agentScene?.type === "tool-call" && agentScene.subAgent?.agentType).toBe("Shell");
+    expect(replay.meta.subAgentSummary?.[0]?.agentType).toBe("Shell");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/scanner-cursor-duration.test.ts
+++ b/packages/cli/test/scanner-cursor-duration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/providers/cursor/parser.js", () => ({
+  parseCursorSession: vi.fn(),
+}));
+
+import { parseCursorSession } from "../src/providers/cursor/parser.js";
+import { scanSession } from "../src/scanner.js";
+
+const mockedParseCursorSession = vi.mocked(parseCursorSession);
+
+describe("scanSession cursor duration", () => {
+  it("does not fall back to wall-clock start/end duration for Cursor sessions", async () => {
+    mockedParseCursorSession.mockResolvedValueOnce({
+      sessionId: "cursor-session",
+      slug: "cursor-slug",
+      title: "Cursor session",
+      cwd: "/repo",
+      turns: [
+        { role: "user", blocks: [{ type: "text", text: "hello" }] },
+        { role: "assistant", blocks: [{ type: "text", text: "hi" }] },
+      ],
+      startTime: "2025-01-01T00:00:00.000Z",
+      endTime: "2025-01-02T00:00:00.000Z",
+      dataSource: "global-state",
+      dataSourceInfo: {
+        primary: "global-state",
+        sources: ["cursor/user/globalStorage/state.vscdb"],
+        notes: ["Duration is unavailable for this Cursor global-state session."],
+      },
+    });
+
+    const result = await scanSession({
+      sessionId: "cursor-session",
+      provider: "cursor",
+      project: "~/Code/project",
+      slug: "cursor-slug",
+      filePaths: ["/tmp/session.jsonl"],
+      timestamp: "2025-01-01T00:00:00.000Z",
+    });
+
+    expect(result.startTime).toBe("2025-01-01T00:00:00.000Z");
+    expect(result.endTime).toBe("2025-01-02T00:00:00.000Z");
+    expect(result.durationMs).toBeUndefined();
+  });
+});

--- a/packages/cli/test/scanner-cursor-duration.test.ts
+++ b/packages/cli/test/scanner-cursor-duration.test.ts
@@ -43,4 +43,43 @@ describe("scanSession cursor duration", () => {
     expect(result.endTime).toBe("2025-01-02T00:00:00.000Z");
     expect(result.durationMs).toBeUndefined();
   });
+
+  it("does not double-count subagents when parser summary already exists", async () => {
+    mockedParseCursorSession.mockResolvedValueOnce({
+      sessionId: "cursor-session",
+      slug: "cursor-slug",
+      title: "Cursor session",
+      cwd: "/repo",
+      turns: [
+        { role: "user", blocks: [{ type: "text", text: "delegate" }] },
+        {
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool_use",
+              name: "Agent",
+              input: { subagent_type: "explore" },
+            },
+          ],
+        },
+      ],
+      subAgentSummary: [{ agentId: "agent-1", agentType: "Explore", toolCalls: 0 }],
+      dataSource: "global-state",
+      dataSourceInfo: {
+        primary: "global-state",
+        sources: ["cursor/user/globalStorage/state.vscdb"],
+      },
+    });
+
+    const result = await scanSession({
+      sessionId: "cursor-session",
+      provider: "cursor",
+      project: "~/Code/project",
+      slug: "cursor-slug",
+      filePaths: ["/tmp/session.jsonl"],
+      timestamp: "2025-01-01T00:00:00.000Z",
+    });
+
+    expect(result.subAgentCount).toBe(1);
+  });
 });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -17,6 +17,9 @@ function makeLine(obj: Record<string, any>): string {
 
 let tmpDir: string;
 let fixturePath: string;
+const CURSOR_FIXTURE = join(import.meta.dirname, "fixtures/cursor-session.jsonl");
+const CURSOR_TOOL_FIXTURE_1 = join(import.meta.dirname, "fixtures/cursor-tool-1.txt");
+const CURSOR_TOOL_FIXTURE_2 = join(import.meta.dirname, "fixtures/cursor-tool-2.txt");
 
 beforeAll(async () => {
   tmpDir = join(tmpdir(), `scanner-test-${Date.now()}`);
@@ -274,6 +277,66 @@ describe("scanSession", () => {
     expect(result.entrypoint).toBe("cli");
     expect(result.permissionMode).toBe("default");
   });
+
+  it("counts Delete tool calls as modified files", async () => {
+    const deleteFixturePath = join(tmpDir, "delete-session.jsonl");
+    await writeFile(
+      deleteFixturePath,
+      [
+        makeLine({
+          type: "assistant",
+          timestamp: "2025-03-20T10:00:05Z",
+          message: {
+            role: "assistant",
+            id: "msg-a-delete",
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-delete",
+                name: "Delete",
+                input: {
+                  file_path: "/Users/test/Code/my-project/src/obsolete.ts",
+                },
+              },
+            ],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "delete-session-1",
+      provider: "claude-code",
+      project: "~/Code/my-project",
+      slug: "delete-session",
+      filePaths: [deleteFixturePath],
+    });
+
+    expect(result.toolCallCount).toBe(1);
+    expect(result.editCount).toBe(1);
+    expect(result.filesModified).toContainEqual({
+      file: "/Users/test/Code/my-project/src/obsolete.ts",
+      count: 1,
+    });
+  });
+
+  it("uses the Cursor parser so tool-backed sessions contribute to stats", async () => {
+    const result = await scanSession({
+      sessionId: "cursor-session",
+      provider: "cursor",
+      project: "~/test/project",
+      slug: "cursor-s",
+      filePaths: [CURSOR_FIXTURE],
+      toolPaths: [CURSOR_TOOL_FIXTURE_1, CURSOR_TOOL_FIXTURE_2],
+      timestamp: "2026-03-20T10:00:00.000Z",
+    });
+
+    expect(result.promptCount).toBe(3);
+    expect(result.toolCallCount).toBe(2);
+    expect(result.startTime).toBe("2026-03-20T10:00:00.000Z");
+    expect(result.filesModified).toEqual([]);
+  });
 });
 
 // ─── Aggregation tests ──────────────────────────────────────────────
@@ -449,5 +512,53 @@ describe("aggregateUserInsights", () => {
     const insights = aggregateUserInsights(scans);
 
     expect(insights.avgSessionDurationMs).toBe(45000); // (60000 + 30000) / 2
+  });
+
+  it("marks Cursor aggregates as partial when metrics are missing or estimated", () => {
+    const insights = aggregateUserInsights([
+      {
+        sessionId: "cursor-1",
+        provider: "cursor",
+        project: "~/Code/proj-cursor",
+        slug: "cursor-1",
+        startTime: "2025-03-19T10:00:00Z",
+        durationMs: 30000,
+        promptCount: 5,
+        toolCallCount: 10,
+        editCount: 1,
+        filesModified: [],
+        subAgentCount: 0,
+        apiErrorCount: 0,
+        compactionCount: 0,
+        dataQualityNotes: ["Duration is estimated from session start/end timestamps."],
+      },
+      {
+        sessionId: "cursor-2",
+        provider: "cursor",
+        project: "~/Code/proj-cursor",
+        slug: "cursor-2",
+        startTime: "2025-03-20T10:00:00Z",
+        promptCount: 2,
+        toolCallCount: 3,
+        editCount: 0,
+        filesModified: [],
+        subAgentCount: 0,
+        apiErrorCount: 0,
+        compactionCount: 0,
+      },
+    ]);
+
+    expect(insights.dataQuality?.notes).toContain(
+      "1/2 Cursor sessions use best-effort duration estimates.",
+    );
+    expect(insights.dataQuality?.notes).toContain(
+      "1/2 Cursor sessions do not have enough timing data to compute duration.",
+    );
+    expect(insights.dataQuality?.notes).toContain(
+      "2/2 Cursor sessions do not include token snapshots, so token and cost totals are partial.",
+    );
+    expect(insights.dataQuality?.notes).toContain(
+      "2/2 Cursor sessions do not include per-turn stats.",
+    );
   });
 });

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -221,6 +221,29 @@ describe("transform — tool scene enrichment", () => {
     expect(scene.type === "tool-call" && scene.diff?.newContent).toBe("export const foo = 1;");
   });
 
+  it("enriches Delete tool with a removal diff", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [
+          assistantToolTurn(
+            "Delete",
+            {
+              file_path: "/tmp/test/old.ts",
+            },
+            "File deleted.",
+          ),
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+    const scene = replay.scenes[0];
+    expect(scene.type).toBe("tool-call");
+    expect(scene.type === "tool-call" && scene.diff?.filePath).toBe("/tmp/test/old.ts");
+    expect(scene.type === "tool-call" && scene.diff?.oldContent).toBe("(file deleted)");
+    expect(scene.type === "tool-call" && scene.diff?.newContent).toBe("");
+  });
+
   it("enriches Bash tool with command + stdout", () => {
     const replay = transformToReplay(
       buildParsed({
@@ -519,6 +542,19 @@ describe("transform — metadata", () => {
       "~/project",
     );
     expect(replay.meta.stats.durationMs).toBe(150000);
+  });
+
+  it("does not derive wall-clock duration for parsed Cursor sessions when provider duration is missing", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        dataSource: "global-state",
+        startTime: "2025-01-01T00:00:00.000Z",
+        endTime: "2025-01-02T00:00:00.000Z",
+      }),
+      "cursor",
+      "~/project",
+    );
+    expect(replay.meta.stats.durationMs).toBeUndefined();
   });
 
   it("prefers provider-reported duration over timestamp-derived fallback", () => {

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -79,6 +79,7 @@ export default memo(function CodeDiffBlock({
   const language = guessLanguage(filePath);
   const isDark = useSyncExternalStore(subscribe, getIsDark);
   const isNewFile = !oldContent;
+  const isDeletedFile = toolName === "Delete" && !newContent;
 
   return (
     <div className="bg-terminal-surface rounded-xl overflow-hidden shadow-layer-sm">
@@ -88,6 +89,11 @@ export default memo(function CodeDiffBlock({
         {isNewFile && (
           <span className="text-xs px-1.5 py-0.5 rounded bg-terminal-green/20 text-terminal-green">
             new
+          </span>
+        )}
+        {isDeletedFile && (
+          <span className="text-xs px-1.5 py-0.5 rounded bg-terminal-red/20 text-terminal-red">
+            deleted
           </span>
         )}
       </div>

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -406,6 +406,32 @@ function MetricCardSkeleton() {
   );
 }
 
+function RecentProjectsSkeleton() {
+  return (
+    <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm animate-pulse">
+      <div className="flex items-center justify-between mb-3">
+        <div className="h-3 w-28 skeleton rounded" />
+        <div className="h-3 w-14 skeleton rounded opacity-40" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+        {Array.from({ length: 5 }, (_, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg bg-terminal-bg"
+          >
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="h-3.5 w-24 max-w-[70%] skeleton rounded" />
+              <div className="h-3 w-36 max-w-full skeleton rounded opacity-40" />
+            </div>
+            <div className="h-3 w-10 shrink-0 skeleton rounded opacity-30" />
+          </div>
+        ))}
+      </div>
+      <div className="h-9 mt-2 rounded-lg bg-terminal-surface-2 skeleton opacity-20" />
+    </div>
+  );
+}
+
 function ActivityChart({ data }: { data: InsightStats["activityByDay"] }) {
   const maxVal = Math.max(...data.map((d) => d.claude + d.cursor), 1);
   const hasActivity = data.some((d) => d.claude > 0 || d.cursor > 0);
@@ -914,6 +940,8 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const { scanStatus, userInsights } = useScanInsightsContext();
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateErrorSlug, setGenerateErrorSlug] = useState<string | null>(null);
+  const showRecentProjectsSkeleton =
+    !userInsights && (loadingSources || Boolean(scanStatus?.running) || sources.length > 0);
 
   const handleOpenReplay = (slug: string) => {
     navigateTo({ view: null, session: slug });
@@ -1079,7 +1107,9 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
         </div>
 
         {/* Recent Projects (from scan data — top 5 by lastActivity) */}
-        {userInsights && userInsights.topProjects.length > 1 && (
+        {showRecentProjectsSkeleton ? (
+          <RecentProjectsSkeleton />
+        ) : userInsights && userInsights.topProjects.length > 1 ? (
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
@@ -1133,7 +1163,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
               </button>
             )}
           </div>
-        )}
+        ) : null}
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import type { ReplaySession } from "../types";
 
 export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[] {
@@ -36,21 +37,49 @@ export function DataQualityIndicator({
   title: string;
   className?: string;
 }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement | null>(null);
   const lines = title
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
+  const isVisible = open;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleEscape);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [open]);
 
   return (
-    <span className={`group relative inline-flex ${className}`}>
+    <span ref={rootRef} className={`group relative inline-flex ${className}`}>
       <button
         type="button"
+        aria-expanded={open}
         className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-terminal-orange/40 bg-terminal-orange/10 px-1 text-[10px] font-sans font-bold leading-none text-terminal-orange transition-colors hover:border-terminal-orange/70 hover:bg-terminal-orange/15 focus:outline-none focus:ring-2 focus:ring-terminal-orange/30"
         title={title}
+        onClick={() => setOpen((value) => !value)}
       >
         !
       </button>
-      <div className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 w-72 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-lg border border-terminal-orange/30 bg-terminal-bg/95 px-3 py-2 text-left opacity-0 shadow-layer-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+      <div
+        className={`pointer-events-none absolute left-1/2 top-full z-30 mt-2 w-72 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-xl border border-terminal-border-subtle bg-terminal-surface-2 px-3 py-2.5 text-left shadow-layer-xl transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 ${isVisible ? "opacity-100" : "opacity-0"}`}
+      >
         <div className="mb-1 text-[10px] font-sans font-semibold uppercase tracking-widest text-terminal-orange">
           Data Quality
         </div>

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -1,0 +1,67 @@
+import type { ReplaySession } from "../types";
+
+export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[] {
+  const notes = [...(meta.dataSourceInfo?.notes || [])];
+
+  if (
+    meta.provider === "cursor" &&
+    (meta.dataSource === "sqlite" || meta.dataSource === "global-state")
+  ) {
+    notes.unshift("Some Cursor metrics are best-effort estimates and may be incomplete.");
+  }
+  if (!meta.stats.tokenUsage) {
+    notes.push("Token and cost metrics may be unavailable.");
+  }
+
+  return [...new Set(notes)];
+}
+
+export function getSessionMetricQuality(meta: ReplaySession["meta"]): {
+  duration?: string;
+  tokens?: string;
+  turnStats?: string;
+} {
+  const notes = getSessionDataQualityNotes(meta);
+  return {
+    duration: notes.find((note) => /duration/i.test(note)),
+    tokens: notes.find((note) => /token|cost|model attribution/i.test(note)),
+    turnStats: notes.find((note) => /per-turn|turn stats|turn metrics/i.test(note)),
+  };
+}
+
+export function DataQualityIndicator({
+  title,
+  className = "",
+}: {
+  title: string;
+  className?: string;
+}) {
+  const lines = title
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return (
+    <span className={`group relative inline-flex ${className}`}>
+      <button
+        type="button"
+        className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-terminal-orange/40 bg-terminal-orange/10 px-1 text-[10px] font-sans font-bold leading-none text-terminal-orange transition-colors hover:border-terminal-orange/70 hover:bg-terminal-orange/15 focus:outline-none focus:ring-2 focus:ring-terminal-orange/30"
+        title={title}
+      >
+        !
+      </button>
+      <div className="pointer-events-none absolute left-1/2 top-full z-30 mt-2 w-72 max-w-[calc(100vw-2rem)] -translate-x-1/2 rounded-lg border border-terminal-orange/30 bg-terminal-bg/95 px-3 py-2 text-left opacity-0 shadow-layer-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        <div className="mb-1 text-[10px] font-sans font-semibold uppercase tracking-widest text-terminal-orange">
+          Data Quality
+        </div>
+        <div className="space-y-1">
+          {lines.map((line) => (
+            <div key={line} className="text-[11px] font-mono leading-relaxed text-terminal-dim">
+              {line}
+            </div>
+          ))}
+        </div>
+      </div>
+    </span>
+  );
+}

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -17,6 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { DataQualityIndicator } from "./DataQualityIndicator";
 import { formatDuration } from "./StatsPanel";
 
 // ─── Types (mirror the server scanner types) ────────────────────────
@@ -62,6 +63,9 @@ interface ProjectInsights {
   sessionsPerDay: Record<string, number>;
   avgSessionDurationMs: number;
   memory?: ProjectMemory;
+  dataQuality?: {
+    notes: string[];
+  };
 }
 
 interface UserInsights {
@@ -93,6 +97,9 @@ interface UserInsights {
   subAgentTotal: number;
   apiErrorTotal: number;
   avgSessionDurationMs: number;
+  dataQuality?: {
+    notes: string[];
+  };
 }
 
 interface ScanStatus {
@@ -464,7 +471,7 @@ export function ProjectInsightsPanel({ insights }: { insights: ProjectInsights }
           {insights.hotFiles.length > 0 && (
             <div>
               <div className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold mb-2">
-                Most edited files
+                Most modified files
               </div>
               <div className="space-y-1 max-h-32 overflow-y-auto">
                 {insights.hotFiles.slice(0, 10).map((f) => (
@@ -745,6 +752,7 @@ export function TitleInsightsHeader({
   const totalToolCalls = pi?.totalToolCalls ?? ui?.totalToolCalls ?? 0;
   const avgSessionDurationMs = pi?.avgSessionDurationMs ?? ui?.avgSessionDurationMs ?? 0;
   const sessionsPerDay = pi?.sessionsPerDay ?? ui?.sessionsPerDay ?? {};
+  const dataQualityNotes = pi?.dataQuality?.notes ?? ui?.dataQuality?.notes ?? [];
 
   const title = pi ? pi.project.split("/").pop() || pi.project : "All Projects";
   const subtitle = pi ? pi.project : `${ui?.totalProjects ?? 0} projects`;
@@ -758,6 +766,9 @@ export function TitleInsightsHeader({
         <div className="flex items-baseline gap-2 min-w-0">
           <span className={`w-1.5 h-1.5 rounded-full ${accentDot} shrink-0 self-center`} />
           <h2 className="text-base font-sans font-semibold text-terminal-text truncate">{title}</h2>
+          {dataQualityNotes.length > 0 && (
+            <DataQualityIndicator title={dataQualityNotes.join("\n")} className="shrink-0" />
+          )}
           <span className="text-[10px] font-mono text-terminal-dimmer truncate hidden sm:inline">
             {subtitle}
           </span>
@@ -869,7 +880,7 @@ export function TitleInsightsHeader({
           {pi.hotFiles.length > 0 && (
             <div>
               <div className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold mb-1.5">
-                Most edited files
+                Most modified files
               </div>
               <div className="space-y-0.5 max-h-28 overflow-y-auto">
                 {pi.hotFiles.slice(0, 10).map((f) => (

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from "react";
 import type { ReplaySession } from "../types";
+import {
+  DataQualityIndicator,
+  getSessionDataQualityNotes,
+  getSessionMetricQuality,
+} from "./DataQualityIndicator";
 
 interface Props {
   session: ReplaySession;
@@ -66,6 +71,8 @@ export default function StatsPanel({ session }: Props) {
   }, [session]);
 
   const { meta } = session;
+  const dataQualityNotes = useMemo(() => getSessionDataQualityNotes(meta), [meta]);
+  const metricQuality = useMemo(() => getSessionMetricQuality(meta), [meta]);
 
   return (
     <div className="p-4 space-y-6 text-xs font-mono">
@@ -85,6 +92,9 @@ export default function StatsPanel({ session }: Props) {
         <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap">
           {meta.model && <span className="text-terminal-dim">{meta.model}</span>}
           {meta.provider && <span>{meta.provider}</span>}
+          {dataQualityNotes.length > 0 && (
+            <DataQualityIndicator title={dataQualityNotes.join("\n")} />
+          )}
         </div>
         {meta.gitBranch && (
           <div className="text-terminal-dim mt-0.5">
@@ -137,12 +147,21 @@ export default function StatsPanel({ session }: Props) {
         <StatCard label="Files Modified" value={stats.filesModified} color="text-terminal-blue" />
       </div>
 
-      {(stats.durationMs || stats.costEstimate !== undefined) && (
+      {(stats.durationMs ||
+        stats.costEstimate !== undefined ||
+        metricQuality.duration ||
+        metricQuality.tokens ||
+        metricQuality.turnStats) && (
         <div className="text-terminal-dim space-y-0.5">
-          {stats.durationMs && (
+          {(stats.durationMs || metricQuality.duration) && (
             <div>
               Duration:{" "}
-              <span className="text-terminal-text">{formatDuration(stats.durationMs)}</span>
+              <span className="text-terminal-text">
+                {stats.durationMs ? formatDuration(stats.durationMs) : "unavailable"}
+              </span>
+              {metricQuality.duration && (
+                <DataQualityIndicator title={metricQuality.duration} className="ml-1" />
+              )}
             </div>
           )}
           {stats.costEstimate !== undefined && (
@@ -155,6 +174,21 @@ export default function StatsPanel({ session }: Props) {
                   : stats.costEstimate.toFixed(2)}
               </span>
               <span className="text-terminal-dimmer"> (estimate)</span>
+              {metricQuality.tokens && (
+                <DataQualityIndicator title={metricQuality.tokens} className="ml-1" />
+              )}
+            </div>
+          )}
+          {!stats.tokenUsage && metricQuality.tokens && (
+            <div>
+              Tokens: <span className="text-terminal-text">unavailable</span>
+              <DataQualityIndicator title={metricQuality.tokens} className="ml-1" />
+            </div>
+          )}
+          {!meta.stats.turnStats?.length && metricQuality.turnStats && (
+            <div>
+              Turn Stats: <span className="text-terminal-text">limited</span>
+              <DataQualityIndicator title={metricQuality.turnStats} className="ml-1" />
             </div>
           )}
         </div>
@@ -162,8 +196,9 @@ export default function StatsPanel({ session }: Props) {
 
       {stats.tokenUsage && (
         <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
+          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest flex items-center gap-1.5">
             Tokens
+            {metricQuality.tokens && <DataQualityIndicator title={metricQuality.tokens} />}
           </div>
           <div className="text-terminal-dim leading-relaxed space-y-0.5">
             <div>

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import type { ReplaySession, TurnStat } from "../types";
+import {
+  DataQualityIndicator,
+  getSessionDataQualityNotes,
+  getSessionMetricQuality,
+} from "./DataQualityIndicator";
 import { fmtNum, formatDuration, StatCard } from "./StatsPanel";
 
 interface Props {
@@ -58,27 +63,12 @@ function useChartHover(turnCount: number) {
   return { hovered, ref, onMouseMove, onMouseLeave };
 }
 
-function getDataQualityNotes(meta: ReplaySession["meta"]): string[] {
-  const notes = [...(meta.dataSourceInfo?.notes || [])];
-
-  if (
-    meta.provider === "cursor" &&
-    (meta.dataSource === "sqlite" || meta.dataSource === "global-state")
-  ) {
-    notes.unshift("Some Cursor metrics are estimates and may be incomplete for this session.");
-  }
-  if (!meta.stats.tokenUsage) {
-    notes.push("Token and cost metrics may be unavailable.");
-  }
-
-  return [...new Set(notes)];
-}
-
 // --- Main component ---
 
 export default function SummaryView({ session }: Props) {
   const { meta, scenes } = session;
-  const dataQualityNotes = useMemo(() => getDataQualityNotes(meta), [meta]);
+  const dataQualityNotes = useMemo(() => getSessionDataQualityNotes(meta), [meta]);
+  const metricQuality = useMemo(() => getSessionMetricQuality(meta), [meta]);
   // File table merges edited + read-only into one component
 
   const stats = useMemo(() => {
@@ -287,6 +277,9 @@ export default function SummaryView({ session }: Props) {
               {meta.provider}
             </span>
           )}
+          {dataQualityNotes.length > 0 && (
+            <DataQualityIndicator title={dataQualityNotes.join("\n")} className="shrink-0" />
+          )}
           {meta.gitBranch && (
             <span
               className="shrink-0 text-[10px] font-mono text-terminal-purple px-1.5 py-0.5 rounded bg-terminal-purple/10 border border-terminal-purple/20"
@@ -359,10 +352,15 @@ export default function SummaryView({ session }: Props) {
                 Model: <span className="text-terminal-text font-semibold">{meta.model}</span>
               </div>
             )}
-            {stats.durationMs && (
+            {(stats.durationMs || metricQuality.duration) && (
               <div>
                 Duration:{" "}
-                <span className="text-terminal-text">{formatDuration(stats.durationMs)}</span>
+                <span className="text-terminal-text">
+                  {stats.durationMs ? formatDuration(stats.durationMs) : "unavailable"}
+                </span>
+                {metricQuality.duration && (
+                  <DataQualityIndicator title={metricQuality.duration} className="ml-1" />
+                )}
               </div>
             )}
             {stats.costEstimate !== undefined && (
@@ -375,9 +373,12 @@ export default function SummaryView({ session }: Props) {
                     : stats.costEstimate.toFixed(2)}
                 </span>
                 <span className="text-terminal-dimmer"> (est.)</span>
+                {metricQuality.tokens && (
+                  <DataQualityIndicator title={metricQuality.tokens} className="ml-1" />
+                )}
               </div>
             )}
-            {stats.tokenUsage && (
+            {stats.tokenUsage ? (
               <>
                 <div>
                   In:{" "}
@@ -399,6 +400,19 @@ export default function SummaryView({ session }: Props) {
                   created
                 </div>
               </>
+            ) : (
+              metricQuality.tokens && (
+                <div>
+                  Tokens: <span className="text-terminal-text">unavailable</span>
+                  <DataQualityIndicator title={metricQuality.tokens} className="ml-1" />
+                </div>
+              )
+            )}
+            {!hasTurnStats && metricQuality.turnStats && (
+              <div>
+                Turn Stats: <span className="text-terminal-text">limited</span>
+                <DataQualityIndicator title={metricQuality.turnStats} className="ml-1" />
+              </div>
             )}
           </div>
         </div>
@@ -634,6 +648,7 @@ export default function SummaryView({ session }: Props) {
 const AGENT_TYPE_COLORS: Record<string, string> = {
   Explore: "bg-blue-500/20 text-blue-300 border-blue-500/30",
   Plan: "bg-purple-500/20 text-purple-300 border-purple-500/30",
+  Shell: "bg-cyan-500/20 text-cyan-300 border-cyan-500/30",
   "general-purpose": "bg-green-500/20 text-green-300 border-green-500/30",
   "claude-code-guide": "bg-amber-500/20 text-amber-300 border-amber-500/30",
 };

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -34,6 +34,8 @@ function toolIcon(name: string): string {
       return "\u270F\uFE0F";
     case "Edit":
       return "\u2702\uFE0F";
+    case "Delete":
+      return "\uD83D\uDDD1\uFE0F";
     case "Bash":
       return "$";
     case "Glob":
@@ -50,6 +52,7 @@ function toolIcon(name: string): string {
 const AGENT_TYPE_COLORS: Record<string, string> = {
   Explore: "bg-blue-500/20 text-blue-300 border-blue-500/30",
   Plan: "bg-purple-500/20 text-purple-300 border-purple-500/30",
+  Shell: "bg-cyan-500/20 text-cyan-300 border-cyan-500/30",
   "general-purpose": "bg-green-500/20 text-green-300 border-green-500/30",
   "claude-code-guide": "bg-amber-500/20 text-amber-300 border-amber-500/30",
 };


### PR DESCRIPTION
## Summary
- improve Cursor best-effort stats by surfacing data-quality warnings in dashboard and session views, including visible tooltips and loading skeletons for the Recent Projects panel
- normalize more Cursor edit/delete activity into modified-file attribution so hot files and session stats better reflect real edits
- stop using wall-clock session ranges as a Cursor duration fallback so idle overnight or multi-day gaps no longer inflate duration totals

## Test plan
- [x] `pnpm exec vitest run packages/cli/test/scanner-cursor-duration.test.ts packages/cli/test/transform-comprehensive.test.ts packages/cli/test/scanner.test.ts packages/cli/test/cursor-parser-comprehensive.test.ts packages/cli/src/providers/cursor/sqlite-reader.test.ts`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [x] manual browser verification of Cursor data-quality indicators and session warnings

Made with [Cursor](https://cursor.com)