### PR TITLE
fix: estimate active duration instead of wall-clock time

### DIFF
--- a/packages/cli/src/duration.ts
+++ b/packages/cli/src/duration.ts
@@ -4,7 +4,7 @@
  * When `turn_duration` events are missing (e.g. VS Code extension sessions),
  * we approximate active time by summing gaps between consecutive timestamps,
  * capping each gap at `maxGapMs`.  Gaps larger than the threshold represent
- * idle time (lunch, sleep, context-switch) and are clamped.
+ * idle time (lunch, sleep, context-switch) and are capped to `maxGapMs`.
  */
 
 const DEFAULT_MAX_GAP_MS = 5 * 60 * 1000; // 5 minutes

--- a/packages/cli/src/duration.ts
+++ b/packages/cli/src/duration.ts
@@ -1,0 +1,32 @@
+/**
+ * Estimate active session duration from message timestamps.
+ *
+ * When `turn_duration` events are missing (e.g. VS Code extension sessions),
+ * we approximate active time by summing gaps between consecutive timestamps,
+ * capping each gap at `maxGapMs`.  Gaps larger than the threshold represent
+ * idle time (lunch, sleep, context-switch) and are clamped.
+ */
+
+const DEFAULT_MAX_GAP_MS = 5 * 60 * 1000; // 5 minutes
+
+export function estimateActiveDuration(
+  timestamps: string[],
+  maxGapMs = DEFAULT_MAX_GAP_MS,
+): number | undefined {
+  if (timestamps.length < 2) return undefined;
+
+  const sorted = timestamps
+    .map((t) => Date.parse(t))
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+
+  if (sorted.length < 2) return undefined;
+
+  let active = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = sorted[i] - sorted[i - 1];
+    active += Math.min(gap, maxGapMs);
+  }
+
+  return active > 0 ? active : undefined;
+}

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -86,7 +86,7 @@ export async function parseClaudeCodeSession(
   // User prompts in order
   const userTurns: ParsedTurn[] = [];
 
-  // All message timestamps — used to estimate active duration when turn_duration events are missing
+  // All JSONL entry timestamps — used to estimate active duration when turn_duration events are missing
   const allTimestamps: string[] = [];
 
   for (const line of lines) {
@@ -569,9 +569,9 @@ function buildTurnStats(
       durationMs = sortedDurations[durationIdx].durationMs;
       durationIdx++;
     } else if (group.startTimestamp && group.endTimestamp) {
-      // Fallback: derive from timestamp range (for last turn without turn_duration event)
-      const diff = Date.parse(group.endTimestamp) - Date.parse(group.startTimestamp);
-      if (diff > 0) durationMs = diff;
+      // Fallback: estimate active duration from turn timestamps (avoids wall-clock inflation
+      // for VS Code sessions where turn_duration events are absent)
+      durationMs = estimateActiveDuration([group.startTimestamp, group.endTimestamp]);
     }
 
     const stat: TurnStat = { turnIndex: i };

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -2,6 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrLink, TurnStat } from "@vibe-replay/types";
 import { isSystemGeneratedMessage } from "../../clean-prompt.js";
+import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, RawMessage } from "../../types.js";
 import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
 
@@ -85,6 +86,9 @@ export async function parseClaudeCodeSession(
   // User prompts in order
   const userTurns: ParsedTurn[] = [];
 
+  // All message timestamps — used to estimate active duration when turn_duration events are missing
+  const allTimestamps: string[] = [];
+
   for (const line of lines) {
     let obj: RawMessage;
     try {
@@ -92,6 +96,9 @@ export async function parseClaudeCodeSession(
     } catch {
       continue;
     }
+
+    // Collect timestamps for active-duration estimation
+    if (obj.timestamp) allTimestamps.push(obj.timestamp);
 
     // Extract metadata
     if (!sessionId && obj.sessionId) sessionId = obj.sessionId;
@@ -416,7 +423,7 @@ export async function parseClaudeCodeSession(
     model,
     startTime,
     endTime,
-    totalDurationMs: totalDurationMs || undefined,
+    totalDurationMs: totalDurationMs || estimateActiveDuration(allTimestamps),
     turns: finalTurns,
     tokenUsage,
     tokenUsageByModel,

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -13,13 +13,14 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileCache, writeFileCache } from "./cache.js";
+import { estimateActiveDuration } from "./duration.js";
 import { estimateCost, estimateCostSimple } from "./pricing.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
-const SCANNER_VERSION = 3;
+const SCANNER_VERSION = 4;
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -209,6 +210,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
   let compactionCount = 0;
   let apiErrorCount = 0;
   let totalDurationMs = 0;
+  const allTimestamps: string[] = [];
 
   // Token usage tracking (deduplicate by message ID)
   const usageByMsgId = new Map<
@@ -255,6 +257,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
 
       // Timestamps
       if (obj.timestamp) {
+        allTimestamps.push(obj.timestamp);
         if (!startTime || obj.timestamp < startTime) startTime = obj.timestamp;
         if (!endTime || obj.timestamp > endTime) endTime = obj.timestamp;
       }
@@ -412,11 +415,10 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     costEstimate = estimateCostSimple(tokenUsage, model);
   }
 
-  // Derive duration from turn_duration events or timestamp range
+  // Derive duration: prefer turn_duration sum (CLI), fall back to active-duration estimate (VS Code)
   let durationMs = totalDurationMs || undefined;
-  if (!durationMs && startTime && endTime) {
-    const diff = Date.parse(endTime) - Date.parse(startTime);
-    if (diff > 0) durationMs = diff;
+  if (!durationMs) {
+    durationMs = estimateActiveDuration(allTimestamps);
   }
 
   const gitBranch = gitBranches.length > 0 ? gitBranches[gitBranches.length - 1] : undefined;

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -125,13 +125,10 @@ export function transformToReplay(
     costEstimate = estimateCostSimple(parsed.tokenUsage, parsed.model || "");
   }
 
-  const derivedDurationMs = deriveDurationFromRange(parsed.startTime, parsed.endTime);
+  // Duration: parser now provides totalDurationMs from turn_duration events
+  // or active-duration estimation — no wall-clock fallback needed.
   const durationMs =
-    parsed.totalDurationMs && parsed.totalDurationMs > 0
-      ? parsed.totalDurationMs
-      : provider === "cursor" && parsed.dataSource
-        ? undefined
-        : derivedDurationMs;
+    parsed.totalDurationMs && parsed.totalDurationMs > 0 ? parsed.totalDurationMs : undefined;
 
   return {
     meta: {
@@ -177,14 +174,6 @@ export function transformToReplay(
     },
     scenes,
   };
-}
-
-function deriveDurationFromRange(start?: string, end?: string): number | undefined {
-  if (!start || !end) return undefined;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
-  return Math.round(endMs - startMs);
 }
 
 function buildToolScene(

--- a/packages/cli/test/duration.test.ts
+++ b/packages/cli/test/duration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { estimateActiveDuration } from "../src/duration.js";
+
+describe("estimateActiveDuration", () => {
+  it("returns undefined for empty array", () => {
+    expect(estimateActiveDuration([])).toBeUndefined();
+  });
+
+  it("returns undefined for single timestamp", () => {
+    expect(estimateActiveDuration(["2026-03-25T10:00:00Z"])).toBeUndefined();
+  });
+
+  it("sums gaps within the 5-minute threshold", () => {
+    const timestamps = [
+      "2026-03-25T10:00:00Z",
+      "2026-03-25T10:01:00Z", // +1m
+      "2026-03-25T10:03:00Z", // +2m
+      "2026-03-25T10:04:30Z", // +1.5m
+    ];
+    // Total: 4.5 minutes = 270_000 ms
+    expect(estimateActiveDuration(timestamps)).toBe(270_000);
+  });
+
+  it("caps gaps at maxGapMs (idle time excluded)", () => {
+    const timestamps = [
+      "2026-03-25T10:00:00Z",
+      "2026-03-25T10:02:00Z", // +2m (active)
+      "2026-03-25T18:00:00Z", // +8h (idle — capped at 5m)
+      "2026-03-25T18:01:00Z", // +1m (active)
+    ];
+    // 2m + 5m (capped) + 1m = 8m = 480_000 ms
+    expect(estimateActiveDuration(timestamps)).toBe(480_000);
+  });
+
+  it("handles out-of-order timestamps", () => {
+    const timestamps = ["2026-03-25T10:03:00Z", "2026-03-25T10:00:00Z", "2026-03-25T10:01:00Z"];
+    // Sorted: 10:00, 10:01, 10:03 → 1m + 2m = 3m = 180_000 ms
+    expect(estimateActiveDuration(timestamps)).toBe(180_000);
+  });
+
+  it("respects custom maxGapMs", () => {
+    const timestamps = [
+      "2026-03-25T10:00:00Z",
+      "2026-03-25T10:10:00Z", // +10m
+    ];
+    // Default max gap (5m): capped → 300_000
+    expect(estimateActiveDuration(timestamps)).toBe(300_000);
+    // Custom max gap (15m): not capped → 600_000
+    expect(estimateActiveDuration(timestamps, 15 * 60 * 1000)).toBe(600_000);
+  });
+
+  it("skips invalid timestamps", () => {
+    const timestamps = ["2026-03-25T10:00:00Z", "invalid", "2026-03-25T10:02:00Z"];
+    expect(estimateActiveDuration(timestamps)).toBe(120_000);
+  });
+
+  it("returns a realistic estimate for a multi-day session", () => {
+    // Simulates a session spanning 3 days but with only ~30 min of actual work
+    const timestamps = [
+      "2026-03-24T14:00:00Z", // Day 1
+      "2026-03-24T14:05:00Z",
+      "2026-03-24T14:08:00Z",
+      "2026-03-24T14:10:00Z",
+      // 16h gap (overnight)
+      "2026-03-25T06:00:00Z", // Day 2
+      "2026-03-25T06:03:00Z",
+      "2026-03-25T06:07:00Z",
+      // 12h gap
+      "2026-03-25T18:00:00Z", // Day 2 evening
+      "2026-03-25T18:02:00Z",
+      "2026-03-25T18:04:00Z",
+    ];
+    const result = estimateActiveDuration(timestamps)!;
+    // Active time: (5+3+2) + 5(cap) + (3+4) + 5(cap) + (2+2) = 31 min
+    expect(result).toBe(31 * 60 * 1000);
+    // NOT 52 hours of wall clock time
+    expect(result).toBeLessThan(60 * 60 * 1000); // under 1 hour
+  });
+});

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -532,7 +532,7 @@ describe("transform — metadata", () => {
     expect(replay.meta.generator).toEqual(gen);
   });
 
-  it("falls back to start/end timestamps for duration when provider duration is missing", () => {
+  it("returns undefined duration when provider duration is missing (no wall-clock fallback)", () => {
     const replay = transformToReplay(
       buildParsed({
         startTime: "2025-01-01T00:00:00.000Z",
@@ -541,7 +541,8 @@ describe("transform — metadata", () => {
       "cursor",
       "~/project",
     );
-    expect(replay.meta.stats.durationMs).toBe(150000);
+    // Wall-clock fallback removed — duration comes from turn_duration or active estimation only
+    expect(replay.meta.stats.durationMs).toBeUndefined();
   });
 
   it("does not derive wall-clock duration for parsed Cursor sessions when provider duration is missing", () => {


### PR DESCRIPTION
## Summary

- VS Code Claude Code extension doesn't write `turn_duration` events to JSONL files, causing duration to fall back to wall-clock time (`endTime - startTime`). A session spanning 3 days showed 78 hours instead of actual ~30 minutes of work.
- Added `estimateActiveDuration()` — sums gaps between consecutive message timestamps, capping each gap at 5 minutes (idle time excluded)
- Parser and scanner both use this as fallback when `turn_duration` events are missing
- Removed the wall-clock `deriveDurationFromRange` fallback from transform.ts
- Bumped `SCANNER_VERSION` to 4 to invalidate cached scan results

## Test plan

- [x] New unit tests for `estimateActiveDuration()` (8 tests covering edge cases)
- [x] Updated existing transform test that expected wall-clock fallback
- [x] All 539 unit tests pass
- [x] All E2E tests pass (15 passed, 37 skipped for unrelated auth tests)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)