### PR TITLE
fix: include sub-agent file edits in stats, heatmap, and scanner

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -359,7 +359,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     }
   }
 
-  // Count subagent files (don't parse them — just count)
+  // Count subagent files and extract their file modifications
   let subAgentCount = 0;
   if (input.filePaths.length > 0) {
     const mainFile = input.filePaths[0];
@@ -367,7 +367,45 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     const subagentsDir = join(sessionDir, "subagents");
     try {
       const files = await readdir(subagentsDir);
-      subAgentCount = files.filter((f) => f.endsWith(".jsonl")).length;
+      const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
+      subAgentCount = jsonlFiles.length;
+
+      // Scan sub-agent JSONL files for file modifications
+      for (const saFile of jsonlFiles) {
+        let saContent: string;
+        try {
+          saContent = await readFile(join(subagentsDir, saFile), "utf-8");
+        } catch {
+          continue;
+        }
+        for (const saLine of saContent.split("\n")) {
+          if (!saLine.trim()) continue;
+          let saObj: any;
+          try {
+            saObj = JSON.parse(saLine);
+          } catch {
+            continue;
+          }
+          const saMsg = saObj?.message;
+          if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
+          for (const block of saMsg.content) {
+            if (block.type !== "tool_use") continue;
+            if (
+              block.name === "Edit" ||
+              block.name === "Write" ||
+              block.name === "NotebookEdit" ||
+              block.name === "Delete"
+            ) {
+              const fp = block.input?.file_path || block.input?.filePath;
+              if (fp) {
+                editCount++;
+                const short = shortenPath(fp);
+                fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
+              }
+            }
+          }
+        }
+      }
     } catch {
       // No subagents directory
     }
@@ -515,6 +553,31 @@ function buildScanResultFromParsed(
         typeof block.input.subagent_type === "string"
       ) {
         derivedSubAgentCount++;
+      }
+
+      // Count file modifications from sub-agent scenes
+      if (block.name === "Agent" && block._subAgent?.scenes) {
+        for (const saScene of block._subAgent.scenes) {
+          if (saScene.type !== "tool-call") continue;
+          const saTool = saScene.toolName;
+          if (
+            saTool !== "Edit" &&
+            saTool !== "Write" &&
+            saTool !== "NotebookEdit" &&
+            saTool !== "Delete"
+          ) {
+            continue;
+          }
+          const saPath =
+            saScene.input?.file_path ??
+            saScene.input?.filePath ??
+            saScene.input?.path ??
+            saScene.input?.relativeWorkspacePath;
+          if (typeof saPath !== "string" || !saPath.trim()) continue;
+          editCount++;
+          const short = shortenPath(saPath);
+          fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
+        }
       }
 
       if (

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -346,7 +346,11 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
               block.name === "NotebookEdit" ||
               block.name === "Delete"
             ) {
-              const fp = block.input?.file_path || block.input?.filePath;
+              const fp =
+                block.input?.file_path ??
+                block.input?.filePath ??
+                block.input?.path ??
+                block.input?.relativeWorkspacePath;
               if (fp) {
                 editCount++;
                 const short = shortenPath(fp);
@@ -396,7 +400,11 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
               block.name === "NotebookEdit" ||
               block.name === "Delete"
             ) {
-              const fp = block.input?.file_path || block.input?.filePath;
+              const fp =
+                block.input?.file_path ??
+                block.input?.filePath ??
+                block.input?.path ??
+                block.input?.relativeWorkspacePath;
               if (fp) {
                 editCount++;
                 const short = shortenPath(fp);

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -338,14 +338,39 @@ const SECRET_PATTERNS = [
 
 function redactSubAgentScene(s: any): Scene {
   if (s.type === "tool-call") {
-    return {
+    const toolName = s.toolName || "";
+    const input = s.input || {};
+    const scene: Scene = {
       type: "tool-call",
-      toolName: s.toolName || "",
+      toolName,
       input: s.input ? sanitizeInput(s.input) : {},
       result: truncate(redactPath(s.result || ""), 1000),
       timestamp: s.timestamp,
       isError: s.isError || false,
     };
+
+    // Preserve diff for file-modifying tools (same logic as buildToolScene)
+    if (toolName === "Edit" && input.file_path) {
+      (scene as any).diff = {
+        filePath: redactPath(input.file_path),
+        oldContent: input.old_string ?? "",
+        newContent: input.new_string ?? "",
+      };
+    } else if (toolName === "Write" && input.file_path) {
+      (scene as any).diff = {
+        filePath: redactPath(input.file_path),
+        oldContent: "",
+        newContent: truncate(input.content || "", 3000),
+      };
+    } else if (toolName === "Delete" && input.file_path) {
+      (scene as any).diff = {
+        filePath: redactPath(input.file_path),
+        oldContent: input.old_string ?? "(file deleted)",
+        newContent: "",
+      };
+    }
+
+    return scene;
   }
   return {
     type: s.type || "text-response",

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -43,6 +43,13 @@ export default function StatsPanel({ session }: Props) {
           if (scene.subAgent) {
             subAgentCount++;
             delegatedTools += scene.subAgent.toolCalls;
+            // Count file modifications from sub-agent scenes
+            for (const saScene of scene.subAgent.scenes) {
+              if (saScene.type === "tool-call" && saScene.diff) {
+                editCount++;
+                filesModified.add(saScene.diff.filePath);
+              }
+            }
           }
           break;
         }

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -187,6 +187,23 @@ export default function SummaryView({ session }: Props) {
               model: sa.model,
               sceneCount: sa.scenes.length,
             });
+            // Count file modifications from sub-agent scenes
+            for (const saScene of sa.scenes) {
+              if (saScene.type === "tool-call" && saScene.diff) {
+                const f = getFile(saScene.diff.filePath);
+                f.editCount++;
+                const turnIdx = turns.length;
+                f.turnEdits.set(turnIdx, (f.turnEdits.get(turnIdx) || 0) + 1);
+                const oldL = saScene.diff.oldContent
+                  ? saScene.diff.oldContent.split("\n").length
+                  : 0;
+                const newL = saScene.diff.newContent
+                  ? saScene.diff.newContent.split("\n").length
+                  : 0;
+                f.linesAdded += Math.max(0, newL - oldL);
+                f.linesRemoved += Math.max(0, oldL - newL);
+              }
+            }
           } else if (tn === "Bash") {
             if (scene.bashOutput) {
               const cat = classifyBash(scene.bashOutput.command);


### PR DESCRIPTION
## Summary
- Sub-agent file modifications (Edit/Write/Delete) were completely excluded from all file statistics — heatmap, files modified count, lines changed, and dashboard hotfiles were all undercounting
- Root cause: `redactSubAgentScene()` stripped `diff` data from sub-agent scenes, and all downstream consumers only counted top-level scene diffs
- Fixed in 4 locations: transform pipeline (preserve diff), viewer StatsPanel & SummaryView (count sub-agent diffs), scanner (parse sub-agent JSONL files)

## Test plan
- [x] All 539 unit tests pass
- [x] All 52 E2E tests pass
- [x] Lint passes
- [ ] Manual: generate replay from session with sub-agents that edit files, verify Files Modified count and file heatmap include sub-agent edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)