### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump CLI version from 0.1.1 to 0.1.2 for next release

## Verification
- `node packages/cli/dist/index.js --version` → `0.1.2`
- All 652 unit tests pass
- All 52 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)