### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Patch version bump from 0.1.2 to 0.1.3
- All unit tests (681 tests) and E2E tests (52 tests) pass
- CLI `--version` output verified as `0.1.3`

## Test plan
- [x] `pnpm build` succeeds
- [x] `node packages/cli/dist/index.js --version` outputs `0.1.3`
- [x] `pnpm test` — 681 tests pass
- [x] `pnpm test:e2e` — 52 tests pass
- [x] `pnpm lint:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)