### PR TITLE
fix(ci): remove broken npm self-upgrade from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
           node-version: 22
           cache: pnpm
 
-      - run: npm install -g npm@latest
-
       - run: pnpm install --frozen-lockfile
 
       - name: Sync version from tag


### PR DESCRIPTION
## Summary
- Remove `npm install -g npm@latest` step from release.yml
- This step caused v0.1.3 release to fail with `Cannot find module 'promise-retry'` on Node 22.22.2 runners
- The step is unnecessary since publishing uses pnpm, not npm

## Test plan
- [x] After merge, re-run the v0.1.3 release or delete and re-create it to trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)