### PR TITLE
fix(ci): pin Node to 22.22.1 to fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '22.22.1'
           cache: pnpm
 
       - run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- Pin `node-version` to `22.22.1` in release workflow
- Node 22.22.2 has a [known regression](https://github.com/nodejs/node/issues/62425) where `npm install -g npm@latest` fails with `Cannot find module 'promise-retry'`
- This caused the v0.1.3 release to fail ([run](https://github.com/tuo-lei/vibe-replay/actions/runs/23884378263))

## Test plan
- [x] Only change is pinning node version — no workflow logic changes
- [ ] After merge, delete and recreate v0.1.3 release to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)