### PR TITLE
fix(ci): restore npm upgrade for OIDC publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: '22.22.1'
           cache: pnpm
 
+      - run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - name: Sync version from tag


### PR DESCRIPTION
## Summary
- Restore `npm install -g npm@latest` step that PR #123 accidentally removed
- This step is required: it upgrades npm to v11+ which enables OIDC trusted publisher auth for `pnpm publish`
- Node remains pinned to 22.22.1 to avoid the promise-retry regression in 22.22.2

## Context
- v0.1.3 release failed twice: first from Node 22.22.2 bug, then from missing npm upgrade
- v0.1.1 succeeded because npm upgrade worked and enabled OIDC auth

## Test plan
- [ ] After merge, delete and recreate v0.1.3 release to trigger workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)