### PR TITLE
feat: enhance AI Coach with outcome, friction, and AI performance analysis

### DIFF
--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -30,12 +30,32 @@ export interface FeedbackItem {
   improvedPrompt?: string;
 }
 
+export interface FrictionPoint {
+  type: "misunderstood" | "wrong_approach" | "buggy_code" | "excessive_changes" | "user_unclear";
+  description: string;
+  turn: number;
+}
+
 export interface FeedbackResult {
   summary: string;
   score: number;
   strengths: string[];
   improvements: string[];
   feedbackItems: FeedbackItem[];
+  // Session-level analysis (Phase 1A — optional for weaker models)
+  outcome?:
+    | "fully_achieved"
+    | "mostly_achieved"
+    | "partially_achieved"
+    | "not_achieved"
+    | "unclear";
+  sessionGoal?: string;
+  frictionPoints?: FrictionPoint[];
+  aiPerformance?: {
+    rating: "poor" | "below_average" | "average" | "good" | "excellent";
+    strengths: string[];
+    weaknesses: string[];
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +106,9 @@ export function buildSessionDigest(session: ReplaySession): string {
 
   // Adaptive truncation budgets based on number of prompts
   const maxPromptChars = Math.min(3000, Math.floor(25000 / Math.max(promptCount, 1)));
-  const maxResponseChars = Math.min(800, Math.floor(12000 / Math.max(promptCount, 1)));
+  const maxResponseChars = Math.min(1500, Math.floor(20000 / Math.max(promptCount, 1)));
+  const maxDiffChars = Math.min(500, Math.floor(8000 / Math.max(promptCount, 1)));
+  const maxBashOutputChars = Math.min(300, Math.floor(5000 / Math.max(promptCount, 1)));
 
   let turnNum = 0;
   let turnLines: string[] = [];
@@ -133,12 +155,33 @@ export function buildSessionDigest(session: ReplaySession): string {
     } else if (scene.type === "tool-call") {
       if (scene.diff) {
         turnLines.push(`  - ${scene.toolName}: ${scene.diff.filePath}`);
+        // Include diff content so the coach can evaluate code quality
+        if (scene.diff.diff && responseChars < maxResponseChars) {
+          const diffPreview =
+            scene.diff.diff.length > maxDiffChars
+              ? `${scene.diff.diff.slice(0, maxDiffChars)}...`
+              : scene.diff.diff;
+          turnLines.push(`    ${diffPreview.replace(/\n/g, "\n    ")}`);
+          responseChars += diffPreview.length;
+        }
       } else if (scene.bashOutput) {
         const cmd =
           scene.bashOutput.command.length > 120
             ? `${scene.bashOutput.command.slice(0, 120)}...`
             : scene.bashOutput.command;
         turnLines.push(`  - Bash: ${cmd}`);
+        // Include command output so the coach can see results/errors
+        if (scene.bashOutput.output && responseChars < maxResponseChars) {
+          const output = scene.bashOutput.output.trim();
+          if (output) {
+            const outputPreview =
+              output.length > maxBashOutputChars
+                ? `${output.slice(0, maxBashOutputChars)}...`
+                : output;
+            turnLines.push(`    Output: ${outputPreview.replace(/\n/g, "\n    ")}`);
+            responseChars += outputPreview.length;
+          }
+        }
       } else {
         const input = JSON.stringify(scene.input).slice(0, 100);
         turnLines.push(`  - ${scene.toolName}: ${input}`);
@@ -149,10 +192,10 @@ export function buildSessionDigest(session: ReplaySession): string {
   }
   flush();
 
-  // Hard cap for safety (roughly 30KB ≈ ~7500 tokens)
+  // Hard cap for safety (roughly 40KB ≈ ~10000 tokens)
   const digest = lines.join("\n");
-  if (digest.length > 35000) {
-    return `${digest.slice(0, 35000)}\n\n... (remaining turns omitted due to length)`;
+  if (digest.length > 50000) {
+    return `${digest.slice(0, 50000)}\n\n... (remaining turns omitted due to length)`;
   }
   return digest;
 }
@@ -162,7 +205,21 @@ export function buildSessionDigest(session: ReplaySession): string {
 // ---------------------------------------------------------------------------
 
 const FEEDBACK_SCHEMA = `{
-  "summary": "<string: 2-3 paragraph overall assessment>",
+  "sessionGoal": "<string: one sentence — what the user was trying to achieve>",
+  "outcome": "<fully_achieved|mostly_achieved|partially_achieved|not_achieved|unclear>",
+  "frictionPoints": [
+    {
+      "type": "<misunderstood|wrong_approach|buggy_code|excessive_changes|user_unclear>",
+      "description": "<string: what went wrong>",
+      "turn": <number: which turn this happened in>
+    }
+  ],
+  "aiPerformance": {
+    "rating": "<poor|below_average|average|good|excellent>",
+    "strengths": ["<string>"],
+    "weaknesses": ["<string>"]
+  },
+  "summary": "<string: 2-3 paragraph overall assessment covering both prompting technique AND session effectiveness>",
   "score": <number 1-10>,
   "strengths": ["<string>", ...],
   "improvements": ["<string>", ...],
@@ -172,13 +229,27 @@ const FEEDBACK_SCHEMA = `{
       "title": "<string: short descriptive title>",
       "feedback": "<string: detailed actionable feedback>",
       "category": "<clarity|specificity|context|efficiency|iteration|tool-usage>",
-      "improvedPrompt": "<string|null: optional rewritten prompt>"
+      "improvedPrompt": "<string|null: rewritten prompt — REQUIRED for clarity/specificity/context>"
     }
   ]
 }`;
 
 const FEEDBACK_EXAMPLE = `{
-  "summary": "The user demonstrates good instincts for task decomposition, breaking complex work into manageable steps. However, several prompts lack specificity — the AI had to spend extra turns searching for context that could have been provided upfront. The strongest prompts came later in the session after the user learned what information the AI needed.",
+  "sessionGoal": "Fix an authentication bug and add test coverage",
+  "outcome": "mostly_achieved",
+  "frictionPoints": [
+    {
+      "type": "misunderstood",
+      "description": "AI searched the wrong directory for auth files because user didn't specify the path",
+      "turn": 1
+    }
+  ],
+  "aiPerformance": {
+    "rating": "good",
+    "strengths": ["Found and fixed the bug correctly once pointed to the right file"],
+    "weaknesses": ["Wasted 3 tool calls searching before asking for clarification"]
+  },
+  "summary": "The user demonstrates good instincts for task decomposition, breaking complex work into manageable steps. However, several prompts lack specificity — the AI had to spend extra turns searching for context that could have been provided upfront. The goal was mostly achieved: the bug was fixed but tests were not added due to running out of context.",
   "score": 6,
   "strengths": [
     "Good task decomposition — complex feature was broken into clear steps",
@@ -212,7 +283,7 @@ function buildFeedbackPrompt(digest: string, session: ReplaySession): string {
     ? `$${session.meta.stats.costEstimate.toFixed(2)}`
     : "unknown";
 
-  return `You are an expert AI coding coach. Analyze this recorded AI coding session and provide detailed, constructive feedback on the user's prompting technique.
+  return `You are an expert AI coding coach. Analyze this recorded AI coding session and provide feedback on BOTH the user's prompting technique AND the overall session effectiveness.
 
 ## Session Info
 - Provider: ${session.meta.provider}
@@ -230,7 +301,19 @@ ${digest}
 ## Valid User-Prompt Scene Indices
 ONLY use these values for sceneIndex: [${userPromptIndices.join(", ")}]
 
-## Analysis Guidelines
+## Step 1: Session-Level Analysis
+First, assess the session as a whole:
+- **Goal**: What was the user trying to achieve? (one sentence)
+- **Outcome**: Was the goal achieved? (fully_achieved / mostly_achieved / partially_achieved / not_achieved / unclear)
+- **Friction**: Where did things go wrong? Classify each friction point:
+  - misunderstood: AI misinterpreted the user's request
+  - wrong_approach: AI took wrong approach to correct goal
+  - buggy_code: AI produced code that didn't work
+  - excessive_changes: AI over-engineered or changed too much
+  - user_unclear: User's prompt was too vague to act on
+- **AI Performance**: How well did the AI perform? Rate and list specific strengths/weaknesses based on what you observe in the transcript (tool call results, code diffs, bash output).
+
+## Step 2: Per-Prompt Analysis
 For each user prompt, consider:
 1. **Clarity** — Was it unambiguous? Could the AI misinterpret?
 2. **Specificity** — Enough detail, file paths, constraints?
@@ -254,8 +337,8 @@ CRITICAL RULES:
 - sceneIndex MUST be one of: [${userPromptIndices.join(", ")}]
 - Provide feedback for the most impactful prompts (at least ${Math.min(userPromptIndices.length, 3)}, up to ${Math.min(userPromptIndices.length, 10)})
 - score: 1 = very poor, 5 = average, 8 = strong, 10 = expert
+- For feedback items with category "clarity", "specificity", or "context", you MUST provide an improvedPrompt showing a concrete rewrite
 - Be constructive and encouraging, but honest
-- improvedPrompt is optional — only when you have a concretely better version
 - Think step by step about each prompt in context before judging it`;
 }
 
@@ -428,12 +511,68 @@ export function parseFeedbackResponse(
     });
   }
 
+  // Parse new session-level fields (optional — graceful degradation for weaker models)
+  const validOutcomes = new Set([
+    "fully_achieved",
+    "mostly_achieved",
+    "partially_achieved",
+    "not_achieved",
+    "unclear",
+  ]);
+  const validFrictionTypes = new Set([
+    "misunderstood",
+    "wrong_approach",
+    "buggy_code",
+    "excessive_changes",
+    "user_unclear",
+  ]);
+  const validAiRatings = new Set(["poor", "below_average", "average", "good", "excellent"]);
+
+  const outcome = validOutcomes.has(parsed.outcome) ? parsed.outcome : undefined;
+  const sessionGoal =
+    typeof parsed.sessionGoal === "string" && parsed.sessionGoal ? parsed.sessionGoal : undefined;
+
+  let frictionPoints: FrictionPoint[] | undefined;
+  if (Array.isArray(parsed.frictionPoints) && parsed.frictionPoints.length > 0) {
+    frictionPoints = parsed.frictionPoints
+      .filter(
+        (f: any) =>
+          f &&
+          typeof f === "object" &&
+          validFrictionTypes.has(f.type) &&
+          typeof f.description === "string" &&
+          typeof f.turn === "number",
+      )
+      .map((f: any) => ({ type: f.type, description: f.description, turn: f.turn }));
+    if (frictionPoints.length === 0) frictionPoints = undefined;
+  }
+
+  let aiPerformance: FeedbackResult["aiPerformance"];
+  if (parsed.aiPerformance && typeof parsed.aiPerformance === "object") {
+    const ap = parsed.aiPerformance;
+    if (validAiRatings.has(ap.rating)) {
+      aiPerformance = {
+        rating: ap.rating,
+        strengths: Array.isArray(ap.strengths)
+          ? ap.strengths.filter((s: any) => typeof s === "string")
+          : [],
+        weaknesses: Array.isArray(ap.weaknesses)
+          ? ap.weaknesses.filter((s: any) => typeof s === "string")
+          : [],
+      };
+    }
+  }
+
   return {
     summary: parsed.summary,
     score: parsed.score,
     strengths: parsed.strengths.filter((s: any) => typeof s === "string"),
     improvements: parsed.improvements.filter((s: any) => typeof s === "string"),
     feedbackItems: items,
+    outcome,
+    sessionGoal,
+    frictionPoints,
+    aiPerformance,
   };
 }
 
@@ -602,16 +741,66 @@ export function feedbackToAnnotations(feedback: FeedbackResult): Annotation[] {
   const annotations: Annotation[] = [];
 
   // Overall summary (attached to first scene)
-  const summaryBody = [
-    `## Prompting Score: ${feedback.score}/10\n`,
-    feedback.summary,
-    "",
-    "**Strengths**",
-    ...feedback.strengths.map((s) => `- ${s}`),
-    "",
-    "**Areas for Improvement**",
-    ...feedback.improvements.map((s) => `- ${s}`),
-  ].join("\n");
+  const outcomeLabel: Record<string, string> = {
+    fully_achieved: "Fully Achieved",
+    mostly_achieved: "Mostly Achieved",
+    partially_achieved: "Partially Achieved",
+    not_achieved: "Not Achieved",
+    unclear: "Unclear",
+  };
+
+  const summaryParts: string[] = [];
+
+  // Session goal + outcome header
+  if (feedback.sessionGoal || feedback.outcome) {
+    const goalLine = feedback.sessionGoal ? `**Goal:** ${feedback.sessionGoal}` : "";
+    const outcomeLine = feedback.outcome
+      ? `**Outcome:** ${outcomeLabel[feedback.outcome] || feedback.outcome}`
+      : "";
+    summaryParts.push([goalLine, outcomeLine].filter(Boolean).join(" · "));
+    summaryParts.push("");
+  }
+
+  summaryParts.push(`## Prompting Score: ${feedback.score}/10\n`);
+  summaryParts.push(feedback.summary);
+
+  // AI performance
+  if (feedback.aiPerformance) {
+    const ap = feedback.aiPerformance;
+    const ratingLabel: Record<string, string> = {
+      poor: "Poor",
+      below_average: "Below Average",
+      average: "Average",
+      good: "Good",
+      excellent: "Excellent",
+    };
+    summaryParts.push("");
+    summaryParts.push(`**AI Performance:** ${ratingLabel[ap.rating] || ap.rating}`);
+    if (ap.strengths.length > 0) {
+      summaryParts.push(...ap.strengths.map((s) => `- (+) ${s}`));
+    }
+    if (ap.weaknesses.length > 0) {
+      summaryParts.push(...ap.weaknesses.map((s) => `- (-) ${s}`));
+    }
+  }
+
+  // Friction points
+  if (feedback.frictionPoints && feedback.frictionPoints.length > 0) {
+    summaryParts.push("");
+    summaryParts.push("**Friction Points**");
+    for (const fp of feedback.frictionPoints) {
+      summaryParts.push(`- Turn ${fp.turn}: \`${fp.type}\` — ${fp.description}`);
+    }
+  }
+
+  summaryParts.push("");
+  summaryParts.push("**Strengths**");
+  summaryParts.push(...feedback.strengths.map((s) => `- ${s}`));
+  summaryParts.push("");
+  summaryParts.push("**Areas for Improvement**");
+  summaryParts.push(...feedback.improvements.map((s) => `- ${s}`));
+
+  const summaryBody = summaryParts.join("\n");
 
   annotations.push({
     id: randomUUID(),

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -156,11 +156,10 @@ export function buildSessionDigest(session: ReplaySession): string {
       if (scene.diff) {
         turnLines.push(`  - ${scene.toolName}: ${scene.diff.filePath}`);
         // Include diff content so the coach can evaluate code quality
-        if (scene.diff.diff && responseChars < maxResponseChars) {
+        const diffText = scene.diff.newContent || scene.diff.oldContent;
+        if (diffText && responseChars < maxResponseChars) {
           const diffPreview =
-            scene.diff.diff.length > maxDiffChars
-              ? `${scene.diff.diff.slice(0, maxDiffChars)}...`
-              : scene.diff.diff;
+            diffText.length > maxDiffChars ? `${diffText.slice(0, maxDiffChars)}...` : diffText;
           turnLines.push(`    ${diffPreview.replace(/\n/g, "\n    ")}`);
           responseChars += diffPreview.length;
         }
@@ -171,8 +170,8 @@ export function buildSessionDigest(session: ReplaySession): string {
             : scene.bashOutput.command;
         turnLines.push(`  - Bash: ${cmd}`);
         // Include command output so the coach can see results/errors
-        if (scene.bashOutput.output && responseChars < maxResponseChars) {
-          const output = scene.bashOutput.output.trim();
+        if (scene.bashOutput.stdout && responseChars < maxResponseChars) {
+          const output = scene.bashOutput.stdout.trim();
           if (output) {
             const outputPreview =
               output.length > maxBashOutputChars

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -2303,6 +2303,8 @@ export async function startServer(
         annotations: newAnnotations,
         score: fb.result.score,
         itemCount: fb.result.feedbackItems.length,
+        outcome: fb.result.outcome,
+        sessionGoal: fb.result.sessionGoal,
       });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);

--- a/packages/cli/test/feedback.test.ts
+++ b/packages/cli/test/feedback.test.ts
@@ -486,6 +486,109 @@ describe("parseFeedbackResponse", () => {
     expect(result!.feedbackItems[0].improvedPrompt).toBeUndefined();
   });
 
+  // --- Session-level fields (Phase 1A) ---
+
+  it("parses outcome and sessionGoal when present", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        outcome: "mostly_achieved",
+        sessionGoal: "Fix the login bug",
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBe("mostly_achieved");
+    expect(result!.sessionGoal).toBe("Fix the login bug");
+  });
+
+  it("ignores invalid outcome values", () => {
+    const result = parseFeedbackResponse(makeValidFeedbackJson({ outcome: "kinda_done" }), session);
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBeUndefined();
+  });
+
+  it("parses frictionPoints when valid", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        frictionPoints: [
+          { type: "misunderstood", description: "AI read wrong file", turn: 2 },
+          { type: "buggy_code", description: "Test failed", turn: 4 },
+        ],
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.frictionPoints).toHaveLength(2);
+    expect(result!.frictionPoints![0].type).toBe("misunderstood");
+    expect(result!.frictionPoints![1].turn).toBe(4);
+  });
+
+  it("filters out invalid frictionPoints entries", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        frictionPoints: [
+          { type: "invalid_type", description: "nope", turn: 1 },
+          { type: "buggy_code", description: "valid", turn: 3 },
+          { type: "wrong_approach" }, // missing description and turn
+        ],
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.frictionPoints).toHaveLength(1);
+    expect(result!.frictionPoints![0].type).toBe("buggy_code");
+  });
+
+  it("sets frictionPoints to undefined when all entries are invalid", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        frictionPoints: [{ type: "fake", description: "nope", turn: 1 }],
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.frictionPoints).toBeUndefined();
+  });
+
+  it("parses aiPerformance when valid", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        aiPerformance: {
+          rating: "good",
+          strengths: ["Fast search"],
+          weaknesses: ["Missed edge case"],
+        },
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.aiPerformance).toBeDefined();
+    expect(result!.aiPerformance!.rating).toBe("good");
+    expect(result!.aiPerformance!.strengths).toEqual(["Fast search"]);
+    expect(result!.aiPerformance!.weaknesses).toEqual(["Missed edge case"]);
+  });
+
+  it("ignores aiPerformance with invalid rating", () => {
+    const result = parseFeedbackResponse(
+      makeValidFeedbackJson({
+        aiPerformance: { rating: "meh", strengths: [], weaknesses: [] },
+      }),
+      session,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.aiPerformance).toBeUndefined();
+  });
+
+  it("gracefully handles missing session-level fields", () => {
+    // Basic JSON without any new fields — should still parse fine
+    const result = parseFeedbackResponse(makeValidFeedbackJson(), session);
+    expect(result).not.toBeNull();
+    expect(result!.outcome).toBeUndefined();
+    expect(result!.sessionGoal).toBeUndefined();
+    expect(result!.frictionPoints).toBeUndefined();
+    expect(result!.aiPerformance).toBeUndefined();
+  });
+
   it("extracts JSON from noisy output with surrounding text", () => {
     const json = makeValidFeedbackJson();
     const noisy = `Here is my analysis:\n\n${json}\n\nI hope this helps!`;
@@ -580,6 +683,25 @@ describe("buildSessionDigest", () => {
     });
     const digest = buildSessionDigest(session);
     expect(digest).toContain("Bash: pnpm test");
+    expect(digest).toContain("all passed");
+  });
+
+  it("includes diff newContent in digest", () => {
+    const session = makeSession({
+      scenes: [
+        { type: "user-prompt", content: "Edit file" },
+        {
+          type: "tool-call",
+          toolName: "Edit",
+          input: { file_path: "src/app.ts" },
+          result: "ok",
+          diff: { filePath: "src/app.ts", oldContent: "const x = 1;", newContent: "const x = 2;" },
+        },
+      ],
+    });
+    const digest = buildSessionDigest(session);
+    expect(digest).toContain("Edit: src/app.ts");
+    expect(digest).toContain("const x = 2;");
   });
 
   it("truncates long bash commands", () => {

--- a/packages/cli/test/feedback.test.ts
+++ b/packages/cli/test/feedback.test.ts
@@ -671,8 +671,8 @@ describe("buildSessionDigest", () => {
       },
     });
     const digest = buildSessionDigest(session);
-    expect(digest.length).toBeLessThanOrEqual(35100); // 35000 + suffix message
-    if (digest.length > 35000) {
+    expect(digest.length).toBeLessThanOrEqual(50100); // 50000 + suffix message
+    if (digest.length > 50000) {
       expect(digest).toContain("remaining turns omitted due to length");
     }
   });


### PR DESCRIPTION
## Summary

Inspired by Claude Code's `/insights` architecture (deep-dived the leaked source), this enhances the AI Coach from pure prompting-technique feedback to holistic session analysis:

- **Session-level analysis**: adds `outcome` (fully/mostly/partially achieved), `sessionGoal`, `frictionPoints` (classified as misunderstood/wrong_approach/buggy_code/excessive_changes/user_unclear), and `aiPerformance` (rating + strengths/weaknesses)
- **Richer digest**: includes diff content (up to 500 chars) and bash output (up to 300 chars) so the coach can evaluate code quality and results, not just prompts. Response budget increased from 800→1500 chars, hard cap from 35KB→50KB
- **Structured prompt**: reorganized into Step 1 (session-level assessment) + Step 2 (per-prompt analysis)
- **Forced improvedPrompt**: clarity/specificity/context feedback items now require a concrete rewrite
- **Graceful degradation**: all new fields are optional — weaker models that can't produce them still work fine

### Eval results (opencode, weak model)

Tested on 6 sessions across different sizes and providers:

| Session | Prompts | Scenes | Provider | Score | Outcome | Items | Time |
|---------|---------|--------|----------|-------|---------|-------|------|
| multitool-slug | 1 | 7 | claude-code | 4/10 | unclear | 1 | 34s |
| snazzy-squishing-bubble | 2 | 22 | claude-code | 9/10 | fully_achieved | 2 | 34s |
| cb09f9d4 | 8 | 143 | cursor | 6/10 | mostly_achieved | 6 | 78s |
| mighty-questing-waffle | 8 | 183 | claude-code | 7/10 | fully_achieved | 7 | 83s |
| snazzy-bouncing-dove | 20 | 254 | claude-code | 7/10 | mostly_achieved | 7 | 82s |
| clever-seeking-fairy | 4 | 273 | claude-code | 7/10 | fully_achieved | 4 | 91s |

- **100% JSON parse success** — no failures even with the weaker model
- **6/6 sessions** returned all new fields (Goal, Outcome, AI Performance, Friction)
- **78% of feedback items** included improvedPrompt (up from ~30% before)
- Score distribution is reasonable: 4/10 for a vague 1-turn session, 9/10 for an efficient 2-prompt workflow

## Test plan

- [x] Unit tests pass (`pnpm test` — 594 tests)
- [x] E2E tests pass (`pnpm build && pnpm test:e2e` — 23 tests)
- [x] Lint passes (`pnpm lint:check`)
- [x] Tested with opencode on 6 diverse sessions (1–20 prompts, both providers)
- [ ] Manual: run AI Coach in editor UI and verify summary annotation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)