### PR TITLE
docs(website): clarify Cursor insight estimate caveats

### DIFF
--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -17,12 +17,12 @@ const features = [
   },
   {
     title: "Session insights & cost tracking",
-    desc: "Auto-generated analytics for every session: token burn over time, context window usage, cache hit rates, tool call breakdown, and cost estimates. See exactly what each session costs.",
+    desc: "Auto-generated analytics for every session: token burn over time, context window usage, cache hit rates, tool call breakdown, and cost estimates. When a provider only exposes partial local data, vibe-replay shows data-quality hints instead of pretending the numbers are exact.",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" /></svg>`,
   },
   {
     title: "Local dashboard",
-    desc: "Browse, search, and manage all sessions across projects. Activity heatmaps, project-level analytics, and cost totals — all running locally on your machine.",
+    desc: "Browse, search, and manage all sessions across projects. Activity heatmaps, project-level analytics, and cost estimates with data-quality hints — all running locally on your machine.",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25a2.25 2.25 0 01-2.25-2.25v-2.25z" /></svg>`,
   },
   {

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -22,7 +22,7 @@
             <span class="w-8 h-8 rounded-lg bg-gradient-to-br from-accent/10 to-cyan-400/5 flex items-center justify-center text-accent font-mono text-sm font-bold">1</span>
             <h3 class="text-xl font-semibold">All your sessions, one place</h3>
           </div>
-          <p class="text-text-secondary leading-relaxed">A local dashboard shows every session across <span class="text-[#D97706] font-medium">Claude Code</span> and <span class="text-[#0096FF] font-medium">Cursor</span> &mdash; with activity heatmaps, project-level analytics, cost totals, and session counts. Runs entirely on your machine.</p>
+          <p class="text-text-secondary leading-relaxed">A local dashboard shows every session across <span class="text-[#D97706] font-medium">Claude Code</span> and <span class="text-[#0096FF] font-medium">Cursor</span> &mdash; with activity heatmaps, project-level analytics, cost estimates, and data-quality hints when local provider data is partial. Runs entirely on your machine.</p>
           <p class="text-text-muted text-sm mt-3 font-mono">$ npx vibe-replay -d</p>
         </div>
         <div class="md:w-3/5">
@@ -46,7 +46,7 @@
             <span class="w-8 h-8 rounded-lg bg-gradient-to-br from-accent/10 to-cyan-400/5 flex items-center justify-center text-accent font-mono text-sm font-bold">2</span>
             <h3 class="text-xl font-semibold">Deep insights for every session</h3>
           </div>
-          <p class="text-text-secondary leading-relaxed">Auto-generated analytics: token burn &amp; cost per turn, context window usage, cache hit rates, tool call distribution, sub-agent delegation, and file impact tracking. Know exactly what each session costs.</p>
+          <p class="text-text-secondary leading-relaxed">Auto-generated analytics: token burn &amp; cost per turn, context window usage, cache hit rates, tool call distribution, sub-agent delegation, and file impact tracking. When Cursor only exposes partial local data, vibe-replay shows estimates and tells you where the gaps are.</p>
         </div>
         <div class="md:w-3/5">
           <div class="rounded-xl border border-border/50 overflow-hidden shadow-lg shadow-accent/5">

--- a/website/src/content/blog/cursor-local-storage.md
+++ b/website/src/content/blog/cursor-local-storage.md
@@ -253,6 +253,8 @@ I found bubble payloads with token snapshots like:
 
 That's enough to do best-effort token and cost estimation for some Cursor sessions.
 
+The important caveat, after building and testing [vibe-replay](https://github.com/tuo-lei/vibe-replay) against a much larger Cursor corpus, is coverage: many sessions still have **no** usable token snapshots. In practice, that means aggregate Cursor cost totals are often a **lower bound**, not a full bill.
+
 ### Timing
 
 I also found fields like:
@@ -263,7 +265,7 @@ I also found fields like:
 }
 ```
 
-So Cursor does expose some local timing signals. They just aren't sitting in one neat append-only log.
+So Cursor does expose some local timing signals. They just aren't sitting in one neat append-only log, and coverage is uneven enough that duration often has to be reconstructed from partial signals instead of read directly from one authoritative source.
 
 ### File context
 


### PR DESCRIPTION
## Summary
- clarify the Cursor storage deep-dive so token cost totals are described as lower bounds when local token snapshots are missing
- update website marketing copy to stop implying exact per-session Cursor costs or complete local timing coverage
- align the dashboard/insights messaging with the product's new data-quality hints for partial provider data

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm --filter @vibe-replay/website build`


Made with [Cursor](https://cursor.com)