### PR TITLE
feat(viewer): improve dashboard home UX and unify header navigation

### DIFF
--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -320,49 +320,47 @@ export default function App() {
   if (loadState.status === "dashboard") {
     return (
       <div className="h-screen bg-terminal-bg flex flex-col overflow-hidden">
-        <header className="border-b border-terminal-border-subtle px-5 py-2.5 flex items-center justify-between shrink-0 glass-effect z-40 safe-top">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => navigateTo({ view: null, session: null })}
-              className="text-sm font-sans font-bold bg-gradient-to-r from-terminal-green to-terminal-blue bg-clip-text text-transparent hover:opacity-80 transition-opacity"
-            >
-              vibe-replay
-            </button>
-            <span className="instant-tooltip inline-flex items-center gap-1.5 text-[10px] font-sans font-bold px-2.5 py-1 rounded-full bg-terminal-green/10 text-terminal-green uppercase tracking-wider border border-terminal-green/20">
-              <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
-              Local
-              <span className="instant-tooltip-text">
-                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
+        <Dashboard
+          headerLeft={
+            <div className="flex items-center gap-2.5 shrink-0">
+              <button
+                onClick={() => navigateTo({ view: null, session: null })}
+                className="text-sm font-sans font-bold bg-gradient-to-r from-terminal-green to-terminal-blue bg-clip-text text-transparent hover:opacity-80 transition-opacity"
+              >
+                vibe-replay
+              </button>
+              <span className="instant-tooltip inline-flex items-center gap-1 text-[9px] font-sans font-bold px-2 py-0.5 rounded-full bg-terminal-green/10 text-terminal-green uppercase tracking-wider border border-terminal-green/20">
+                <span className="w-1 h-1 rounded-full bg-terminal-green animate-pulse" />
+                Local
+                <span className="instant-tooltip-text">
+                  {`v${__CLI_VERSION__}\nViewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
+                </span>
               </span>
-            </span>
-            <span className="text-terminal-border/40 text-sm select-none">|</span>
-            <span className="text-sm font-sans font-semibold text-terminal-text/90">Dashboard</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <GitHubStarButton />
-            <button
-              onClick={toggleTheme}
-              className="w-7 h-7 flex items-center justify-center rounded-md border border-terminal-border text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover text-sm transition-colors"
-            >
-              {theme === "dark" ? "\u263E" : "\u2600"}
-            </button>
-            <DashboardAuthStatus isEditor={true} />
-          </div>
-        </header>
-        <Dashboard />
+            </div>
+          }
+          headerRight={
+            <div className="flex items-center gap-2 shrink-0">
+              <GitHubStarButton />
+              <button
+                onClick={toggleTheme}
+                className="w-7 h-7 flex items-center justify-center rounded-md bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover text-sm transition-colors"
+              >
+                {theme === "dark" ? "\u263E" : "\u2600"}
+              </button>
+              <DashboardAuthStatus isEditor={true} />
+            </div>
+          }
+        />
       </div>
     );
   }
 
   const { meta } = session!;
-  // Show back-to-dashboard button when viewing a session via ?session= param
-  const showDashboardBack = isEditor && new URLSearchParams(window.location.search).has("session");
-
   return (
     <div className="h-screen bg-terminal-bg flex flex-col overflow-hidden">
-      <header className="relative z-40 border-b border-terminal-border-subtle px-5 pt-5 pb-3 md:py-3 flex items-center justify-between shrink-0 glass-effect safe-top">
-        {/* Left: branding + session info */}
-        <div className="flex items-center gap-2 md:gap-3 min-w-0">
+      <header className="relative z-40 border-b border-terminal-border-subtle px-5 py-2 flex items-center gap-4 shrink-0 glass-effect safe-top">
+        {/* Left: branding */}
+        <div className="flex items-center gap-2.5 shrink-0">
           {isEditor ? (
             <button
               onClick={() => navigateTo({ view: "dashboard", session: null })}
@@ -381,97 +379,64 @@ export default function App() {
             </a>
           )}
           {isEditor && (
-            <span className="instant-tooltip inline-flex items-center gap-1.5 text-[10px] font-sans font-bold px-2.5 py-1 rounded-full bg-terminal-green/10 text-terminal-green uppercase tracking-wider border border-terminal-green/20">
-              <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
+            <span className="instant-tooltip inline-flex items-center gap-1 text-[9px] font-sans font-bold px-2 py-0.5 rounded-full bg-terminal-green/10 text-terminal-green uppercase tracking-wider border border-terminal-green/20">
+              <span className="w-1 h-1 rounded-full bg-terminal-green animate-pulse" />
               Local
               <span className="instant-tooltip-text">
-                {`Viewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
+                {`v${__CLI_VERSION__}\nViewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
               </span>
             </span>
-          )}
-          {showDashboardBack && (
-            <span className="hidden md:flex items-center gap-0.5">
-              <span className="text-terminal-border/40 text-sm select-none">|</span>
-              <button
-                onClick={() => navigateTo({ view: "dashboard", session: null })}
-                className="flex items-center gap-0.5 text-sm font-sans font-medium text-terminal-dim hover:text-terminal-text transition-colors"
-              >
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M10 3L5 8l5 5" />
-                </svg>
-                Dashboard
-              </button>
-            </span>
-          )}
-          {meta.title && (
-            <>
-              <span className="text-terminal-border/40 text-sm select-none hidden md:inline">
-                |
-              </span>
-              <button
-                type="button"
-                onClick={() => {
-                  returnToLandingRef.current?.();
-                  handleViewChange("replay");
-                }}
-                className="text-terminal-text text-xs font-sans font-medium truncate max-w-[180px] md:max-w-[300px] hover:text-terminal-green transition-colors"
-                title="Back to landing page"
-              >
-                {meta.title}
-              </button>
-            </>
-          )}
-          {gistOwner && (
-            <div className="hidden sm:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
-              <span className="text-terminal-border">&middot;</span>
-              <span className="text-terminal-dimmer">shared by</span>
-              <a
-                href={`https://github.com/${gistOwner}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-terminal-dim hover:text-terminal-text transition-colors"
-              >
-                @{gistOwner}
-              </a>
-            </div>
           )}
         </div>
 
-        <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
-          {/* Dashboard button (editor mode only, when not already navigated from dashboard) */}
-          {isEditor && !showDashboardBack && (
-            <button
-              onClick={() => navigateTo({ view: "dashboard", session: null })}
-              className="h-7 px-2.5 flex items-center gap-1.5 rounded-md bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover text-xs font-sans font-medium transition-colors"
-              title="All replays"
-            >
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
+        {/* Tabs (editor) */}
+        {isEditor && (
+          <nav className="hidden md:inline-flex items-center rounded-xl bg-terminal-surface p-0.5 shadow-layer-sm shrink-0">
+            {(["home", "sessions", "replays", "projects", "insights"] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => navigateTo({ view: "dashboard", session: null, tab: t })}
+                className="px-3.5 py-1.5 text-xs font-sans font-semibold rounded-lg text-terminal-dim hover:text-terminal-text transition-all duration-200 ease-material"
               >
-                <rect x="1" y="1" width="6" height="6" rx="1" />
-                <rect x="9" y="1" width="6" height="6" rx="1" />
-                <rect x="1" y="9" width="6" height="6" rx="1" />
-                <rect x="9" y="9" width="6" height="6" rx="1" />
-              </svg>
-              <span className="hidden sm:inline">Dashboard</span>
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </button>
+            ))}
+          </nav>
+        )}
+        {/* Session title */}
+        {meta.title && (
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-terminal-border/40 text-sm select-none hidden md:inline">|</span>
+            <button
+              type="button"
+              onClick={() => {
+                returnToLandingRef.current?.();
+                handleViewChange("replay");
+              }}
+              className="text-terminal-text text-xs font-sans font-medium truncate max-w-[180px] md:max-w-[300px] hover:text-terminal-green transition-colors"
+              title="Back to landing page"
+            >
+              {meta.title}
             </button>
-          )}
+            {gistOwner && (
+              <div className="hidden sm:flex items-center gap-1.5 text-xs font-mono text-terminal-dim">
+                <span className="text-terminal-border">&middot;</span>
+                <span className="text-terminal-dimmer">shared by</span>
+                <a
+                  href={`https://github.com/${gistOwner}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-terminal-dim hover:text-terminal-text transition-colors"
+                >
+                  @{gistOwner}
+                </a>
+              </div>
+            )}
+          </div>
+        )}
+        <div className="flex-1" />
 
+        <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
           {/* Display mode + Star + Theme — desktop inline */}
           <div ref={customRef} className="hidden md:flex items-center gap-1.5">
             {/* Display mode: segmented control + Custom dropdown */}

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -29,7 +29,6 @@ import {
 import InsightsPage from "./InsightsPage";
 import {
   ScanInsightsProvider,
-  ScanProgressBar,
   TitleInsightsHeader,
   TitleInsightsHeaderSkeleton,
   useScanInsightsContext,
@@ -1855,13 +1854,6 @@ function SessionsPanel() {
           </div>
         )}
 
-        {/* Background scan progress */}
-        {scanStatus?.running && (
-          <div className="mx-4 mb-2 shrink-0">
-            <ScanProgressBar status={scanStatus} />
-          </div>
-        )}
-
         {/* Error toast */}
         {refreshError && (
           <div className="mx-4 mb-2 flex items-center gap-2 bg-terminal-orange-subtle rounded-lg px-3 py-2.5 text-xs font-mono text-terminal-orange shrink-0 shadow-layer-sm">
@@ -2191,8 +2183,7 @@ function ReplaysPanel() {
   const [showArchived, setShowArchived] = useState(getShowArchivedFromUrl());
 
   // Background scan + insights (shared singleton context)
-  const { scanStatus, userInsights, projectInsightsCache, fetchProjectInsights } =
-    useScanInsightsContext();
+  const { userInsights, projectInsightsCache, fetchProjectInsights } = useScanInsightsContext();
 
   // Fetch project insights when selected project changes
   useEffect(() => {
@@ -2683,13 +2674,6 @@ function ReplaysPanel() {
           </div>
         )}
 
-        {/* Scan progress */}
-        {scanStatus?.running && (
-          <div className="mx-4 mb-2 shrink-0">
-            <ScanProgressBar status={scanStatus} />
-          </div>
-        )}
-
         {/* Replay list */}
         <div className="flex-1 overflow-y-auto">
           {showInitialLoading ? (
@@ -2727,24 +2711,46 @@ function ReplaysPanel() {
   );
 }
 
-// ─── Nav scan indicator (lives inside ScanInsightsProvider) ─────────
+// ─── Global scan toast (fixed bottom-right, no layout shift) ────────
 
-function NavScanIndicator() {
+function ScanToast() {
   const { scanStatus } = useScanInsightsContext();
-  if (!scanStatus?.running || !scanStatus.total) return null;
+  if (!scanStatus?.running) return null;
+
+  const label =
+    scanStatus.phase === "discovering"
+      ? "Discovering sessions..."
+      : scanStatus.total > 0
+        ? `Scanning ${scanStatus.scanned}/${scanStatus.total}`
+        : "Preparing scan...";
+
+  const pct = scanStatus.total > 0 ? Math.round((scanStatus.scanned / scanStatus.total) * 100) : 0;
+
   return (
-    <div className="flex items-center gap-2">
-      <div className="w-1.5 h-1.5 rounded-full bg-terminal-purple animate-pulse" />
-      <span className="text-xs font-mono text-terminal-dim tabular-nums">
-        Scanning {scanStatus.scanned}/{scanStatus.total}
-      </span>
+    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-xs font-mono bg-terminal-surface border border-terminal-border shadow-layer-md animate-in fade-in slide-in-from-bottom-2 duration-300">
+      <span className="w-1.5 h-1.5 rounded-full bg-terminal-purple animate-pulse shrink-0" />
+      <span className="text-terminal-dim">{label}</span>
+      {scanStatus.total > 0 && (
+        <div className="w-16 h-1 rounded-full bg-terminal-surface-2 overflow-hidden">
+          <div
+            className="h-full bg-terminal-purple rounded-full transition-all duration-300"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
     </div>
   );
 }
 
 // ─── Main Dashboard ─────────────────────────────────────────────────
 
-export default function Dashboard() {
+export default function Dashboard({
+  headerLeft,
+  headerRight,
+}: {
+  headerLeft?: React.ReactNode;
+  headerRight?: React.ReactNode;
+}) {
   const isEditor = !!window.__VIBE_REPLAY_EDITOR__;
 
   // Sync tab with URL query param
@@ -2774,7 +2780,7 @@ export default function Dashboard() {
     <button
       key={id}
       onClick={() => handleTabChange(id)}
-      className={`px-5 py-2 text-xs font-sans font-semibold rounded-lg transition-all duration-200 ease-material ${
+      className={`px-3.5 py-1.5 text-xs font-sans font-semibold rounded-lg transition-all duration-200 ease-material ${
         tab === id
           ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
           : "text-terminal-dim hover:text-terminal-text"
@@ -2787,17 +2793,19 @@ export default function Dashboard() {
   return (
     <ScanInsightsProvider>
       <div className="flex-1 flex flex-col min-h-0">
-        {/* Tab bar — only show when running with local server */}
+        {/* Unified header: logo + tabs + actions in one row */}
         {isEditor && (
-          <div className="shrink-0 px-5 py-3 border-b border-terminal-border-subtle bg-terminal-surface/30 flex items-center justify-between">
-            <div className="inline-flex items-center rounded-xl bg-terminal-surface p-0.5 shadow-layer-sm">
+          <div className="shrink-0 px-5 py-2 border-b border-terminal-border-subtle glass-effect z-40 safe-top flex items-center gap-4">
+            {headerLeft}
+            <div className="inline-flex items-center rounded-xl bg-terminal-surface p-0.5 shadow-layer-sm shrink-0">
               {tabButton("home", "Home")}
               {tabButton("sessions", "Sessions")}
               {tabButton("replays", "Replays")}
               {tabButton("projects", "Projects")}
               {tabButton("insights", "Insights")}
             </div>
-            <NavScanIndicator />
+            <div className="flex-1" />
+            {headerRight}
           </div>
         )}
 
@@ -2814,6 +2822,7 @@ export default function Dashboard() {
           <ReplaysPanel />
         )}
       </div>
+      <ScanToast />
     </ScanInsightsProvider>
   );
 }

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -2715,22 +2715,50 @@ function ReplaysPanel() {
 
 function ScanToast() {
   const { scanStatus } = useScanInsightsContext();
-  if (!scanStatus?.running) return null;
+  const isRunning = !!scanStatus?.running;
+  const [visible, setVisible] = useState(false);
+  const [exiting, setExiting] = useState(false);
+  const lastStatusRef = useRef(scanStatus);
+  if (scanStatus) lastStatusRef.current = scanStatus;
+  const displayStatus = lastStatusRef.current;
+
+  useEffect(() => {
+    if (isRunning) {
+      setExiting(false);
+      setVisible(true);
+    } else if (visible) {
+      setExiting(true);
+      const timer = setTimeout(() => {
+        setVisible(false);
+        setExiting(false);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isRunning, visible]);
+
+  if (!visible || !displayStatus) return null;
 
   const label =
-    scanStatus.phase === "discovering"
+    displayStatus.phase === "discovering"
       ? "Discovering sessions..."
-      : scanStatus.total > 0
-        ? `Scanning ${scanStatus.scanned}/${scanStatus.total}`
+      : displayStatus.total > 0
+        ? `Scanning ${displayStatus.scanned}/${displayStatus.total}`
         : "Preparing scan...";
 
-  const pct = scanStatus.total > 0 ? Math.round((scanStatus.scanned / scanStatus.total) * 100) : 0;
+  const pct =
+    displayStatus.total > 0 ? Math.round((displayStatus.scanned / displayStatus.total) * 100) : 0;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-xs font-mono bg-terminal-surface border border-terminal-border shadow-layer-md animate-in fade-in slide-in-from-bottom-2 duration-300">
+    <div
+      className={`fixed bottom-4 right-4 z-50 flex items-center gap-2.5 rounded-lg px-3.5 py-2.5 text-xs font-mono bg-terminal-surface border border-terminal-border shadow-layer-md transition-all duration-300 ${
+        exiting
+          ? "opacity-0 translate-y-2"
+          : "opacity-100 translate-y-0 animate-in fade-in slide-in-from-bottom-2 duration-300"
+      }`}
+    >
       <span className="w-1.5 h-1.5 rounded-full bg-terminal-purple animate-pulse shrink-0" />
       <span className="text-terminal-dim">{label}</span>
-      {scanStatus.total > 0 && (
+      {displayStatus.total > 0 && (
         <div className="w-16 h-1 rounded-full bg-terminal-surface-2 overflow-hidden">
           <div
             className="h-full bg-terminal-purple rounded-full transition-all duration-300"

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -349,99 +349,6 @@ function AnimatedMetricValue({
 
 // ─── UI Components ───────────────────────────────────────────────────
 
-function MetricCard({
-  label,
-  value,
-  sub,
-  color = "green",
-  icon,
-  onClick,
-}: {
-  label: string;
-  value: React.ReactNode;
-  sub?: string;
-  color?: "green" | "blue" | "orange" | "purple";
-  icon: React.ReactNode;
-  onClick?: () => void;
-}) {
-  const textColor: Record<string, string> = {
-    green: "text-terminal-green",
-    blue: "text-terminal-blue",
-    orange: "text-terminal-orange",
-    purple: "text-terminal-purple",
-  };
-  const bgColor: Record<string, string> = {
-    green: "bg-terminal-green/10",
-    blue: "bg-terminal-blue/10",
-    orange: "bg-terminal-orange/10",
-    purple: "bg-terminal-purple/10",
-  };
-  const gradientBorder: Record<string, string> = {
-    green: "from-terminal-green/20 to-terminal-blue/10",
-    blue: "from-terminal-blue/20 to-terminal-cyan/10",
-    orange: "from-terminal-orange/20 to-terminal-red/10",
-    purple: "from-terminal-purple/20 to-terminal-blue/10",
-  };
-
-  return (
-    <div
-      role={onClick ? "button" : undefined}
-      tabIndex={onClick ? 0 : undefined}
-      onClick={onClick}
-      onKeyDown={
-        onClick
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") onClick();
-            }
-          : undefined
-      }
-      className={`premium-card bg-terminal-surface rounded-xl p-5 shadow-layer-sm hover:bg-terminal-surface-hover transition-all duration-300 hover-lift group ${onClick ? "cursor-pointer" : ""}`}
-    >
-      <div className="flex items-start justify-between relative z-10">
-        <div className="space-y-1.5">
-          <p className="text-[10px] font-sans font-bold text-terminal-dim uppercase tracking-widest opacity-80 group-hover:opacity-100 transition-opacity">
-            {label}
-          </p>
-          <p
-            className={`text-3xl font-mono font-bold tabular-nums tracking-tight ${textColor[color]}`}
-          >
-            {value}
-          </p>
-          {sub && (
-            <p className="text-[11px] font-mono text-terminal-dimmer flex items-center gap-1.5">
-              <span className={`w-1 h-1 rounded-full ${textColor[color]} opacity-50`} />
-              {sub}
-            </p>
-          )}
-        </div>
-        <div
-          className={`w-11 h-11 rounded-xl flex items-center justify-center ${bgColor[color]} border border-white/5 shadow-inner transition-transform duration-300 group-hover:scale-110 group-hover:rotate-3`}
-        >
-          {icon}
-        </div>
-      </div>
-      <div
-        className={`absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br ${gradientBorder[color]} blur-2xl -z-10 pointer-events-none`}
-      />
-    </div>
-  );
-}
-
-function MetricCardSkeleton() {
-  return (
-    <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-3">
-      <div className="flex justify-between">
-        <div className="space-y-2 flex-1">
-          <div className="h-3 w-20 skeleton opacity-40" />
-          <div className="h-8 w-24 skeleton opacity-60" />
-          <div className="h-3 w-32 skeleton opacity-30" />
-        </div>
-        <div className="w-11 h-11 rounded-xl skeleton opacity-20" />
-      </div>
-    </div>
-  );
-}
-
 function RecentProjectsSkeleton() {
   return (
     <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm animate-pulse">
@@ -464,28 +371,6 @@ function RecentProjectsSkeleton() {
         ))}
       </div>
       <div className="h-9 mt-2 rounded-lg bg-terminal-surface-2 skeleton opacity-20" />
-    </div>
-  );
-}
-
-function ProviderBreakdownInline({ breakdown }: { breakdown: InsightStats["providerBreakdown"] }) {
-  const colors: Record<string, string> = {
-    "claude-code": "bg-terminal-orange",
-    cursor: "bg-terminal-blue",
-  };
-  return (
-    <div className="flex items-center gap-3">
-      {breakdown.map((b) => (
-        <div key={b.provider} className="flex items-center gap-1.5">
-          <span
-            className={`w-2 h-2 rounded-sm ${colors[b.provider] || "bg-terminal-dim"}`}
-            style={{ opacity: 0.7 }}
-          />
-          <span className="text-[10px] font-mono text-terminal-dimmer">
-            {b.label} {b.count}
-          </span>
-        </div>
-      ))}
     </div>
   );
 }
@@ -818,45 +703,6 @@ function SystemChecksSection() {
   );
 }
 
-// ─── Icons ───────────────────────────────────────────────────────────
-
-const I = ({ c, children }: { c: string; children: React.ReactNode }) => (
-  <svg
-    width="18"
-    height="18"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={c}
-  >
-    {children}
-  </svg>
-);
-const SessionsIcon = () => (
-  <I c="text-terminal-green">
-    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-  </I>
-);
-const ReplaysIcon = () => (
-  <I c="text-terminal-blue">
-    <polygon points="5 3 19 12 5 21 5 3" />
-  </I>
-);
-const PromptsIcon = () => (
-  <I c="text-terminal-green">
-    <polyline points="4 17 10 11 4 5" />
-    <line x1="12" y1="19" x2="20" y2="19" />
-  </I>
-);
-const ToolsIcon = () => (
-  <I c="text-terminal-orange">
-    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
-  </I>
-);
-
 // ─── Main Component ──────────────────────────────────────────────────
 
 export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
@@ -987,20 +833,24 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
 
   if (loading && !sources.length && !replays.length) {
     return (
-      <div className="flex-1 overflow-auto p-4 md:p-8 space-y-8 animate-in fade-in duration-500">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {[...Array(4)].map((_, i) => (
-            <MetricCardSkeleton key={i} />
-          ))}
-        </div>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 space-y-6">
-            <div className="bg-terminal-surface rounded-xl p-6 h-[300px] skeleton opacity-10" />
-            <div className="bg-terminal-surface rounded-xl p-6 h-[400px] skeleton opacity-10" />
+      <div className="flex-1 overflow-auto animate-in fade-in duration-500">
+        <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-6 animate-pulse">
+          {/* Overview + activity skeleton */}
+          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-4">
+            <div className="grid grid-cols-4 gap-6">
+              {Array.from({ length: 4 }, (_, i) => (
+                <div key={i} className="space-y-2">
+                  <div className="h-7 w-16 skeleton rounded" />
+                  <div className="h-3 w-12 skeleton rounded opacity-40" />
+                </div>
+              ))}
+            </div>
+            <div className="h-[120px] w-full skeleton rounded opacity-15" />
           </div>
-          <div className="space-y-6">
-            <div className="bg-terminal-surface rounded-xl p-6 h-[250px] skeleton opacity-10" />
-            <div className="bg-terminal-surface rounded-xl p-6 h-[350px] skeleton opacity-10" />
+          {/* Sessions + Replays skeleton */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div className="bg-terminal-surface rounded-xl p-4 h-[300px] skeleton opacity-10" />
+            <div className="bg-terminal-surface rounded-xl p-4 h-[300px] skeleton opacity-10" />
           </div>
         </div>
       </div>
@@ -1017,115 +867,124 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     );
   }
 
-  const hasCounts = sources.every((s) => s.promptCount != null);
-  const countsSub = userInsights
-    ? `across ${displayProjectCount} projects`
-    : hasCounts
-      ? `across ${insights.projectCount} projects`
-      : `${sources.filter((s) => s.promptCount != null).length} of ${sources.length} scanned`;
-
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-6">
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          <MetricCard
-            label="Sessions"
-            value={<AnimatedMetricValue value={insights.totalSessions} />}
-            sub={`${displayProjectCount} project${displayProjectCount !== 1 ? "s" : ""}`}
-            color="green"
-            icon={<SessionsIcon />}
+        {/* Combined Overview + Activity */}
+        <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
+          {/* Compact stats row */}
+          <div className="flex items-start justify-between mb-4">
+            <div className="grid grid-cols-4 gap-x-6 gap-y-1 flex-1 min-w-0">
+              <div>
+                <div className="text-2xl font-mono font-bold text-terminal-green tabular-nums">
+                  <AnimatedMetricValue value={insights.totalSessions} />
+                </div>
+                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest mt-0.5">
+                  sessions
+                </div>
+              </div>
+              <div>
+                <div className="text-2xl font-mono font-bold text-terminal-blue tabular-nums">
+                  <AnimatedMetricValue value={insights.totalReplays} />
+                </div>
+                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest mt-0.5">
+                  replays
+                </div>
+              </div>
+              <div>
+                <div className="text-2xl font-mono font-bold text-terminal-green tabular-nums">
+                  <AnimatedMetricValue value={displayTotalPrompts} />
+                </div>
+                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest mt-0.5">
+                  turns
+                </div>
+              </div>
+              <div>
+                <div className="text-2xl font-mono font-bold text-terminal-orange tabular-nums">
+                  <AnimatedMetricValue value={displayTotalToolCalls} />
+                </div>
+                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest mt-0.5">
+                  tool calls
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              {displayProviderBreakdown.map((b) => (
+                <div
+                  key={b.provider}
+                  className={`flex items-center gap-1.5 px-2 py-0.5 rounded-md ${b.provider === "claude-code" ? "bg-terminal-orange/8" : b.provider === "cursor" ? "bg-terminal-blue/8" : "bg-terminal-dim/8"}`}
+                >
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${b.provider === "claude-code" ? "bg-terminal-orange" : b.provider === "cursor" ? "bg-terminal-blue" : "bg-terminal-dim"}`}
+                  />
+                  <span
+                    className={`text-[10px] font-mono tabular-nums ${b.provider === "claude-code" ? "text-terminal-orange/80" : b.provider === "cursor" ? "text-terminal-blue/80" : "text-terminal-dim"}`}
+                  >
+                    {b.label}
+                  </span>
+                  <span
+                    className={`text-[10px] font-mono font-bold tabular-nums ${b.provider === "claude-code" ? "text-terminal-orange" : b.provider === "cursor" ? "text-terminal-blue" : "text-terminal-dim"}`}
+                  >
+                    {b.count}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Heatmap */}
+          <ContributionHeatmap sessionsPerDay={displaySessionsPerDay} weeks={52} />
+
+          {/* CTA link */}
+          <button
             onClick={() => onNavigate("insights")}
-          />
-          <MetricCard
-            label="Replays"
-            value={<AnimatedMetricValue value={insights.totalReplays} />}
-            sub={insights.publishedCount > 0 ? `${insights.publishedCount} published` : undefined}
-            color="blue"
-            icon={<ReplaysIcon />}
-            onClick={() => onNavigate("insights")}
-          />
-          <MetricCard
-            label="Turns"
-            value={<AnimatedMetricValue value={displayTotalPrompts} />}
-            sub={countsSub}
-            color="green"
-            icon={<PromptsIcon />}
-            onClick={() => onNavigate("insights")}
-          />
-          <MetricCard
-            label="Tool Calls"
-            value={<AnimatedMetricValue value={displayTotalToolCalls} />}
-            sub={countsSub}
-            color="orange"
-            icon={<ToolsIcon />}
-            onClick={() => onNavigate("insights")}
-          />
+            className="w-full py-2 mt-3 text-xs font-sans font-semibold rounded-lg bg-terminal-surface-2 text-terminal-dim hover:text-terminal-green hover:bg-terminal-surface-hover transition-colors"
+          >
+            View personal insights &rarr;
+          </button>
         </div>
 
-        {scanStatus?.running && (
-          <div className="rounded-xl border border-terminal-purple/20 bg-terminal-surface px-4 py-3">
-            <div className="flex items-center gap-2 text-sm font-sans text-terminal-text">
-              <span className="w-2 h-2 rounded-full bg-terminal-purple animate-pulse" />
-              <span>
-                {scanStatus.phase === "discovering"
-                  ? "Refreshing session discovery"
-                  : "Refreshing dashboard insights"}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
+                Recent Sessions
+              </h3>
+              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
+                {insights.totalSessions} total
               </span>
             </div>
-            <p className="mt-1 text-xs font-mono text-terminal-dim">
-              {scanStatus.phase === "discovering"
-                ? "Showing the last completed dashboard while new sessions are discovered."
-                : scanStatus.total > 0
-                  ? `Showing cached totals while ${scanStatus.scanned}/${scanStatus.total} sessions refresh.`
-                  : "Showing cached totals while the latest scan spins up."}
-            </p>
+            <RecentSessionsList
+              sessions={insights.recentSources}
+              isLoading={loadingSources}
+              onViewAll={() => onNavigate("sessions")}
+              onGenerate={handleGenerate}
+              onViewReplay={handleOpenReplay}
+              onSessionClick={(s) => setSelectedSlug(s.slug)}
+              generatingSlug={generatingSlug}
+              generateErrorSlug={generateErrorSlug}
+            />
           </div>
-        )}
 
-        {/* Activity Heatmap (GitHub-style, full width) */}
-        <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-              Activity
-            </h3>
-            <ProviderBreakdownInline breakdown={displayProviderBreakdown} />
+          <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
+                Recent Replays
+              </h3>
+              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
+                {insights.totalReplays} total
+              </span>
+            </div>
+            <RecentReplaysList
+              replays={insights.recentReplays}
+              isLoading={loadingReplays}
+              onViewAll={() => onNavigate("replays")}
+              onOpen={handleOpenReplay}
+            />
           </div>
-          <ContributionHeatmap sessionsPerDay={displaySessionsPerDay} weeks={52} />
         </div>
 
-        {/* CTA to Insights */}
-        <button
-          onClick={() => onNavigate("insights")}
-          className="w-full py-3.5 rounded-xl bg-gradient-to-r from-terminal-green/10 to-terminal-blue/10 border border-terminal-green/20 hover:border-terminal-green/40 text-sm font-sans font-medium text-terminal-text hover:text-terminal-green transition-all group flex items-center justify-center gap-2"
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            className="text-terminal-green"
-          >
-            <path d="M3 3v18h18" />
-            <path d="M7 16l4-8 4 4 5-10" />
-          </svg>
-          View your personal insights
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 16 16"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            className="opacity-50 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all"
-          >
-            <path d="M5 3l5 5-5 5" />
-          </svg>
-        </button>
-
-        {/* Recent Projects (from scan data — top 5 by lastActivity) */}
+        {/* Recent Projects (below sessions/replays to match tab menu order) */}
         {showRecentProjectsSkeleton ? (
           <RecentProjectsSkeleton />
         ) : userInsights && userInsights.topProjects.length > 1 ? (
@@ -1183,46 +1042,6 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             )}
           </div>
         ) : null}
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-          <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                Recent Sessions
-              </h3>
-              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
-                {insights.totalSessions} total
-              </span>
-            </div>
-            <RecentSessionsList
-              sessions={insights.recentSources}
-              isLoading={loadingSources}
-              onViewAll={() => onNavigate("sessions")}
-              onGenerate={handleGenerate}
-              onViewReplay={handleOpenReplay}
-              onSessionClick={(s) => setSelectedSlug(s.slug)}
-              generatingSlug={generatingSlug}
-              generateErrorSlug={generateErrorSlug}
-            />
-          </div>
-
-          <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                Recent Replays
-              </h3>
-              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
-                {insights.totalReplays} total
-              </span>
-            </div>
-            <RecentReplaysList
-              replays={insights.recentReplays}
-              isLoading={loadingReplays}
-              onViewAll={() => onNavigate("replays")}
-              onOpen={handleOpenReplay}
-            />
-          </div>
-        </div>
 
         <SystemChecksSection />
       </div>

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -51,8 +51,8 @@ function useDashboardData() {
   const [loadingSources, setLoadingSources] = useState(true);
   const [loadingReplays, setLoadingReplays] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [scanProgress, setScanProgress] = useState<number | null>(null);
-  const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
+  const [, setScanProgress] = useState<number | null>(null);
+  const [, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const wasEnrichingRef = useRef(false);
   const hasCursorSources = useMemo(
     () => sources.some((source) => source.provider === "cursor"),
@@ -221,8 +221,6 @@ function useDashboardData() {
     loadingSources,
     loadingReplays,
     error,
-    scanProgress,
-    enrichmentStatus,
   };
 }
 

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -667,8 +667,7 @@ function ShareCard({
         <div className="flex items-center justify-between pt-4 border-t border-terminal-border/30">
           <div className="flex items-center gap-4">
             {streak.current > 0 && (
-              <span className="text-xs font-mono text-terminal-dim flex items-center gap-1.5">
-                <span className="text-terminal-orange">&#9632;</span>
+              <span className="text-xs font-mono text-terminal-dim">
                 {streak.current} day streak
               </span>
             )}
@@ -1254,26 +1253,6 @@ export default function InsightsPage() {
             ))}
           </div>
         </div>
-
-        {scanStatus?.running && (
-          <div className="rounded-xl border border-terminal-blue/20 bg-terminal-surface px-4 py-3">
-            <div className="flex items-center gap-2 text-sm font-sans text-terminal-text">
-              <span className="w-2 h-2 rounded-full bg-terminal-blue animate-pulse" />
-              <span>
-                {scanStatus.phase === "discovering"
-                  ? "Refreshing source discovery in the background"
-                  : "Refreshing insights in the background"}
-              </span>
-            </div>
-            <p className="mt-1 text-xs font-mono text-terminal-dim">
-              {scanStatus.phase === "discovering"
-                ? "Showing your last completed insights while we look for new sessions."
-                : scanStatus.total > 0
-                  ? `Showing cached insights while ${scanStatus.scanned}/${scanStatus.total} sessions refresh.`
-                  : "Showing cached insights while new scan data loads."}
-            </p>
-          </div>
-        )}
 
         {/* Share Card */}
         <ShareCard

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -81,6 +81,7 @@ export interface SourceSession {
 }
 
 declare global {
+  const __CLI_VERSION__: string;
   interface Window {
     __VIBE_REPLAY_DATA__?: ReplaySession;
     __VIBE_REPLAY_EDITOR__?: boolean;

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -1,6 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
+
+/** Read CLI package.json version at build time */
+function getCliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(resolve(__dirname, "../cli/package.json"), "utf-8"));
+    return pkg.version || "dev";
+  } catch {
+    return "dev";
+  }
+}
 
 /** Inject __VIBE_REPLAY_EDITOR__ flag in dev mode so the viewer enters editor mode */
 function editorFlagPlugin(): Plugin {
@@ -20,6 +32,7 @@ export default defineConfig({
     // Bake cloud API URL at build time. Vite's import.meta.env.VITE_* replacement
     // runs before define, so we use a custom global instead.
     __CLOUD_API_URL__: JSON.stringify(process.env.VITE_CLOUD_API_URL || "https://vibe-replay.com"),
+    __CLI_VERSION__: JSON.stringify(getCliVersion()),
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary

- **Compact overview card**: Merged 4 separate stat cards + activity heatmap + CTA into one unified card, saving ~200px vertical space
- **Unified header**: Dashboard and replay views now share the same left-aligned layout (logo → LOCAL → tabs → content → actions) instead of two different styles
- **ScanToast**: Replaced inline scan progress banners (which caused layout shifts) with a fixed bottom-right toast notification
- **Layout reorder**: Recent Projects moved below Sessions/Replays to match tab menu order (Home → Sessions → Replays → Projects → Insights)
- **Version in tooltip**: LOCAL badge tooltip now shows CLI version (e.g. `v0.1.3`)
- **Cleanup**: Removed unused MetricCard, icon components, NavScanIndicator, and standalone Dashboard button (-214 lines net)

## Test plan

- [x] `pnpm lint:check` passes
- [x] `pnpm test` — 607 CLI + 87 viewer unit tests pass
- [x] `pnpm build && pnpm test:e2e` — 23 E2E tests pass
- [ ] Visual review: dashboard home layout is compact and consistent
- [ ] Visual review: replay header matches dashboard header style
- [ ] Scan toast appears bottom-right during background scan without layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)