### PR TITLE
feat: persistent local insights store with cloud sync and online dashboard

### DIFF
--- a/cloudflare/drizzle/0004_tough_shiver_man.sql
+++ b/cloudflare/drizzle/0004_tough_shiver_man.sql
@@ -1,0 +1,30 @@
+CREATE TABLE `session_insights` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`session_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`slug` text NOT NULL,
+	`title` text,
+	`project` text,
+	`model` text,
+	`start_time` text,
+	`duration_ms` integer,
+	`prompt_count` integer DEFAULT 0,
+	`tool_call_count` integer DEFAULT 0,
+	`edit_count` integer DEFAULT 0,
+	`cost_estimate` real,
+	`has_pr` integer DEFAULT false,
+	`sub_agent_count` integer DEFAULT 0,
+	`api_error_count` integer DEFAULT 0,
+	`metadata` text,
+	`captured_at` text NOT NULL,
+	`captured_by_version` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_insights_user` ON `session_insights` (`user_id`);--> statement-breakpoint
+CREATE INDEX `idx_insights_project` ON `session_insights` (`user_id`,`project`);--> statement-breakpoint
+CREATE INDEX `idx_insights_start` ON `session_insights` (`user_id`,`start_time`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_user_session` ON `session_insights` (`user_id`,`session_id`);

--- a/cloudflare/drizzle/meta/0004_snapshot.json
+++ b/cloudflare/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,880 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2e5af026-010e-4885-8e55-fe8b678448c6",
+  "prevId": "e5dc0a14-e78e-4842-91f3-049f1037f589",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloud_replays": {
+      "name": "cloud_replays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'r2'"
+        },
+        "gist_id": {
+          "name": "gist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_url": {
+          "name": "gist_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_owner": {
+          "name": "gist_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-code'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scene_count": {
+          "name": "scene_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_prompts": {
+          "name": "user_prompts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_estimate": {
+          "name": "cost_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unlisted'"
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloud_replays_gist_id_unique": {
+          "name": "cloud_replays_gist_id_unique",
+          "columns": ["gist_id"],
+          "isUnique": true
+        },
+        "idx_cloud_replays_user": {
+          "name": "idx_cloud_replays_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_cloud_replays_expires": {
+          "name": "idx_cloud_replays_expires",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "idx_cloud_replays_gist": {
+          "name": "idx_cloud_replays_gist",
+          "columns": ["gist_id"],
+          "isUnique": false
+        },
+        "idx_cloud_replays_public": {
+          "name": "idx_cloud_replays_public",
+          "columns": ["visibility", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cloud_replays_user_id_user_id_fk": {
+          "name": "cloud_replays_user_id_user_id_fk",
+          "tableFrom": "cloud_replays",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replays": {
+      "name": "replays",
+      "columns": {
+        "gist_id": {
+          "name": "gist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-code'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scene_count": {
+          "name": "scene_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_prompts": {
+          "name": "user_prompts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_estimate": {
+          "name": "cost_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_owner": {
+          "name": "gist_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_replays_created": {
+          "name": "idx_replays_created",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_replays_views": {
+          "name": "idx_replays_views",
+          "columns": ["view_count"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_insights": {
+      "name": "session_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_count": {
+          "name": "prompt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "edit_count": {
+          "name": "edit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_estimate": {
+          "name": "cost_estimate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_pr": {
+          "name": "has_pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "sub_agent_count": {
+          "name": "sub_agent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "api_error_count": {
+          "name": "api_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "captured_by_version": {
+          "name": "captured_by_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_insights_user": {
+          "name": "idx_insights_user",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_insights_project": {
+          "name": "idx_insights_project",
+          "columns": ["user_id", "project"],
+          "isUnique": false
+        },
+        "idx_insights_start": {
+          "name": "idx_insights_start",
+          "columns": ["user_id", "start_time"],
+          "isUnique": false
+        },
+        "uq_user_session": {
+          "name": "uq_user_session",
+          "columns": ["user_id", "session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_insights_user_id_user_id_fk": {
+          "name": "session_insights_user_id_user_id_fk",
+          "tableFrom": "session_insights",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/cloudflare/drizzle/meta/_journal.json
+++ b/cloudflare/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773912285580,
       "tag": "0003_fancy_iron_monger",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1775365329540,
+      "tag": "0004_tough_shiver_man",
+      "breakpoints": true
     }
   ]
 }

--- a/cloudflare/src/db/schema.ts
+++ b/cloudflare/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, integer, real, sqliteTable, text, unique } from "drizzle-orm/sqlite-core";
 
 // ---------------------------------------------------------------------------
 // Replays (existing)
@@ -152,5 +152,57 @@ export const cloudReplays = sqliteTable(
     index("idx_cloud_replays_expires").on(table.expiresAt),
     index("idx_cloud_replays_gist").on(table.gistId),
     index("idx_cloud_replays_public").on(table.visibility, table.createdAt),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Session Insights — synced from CLI for long-term persistence
+// ---------------------------------------------------------------------------
+
+export const sessionInsights = sqliteTable(
+  "session_insights",
+  {
+    id: text("id").primaryKey(), // nanoid, 12 chars
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+
+    // Identity
+    sessionId: text("session_id").notNull(),
+    provider: text("provider").notNull(),
+    slug: text("slug").notNull(),
+
+    // Core queryable fields
+    title: text("title"),
+    project: text("project"),
+    model: text("model"),
+    startTime: text("start_time"),
+    durationMs: integer("duration_ms"),
+
+    // Stats
+    promptCount: integer("prompt_count").default(0),
+    toolCallCount: integer("tool_call_count").default(0),
+    editCount: integer("edit_count").default(0),
+    costEstimate: real("cost_estimate"),
+
+    // Flags
+    hasPR: integer("has_pr", { mode: "boolean" }).default(false),
+    subAgentCount: integer("sub_agent_count").default(0),
+    apiErrorCount: integer("api_error_count").default(0),
+
+    // JSON blob for extensible fields (full SessionInsight minus queryable columns)
+    metadata: text("metadata"),
+
+    // Tracking
+    capturedAt: text("captured_at").notNull(),
+    capturedByVersion: text("captured_by_version"),
+    createdAt: text("created_at").default(sql`(datetime('now'))`).notNull(),
+    updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    unique("uq_user_session").on(table.userId, table.sessionId),
+    index("idx_insights_user").on(table.userId),
+    index("idx_insights_project").on(table.userId, table.project),
+    index("idx_insights_start").on(table.userId, table.startTime),
   ],
 );

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { nanoid } from "nanoid";
 import { type AuthEnv, createAuth, DEV_ORIGINS, PROD_ORIGINS } from "./auth";
-import { cloudReplays, replays } from "./db/schema";
+import { cloudReplays, replays, sessionInsights } from "./db/schema";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1020,6 +1020,261 @@ app.put("/api/replays", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// Session Insights API — synced from CLI for long-term persistence
+// ---------------------------------------------------------------------------
+
+const MAX_INSIGHTS_BATCH = 200;
+
+/** Batch upsert insights from CLI */
+app.post("/api/insights/sync", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const body = await c.req.json();
+  if (!Array.isArray(body.insights) || body.insights.length === 0) {
+    return c.json({ error: "insights array required" }, 400);
+  }
+  if (body.insights.length > MAX_INSIGHTS_BATCH) {
+    return c.json({ error: `Max ${MAX_INSIGHTS_BATCH} insights per batch` }, 400);
+  }
+
+  const db = drizzle(c.env.DB);
+  const cloudIds: Record<string, string> = {};
+  let synced = 0;
+  let failed = 0;
+
+  // Pre-fetch existing records in one query to avoid N+1
+  const sessionIds = body.insights
+    .filter((i: any) => i.sessionId && i.provider)
+    .map((i: any) => String(i.sessionId));
+  const existingRows =
+    sessionIds.length > 0
+      ? await db
+          .select({ id: sessionInsights.id, sessionId: sessionInsights.sessionId })
+          .from(sessionInsights)
+          .where(
+            and(eq(sessionInsights.userId, userId), inArray(sessionInsights.sessionId, sessionIds)),
+          )
+      : [];
+  const existingMap = new Map(existingRows.map((r) => [r.sessionId, r.id]));
+
+  for (const insight of body.insights) {
+    if (!insight.sessionId || !insight.provider) continue;
+
+    const metadata = JSON.stringify(insight);
+    const costEst =
+      insight.costEstimate != null
+        ? Math.max(0, Math.min(Number(insight.costEstimate) || 0, 100_000))
+        : null;
+
+    try {
+      const existingId = existingMap.get(insight.sessionId);
+
+      if (existingId) {
+        await db
+          .update(sessionInsights)
+          .set({
+            title: insight.title?.slice(0, 500) || null,
+            project: insight.project?.slice(0, 500) || null,
+            model: insight.model?.slice(0, 200) || null,
+            startTime: insight.startTime || null,
+            durationMs: clamp(insight.durationMs, 0, 86_400_000),
+            promptCount: clamp(insight.promptCount, 0, 10_000),
+            toolCallCount: clamp(insight.toolCallCount, 0, 100_000),
+            editCount: clamp(insight.editCount, 0, 100_000),
+            costEstimate: costEst,
+            hasPR: insight.hasPR || false,
+            subAgentCount: clamp(insight.subAgentCount, 0, 10_000),
+            apiErrorCount: clamp(insight.apiErrorCount, 0, 10_000),
+            metadata,
+            capturedByVersion: insight.capturedByVersion?.slice(0, 50) || null,
+            updatedAt: new Date().toISOString().replace("T", " ").slice(0, 19),
+          })
+          .where(eq(sessionInsights.id, existingId));
+        cloudIds[insight.sessionId] = existingId;
+      } else {
+        const id = nanoid(12);
+        await db.insert(sessionInsights).values({
+          id,
+          userId,
+          sessionId: insight.sessionId,
+          provider: String(insight.provider).slice(0, 50),
+          slug: String(insight.slug || insight.sessionId.slice(0, 8)).slice(0, 50),
+          title: insight.title?.slice(0, 500) || null,
+          project: insight.project?.slice(0, 500) || null,
+          model: insight.model?.slice(0, 200) || null,
+          startTime: insight.startTime || null,
+          durationMs: clamp(insight.durationMs, 0, 86_400_000),
+          promptCount: clamp(insight.promptCount, 0, 10_000),
+          toolCallCount: clamp(insight.toolCallCount, 0, 100_000),
+          editCount: clamp(insight.editCount, 0, 100_000),
+          costEstimate: costEst,
+          hasPR: insight.hasPR || false,
+          subAgentCount: clamp(insight.subAgentCount, 0, 10_000),
+          apiErrorCount: clamp(insight.apiErrorCount, 0, 10_000),
+          metadata,
+          capturedAt: insight.capturedAt || new Date().toISOString(),
+          capturedByVersion: insight.capturedByVersion?.slice(0, 50) || null,
+        });
+        cloudIds[insight.sessionId] = id;
+        existingMap.set(insight.sessionId, id); // track for duplicate sessionIds in batch
+      }
+      synced++;
+    } catch (e) {
+      failed++;
+      console.error(`Failed to sync insight ${insight.sessionId}:`, e);
+    }
+  }
+
+  return c.json({ synced, failed, total: body.insights.length, cloudIds });
+});
+
+/** List user's synced insights (paginated) */
+app.get("/api/insights", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const project = c.req.query("project");
+  const after = c.req.query("after");
+  const before = c.req.query("before");
+  const limit = Math.min(Number(c.req.query("limit")) || 100, 500);
+  const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
+
+  const db = drizzle(c.env.DB);
+  const conditions = [eq(sessionInsights.userId, userId)];
+  if (project) conditions.push(eq(sessionInsights.project, project));
+  if (after) conditions.push(sql`${sessionInsights.startTime} >= ${after}`);
+  if (before) conditions.push(sql`${sessionInsights.startTime} <= ${before}`);
+
+  const results = await db
+    .select()
+    .from(sessionInsights)
+    .where(and(...conditions))
+    .orderBy(desc(sessionInsights.startTime))
+    .limit(limit)
+    .offset(offset);
+
+  const [countResult] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(sessionInsights)
+    .where(and(...conditions));
+
+  return c.json({
+    insights: results,
+    total: countResult?.count || 0,
+    limit,
+    offset,
+  });
+});
+
+/** Aggregated insights summary for the user */
+app.get("/api/insights/summary", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const db = drizzle(c.env.DB);
+
+  // Aggregate stats
+  const [agg] = await db
+    .select({
+      totalSessions: sql<number>`count(*)`,
+      totalProjects: sql<number>`count(distinct ${sessionInsights.project})`,
+      totalDurationMs: sql<number>`coalesce(sum(${sessionInsights.durationMs}), 0)`,
+      totalCost: sql<number>`coalesce(sum(${sessionInsights.costEstimate}), 0)`,
+      totalPrompts: sql<number>`coalesce(sum(${sessionInsights.promptCount}), 0)`,
+      totalToolCalls: sql<number>`coalesce(sum(${sessionInsights.toolCallCount}), 0)`,
+      totalEdits: sql<number>`coalesce(sum(${sessionInsights.editCount}), 0)`,
+      firstSession: sql<string>`min(${sessionInsights.startTime})`,
+      lastSession: sql<string>`max(${sessionInsights.startTime})`,
+    })
+    .from(sessionInsights)
+    .where(eq(sessionInsights.userId, userId));
+
+  // Provider breakdown
+  const providerRows = await db
+    .select({
+      provider: sessionInsights.provider,
+      count: sql<number>`count(*)`,
+    })
+    .from(sessionInsights)
+    .where(eq(sessionInsights.userId, userId))
+    .groupBy(sessionInsights.provider);
+  const providers: Record<string, number> = {};
+  for (const r of providerRows) providers[r.provider] = r.count;
+
+  // Model breakdown
+  const modelRows = await db
+    .select({
+      model: sessionInsights.model,
+      count: sql<number>`count(*)`,
+    })
+    .from(sessionInsights)
+    .where(and(eq(sessionInsights.userId, userId), sql`${sessionInsights.model} IS NOT NULL`))
+    .groupBy(sessionInsights.model);
+  const models: Record<string, number> = {};
+  for (const r of modelRows) if (r.model) models[r.model] = r.count;
+
+  // Top projects
+  const topProjects = await db
+    .select({
+      project: sessionInsights.project,
+      sessions: sql<number>`count(*)`,
+      cost: sql<number>`coalesce(sum(${sessionInsights.costEstimate}), 0)`,
+      durationMs: sql<number>`coalesce(sum(${sessionInsights.durationMs}), 0)`,
+      prompts: sql<number>`coalesce(sum(${sessionInsights.promptCount}), 0)`,
+      toolCalls: sql<number>`coalesce(sum(${sessionInsights.toolCallCount}), 0)`,
+      edits: sql<number>`coalesce(sum(${sessionInsights.editCount}), 0)`,
+      lastActivity: sql<string>`max(${sessionInsights.startTime})`,
+    })
+    .from(sessionInsights)
+    .where(eq(sessionInsights.userId, userId))
+    .groupBy(sessionInsights.project)
+    .orderBy(sql`count(*) desc`)
+    .limit(20);
+
+  // Sessions per day (last 90 days)
+  const dailyRows = await db
+    .select({
+      day: sql<string>`date(${sessionInsights.startTime})`,
+      count: sql<number>`count(*)`,
+    })
+    .from(sessionInsights)
+    .where(
+      and(
+        eq(sessionInsights.userId, userId),
+        sql`${sessionInsights.startTime} >= date('now', '-90 days')`,
+      ),
+    )
+    .groupBy(sql`date(${sessionInsights.startTime})`)
+    .orderBy(sql`date(${sessionInsights.startTime})`);
+  const sessionsPerDay: Record<string, number> = {};
+  for (const r of dailyRows) if (r.day) sessionsPerDay[r.day] = r.count;
+
+  return c.json({
+    totalSessions: agg?.totalSessions || 0,
+    totalProjects: agg?.totalProjects || 0,
+    totalDurationMs: agg?.totalDurationMs || 0,
+    totalCost: agg?.totalCost || 0,
+    totalPrompts: agg?.totalPrompts || 0,
+    totalToolCalls: agg?.totalToolCalls || 0,
+    totalEdits: agg?.totalEdits || 0,
+    providers,
+    models,
+    topProjects: topProjects.map((p) => ({
+      ...p,
+      project: p.project || "(unknown)",
+    })),
+    timeRange: {
+      first: agg?.firstSession || "",
+      last: agg?.lastSession || "",
+    },
+    sessionsPerDay,
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Short URL for cloud replays — redirect to viewer
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -1,0 +1,226 @@
+/**
+ * Local Insights Store — durable session insights that survive source file deletion.
+ *
+ * Unlike the ephemeral scan cache (which invalidates on CLI version change), the
+ * insights store persists indefinitely at ~/.vibe-replay/insights/store.json.
+ * This ensures insights remain available even after Claude Code's 30-day JSONL
+ * cleanup or Cursor transcript deletion.
+ *
+ * Key design:
+ * - Schema versioned independently from CLI version (forward-migrated, never invalidated)
+ * - Append/update only — sessions are never deleted from the store
+ * - Sync state tracked per-session for cloud sync
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { InsightsStore, SessionInsight } from "@vibe-replay/types";
+import { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
+import type { SessionScanResult } from "./scanner.js";
+import { CLI_VERSION } from "./version.js";
+
+const INSIGHTS_DIR = join(homedir(), ".vibe-replay", "insights");
+const STORE_PATH = join(INSIGHTS_DIR, "store.json");
+
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+
+export async function readInsightsStore(): Promise<InsightsStore> {
+  try {
+    const raw = await readFile(STORE_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<InsightsStore>;
+    return migrateInsightsStore(parsed);
+  } catch {
+    return emptyStore();
+  }
+}
+
+export async function writeInsightsStore(store: InsightsStore): Promise<void> {
+  try {
+    await mkdir(dirname(STORE_PATH), { recursive: true });
+    store.lastUpdated = new Date().toISOString();
+    // Write to temp then rename (atomic on POSIX same-filesystem)
+    const tmpPath = `${STORE_PATH}.tmp`;
+    await writeFile(tmpPath, JSON.stringify(store), "utf-8");
+    await rename(tmpPath, STORE_PATH);
+  } catch {
+    // Best-effort — never break core flows
+  }
+}
+
+function emptyStore(): InsightsStore {
+  return {
+    schemaVersion: INSIGHTS_SCHEMA_VERSION,
+    lastUpdated: new Date().toISOString(),
+    sessions: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+function migrateInsightsStore(raw: Partial<InsightsStore>): InsightsStore {
+  if (!raw || typeof raw !== "object") return emptyStore();
+  const v = raw.schemaVersion ?? 0;
+
+  // v0 → v1: initial schema
+  if (v < 1) {
+    return {
+      schemaVersion: INSIGHTS_SCHEMA_VERSION,
+      lastUpdated: raw.lastUpdated || new Date().toISOString(),
+      sessions: Array.isArray(raw.sessions) ? raw.sessions : [],
+    };
+  }
+
+  // Future migrations go here:
+  // if (v < 2) { ... }
+
+  // Ensure required fields exist even for current/future schema versions
+  return {
+    schemaVersion: raw.schemaVersion ?? INSIGHTS_SCHEMA_VERSION,
+    lastUpdated: raw.lastUpdated || new Date().toISOString(),
+    sessions: Array.isArray(raw.sessions) ? raw.sessions : [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Conversion: SessionScanResult → SessionInsight
+// ---------------------------------------------------------------------------
+
+export function scanResultToInsight(scan: SessionScanResult): SessionInsight {
+  return {
+    sessionId: scan.sessionId,
+    slug: scan.slug,
+    provider: scan.provider,
+    title: scan.title,
+    project: scan.project,
+    model: scan.model,
+    gitBranch: scan.gitBranch,
+    gitBranches: scan.gitBranches,
+    startTime: scan.startTime,
+    endTime: scan.endTime,
+    durationMs: scan.durationMs,
+    promptCount: scan.promptCount,
+    toolCallCount: scan.toolCallCount,
+    editCount: scan.editCount,
+    filesModified: scan.filesModified?.length ? scan.filesModified : undefined,
+    tokenUsage: scan.tokenUsage,
+    costEstimate: scan.costEstimate,
+    hasPR: !!(scan.prLinks && scan.prLinks.length > 0),
+    prLinks: scan.prLinks,
+    skillsUsed: scan.skillsUsed,
+    mcpServersUsed: scan.mcpServersUsed,
+    subAgentCount: scan.subAgentCount,
+    apiErrorCount: scan.apiErrorCount,
+    compactionCount: scan.compactionCount,
+    entrypoint: scan.entrypoint,
+    permissionMode: scan.permissionMode,
+    firstPrompt: scan.firstPrompt,
+    capturedAt: new Date().toISOString(),
+    capturedByVersion: CLI_VERSION,
+    dataSource: scan.dataSource,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Merge — upsert by sessionId, never delete
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge new scan results into the insights store.
+ * - New sessions are inserted
+ * - Existing sessions are updated (if source files still exist = re-scanned)
+ * - Sessions whose source files are gone are kept as-is (precious!)
+ */
+export function mergeInsights(
+  store: InsightsStore,
+  scanResults: SessionScanResult[],
+): InsightsStore {
+  const byId = new Map<string, SessionInsight>();
+  for (const existing of store.sessions) {
+    byId.set(existing.sessionId, existing);
+  }
+
+  for (const scan of scanResults) {
+    const existing = byId.get(scan.sessionId);
+    if (existing) {
+      // Update with fresh data but preserve sync state and provenance
+      const updated = scanResultToInsight(scan);
+      updated.capturedAt = existing.capturedAt; // keep original capture time
+      updated.updatedAt = new Date().toISOString();
+      updated.syncedAt = existing.syncedAt;
+      updated.cloudId = existing.cloudId;
+      byId.set(scan.sessionId, updated);
+    } else {
+      byId.set(scan.sessionId, scanResultToInsight(scan));
+    }
+  }
+
+  return {
+    schemaVersion: INSIGHTS_SCHEMA_VERSION,
+    lastUpdated: new Date().toISOString(),
+    sessions: [...byId.values()],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sync helpers
+// ---------------------------------------------------------------------------
+
+/** Get insights that need syncing (never synced or updated since last sync) */
+export function getUnsyncedInsights(store: InsightsStore): SessionInsight[] {
+  return store.sessions.filter((s) => {
+    if (!s.syncedAt) return true;
+    if (s.updatedAt && s.updatedAt > s.syncedAt) return true;
+    return false;
+  });
+}
+
+/** Mark sessions as synced after successful cloud upload */
+export function markSynced(
+  store: InsightsStore,
+  syncedIds: Map<string, string>, // sessionId → cloudId
+): InsightsStore {
+  const now = new Date().toISOString();
+  const sessions = store.sessions.map((s) => {
+    const cloudId = syncedIds.get(s.sessionId);
+    if (cloudId !== undefined) {
+      return { ...s, syncedAt: now, cloudId };
+    }
+    return s;
+  });
+  return { ...store, sessions, lastUpdated: now };
+}
+
+/** Get store file path (for display/debugging) */
+export function getInsightsStorePath(): string {
+  return STORE_PATH;
+}
+
+/** Get store stats */
+export function getInsightsStats(store: InsightsStore): {
+  total: number;
+  synced: number;
+  unsynced: number;
+  providers: Record<string, number>;
+  projects: number;
+} {
+  let synced = 0;
+  const providers: Record<string, number> = {};
+  const projects = new Set<string>();
+  for (const s of store.sessions) {
+    if (s.syncedAt) synced++;
+    providers[s.provider] = (providers[s.provider] || 0) + 1;
+    projects.add(s.project);
+  }
+  return {
+    total: store.sessions.length,
+    synced,
+    unsynced: store.sessions.length - synced,
+    providers,
+    projects: projects.size,
+  };
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -22,6 +22,7 @@ import {
 import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput } from "./generator.js";
+import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
@@ -970,6 +971,13 @@ export async function startServer(
         computedAt: null,
       };
 
+  /** Persist scan results into the durable local insights store. */
+  const persistInsightsFromScan = async (results: SessionScanResult[]): Promise<void> => {
+    const store = await readInsightsStore();
+    const updated = mergeInsights(store, results);
+    await writeInsightsStore(updated);
+  };
+
   /** Pre-compute all insights from scan results and store in cache. */
   const precomputeInsightsCache = async (results: SessionScanResult[]): Promise<void> => {
     // User-level insights
@@ -1081,6 +1089,9 @@ export async function startServer(
         };
 
         await writeFileCache(scanResultsCacheKey, results);
+
+        // Persist insights to durable local store (survives source file deletion)
+        persistInsightsFromScan(results).catch(() => {});
 
         // Pre-compute insights cache in background (non-blocking)
         precomputeInsightsCache(results).catch(() => {});
@@ -1518,6 +1529,106 @@ export async function startServer(
     }
     const insights = aggregateUserInsights(scans);
     return c.json({ type: "user", insights });
+  });
+
+  // --- Local insights store (durable, survives source deletion) ---
+
+  app.get("/api/insights/local", async (c) => {
+    const store = await readInsightsStore();
+    return c.json(store);
+  });
+
+  app.get("/api/insights/local/stats", async (c) => {
+    const { getInsightsStats } = await import("./insights.js");
+    const store = await readInsightsStore();
+    return c.json(getInsightsStats(store));
+  });
+
+  app.post("/api/insights/sync", async (c) => {
+    const { getUnsyncedInsights, markSynced } = await import("./insights.js");
+    const { loadAuthToken, getApiUrl, getSessionCookieName } = await import(
+      "./publishers/cloud.js"
+    );
+
+    const auth = await loadAuthToken();
+    if (!auth) {
+      return c.json({ error: "Not logged in. Run: vibe-replay auth login" }, 401);
+    }
+
+    const store = await readInsightsStore();
+    const unsynced = getUnsyncedInsights(store);
+    if (unsynced.length === 0) {
+      return c.json({ synced: 0, message: "All insights already synced" });
+    }
+
+    // Batch sync to cloud (chunks of 100)
+    const BATCH_SIZE = 100;
+    let totalSynced = 0;
+    const allSyncedIds = new Map<string, string>();
+    const apiUrl = getApiUrl();
+    const cookieName = getSessionCookieName(apiUrl);
+
+    let lastError: string | undefined;
+
+    for (let i = 0; i < unsynced.length; i += BATCH_SIZE) {
+      const batch = unsynced.slice(i, i + BATCH_SIZE);
+      // Strip local-only fields before sending
+      const payload = batch.map(({ syncedAt, cloudId, ...rest }) => rest);
+
+      let resp: Response;
+      try {
+        resp = await fetch(`${apiUrl}/api/insights/sync`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `${cookieName}=${auth.token}`,
+          },
+          body: JSON.stringify({ insights: payload }),
+          signal: AbortSignal.timeout(30_000),
+        });
+      } catch (e) {
+        lastError = e instanceof Error ? e.message : "Network error";
+        break; // Stop batching on network failure
+      }
+
+      if (!resp.ok) {
+        lastError = await resp.text().catch(() => `HTTP ${resp.status}`);
+        break; // Stop batching on API error
+      }
+
+      let result: { synced: number; cloudIds: Record<string, string> };
+      try {
+        result = await resp.json();
+      } catch {
+        lastError = "Invalid response from cloud API";
+        break;
+      }
+
+      totalSynced += result.synced;
+      for (const [sid, cid] of Object.entries(result.cloudIds)) {
+        allSyncedIds.set(sid, cid);
+      }
+    }
+
+    // Always persist partial progress even if a batch failed
+    if (allSyncedIds.size > 0) {
+      const updated = markSynced(store, allSyncedIds);
+      await writeInsightsStore(updated);
+    }
+
+    if (lastError) {
+      return c.json({
+        error: `Sync failed: ${lastError}`,
+        synced: totalSynced,
+        total: unsynced.length,
+      });
+    }
+
+    return c.json({
+      synced: totalSynced,
+      total: unsynced.length,
+      message: `Synced ${totalSynced} insights to cloud`,
+    });
   });
 
   app.get("/api/memory", async (c) => {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,15 +1,20 @@
 // Shared types — single source of truth
 export type {
   Annotation,
+  CloudInsightsSummary,
   DataSource,
   DataSourceInfo,
+  InsightsStore,
   PrLink,
   ReplaySession,
   Scene,
+  SessionInsight,
   SubAgent,
   TokenUsage,
   TurnStat,
 } from "@vibe-replay/types";
+
+export { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
 
 // CLI-only types below
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -118,6 +118,105 @@ export interface SessionOverlays {
   overlays: SceneOverlay[];
 }
 
+// ---------------------------------------------------------------------------
+// Session Insights — durable local cache that survives source file deletion
+// ---------------------------------------------------------------------------
+
+/** Schema version for the insights store. Bump when adding breaking changes. */
+export const INSIGHTS_SCHEMA_VERSION = 1;
+
+/**
+ * A single session's insights — lightweight metadata persisted locally so it
+ * survives after source JSONL files are deleted (e.g. Claude Code 30-day cleanup).
+ * Maps closely to SessionScanResult but is schema-versioned independently.
+ */
+export interface SessionInsight {
+  // Identity
+  sessionId: string;
+  slug: string;
+  provider: string;
+
+  // Metadata
+  title?: string;
+  project: string;
+  model?: string;
+  gitBranch?: string;
+  gitBranches?: string[];
+
+  // Time
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+
+  // Stats
+  promptCount: number;
+  toolCallCount: number;
+  editCount: number;
+  filesModified?: Array<{ file: string; count: number }>;
+
+  // Cost
+  tokenUsage?: TokenUsage;
+  costEstimate?: number;
+
+  // Derived signals
+  hasPR: boolean;
+  prLinks?: PrLink[];
+  skillsUsed?: string[];
+  mcpServersUsed?: string[];
+  subAgentCount: number;
+  apiErrorCount: number;
+  compactionCount: number;
+
+  // Session context
+  entrypoint?: string;
+  permissionMode?: string;
+
+  // Display
+  firstPrompt?: string;
+
+  // Provenance
+  capturedAt: string;
+  capturedByVersion: string;
+  updatedAt?: string;
+  dataSource?: DataSource;
+
+  // Sync state (local-only, not sent to cloud)
+  syncedAt?: string;
+  cloudId?: string;
+}
+
+/** The on-disk structure for ~/.vibe-replay/insights/store.json */
+export interface InsightsStore {
+  schemaVersion: number;
+  lastUpdated: string;
+  sessions: SessionInsight[];
+}
+
+/** Summary returned by the cloud insights API */
+export interface CloudInsightsSummary {
+  totalSessions: number;
+  totalProjects: number;
+  totalDurationMs: number;
+  totalCost: number;
+  totalPrompts: number;
+  totalToolCalls: number;
+  totalEdits: number;
+  providers: Record<string, number>;
+  models: Record<string, number>;
+  topProjects: Array<{
+    project: string;
+    sessions: number;
+    cost: number;
+    durationMs: number;
+    prompts: number;
+    toolCalls: number;
+    edits: number;
+    lastActivity: string;
+  }>;
+  timeRange: { first: string; last: string };
+  sessionsPerDay: Record<string, number>;
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -2,7 +2,7 @@
 import GitHubStar from "./GitHubStar.astro";
 
 interface Props {
-  active?: "blog" | "explore" | "profile";
+  active?: "blog" | "explore" | "insights" | "profile";
 }
 
 const { active } = Astro.props;
@@ -20,6 +20,7 @@ const linkClass = (page: string) =>
       <span class="text-border hidden sm:inline">|</span>
       <a href="/blog" class={linkClass("blog")}>Blog</a>
       <a href="/explore" class={linkClass("explore")}>Explore</a>
+      <a href="/insights" class={linkClass("insights")}>Insights</a>
     </div>
 
     <!-- Desktop: GitHub star + Auth -->
@@ -54,6 +55,7 @@ const linkClass = (page: string) =>
     <div class="flex flex-col gap-3">
       <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors">Blog</a>
       <a href="/explore" class="text-text-secondary hover:text-accent text-sm transition-colors">Explore Replays</a>
+      <a href="/insights" class="text-text-secondary hover:text-accent text-sm transition-colors">Insights</a>
       <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-secondary hover:text-accent text-sm transition-colors flex items-center gap-2">
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1,0 +1,478 @@
+---
+import Footer from "../components/Footer.astro";
+import GitHubStar from "../components/GitHubStar.astro";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Insights - vibe-replay" description="Track your AI coding sessions across all machines. View cost, productivity trends, and project analytics.">
+  <div class="min-h-screen flex flex-col">
+    <!-- Header -->
+    <nav class="border-b border-border/50 px-6 py-3">
+      <div class="max-w-6xl mx-auto flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
+          <span class="text-border hidden sm:inline">|</span>
+          <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Blog</a>
+          <span class="text-text-secondary text-sm hidden sm:inline">Insights</span>
+        </div>
+        <div class="flex items-center gap-3">
+          <GitHubStar />
+          <div id="auth-container" style="display:none">
+            <button id="auth-login" style="display:none" class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10">
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              Sign in
+            </button>
+            <div id="auth-user" style="display:none" class="relative">
+              <button id="auth-avatar-btn" class="flex items-center justify-center w-8 h-8 rounded-full border border-border/60 hover:border-accent/70 transition-all cursor-pointer overflow-hidden">
+                <img id="auth-avatar" class="w-full h-full rounded-full object-cover" alt="" />
+              </button>
+              <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
+                <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
+                <a href="/profile" class="block px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-colors">Profile</a>
+                <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main content -->
+    <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-10">
+      <!-- Loading state -->
+      <div id="loading" class="text-center py-20">
+        <div class="text-text-muted font-mono text-sm animate-pulse">Loading...</div>
+      </div>
+
+      <!-- Not logged in state -->
+      <div id="signed-out" class="hidden">
+        <div class="flex items-center justify-center py-20">
+          <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md text-center">
+            <div class="text-4xl mb-4">&#128202;</div>
+            <h2 class="text-lg font-semibold text-text-primary mb-2">Sign in to view Insights</h2>
+            <p class="text-text-muted text-sm mb-4">Track your AI coding sessions across all machines. Sync insights from the CLI to view cost trends, project analytics, and more.</p>
+            <p class="text-text-muted text-xs font-mono mb-6">npx vibe-replay &rarr; Dashboard &rarr; Sync Insights</p>
+            <button id="signin-btn" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-medium transition-colors cursor-pointer border border-white/10">
+              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              Sign in with GitHub
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- No data state -->
+      <div id="no-data" class="hidden">
+        <div class="flex items-center justify-center py-20">
+          <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md text-center">
+            <div class="text-4xl mb-4">&#128640;</div>
+            <h2 class="text-lg font-semibold text-text-primary mb-2">No insights synced yet</h2>
+            <p class="text-text-muted text-sm mb-4">Sync your local session insights from the CLI dashboard to see them here.</p>
+            <div class="bg-surface-2 rounded-lg p-4 text-left">
+              <p class="text-text-muted text-xs font-mono mb-1"># In the CLI dashboard, click "Sync Insights"</p>
+              <p class="text-text-muted text-xs font-mono mb-1"># Or use the API endpoint:</p>
+              <p class="text-accent text-xs font-mono">npx vibe-replay -d</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Insights content -->
+      <div id="insights-content" class="hidden">
+        <!-- Page title -->
+        <div class="mb-8">
+          <h1 class="text-2xl font-bold text-text-primary mb-1">Insights</h1>
+          <p class="text-text-muted text-sm font-mono">Your AI coding activity across all machines</p>
+        </div>
+
+        <!-- Summary stats -->
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-8">
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Sessions</div>
+            <div id="stat-sessions" class="text-xl font-bold text-text-primary font-mono">0</div>
+          </div>
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Projects</div>
+            <div id="stat-projects" class="text-xl font-bold text-text-primary font-mono">0</div>
+          </div>
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Total Cost</div>
+            <div id="stat-cost" class="text-xl font-bold text-accent font-mono">$0</div>
+          </div>
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Duration</div>
+            <div id="stat-duration" class="text-xl font-bold text-text-primary font-mono">0h</div>
+          </div>
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Prompts</div>
+            <div id="stat-prompts" class="text-xl font-bold text-text-primary font-mono">0</div>
+          </div>
+          <div class="rounded-xl border border-border bg-surface-1 p-4">
+            <div class="text-[11px] font-mono text-text-muted mb-1">Tool Calls</div>
+            <div id="stat-tools" class="text-xl font-bold text-text-primary font-mono">0</div>
+          </div>
+        </div>
+
+        <!-- Activity chart -->
+        <div class="rounded-xl border border-border bg-surface-1 p-5 mb-8">
+          <h2 class="text-sm font-semibold text-text-primary mb-4">Activity (last 90 days)</h2>
+          <div id="activity-chart" class="flex items-end gap-[2px] h-24 overflow-hidden"></div>
+          <div class="flex justify-between mt-2 text-[10px] font-mono text-text-muted">
+            <span id="chart-start"></span>
+            <span id="chart-end"></span>
+          </div>
+        </div>
+
+        <!-- Two-column: providers/models + top projects -->
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          <!-- Provider & Model breakdown -->
+          <div class="rounded-xl border border-border bg-surface-1 p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">Providers & Models</h2>
+            <div class="mb-4">
+              <div class="text-[11px] font-mono text-text-muted mb-2 uppercase tracking-wider">Providers</div>
+              <div id="providers-list" class="space-y-2"></div>
+            </div>
+            <div>
+              <div class="text-[11px] font-mono text-text-muted mb-2 uppercase tracking-wider">Models</div>
+              <div id="models-list" class="space-y-2"></div>
+            </div>
+          </div>
+
+          <!-- Time range -->
+          <div class="rounded-xl border border-border bg-surface-1 p-5">
+            <h2 class="text-sm font-semibold text-text-primary mb-4">Time Range</h2>
+            <div class="space-y-3">
+              <div>
+                <div class="text-[11px] font-mono text-text-muted mb-1">First session</div>
+                <div id="time-first" class="text-sm font-mono text-text-primary">-</div>
+              </div>
+              <div>
+                <div class="text-[11px] font-mono text-text-muted mb-1">Last session</div>
+                <div id="time-last" class="text-sm font-mono text-text-primary">-</div>
+              </div>
+              <div>
+                <div class="text-[11px] font-mono text-text-muted mb-1">Avg. cost per session</div>
+                <div id="avg-cost" class="text-sm font-mono text-accent">-</div>
+              </div>
+              <div>
+                <div class="text-[11px] font-mono text-text-muted mb-1">Avg. duration per session</div>
+                <div id="avg-duration" class="text-sm font-mono text-text-primary">-</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Top projects -->
+        <div class="rounded-xl border border-border bg-surface-1 p-5 mb-8">
+          <h2 class="text-sm font-semibold text-text-primary mb-4">Top Projects</h2>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border text-[11px] font-mono text-text-muted uppercase tracking-wider">
+                  <th class="text-left py-2 pr-4">Project</th>
+                  <th class="text-right py-2 px-3">Sessions</th>
+                  <th class="text-right py-2 px-3">Cost</th>
+                  <th class="text-right py-2 px-3 hidden sm:table-cell">Duration</th>
+                  <th class="text-right py-2 px-3 hidden md:table-cell">Prompts</th>
+                  <th class="text-right py-2 px-3 hidden md:table-cell">Tools</th>
+                  <th class="text-right py-2 pl-3 hidden lg:table-cell">Edits</th>
+                </tr>
+              </thead>
+              <tbody id="projects-table" class="font-mono text-xs"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <Footer />
+  </div>
+</Layout>
+
+<script>
+  function escapeHtml(s: string): string {
+    const div = document.createElement("div");
+    div.textContent = s;
+    return div.innerHTML;
+  }
+
+  function formatDuration(ms: number): string {
+    if (!ms) return "0m";
+    const secs = Math.floor(ms / 1000);
+    if (secs < 60) return `${secs}s`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ${mins % 60}m`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ${hrs % 24}h`;
+  }
+
+  function formatCost(cost: number): string {
+    if (cost < 0.01) return "$0.00";
+    if (cost < 1) return `$${cost.toFixed(2)}`;
+    if (cost < 100) return `$${cost.toFixed(1)}`;
+    return `$${Math.round(cost)}`;
+  }
+
+  function formatNumber(n: number): string {
+    if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+    return String(n);
+  }
+
+  function formatDateLong(iso: string): string {
+    if (!iso) return "-";
+    const d = new Date(iso);
+    return d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  interface InsightsSummary {
+    totalSessions: number;
+    totalProjects: number;
+    totalDurationMs: number;
+    totalCost: number;
+    totalPrompts: number;
+    totalToolCalls: number;
+    totalEdits: number;
+    providers: Record<string, number>;
+    models: Record<string, number>;
+    topProjects: Array<{
+      project: string;
+      sessions: number;
+      cost: number;
+      durationMs: number;
+      prompts: number;
+      toolCalls: number;
+      edits: number;
+      lastActivity: string;
+    }>;
+    timeRange: { first: string; last: string };
+    sessionsPerDay: Record<string, number>;
+  }
+
+  function renderBreakdown(
+    containerId: string,
+    data: Record<string, number>,
+  ): void {
+    const container = document.getElementById(containerId)!;
+    const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+    if (entries.length === 0) {
+      container.innerHTML = '<div class="text-text-muted text-xs font-mono">No data</div>';
+      return;
+    }
+    const maxCount = entries[0][1];
+    container.innerHTML = entries
+      .slice(0, 8)
+      .map(
+        ([name, count]) => `
+      <div class="flex items-center gap-3">
+        <div class="text-xs font-mono text-text-secondary w-40 truncate shrink-0" title="${escapeHtml(name)}">${escapeHtml(name)}</div>
+        <div class="flex-1 h-4 bg-surface-2 rounded-sm overflow-hidden">
+          <div class="h-full bg-accent/30 rounded-sm" style="width: ${(count / maxCount) * 100}%"></div>
+        </div>
+        <div class="text-[11px] font-mono text-text-muted w-12 text-right shrink-0">${count}</div>
+      </div>
+    `,
+      )
+      .join("");
+  }
+
+  function renderActivityChart(sessionsPerDay: Record<string, number>): void {
+    const chart = document.getElementById("activity-chart")!;
+    const startEl = document.getElementById("chart-start")!;
+    const endEl = document.getElementById("chart-end")!;
+
+    // Generate 90-day range
+    const days: string[] = [];
+    const now = new Date();
+    for (let i = 89; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      days.push(d.toISOString().slice(0, 10));
+    }
+
+    const maxCount = Math.max(1, ...days.map((d) => sessionsPerDay[d] || 0));
+
+    chart.innerHTML = days
+      .map((day) => {
+        const count = sessionsPerDay[day] || 0;
+        const height = count > 0 ? Math.max(4, (count / maxCount) * 96) : 2;
+        const bg = count > 0 ? "bg-accent/60 hover:bg-accent" : "bg-surface-2";
+        const title = `${day}: ${count} session${count !== 1 ? "s" : ""}`;
+        return `<div class="flex-1 min-w-[2px] rounded-t ${bg} transition-colors cursor-default" style="height: ${height}px" title="${title}"></div>`;
+      })
+      .join("");
+
+    startEl.textContent = days[0];
+    endEl.textContent = days[days.length - 1];
+  }
+
+  function renderProjectsTable(
+    projects: InsightsSummary["topProjects"],
+  ): void {
+    const tbody = document.getElementById("projects-table")!;
+    if (projects.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" class="text-center py-8 text-text-muted text-xs font-mono">No projects</td></tr>';
+      return;
+    }
+    tbody.innerHTML = projects
+      .map(
+        (p) => `
+      <tr class="border-b border-border/50 hover:bg-surface-2/50 transition-colors">
+        <td class="py-2.5 pr-4 text-text-primary truncate max-w-[200px]" title="${escapeHtml(p.project)}">${escapeHtml(p.project)}</td>
+        <td class="text-right py-2.5 px-3 text-text-secondary">${p.sessions}</td>
+        <td class="text-right py-2.5 px-3 text-accent">${formatCost(p.cost)}</td>
+        <td class="text-right py-2.5 px-3 text-text-secondary hidden sm:table-cell">${formatDuration(p.durationMs)}</td>
+        <td class="text-right py-2.5 px-3 text-text-secondary hidden md:table-cell">${formatNumber(p.prompts)}</td>
+        <td class="text-right py-2.5 px-3 text-text-secondary hidden md:table-cell">${formatNumber(p.toolCalls)}</td>
+        <td class="text-right py-2.5 pl-3 text-text-secondary hidden lg:table-cell">${formatNumber(p.edits)}</td>
+      </tr>
+    `,
+      )
+      .join("");
+  }
+
+  async function initInsights(): Promise<void> {
+    const loading = document.getElementById("loading")!;
+    const signedOut = document.getElementById("signed-out")!;
+    const noData = document.getElementById("no-data")!;
+    const content = document.getElementById("insights-content")!;
+
+    // Check auth
+    let user: { name?: string; image?: string } | null = null;
+    try {
+      const res = await fetch("/api/auth/get-session", { credentials: "include" });
+      const data = await res.json();
+      if (data?.session && data?.user) user = data.user;
+    } catch { /* ignore */ }
+
+    loading.classList.add("hidden");
+
+    if (!user) {
+      signedOut.classList.remove("hidden");
+      return;
+    }
+
+    // Fetch insights summary
+    let summary: InsightsSummary;
+    try {
+      const res = await fetch("/api/insights/summary", { credentials: "include" });
+      if (!res.ok) throw new Error("Failed to fetch");
+      summary = await res.json();
+    } catch {
+      noData.classList.remove("hidden");
+      return;
+    }
+
+    if (summary.totalSessions === 0) {
+      noData.classList.remove("hidden");
+      return;
+    }
+
+    content.classList.remove("hidden");
+
+    // Populate stats
+    document.getElementById("stat-sessions")!.textContent = formatNumber(summary.totalSessions);
+    document.getElementById("stat-projects")!.textContent = formatNumber(summary.totalProjects);
+    document.getElementById("stat-cost")!.textContent = formatCost(summary.totalCost);
+    document.getElementById("stat-duration")!.textContent = formatDuration(summary.totalDurationMs);
+    document.getElementById("stat-prompts")!.textContent = formatNumber(summary.totalPrompts);
+    document.getElementById("stat-tools")!.textContent = formatNumber(summary.totalToolCalls);
+
+    // Time range
+    document.getElementById("time-first")!.textContent = formatDateLong(summary.timeRange.first);
+    document.getElementById("time-last")!.textContent = formatDateLong(summary.timeRange.last);
+    document.getElementById("avg-cost")!.textContent =
+      summary.totalSessions > 0
+        ? formatCost(summary.totalCost / summary.totalSessions)
+        : "-";
+    document.getElementById("avg-duration")!.textContent =
+      summary.totalSessions > 0
+        ? formatDuration(summary.totalDurationMs / summary.totalSessions)
+        : "-";
+
+    // Breakdowns
+    renderBreakdown("providers-list", summary.providers);
+    renderBreakdown("models-list", summary.models);
+
+    // Activity chart
+    renderActivityChart(summary.sessionsPerDay);
+
+    // Projects table
+    renderProjectsTable(summary.topProjects);
+  }
+
+  // --- Auth UI (same pattern as profile page) ---
+  function initAuth(): void {
+    const container = document.getElementById("auth-container")!;
+    const loginBtn = document.getElementById("auth-login")!;
+    const userEl = document.getElementById("auth-user")!;
+    const avatarBtn = document.getElementById("auth-avatar-btn")!;
+    const avatar = document.getElementById("auth-avatar") as HTMLImageElement;
+    const dropdown = document.getElementById("auth-dropdown")!;
+    const username = document.getElementById("auth-username")!;
+    const logoutBtn = document.getElementById("auth-logout")!;
+    const signinBtn = document.getElementById("signin-btn");
+
+    container.style.display = "";
+
+    fetch("/api/auth/get-session", { credentials: "include" })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data?.session && data?.user) {
+          loginBtn.style.display = "none";
+          userEl.style.display = "";
+          if (data.user.image) avatar.src = data.user.image;
+          username.textContent = data.user.name || data.user.email || "User";
+        } else {
+          loginBtn.style.display = "";
+          userEl.style.display = "none";
+        }
+      })
+      .catch(() => {
+        loginBtn.style.display = "";
+      });
+
+    const doLogin = async () => {
+      try {
+        const res = await fetch("/api/auth/sign-in/social", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ provider: "github", callbackURL: "/insights" }),
+        });
+        const data = await res.json();
+        if (data?.url) window.location.href = data.url;
+      } catch {
+        // Fallback to redirect-based login
+        window.location.href = "/auth/login?callback=/insights";
+      }
+    };
+    loginBtn.addEventListener("click", doLogin);
+    signinBtn?.addEventListener("click", doLogin);
+
+    avatarBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      dropdown.classList.toggle("hidden");
+    });
+    document.addEventListener("click", () => dropdown.classList.add("hidden"));
+
+    logoutBtn.addEventListener("click", async () => {
+      try {
+        await fetch("/api/auth/sign-out", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: "{}",
+        });
+      } catch { /* ignore */ }
+      window.location.reload();
+    });
+  }
+
+  initAuth();
+  initInsights();
+</script>


### PR DESCRIPTION
## Summary

- **Local insights store** (`~/.vibe-replay/insights/store.json`): auto-captures session metadata after each background scan. Schema-versioned independently from CLI — survives CLI upgrades and source file deletion (Claude Code 30-day cleanup).
- **Cloud sync API**: `POST /api/insights/sync` pushes unsynced insights to D1 in batches with pre-fetched upsert. `GET /api/insights` (paginated) and `GET /api/insights/summary` (aggregated stats) for querying.
- **Online dashboard**: `vibe-replay.com/insights` — shows total cost, duration, prompts, tool calls, activity chart (90 days), provider/model breakdown, and top projects table. Requires GitHub auth.
- **DB migration**: `session_insights` table with queryable columns + JSON metadata blob. Already applied to production D1.

## Test plan

After deploy, from the CLI dashboard:

- [ ] Run `npx vibe-replay -d`, wait for scan to complete
- [ ] Verify `~/.vibe-replay/insights/store.json` exists with session data
- [ ] In dashboard, click "Sync Insights" (requires login)
- [ ] Visit `vibe-replay.com/insights` to see synced data
- [ ] Verify insights persist after CLI version upgrade (store is not version-locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)