### PR TITLE
refactor: replace per-session cloud storage with daily time-series

### DIFF
--- a/cloudflare/drizzle/0007_replace_session_with_daily_insights.sql
+++ b/cloudflare/drizzle/0007_replace_session_with_daily_insights.sql
@@ -1,0 +1,29 @@
+DROP TABLE IF EXISTS `session_insights`;
+--> statement-breakpoint
+CREATE TABLE `daily_insights` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`machine_id` text NOT NULL,
+	`machine_name` text,
+	`date` text NOT NULL,
+	`sessions` integer DEFAULT 0 NOT NULL,
+	`prompts` integer DEFAULT 0 NOT NULL,
+	`tool_calls` integer DEFAULT 0 NOT NULL,
+	`edits` integer DEFAULT 0 NOT NULL,
+	`duration_ms` integer DEFAULT 0 NOT NULL,
+	`cost` real DEFAULT 0 NOT NULL,
+	`projects` text,
+	`models` text,
+	`providers` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_daily` ON `daily_insights` (`user_id`,`machine_id`,`date`);
+--> statement-breakpoint
+CREATE INDEX `idx_daily_user` ON `daily_insights` (`user_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_daily_date` ON `daily_insights` (`user_id`,`date`);
+--> statement-breakpoint
+CREATE INDEX `idx_daily_machine` ON `daily_insights` (`user_id`,`machine_id`);

--- a/cloudflare/drizzle/meta/_journal.json
+++ b/cloudflare/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775716199077,
       "tag": "0006_material_vindicator",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1775800000000,
+      "tag": "0007_replace_session_with_daily_insights",
+      "breakpoints": true
     }
   ]
 }

--- a/cloudflare/src/db/schema.ts
+++ b/cloudflare/src/db/schema.ts
@@ -182,58 +182,42 @@ export const cloudReplays = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
-// Session Insights — synced from CLI for long-term persistence
+// Daily Insights — Prometheus-style time-series with (user, machine, date) labels
 // ---------------------------------------------------------------------------
 
-export const sessionInsights = sqliteTable(
-  "session_insights",
+export const dailyInsights = sqliteTable(
+  "daily_insights",
   {
-    id: text("id").primaryKey(), // nanoid, 12 chars
+    id: text("id").primaryKey(),
     userId: text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
 
-    // Identity
-    sessionId: text("session_id").notNull(),
-    provider: text("provider").notNull(),
-    slug: text("slug").notNull(),
-
-    // Core queryable fields
-    title: text("title"),
-    project: text("project"),
-    model: text("model"),
-    startTime: text("start_time"),
-    durationMs: integer("duration_ms"),
-
-    // Stats
-    promptCount: integer("prompt_count").default(0),
-    toolCallCount: integer("tool_call_count").default(0),
-    editCount: integer("edit_count").default(0),
-    costEstimate: real("cost_estimate"),
-
-    // Flags
-    hasPR: integer("has_pr", { mode: "boolean" }).default(false),
-    subAgentCount: integer("sub_agent_count").default(0),
-    apiErrorCount: integer("api_error_count").default(0),
-
-    // Machine identity (for multi-machine aggregation)
-    machineId: text("machine_id"),
+    // Labels (dimensions for WHERE/GROUP BY)
+    machineId: text("machine_id").notNull(),
     machineName: text("machine_name"),
+    date: text("date").notNull(), // "2026-04-08"
 
-    // JSON blob for extensible fields (full SessionInsight minus queryable columns)
-    metadata: text("metadata"),
+    // Counters (aggregated metrics)
+    sessions: integer("sessions").default(0).notNull(),
+    prompts: integer("prompts").default(0).notNull(),
+    toolCalls: integer("tool_calls").default(0).notNull(),
+    edits: integer("edits").default(0).notNull(),
+    durationMs: integer("duration_ms").default(0).notNull(),
+    cost: real("cost").default(0).notNull(),
 
-    // Tracking
-    capturedAt: text("captured_at").notNull(),
-    capturedByVersion: text("captured_by_version"),
+    // JSON breakdowns (for charts, not filtering)
+    projects: text("projects"), // {"~/Code/x": {sessions, cost, prompts, toolCalls, edits, durationMs}}
+    models: text("models"), // {"claude-opus-4-6": {sessions, cost}}
+    providers: text("providers"), // {"claude-code": {sessions, cost}}
+
     createdAt: text("created_at").default(sql`(datetime('now'))`).notNull(),
     updatedAt: text("updated_at").default(sql`(datetime('now'))`),
   },
   (table) => [
-    unique("uq_user_session").on(table.userId, table.sessionId),
-    index("idx_insights_user").on(table.userId),
-    index("idx_insights_project").on(table.userId, table.project),
-    index("idx_insights_start").on(table.userId, table.startTime),
-    index("idx_insights_machine").on(table.userId, table.machineId),
+    unique("uq_daily").on(table.userId, table.machineId, table.date),
+    index("idx_daily_user").on(table.userId),
+    index("idx_daily_date").on(table.userId, table.date),
+    index("idx_daily_machine").on(table.userId, table.machineId),
   ],
 );

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { nanoid } from "nanoid";
 import { type AuthEnv, createAuth, DEV_ORIGINS, PROD_ORIGINS } from "./auth";
-import { cloudReplays, replays, sessionInsights, userFiles } from "./db/schema";
+import { cloudReplays, dailyInsights, replays, userFiles } from "./db/schema";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1034,182 +1034,114 @@ app.put("/api/replays", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// Session Insights API — synced from CLI for long-term persistence
+// Daily Insights API — Prometheus-style time-series (user × machine × date)
 // ---------------------------------------------------------------------------
 
-const MAX_INSIGHTS_BATCH = 200;
+const MAX_DAILY_BATCH = 400; // ~1 year of data per machine
 
-/** Batch upsert insights from CLI */
+/** Upsert daily insight rows from CLI */
 app.post("/api/insights/sync", async (c) => {
   const authResult = await requireAuth(c);
   if (authResult instanceof Response) return authResult;
   const { userId } = authResult;
 
   const body = await c.req.json();
-  if (!Array.isArray(body.insights) || body.insights.length === 0) {
-    return c.json({ error: "insights array required" }, 400);
+  if (!Array.isArray(body.days) || body.days.length === 0) {
+    return c.json({ error: "days array required" }, 400);
   }
-  if (body.insights.length > MAX_INSIGHTS_BATCH) {
-    return c.json({ error: `Max ${MAX_INSIGHTS_BATCH} insights per batch` }, 400);
+  if (body.days.length > MAX_DAILY_BATCH) {
+    return c.json({ error: `Max ${MAX_DAILY_BATCH} days per batch` }, 400);
   }
 
-  const db = drizzle(c.env.DB);
-  const cloudIds: Record<string, string> = {};
   const now = new Date().toISOString().replace("T", " ").slice(0, 19);
 
-  // Filter valid insights
-  const validInsights = body.insights.filter((i: any) => i.sessionId && i.provider);
-  if (validInsights.length === 0) {
-    return c.json({ synced: 0, failed: 0, total: body.insights.length, cloudIds });
-  }
+  // Pre-fetch existing rows for this user+machine combo
+  const machineId = body.machineId?.slice(0, 64);
+  if (!machineId) return c.json({ error: "machineId required" }, 400);
 
-  // Pre-fetch existing records in one query
-  const sessionIds = validInsights.map((i: any) => String(i.sessionId));
-  const existingRows = await db
-    .select({ id: sessionInsights.id, sessionId: sessionInsights.sessionId })
-    .from(sessionInsights)
-    .where(and(eq(sessionInsights.userId, userId), inArray(sessionInsights.sessionId, sessionIds)));
-  const existingMap = new Map(existingRows.map((r) => [r.sessionId, r.id]));
+  const dates = body.days.map((d: any) => String(d.date)).filter(Boolean);
+  const existingRows =
+    dates.length > 0
+      ? await c.env.DB.prepare(
+          `SELECT id, date FROM daily_insights WHERE user_id = ? AND machine_id = ? AND date IN (${dates.map(() => "?").join(",")})`,
+        )
+          .bind(userId, machineId, ...dates)
+          .all<{ id: string; date: string }>()
+      : { results: [] };
+  const existingMap = new Map((existingRows.results || []).map((r) => [r.date, r.id]));
 
-  // Build batch of D1 prepared statements (single round-trip)
+  // Build batch statements
   const statements: D1PreparedStatement[] = [];
-  for (const insight of validInsights) {
-    const metadata = JSON.stringify(insight);
-    const costEst =
-      insight.costEstimate != null
-        ? Math.max(0, Math.min(Number(insight.costEstimate) || 0, 100_000))
-        : null;
-    const existingId = existingMap.get(insight.sessionId);
+  let synced = 0;
 
+  for (const day of body.days) {
+    if (!day.date || typeof day.date !== "string") continue;
+
+    const existingId = existingMap.get(day.date);
     if (existingId) {
       statements.push(
         c.env.DB.prepare(
-          `UPDATE session_insights SET title=?, project=?, model=?, start_time=?, duration_ms=?,
-           prompt_count=?, tool_call_count=?, edit_count=?, cost_estimate=?, has_pr=?,
-           sub_agent_count=?, api_error_count=?, machine_id=?, machine_name=?,
-           metadata=?, captured_by_version=?, updated_at=?
-           WHERE id=?`,
+          `UPDATE daily_insights SET sessions=?, prompts=?, tool_calls=?, edits=?,
+           duration_ms=?, cost=?, projects=?, models=?, providers=?,
+           machine_name=?, updated_at=? WHERE id=?`,
         ).bind(
-          insight.title?.slice(0, 500) || null,
-          insight.project?.slice(0, 500) || null,
-          insight.model?.slice(0, 200) || null,
-          insight.startTime || null,
-          clamp(insight.durationMs, 0, 86_400_000),
-          clamp(insight.promptCount, 0, 10_000),
-          clamp(insight.toolCallCount, 0, 100_000),
-          clamp(insight.editCount, 0, 100_000),
-          costEst,
-          insight.hasPR ? 1 : 0,
-          clamp(insight.subAgentCount, 0, 10_000),
-          clamp(insight.apiErrorCount, 0, 10_000),
-          insight.machineId?.slice(0, 64) || null,
-          insight.machineName?.slice(0, 200) || null,
-          metadata,
-          insight.capturedByVersion?.slice(0, 50) || null,
+          clamp(day.sessions, 0, 10_000),
+          clamp(day.prompts, 0, 100_000),
+          clamp(day.toolCalls, 0, 1_000_000),
+          clamp(day.edits, 0, 1_000_000),
+          clamp(day.durationMs, 0, 86_400_000),
+          Math.max(0, Math.min(Number(day.cost) || 0, 100_000)),
+          day.projects ? String(day.projects).slice(0, 50_000) : null,
+          day.models ? String(day.models).slice(0, 10_000) : null,
+          day.providers ? String(day.providers).slice(0, 10_000) : null,
+          body.machineName?.slice(0, 200) || null,
           now,
           existingId,
         ),
       );
-      cloudIds[insight.sessionId] = existingId;
     } else {
       const id = nanoid(12);
       statements.push(
         c.env.DB.prepare(
-          `INSERT INTO session_insights (id, user_id, session_id, provider, slug, title, project,
-           model, start_time, duration_ms, prompt_count, tool_call_count, edit_count, cost_estimate,
-           has_pr, sub_agent_count, api_error_count, machine_id, machine_name,
-           metadata, captured_at, captured_by_version)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO daily_insights (id, user_id, machine_id, machine_name, date,
+           sessions, prompts, tool_calls, edits, duration_ms, cost,
+           projects, models, providers)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         ).bind(
           id,
           userId,
-          insight.sessionId,
-          String(insight.provider).slice(0, 50),
-          String(insight.slug || insight.sessionId.slice(0, 8)).slice(0, 50),
-          insight.title?.slice(0, 500) || null,
-          insight.project?.slice(0, 500) || null,
-          insight.model?.slice(0, 200) || null,
-          insight.startTime || null,
-          clamp(insight.durationMs, 0, 86_400_000),
-          clamp(insight.promptCount, 0, 10_000),
-          clamp(insight.toolCallCount, 0, 100_000),
-          clamp(insight.editCount, 0, 100_000),
-          costEst,
-          insight.hasPR ? 1 : 0,
-          clamp(insight.subAgentCount, 0, 10_000),
-          clamp(insight.apiErrorCount, 0, 10_000),
-          insight.machineId?.slice(0, 64) || null,
-          insight.machineName?.slice(0, 200) || null,
-          metadata,
-          insight.capturedAt || new Date().toISOString(),
-          insight.capturedByVersion?.slice(0, 50) || null,
+          machineId,
+          body.machineName?.slice(0, 200) || null,
+          day.date,
+          clamp(day.sessions, 0, 10_000),
+          clamp(day.prompts, 0, 100_000),
+          clamp(day.toolCalls, 0, 1_000_000),
+          clamp(day.edits, 0, 1_000_000),
+          clamp(day.durationMs, 0, 86_400_000),
+          Math.max(0, Math.min(Number(day.cost) || 0, 100_000)),
+          day.projects ? String(day.projects).slice(0, 50_000) : null,
+          day.models ? String(day.models).slice(0, 10_000) : null,
+          day.providers ? String(day.providers).slice(0, 10_000) : null,
         ),
       );
-      cloudIds[insight.sessionId] = id;
-      existingMap.set(insight.sessionId, id); // prevent double-INSERT for duplicate sessionIds in batch
+      existingMap.set(day.date, id);
+    }
+    synced++;
+  }
+
+  if (statements.length > 0) {
+    try {
+      await c.env.DB.batch(statements);
+    } catch (e) {
+      console.error("Daily insights batch sync failed:", e);
+      return c.json({ error: "Sync failed", synced: 0 }, 500);
     }
   }
 
-  // Execute all statements in a single D1 batch (one round-trip)
-  try {
-    await c.env.DB.batch(statements);
-  } catch (e) {
-    console.error("Batch sync failed:", e);
-    return c.json(
-      {
-        error: "Batch sync failed",
-        synced: 0,
-        failed: validInsights.length,
-        total: body.insights.length,
-        cloudIds: {},
-      },
-      500,
-    );
-  }
-
-  return c.json({ synced: validInsights.length, failed: 0, total: body.insights.length, cloudIds });
+  return c.json({ synced });
 });
 
-/** List user's synced insights (paginated) */
-app.get("/api/insights", async (c) => {
-  const authResult = await requireAuth(c);
-  if (authResult instanceof Response) return authResult;
-  const { userId } = authResult;
-
-  const project = c.req.query("project");
-  const after = c.req.query("after");
-  const before = c.req.query("before");
-  const limit = Math.min(Number(c.req.query("limit")) || 100, 500);
-  const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
-
-  const db = drizzle(c.env.DB);
-  const conditions = [eq(sessionInsights.userId, userId)];
-  if (project) conditions.push(eq(sessionInsights.project, project));
-  if (after) conditions.push(sql`${sessionInsights.startTime} >= ${after}`);
-  if (before) conditions.push(sql`${sessionInsights.startTime} <= ${before}`);
-
-  const results = await db
-    .select()
-    .from(sessionInsights)
-    .where(and(...conditions))
-    .orderBy(desc(sessionInsights.startTime))
-    .limit(limit)
-    .offset(offset);
-
-  const [countResult] = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(sessionInsights)
-    .where(and(...conditions));
-
-  return c.json({
-    insights: results,
-    total: countResult?.count || 0,
-    limit,
-    offset,
-  });
-});
-
-/** Aggregated insights summary for the user */
+/** Aggregated insights summary — merges all machines' daily data */
 app.get("/api/insights/summary", async (c) => {
   const authResult = await requireAuth(c);
   if (authResult instanceof Response) return authResult;
@@ -1217,100 +1149,128 @@ app.get("/api/insights/summary", async (c) => {
 
   const db = drizzle(c.env.DB);
 
-  // Aggregate stats
+  // Aggregate counters (single query)
   const [agg] = await db
     .select({
-      totalSessions: sql<number>`count(*)`,
-      totalProjects: sql<number>`count(distinct ${sessionInsights.project})`,
-      totalDurationMs: sql<number>`coalesce(sum(${sessionInsights.durationMs}), 0)`,
-      totalCost: sql<number>`coalesce(sum(${sessionInsights.costEstimate}), 0)`,
-      totalPrompts: sql<number>`coalesce(sum(${sessionInsights.promptCount}), 0)`,
-      totalToolCalls: sql<number>`coalesce(sum(${sessionInsights.toolCallCount}), 0)`,
-      totalEdits: sql<number>`coalesce(sum(${sessionInsights.editCount}), 0)`,
-      firstSession: sql<string>`min(${sessionInsights.startTime})`,
-      lastSession: sql<string>`max(${sessionInsights.startTime})`,
+      totalSessions: sql<number>`coalesce(sum(${dailyInsights.sessions}), 0)`,
+      totalDurationMs: sql<number>`coalesce(sum(${dailyInsights.durationMs}), 0)`,
+      totalCost: sql<number>`coalesce(sum(${dailyInsights.cost}), 0)`,
+      totalPrompts: sql<number>`coalesce(sum(${dailyInsights.prompts}), 0)`,
+      totalToolCalls: sql<number>`coalesce(sum(${dailyInsights.toolCalls}), 0)`,
+      totalEdits: sql<number>`coalesce(sum(${dailyInsights.edits}), 0)`,
+      firstDate: sql<string>`min(${dailyInsights.date})`,
+      lastDate: sql<string>`max(${dailyInsights.date})`,
     })
-    .from(sessionInsights)
-    .where(eq(sessionInsights.userId, userId));
+    .from(dailyInsights)
+    .where(eq(dailyInsights.userId, userId));
 
-  // Provider breakdown
-  const providerRows = await db
-    .select({
-      provider: sessionInsights.provider,
-      count: sql<number>`count(*)`,
-    })
-    .from(sessionInsights)
-    .where(eq(sessionInsights.userId, userId))
-    .groupBy(sessionInsights.provider);
-  const providers: Record<string, number> = {};
-  for (const r of providerRows) providers[r.provider] = r.count;
-
-  // Model breakdown
-  const modelRows = await db
-    .select({
-      model: sessionInsights.model,
-      count: sql<number>`count(*)`,
-    })
-    .from(sessionInsights)
-    .where(and(eq(sessionInsights.userId, userId), sql`${sessionInsights.model} IS NOT NULL`))
-    .groupBy(sessionInsights.model);
-  const models: Record<string, number> = {};
-  for (const r of modelRows) if (r.model) models[r.model] = r.count;
-
-  // Top projects
-  const topProjects = await db
-    .select({
-      project: sessionInsights.project,
-      sessions: sql<number>`count(*)`,
-      cost: sql<number>`coalesce(sum(${sessionInsights.costEstimate}), 0)`,
-      durationMs: sql<number>`coalesce(sum(${sessionInsights.durationMs}), 0)`,
-      prompts: sql<number>`coalesce(sum(${sessionInsights.promptCount}), 0)`,
-      toolCalls: sql<number>`coalesce(sum(${sessionInsights.toolCallCount}), 0)`,
-      edits: sql<number>`coalesce(sum(${sessionInsights.editCount}), 0)`,
-      lastActivity: sql<string>`max(${sessionInsights.startTime})`,
-    })
-    .from(sessionInsights)
-    .where(eq(sessionInsights.userId, userId))
-    .groupBy(sessionInsights.project)
-    .orderBy(sql`count(*) desc`)
-    .limit(20);
-
-  // Sessions per day (last 90 days)
+  // Sessions per day (all dates — client handles windowing)
   const dailyRows = await db
     .select({
-      day: sql<string>`date(${sessionInsights.startTime})`,
-      count: sql<number>`count(*)`,
+      date: dailyInsights.date,
+      sessions: sql<number>`sum(${dailyInsights.sessions})`,
     })
-    .from(sessionInsights)
-    .where(
-      and(
-        eq(sessionInsights.userId, userId),
-        sql`${sessionInsights.startTime} >= date('now', '-90 days')`,
-      ),
-    )
-    .groupBy(sql`date(${sessionInsights.startTime})`)
-    .orderBy(sql`date(${sessionInsights.startTime})`);
+    .from(dailyInsights)
+    .where(eq(dailyInsights.userId, userId))
+    .groupBy(dailyInsights.date)
+    .orderBy(dailyInsights.date);
   const sessionsPerDay: Record<string, number> = {};
-  for (const r of dailyRows) if (r.day) sessionsPerDay[r.day] = r.count;
+  for (const r of dailyRows) sessionsPerDay[r.date] = r.sessions;
+
+  // JSON breakdowns — need to merge across all rows
+  const allRows = await db
+    .select({
+      projects: dailyInsights.projects,
+      models: dailyInsights.models,
+      providers: dailyInsights.providers,
+    })
+    .from(dailyInsights)
+    .where(eq(dailyInsights.userId, userId));
+
+  // Merge JSON breakdowns across all daily rows
+  const projectsAgg: Record<
+    string,
+    {
+      sessions: number;
+      cost: number;
+      prompts: number;
+      toolCalls: number;
+      edits: number;
+      durationMs: number;
+    }
+  > = {};
+  const modelsAgg: Record<string, { sessions: number; cost: number }> = {};
+  const providersAgg: Record<string, { sessions: number; cost: number }> = {};
+
+  for (const row of allRows) {
+    if (row.projects) {
+      try {
+        const p = JSON.parse(row.projects);
+        for (const [name, v] of Object.entries(p) as [string, any][]) {
+          if (!projectsAgg[name])
+            projectsAgg[name] = {
+              sessions: 0,
+              cost: 0,
+              prompts: 0,
+              toolCalls: 0,
+              edits: 0,
+              durationMs: 0,
+            };
+          projectsAgg[name].sessions += v.sessions || 0;
+          projectsAgg[name].cost += v.cost || 0;
+          projectsAgg[name].prompts += v.prompts || 0;
+          projectsAgg[name].toolCalls += v.toolCalls || 0;
+          projectsAgg[name].edits += v.edits || 0;
+          projectsAgg[name].durationMs += v.durationMs || 0;
+        }
+      } catch {
+        /* skip malformed */
+      }
+    }
+    if (row.models) {
+      try {
+        const m = JSON.parse(row.models);
+        for (const [name, v] of Object.entries(m) as [string, any][]) {
+          if (!modelsAgg[name]) modelsAgg[name] = { sessions: 0, cost: 0 };
+          modelsAgg[name].sessions += v.sessions || 0;
+          modelsAgg[name].cost += v.cost || 0;
+        }
+      } catch {
+        /* skip */
+      }
+    }
+    if (row.providers) {
+      try {
+        const pr = JSON.parse(row.providers);
+        for (const [name, v] of Object.entries(pr) as [string, any][]) {
+          if (!providersAgg[name]) providersAgg[name] = { sessions: 0, cost: 0 };
+          providersAgg[name].sessions += v.sessions || 0;
+          providersAgg[name].cost += v.cost || 0;
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+
+  // Sort top projects by sessions desc
+  const topProjects = Object.entries(projectsAgg)
+    .map(([project, v]) => ({ project, ...v }))
+    .sort((a, b) => b.sessions - a.sessions)
+    .slice(0, 20);
 
   return c.json({
     totalSessions: agg?.totalSessions || 0,
-    totalProjects: agg?.totalProjects || 0,
+    totalProjects: Object.keys(projectsAgg).length,
     totalDurationMs: agg?.totalDurationMs || 0,
     totalCost: agg?.totalCost || 0,
     totalPrompts: agg?.totalPrompts || 0,
     totalToolCalls: agg?.totalToolCalls || 0,
     totalEdits: agg?.totalEdits || 0,
-    providers,
-    models,
-    topProjects: topProjects.map((p) => ({
-      ...p,
-      project: p.project || "(unknown)",
-    })),
-    timeRange: {
-      first: agg?.firstSession || "",
-      last: agg?.lastSession || "",
-    },
+    providers: Object.fromEntries(Object.entries(providersAgg).map(([k, v]) => [k, v.sessions])),
+    models: Object.fromEntries(Object.entries(modelsAgg).map(([k, v]) => [k, v.sessions])),
+    topProjects,
+    timeRange: { first: agg?.firstDate || "", last: agg?.lastDate || "" },
     sessionsPerDay,
   });
 });

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1075,7 +1075,7 @@ app.post("/api/insights/sync", async (c) => {
   let synced = 0;
 
   for (const day of body.days) {
-    if (!day.date || typeof day.date !== "string") continue;
+    if (!day.date || !/^\d{4}-\d{2}-\d{2}$/.test(day.date)) continue;
 
     const existingId = existingMap.get(day.date);
     if (existingId) {
@@ -1141,7 +1141,6 @@ app.post("/api/insights/sync", async (c) => {
   return c.json({ synced });
 });
 
-/** Aggregated insights summary — merges all machines' daily data */
 /** Return dates already synced for a given machine (for delta sync). */
 app.get("/api/insights/dates", async (c) => {
   const authResult = await requireAuth(c);

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1142,6 +1142,26 @@ app.post("/api/insights/sync", async (c) => {
 });
 
 /** Aggregated insights summary — merges all machines' daily data */
+/** Return dates already synced for a given machine (for delta sync). */
+app.get("/api/insights/dates", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const machineId = c.req.query("machineId");
+  if (!machineId) return c.json({ error: "machineId required" }, 400);
+
+  const db = drizzle(c.env.DB);
+  const rows = await db
+    .select({ date: dailyInsights.date })
+    .from(dailyInsights)
+    .where(and(eq(dailyInsights.userId, userId), eq(dailyInsights.machineId, machineId)))
+    .orderBy(dailyInsights.date);
+
+  return c.json({ dates: rows.map((r) => r.date) });
+});
+
+/** Aggregated insights summary — merges all machines' daily data */
 app.get("/api/insights/summary", async (c) => {
   const authResult = await requireAuth(c);
   if (authResult instanceof Response) return authResult;

--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -150,12 +150,10 @@ export function mergeInsights(
   for (const scan of scanResults) {
     const existing = byId.get(scan.sessionId);
     if (existing) {
-      // Update with fresh scan data but preserve original provenance + sync state
+      // Update with fresh scan data but preserve original provenance
       const updated = scanResultToInsight(scan);
       updated.capturedAt = existing.capturedAt;
       updated.updatedAt = new Date().toISOString();
-      updated.syncedAt = existing.syncedAt;
-      updated.cloudId = existing.cloudId;
       // Preserve original capture machine (session belongs to where it ran, not where it's re-scanned)
       updated.machineId = existing.machineId ?? updated.machineId;
       updated.machineName = existing.machineName ?? updated.machineName;

--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -173,32 +173,139 @@ export function mergeInsights(
 }
 
 // ---------------------------------------------------------------------------
-// Sync helpers
+// Daily aggregation for cloud sync
 // ---------------------------------------------------------------------------
 
-/** Get insights that need syncing (never synced or updated since last sync) */
-export function getUnsyncedInsights(store: InsightsStore): SessionInsight[] {
-  return store.sessions.filter((s) => {
-    if (!s.syncedAt) return true;
-    if (s.updatedAt && s.updatedAt > s.syncedAt) return true;
-    return false;
-  });
+interface DailyBreakdown {
+  sessions: number;
+  cost: number;
+  prompts: number;
+  toolCalls: number;
+  edits: number;
+  durationMs: number;
 }
 
-/** Mark sessions as synced after successful cloud upload */
-export function markSynced(
-  store: InsightsStore,
-  syncedIds: Map<string, string>, // sessionId → cloudId
-): InsightsStore {
-  const now = new Date().toISOString();
-  const sessions = store.sessions.map((s) => {
-    const cloudId = syncedIds.get(s.sessionId);
-    if (cloudId !== undefined) {
-      return { ...s, syncedAt: now, cloudId };
+interface DailyRow {
+  date: string;
+  sessions: number;
+  prompts: number;
+  toolCalls: number;
+  edits: number;
+  durationMs: number;
+  cost: number;
+  projects: string; // JSON
+  models: string; // JSON
+  providers: string; // JSON
+}
+
+/**
+ * Aggregate local session insights into daily rows for cloud sync.
+ * Groups by date, computes JSON breakdowns for project/model/provider.
+ */
+export function aggregateDailyInsights(store: InsightsStore): {
+  machineId: string;
+  machineName: string;
+  days: DailyRow[];
+} {
+  const byDate = new Map<
+    string,
+    {
+      sessions: number;
+      prompts: number;
+      toolCalls: number;
+      edits: number;
+      durationMs: number;
+      cost: number;
+      projects: Record<string, DailyBreakdown>;
+      models: Record<string, { sessions: number; cost: number }>;
+      providers: Record<string, { sessions: number; cost: number }>;
     }
-    return s;
-  });
-  return { ...store, sessions, lastUpdated: now };
+  >();
+
+  for (const s of store.sessions) {
+    const date = s.startTime?.slice(0, 10);
+    if (!date) continue;
+
+    let day = byDate.get(date);
+    if (!day) {
+      day = {
+        sessions: 0,
+        prompts: 0,
+        toolCalls: 0,
+        edits: 0,
+        durationMs: 0,
+        cost: 0,
+        projects: {},
+        models: {},
+        providers: {},
+      };
+      byDate.set(date, day);
+    }
+
+    day.sessions++;
+    day.prompts += s.promptCount;
+    day.toolCalls += s.toolCallCount;
+    day.edits += s.editCount;
+    day.durationMs += s.durationMs || 0;
+    day.cost += s.costEstimate || 0;
+
+    // Project breakdown
+    const proj = s.project;
+    if (proj) {
+      if (!day.projects[proj])
+        day.projects[proj] = {
+          sessions: 0,
+          cost: 0,
+          prompts: 0,
+          toolCalls: 0,
+          edits: 0,
+          durationMs: 0,
+        };
+      day.projects[proj].sessions++;
+      day.projects[proj].cost += s.costEstimate || 0;
+      day.projects[proj].prompts += s.promptCount;
+      day.projects[proj].toolCalls += s.toolCallCount;
+      day.projects[proj].edits += s.editCount;
+      day.projects[proj].durationMs += s.durationMs || 0;
+    }
+
+    // Model breakdown
+    const model = s.model;
+    if (model) {
+      if (!day.models[model]) day.models[model] = { sessions: 0, cost: 0 };
+      day.models[model].sessions++;
+      day.models[model].cost += s.costEstimate || 0;
+    }
+
+    // Provider breakdown
+    const prov = s.provider;
+    if (prov) {
+      if (!day.providers[prov]) day.providers[prov] = { sessions: 0, cost: 0 };
+      day.providers[prov].sessions++;
+      day.providers[prov].cost += s.costEstimate || 0;
+    }
+  }
+
+  const days: DailyRow[] = [...byDate.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, d]) => ({
+      date,
+      sessions: d.sessions,
+      prompts: d.prompts,
+      toolCalls: d.toolCalls,
+      edits: d.edits,
+      durationMs: d.durationMs,
+      cost: d.cost,
+      projects: JSON.stringify(d.projects),
+      models: JSON.stringify(d.models),
+      providers: JSON.stringify(d.providers),
+    }));
+
+  return {
+    machineId: getMachineId(),
+    machineName: getMachineName(),
+    days,
+  };
 }
 
 /** Get store file path (for display/debugging) */
@@ -209,23 +316,17 @@ export function getInsightsStorePath(): string {
 /** Get store stats */
 export function getInsightsStats(store: InsightsStore): {
   total: number;
-  synced: number;
-  unsynced: number;
   providers: Record<string, number>;
   projects: number;
 } {
-  let synced = 0;
   const providers: Record<string, number> = {};
   const projects = new Set<string>();
   for (const s of store.sessions) {
-    if (s.syncedAt) synced++;
     providers[s.provider] = (providers[s.provider] || 0) + 1;
     projects.add(s.project);
   }
   return {
     total: store.sessions.length,
-    synced,
-    unsynced: store.sessions.length - synced,
     providers,
     projects: projects.size,
   };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1006,12 +1006,29 @@ export async function startServer(
 
     const apiUrl = getUrl();
     const cookieName = getCookie(apiUrl);
+    const headers = { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` };
+
+    // Delta sync: fetch dates already on cloud, skip them
+    try {
+      const datesResp = await fetch(
+        `${apiUrl}/api/insights/dates?machineId=${encodeURIComponent(daily.machineId)}`,
+        { headers, signal: AbortSignal.timeout(10_000) },
+      );
+      if (datesResp.ok) {
+        const { dates } = (await datesResp.json()) as { dates: string[] };
+        const existing = new Set(dates);
+        daily.days = daily.days.filter((d) => !existing.has(d.date));
+        if (daily.days.length === 0) return { synced: 0, total: 0 };
+      }
+    } catch {
+      // Failed to fetch dates — fall back to full sync (cloud will upsert)
+    }
 
     let resp: Response;
     try {
       resp = await fetch(`${apiUrl}/api/insights/sync`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` },
+        headers,
         body: JSON.stringify(daily),
         signal: AbortSignal.timeout(30_000),
       });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -978,19 +978,19 @@ export async function startServer(
     await writeInsightsStore(updated);
   };
 
-  /** Max insights per cloud sync request (D1 batch API, single round-trip per chunk). */
-  const INSIGHTS_SYNC_BATCH = 100;
+  /** Track last auto-sync date to avoid syncing more than once per day. */
+  let lastAutoSyncDate: string | null = null;
 
   /**
-   * Core sync logic: push unsynced insights to cloud in batches.
-   * Returns { synced, total, error? }. Persists partial progress on failure.
+   * Aggregate local insights by (date, machineId) and push to cloud.
+   * Each day becomes one row in cloud — Prometheus-style time series.
    */
   const syncInsightsToCloud = async (): Promise<{
     synced: number;
     total: number;
     error?: string;
   }> => {
-    const { getUnsyncedInsights, markSynced } = await import("./insights.js");
+    const { aggregateDailyInsights } = await import("./insights.js");
     const {
       loadAuthToken: loadAuth,
       getApiUrl: getUrl,
@@ -1001,66 +1001,56 @@ export async function startServer(
     if (!auth) return { synced: 0, total: 0, error: "Not logged in" };
 
     const store = await readInsightsStore();
-    const unsynced = getUnsyncedInsights(store);
-    if (unsynced.length === 0) return { synced: 0, total: 0 };
+    const daily = aggregateDailyInsights(store);
+    if (daily.days.length === 0) return { synced: 0, total: 0 };
 
     const apiUrl = getUrl();
     const cookieName = getCookie(apiUrl);
-    let totalSynced = 0;
-    let lastError: string | undefined;
-    const allSyncedIds = new Map<string, string>();
 
-    for (let i = 0; i < unsynced.length; i += INSIGHTS_SYNC_BATCH) {
-      const batch = unsynced.slice(i, i + INSIGHTS_SYNC_BATCH);
-      const payload = batch.map(({ syncedAt, cloudId, ...rest }) => rest);
-
-      let resp: Response;
-      try {
-        resp = await fetch(`${apiUrl}/api/insights/sync`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` },
-          body: JSON.stringify({ insights: payload }),
-          signal: AbortSignal.timeout(30_000),
-        });
-      } catch (e) {
-        lastError = e instanceof Error ? e.message : "Network error";
-        break;
-      }
-
-      if (resp.status === 401) {
-        await clearLocalAuthSession();
-        lastError = "Session expired";
-        break;
-      }
-      if (!resp.ok) {
-        lastError = await resp.text().catch(() => `HTTP ${resp.status}`);
-        break;
-      }
-
-      let result: { synced: number; cloudIds: Record<string, string> };
-      try {
-        result = await resp.json();
-      } catch {
-        lastError = "Invalid response from cloud API";
-        break;
-      }
-
-      totalSynced += result.synced;
-      for (const [sid, cid] of Object.entries(result.cloudIds)) allSyncedIds.set(sid, cid);
+    let resp: Response;
+    try {
+      resp = await fetch(`${apiUrl}/api/insights/sync`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` },
+        body: JSON.stringify(daily),
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (e) {
+      return {
+        synced: 0,
+        total: daily.days.length,
+        error: e instanceof Error ? e.message : "Network error",
+      };
     }
 
-    // Always persist partial progress
-    if (allSyncedIds.size > 0) {
-      const updated = markSynced(store, allSyncedIds);
-      await writeInsightsStore(updated);
+    if (resp.status === 401) {
+      await clearLocalAuthSession();
+      return { synced: 0, total: daily.days.length, error: "Session expired" };
+    }
+    if (!resp.ok) {
+      const err = await resp.text().catch(() => `HTTP ${resp.status}`);
+      return { synced: 0, total: daily.days.length, error: err };
     }
 
-    return { synced: totalSynced, total: unsynced.length, error: lastError };
+    let result: { synced: number };
+    try {
+      result = await resp.json();
+    } catch {
+      return { synced: 0, total: daily.days.length, error: "Invalid response" };
+    }
+
+    return { synced: result.synced, total: daily.days.length };
   };
 
-  /** Auto-sync insights to cloud if user is logged in. Fire-and-forget. */
+  /**
+   * Auto-sync insights to cloud if user is logged in.
+   * Runs at most once per calendar day to avoid excessive writes.
+   */
   const autoSyncInsights = async (): Promise<void> => {
-    await syncInsightsToCloud();
+    const today = new Date().toISOString().slice(0, 10);
+    if (lastAutoSyncDate === today) return; // Already synced today
+    const result = await syncInsightsToCloud();
+    if (!result.error) lastAutoSyncDate = today;
   };
 
   /** Pre-compute all insights from scan results and store in cache. */

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1017,7 +1017,9 @@ export async function startServer(
       if (datesResp.ok) {
         const { dates } = (await datesResp.json()) as { dates: string[] };
         const existing = new Set(dates);
-        daily.days = daily.days.filter((d) => !existing.has(d.date));
+        const today = new Date().toISOString().slice(0, 10);
+        // Always re-sync today (may have new sessions since last sync)
+        daily.days = daily.days.filter((d) => !existing.has(d.date) || d.date === today);
         if (daily.days.length === 0) return { synced: 0, total: 0 };
       }
     } catch {

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,7 +1,6 @@
 // Shared types — single source of truth
 export type {
   Annotation,
-  CloudInsightsSummary,
   DataSource,
   DataSourceInfo,
   InsightsStore,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -183,10 +183,6 @@ export interface SessionInsight {
   // Machine identity (for multi-machine aggregation)
   machineId?: string;
   machineName?: string;
-
-  // Sync state (local-only, not sent to cloud)
-  syncedAt?: string;
-  cloudId?: string;
 }
 
 /** The on-disk structure for ~/.vibe-replay/insights/store.json */
@@ -194,31 +190,6 @@ export interface InsightsStore {
   schemaVersion: number;
   lastUpdated: string;
   sessions: SessionInsight[];
-}
-
-/** Summary returned by the cloud insights API */
-export interface CloudInsightsSummary {
-  totalSessions: number;
-  totalProjects: number;
-  totalDurationMs: number;
-  totalCost: number;
-  totalPrompts: number;
-  totalToolCalls: number;
-  totalEdits: number;
-  providers: Record<string, number>;
-  models: Record<string, number>;
-  topProjects: Array<{
-    project: string;
-    sessions: number;
-    cost: number;
-    durationMs: number;
-    prompts: number;
-    toolCalls: number;
-    edits: number;
-    lastActivity: string;
-  }>;
-  timeRange: { first: string; last: string };
-  sessionsPerDay: Record<string, number>;
 }
 
 export interface ReplaySession {

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -301,7 +301,6 @@ import Layout from "../layouts/Layout.astro";
       prompts: number;
       toolCalls: number;
       edits: number;
-      lastActivity: string;
     }>;
     timeRange: { first: string; last: string };
     sessionsPerDay: Record<string, number>;


### PR DESCRIPTION
## Summary

Prometheus-style redesign of cloud insights storage. Instead of storing 1 row per session (N=185+), store 1 row per (user, machine, date) with aggregate counters.

**Before:** 185 sessions → 185 rows, N+1 or batch of 185 writes per sync
**After:** 185 sessions across 31 days → 31 rows, batch of 31 writes per sync

### Schema change
- DROP `session_insights` (old per-session table)
- CREATE `daily_insights` with `UNIQUE(user_id, machine_id, date)`
- Counters: sessions, prompts, tool_calls, edits, duration_ms, cost
- JSON breakdowns: projects, models, providers (for charts, not SQL filtering)

### CLI changes
- `aggregateDailyInsights()` groups local store by date before sending
- Auto-sync runs at most once per calendar day (was every scan)
- Shared `syncInsightsToCloud()` helper (deduplicated)

### Cloud API changes
- `POST /api/insights/sync` accepts `{machineId, machineName, days[]}` 
- `GET /api/insights/summary` merges daily rows across all machines
- Removed `GET /api/insights` (per-session list no longer exists)

### Cost impact
- D1 writes drop from ~185/sync to ~31/sync (6x reduction)
- A user with 1 year of history: 365 rows instead of ~2000
- Malicious user can only write 1 row per machine per day

## Test plan
- [x] `pnpm build` passes
- [x] 607 unit tests + 52 E2E tests pass
- [x] Migration tested locally (DROP + CREATE)
- [ ] Deploy worker + run migration remote
- [ ] Verify sync from dashboard to cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)