### PR TITLE
fix: unify website navigation and add insights skeleton

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1798,7 +1798,7 @@ export async function startServer(
         signal: AbortSignal.timeout(5_000),
       });
       const data = await resp.json();
-      const valid = !!(data && data.session && data.user);
+      const valid = !!(data?.session && data.user);
       if (!valid) {
         // Token expired — clear it so UI shows logged out
         await clearLocalAuthSession();

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -679,7 +679,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   >("idle");
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
-  const [, setTick] = useState(0); // force re-render for relative time
+  const [tick, setTick] = useState(0);
   const syncPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const syncPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedSession = selectedSlug
@@ -897,7 +897,9 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     return () => clearInterval(timer);
   }, [lastSyncedAt]);
 
-  const syncedAgoLabel = useMemo(() => {
+  // Recomputed on every tick (via setTick) to keep relative time fresh
+  void tick;
+  const syncedAgoLabel = (() => {
     if (!lastSyncedAt) return null;
     const diffMs = Date.now() - lastSyncedAt;
     if (diffMs < 60_000) return "just now";
@@ -905,7 +907,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     if (mins < 60) return `${mins}m ago`;
     const hrs = Math.floor(mins / 60);
     return `${hrs}h ago`;
-  }, [lastSyncedAt /* tick dependency implicitly via setTick re-render */]);
+  })();
 
   if (loading && !sources.length && !replays.length) {
     return (

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -1054,43 +1054,33 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
               className={`py-2.5 px-4 text-xs font-sans font-semibold rounded-lg border transition-all duration-200 disabled:opacity-50 disabled:cursor-wait shrink-0 ${
                 syncStatus === "done"
                   ? "bg-terminal-green/8 text-terminal-green border-terminal-green/20"
-                  : "bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border-terminal-border"
+                  : syncStatus === "error"
+                    ? "bg-red-400/8 text-red-400 border-red-400/20"
+                    : "bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border-terminal-border"
               }`}
+              title={syncMessage || undefined}
             >
               {syncStatus === "syncing"
                 ? "Syncing..."
                 : syncStatus === "done" && syncedAgoLabel
                   ? `\u2713 Synced ${syncedAgoLabel}`
-                  : syncStatus === "awaitingLogin"
-                    ? "Waiting..."
-                    : "\u2191 Sync to cloud"}
+                  : syncStatus === "error"
+                    ? "Sync failed"
+                    : syncStatus === "awaitingLogin"
+                      ? "Waiting..."
+                      : "\u2191 Sync to cloud"}
             </button>
-          </div>
-          {/* Cloud insights link after successful sync */}
-          {syncStatus === "done" && (
-            <p className="text-[10px] font-mono mt-1.5 text-terminal-dim">
-              {syncMessage}
-              {" \u00b7 "}
+            {syncStatus === "done" && (
               <a
                 href="https://vibe-replay.com/insights/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-terminal-green hover:underline"
+                className="py-2.5 px-3 text-[11px] font-mono text-terminal-dim hover:text-terminal-green transition-colors shrink-0"
               >
-                View on vibe-replay.com &rarr;
+                View online &rarr;
               </a>
-            </p>
-          )}
-          {/* Awaiting login status */}
-          {syncStatus === "awaitingLogin" && (
-            <p className="text-[10px] font-mono mt-1.5 text-terminal-dim animate-pulse">
-              Waiting for sign in... will auto-sync after login
-            </p>
-          )}
-          {/* Error messages */}
-          {syncMessage && syncStatus === "error" && (
-            <p className="text-[10px] font-mono mt-1.5 text-red-400">{syncMessage}</p>
-          )}
+            )}
+          </div>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-stretch">

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -678,6 +678,8 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     "idle" | "syncing" | "done" | "error" | "needsLogin" | "awaitingLogin"
   >("idle");
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
+  const [, setTick] = useState(0); // force re-render for relative time
   const syncPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const syncPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedSession = selectedSlug
@@ -801,30 +803,31 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const doSync = async () => {
     setSyncStatus("syncing");
     setSyncMessage(null);
-    let needsLogin = false;
     try {
       const resp = await fetch("/api/insights/sync", { method: "POST" });
       const data = await resp.json();
       if (resp.status === 401) {
         setSyncStatus("needsLogin");
         setSyncMessage(null);
-        needsLogin = true;
         return;
       }
       if (!resp.ok || data.error) {
         setSyncStatus("error");
         setSyncMessage(data.error || "Sync failed");
+        setTimeout(() => {
+          setSyncStatus((s) => (s === "error" ? "idle" : s));
+          setSyncMessage(null);
+        }, 4000);
       } else {
         setSyncStatus("done");
         setSyncMessage(data.message || `Synced ${data.synced ?? 0} insights`);
+        setLastSyncedAt(Date.now());
       }
     } catch {
       setSyncStatus("error");
       setSyncMessage("Network error");
-    }
-    if (!needsLogin) {
       setTimeout(() => {
-        setSyncStatus("idle");
+        setSyncStatus((s) => (s === "error" ? "idle" : s));
         setSyncMessage(null);
       }, 4000);
     }
@@ -886,6 +889,23 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
       if (syncPollTimeoutRef.current) clearTimeout(syncPollTimeoutRef.current);
     };
   }, []);
+
+  // Tick every 30s to update "synced X ago" relative time
+  useEffect(() => {
+    if (!lastSyncedAt) return;
+    const timer = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(timer);
+  }, [lastSyncedAt]);
+
+  const syncedAgoLabel = useMemo(() => {
+    if (!lastSyncedAt) return null;
+    const diffMs = Date.now() - lastSyncedAt;
+    if (diffMs < 60_000) return "just now";
+    const mins = Math.floor(diffMs / 60_000);
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    return `${hrs}h ago`;
+  }, [lastSyncedAt /* tick dependency implicitly via setTick re-render */]);
 
   if (loading && !sources.length && !replays.length) {
     return (
@@ -1031,30 +1051,45 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             <button
               onClick={handleSyncInsights}
               disabled={syncStatus === "syncing" || syncStatus === "awaitingLogin"}
-              className="py-2.5 px-4 text-xs font-sans font-semibold rounded-lg bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border border-terminal-border transition-all duration-200 disabled:opacity-50 disabled:cursor-wait shrink-0"
+              className={`py-2.5 px-4 text-xs font-sans font-semibold rounded-lg border transition-all duration-200 disabled:opacity-50 disabled:cursor-wait shrink-0 ${
+                syncStatus === "done"
+                  ? "bg-terminal-green/8 text-terminal-green border-terminal-green/20"
+                  : "bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border-terminal-border"
+              }`}
             >
               {syncStatus === "syncing"
                 ? "Syncing..."
-                : syncStatus === "done"
-                  ? "\u2713 Synced"
+                : syncStatus === "done" && syncedAgoLabel
+                  ? `\u2713 Synced ${syncedAgoLabel}`
                   : syncStatus === "awaitingLogin"
                     ? "Waiting..."
                     : "\u2191 Sync to cloud"}
             </button>
           </div>
+          {/* Cloud insights link after successful sync */}
+          {syncStatus === "done" && (
+            <p className="text-[10px] font-mono mt-1.5 text-terminal-dim">
+              {syncMessage}
+              {" \u00b7 "}
+              <a
+                href="https://vibe-replay.com/insights/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-terminal-green hover:underline"
+              >
+                View on vibe-replay.com &rarr;
+              </a>
+            </p>
+          )}
           {/* Awaiting login status */}
           {syncStatus === "awaitingLogin" && (
             <p className="text-[10px] font-mono mt-1.5 text-terminal-dim animate-pulse">
               Waiting for sign in... will auto-sync after login
             </p>
           )}
-          {/* Success/error messages */}
-          {syncMessage && syncStatus !== "awaitingLogin" && syncStatus !== "needsLogin" && (
-            <p
-              className={`text-[10px] font-mono mt-1.5 ${syncStatus === "error" ? "text-red-400" : "text-terminal-dim"}`}
-            >
-              {syncMessage}
-            </p>
+          {/* Error messages */}
+          {syncMessage && syncStatus === "error" && (
+            <p className="text-[10px] font-mono mt-1.5 text-red-400">{syncMessage}</p>
           )}
         </div>
 

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -674,8 +674,12 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateErrorSlug, setGenerateErrorSlug] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
-  const [syncStatus, setSyncStatus] = useState<"idle" | "syncing" | "done" | "error">("idle");
+  const [syncStatus, setSyncStatus] = useState<
+    "idle" | "syncing" | "done" | "error" | "needsLogin" | "awaitingLogin"
+  >("idle");
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const syncPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const syncPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedSession = selectedSlug
     ? (sources.find((s) => s.slug === selectedSlug) ?? null)
     : null;
@@ -794,12 +798,19 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     }
   };
 
-  const handleSyncInsights = async () => {
+  const doSync = async () => {
     setSyncStatus("syncing");
     setSyncMessage(null);
+    let needsLogin = false;
     try {
       const resp = await fetch("/api/insights/sync", { method: "POST" });
       const data = await resp.json();
+      if (resp.status === 401) {
+        setSyncStatus("needsLogin");
+        setSyncMessage(null);
+        needsLogin = true;
+        return;
+      }
       if (!resp.ok || data.error) {
         setSyncStatus("error");
         setSyncMessage(data.error || "Sync failed");
@@ -811,11 +822,70 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
       setSyncStatus("error");
       setSyncMessage("Network error");
     }
-    setTimeout(() => {
-      setSyncStatus("idle");
-      setSyncMessage(null);
-    }, 4000);
+    if (!needsLogin) {
+      setTimeout(() => {
+        setSyncStatus("idle");
+        setSyncMessage(null);
+      }, 4000);
+    }
   };
+
+  const handleSyncInsights = () => {
+    doSync();
+  };
+
+  const handleLoginThenSync = async () => {
+    setSyncStatus("awaitingLogin");
+    setSyncMessage("Waiting for sign in...");
+    try {
+      const res = await fetch("/api/auth/login", { method: "POST" });
+      const data = await res.json().catch(() => null);
+      if (res.ok && data?.url) {
+        window.open(data.url, "_blank");
+      }
+    } catch {
+      // fall through — poll will handle it
+    }
+    // Poll for login completion, then auto-sync
+    if (syncPollRef.current) clearInterval(syncPollRef.current);
+    if (syncPollTimeoutRef.current) clearTimeout(syncPollTimeoutRef.current);
+    syncPollRef.current = setInterval(async () => {
+      try {
+        const r = await fetch("/api/auth/get-session");
+        const s = await r.json();
+        if (s?.session) {
+          if (syncPollRef.current) {
+            clearInterval(syncPollRef.current);
+            syncPollRef.current = null;
+          }
+          if (syncPollTimeoutRef.current) {
+            clearTimeout(syncPollTimeoutRef.current);
+            syncPollTimeoutRef.current = null;
+          }
+          window.dispatchEvent(new Event("vibe-auth-change"));
+          doSync();
+        }
+      } catch {}
+    }, 2000);
+    syncPollTimeoutRef.current = setTimeout(
+      () => {
+        if (syncPollRef.current) {
+          clearInterval(syncPollRef.current);
+          syncPollRef.current = null;
+        }
+        setSyncStatus("idle");
+        setSyncMessage(null);
+      },
+      3 * 60 * 1000,
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      if (syncPollRef.current) clearInterval(syncPollRef.current);
+      if (syncPollTimeoutRef.current) clearTimeout(syncPollTimeoutRef.current);
+    };
+  }, []);
 
   if (loading && !sources.length && !replays.length) {
     return (
@@ -960,19 +1030,26 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             </button>
             <button
               onClick={handleSyncInsights}
-              disabled={syncStatus === "syncing"}
+              disabled={syncStatus === "syncing" || syncStatus === "awaitingLogin"}
               className="py-2.5 px-4 text-xs font-sans font-semibold rounded-lg bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border border-terminal-border transition-all duration-200 disabled:opacity-50 disabled:cursor-wait shrink-0"
             >
               {syncStatus === "syncing"
                 ? "Syncing..."
                 : syncStatus === "done"
                   ? "\u2713 Synced"
-                  : syncStatus === "error"
-                    ? "Failed"
+                  : syncStatus === "awaitingLogin"
+                    ? "Waiting..."
                     : "\u2191 Sync to cloud"}
             </button>
           </div>
-          {syncMessage && (
+          {/* Awaiting login status */}
+          {syncStatus === "awaitingLogin" && (
+            <p className="text-[10px] font-mono mt-1.5 text-terminal-dim animate-pulse">
+              Waiting for sign in... will auto-sync after login
+            </p>
+          )}
+          {/* Success/error messages */}
+          {syncMessage && syncStatus !== "awaitingLogin" && syncStatus !== "needsLogin" && (
             <p
               className={`text-[10px] font-mono mt-1.5 ${syncStatus === "error" ? "text-red-400" : "text-terminal-dim"}`}
             >
@@ -1103,6 +1180,111 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           isGenerating={generatingSlug === selectedSession.slug}
           isArchived={false}
         />
+      )}
+
+      {/* Sync login modal */}
+      {(syncStatus === "needsLogin" || syncStatus === "awaitingLogin") && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && syncStatus === "needsLogin") {
+              setSyncStatus("idle");
+            }
+          }}
+        >
+          <div className="relative bg-terminal-surface border border-terminal-border rounded-2xl shadow-2xl max-w-md w-full mx-4 p-6">
+            {/* Close button */}
+            {syncStatus === "needsLogin" && (
+              <button
+                onClick={() => setSyncStatus("idle")}
+                className="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-md text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover transition-colors cursor-pointer"
+              >
+                &times;
+              </button>
+            )}
+
+            {syncStatus === "needsLogin" ? (
+              <>
+                <h3 className="text-base font-bold text-terminal-text mb-1">
+                  Sync Insights to the Cloud
+                </h3>
+                <p className="text-xs text-terminal-dim mb-5">
+                  Sign in with GitHub to unlock your online dashboard.
+                </p>
+
+                {/* Value props */}
+                <div className="space-y-3 mb-6">
+                  <div className="flex items-start gap-3">
+                    <span className="shrink-0 w-7 h-7 rounded-full bg-terminal-green/10 flex items-center justify-center text-xs font-bold font-mono text-terminal-green">
+                      1
+                    </span>
+                    <div>
+                      <div className="text-sm font-semibold text-terminal-text">
+                        Cross-machine dashboard
+                      </div>
+                      <p className="text-[11px] text-terminal-dim mt-0.5">
+                        See all your sessions, costs, and streaks in one place — from any browser.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="shrink-0 w-7 h-7 rounded-full bg-terminal-orange/10 flex items-center justify-center text-xs font-bold font-mono text-terminal-orange">
+                      2
+                    </span>
+                    <div>
+                      <div className="text-sm font-semibold text-terminal-text">
+                        Cost tracking &amp; trends
+                      </div>
+                      <p className="text-[11px] text-terminal-dim mt-0.5">
+                        Track spending by model, spot weekly patterns, and monitor project
+                        breakdowns.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <span className="shrink-0 w-7 h-7 rounded-full bg-terminal-blue/10 flex items-center justify-center text-xs font-bold font-mono text-terminal-blue">
+                      3
+                    </span>
+                    <div>
+                      <div className="text-sm font-semibold text-terminal-text">
+                        Share your coding card
+                      </div>
+                      <p className="text-[11px] text-terminal-dim mt-0.5">
+                        Activity heatmaps, streak badges, and project stats — shareable at a glance.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* CTA */}
+                <button
+                  onClick={handleLoginThenSync}
+                  className="w-full inline-flex items-center justify-center gap-2 h-10 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-semibold transition-colors cursor-pointer border border-white/10"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                  </svg>
+                  Sign in with GitHub
+                </button>
+                <p className="text-[10px] text-terminal-dim text-center mt-3">
+                  We&apos;ll auto-sync your insights right after sign in.
+                </p>
+              </>
+            ) : (
+              /* Awaiting login state */
+              <div className="text-center py-4">
+                <div className="text-2xl mb-3 animate-pulse">&uarr;</div>
+                <h3 className="text-base font-bold text-terminal-text mb-1">
+                  Waiting for sign in...
+                </h3>
+                <p className="text-xs text-terminal-dim">
+                  Complete GitHub sign in in the browser tab. We&apos;ll auto-sync once you&apos;re
+                  in.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -1070,16 +1070,27 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                       ? "Waiting..."
                       : "\u2191 Sync to cloud"}
             </button>
-            {syncStatus === "done" && (
-              <a
-                href="https://vibe-replay.com/insights/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="py-2.5 px-3 text-[11px] font-mono text-terminal-dim hover:text-terminal-green transition-colors shrink-0"
+            <a
+              href="https://vibe-replay.com/insights/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center w-9 h-9 rounded-lg text-terminal-dim hover:text-terminal-green hover:bg-terminal-surface-hover transition-colors shrink-0"
+              title="View insights on vibe-replay.com"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
               >
-                View online &rarr;
-              </a>
-            )}
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+                />
+              </svg>
+            </a>
           </div>
         </div>
 

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -674,6 +674,8 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateErrorSlug, setGenerateErrorSlug] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [syncStatus, setSyncStatus] = useState<"idle" | "syncing" | "done" | "error">("idle");
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const selectedSession = selectedSlug
     ? (sources.find((s) => s.slug === selectedSlug) ?? null)
     : null;
@@ -790,6 +792,29 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     } catch {
       // ignore
     }
+  };
+
+  const handleSyncInsights = async () => {
+    setSyncStatus("syncing");
+    setSyncMessage(null);
+    try {
+      const resp = await fetch("/api/insights/sync", { method: "POST" });
+      const data = await resp.json();
+      if (!resp.ok || data.error) {
+        setSyncStatus("error");
+        setSyncMessage(data.error || "Sync failed");
+      } else {
+        setSyncStatus("done");
+        setSyncMessage(data.message || `Synced ${data.synced ?? 0} insights`);
+      }
+    } catch {
+      setSyncStatus("error");
+      setSyncMessage("Network error");
+    }
+    setTimeout(() => {
+      setSyncStatus("idle");
+      setSyncMessage(null);
+    }, 4000);
   };
 
   if (loading && !sources.length && !replays.length) {
@@ -925,13 +950,35 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           {/* Heatmap */}
           <ContributionHeatmap sessionsPerDay={displaySessionsPerDay} weeks={52} />
 
-          {/* CTA link */}
-          <button
-            onClick={() => onNavigate("insights")}
-            className="w-full py-2.5 mt-3 text-xs font-sans font-semibold rounded-lg bg-terminal-green-subtle text-terminal-green hover:bg-terminal-green-emphasis transition-all duration-200"
-          >
-            View personal insights &rarr;
-          </button>
+          {/* CTA buttons */}
+          <div className="flex gap-2 mt-3">
+            <button
+              onClick={() => onNavigate("insights")}
+              className="flex-1 py-2.5 text-xs font-sans font-semibold rounded-lg bg-terminal-green-subtle text-terminal-green hover:bg-terminal-green-emphasis transition-all duration-200"
+            >
+              View personal insights &rarr;
+            </button>
+            <button
+              onClick={handleSyncInsights}
+              disabled={syncStatus === "syncing"}
+              className="py-2.5 px-4 text-xs font-sans font-semibold rounded-lg bg-terminal-surface text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover border border-terminal-border transition-all duration-200 disabled:opacity-50 disabled:cursor-wait shrink-0"
+            >
+              {syncStatus === "syncing"
+                ? "Syncing..."
+                : syncStatus === "done"
+                  ? "\u2713 Synced"
+                  : syncStatus === "error"
+                    ? "Failed"
+                    : "\u2191 Sync to cloud"}
+            </button>
+          </div>
+          {syncMessage && (
+            <p
+              className={`text-[10px] font-mono mt-1.5 ${syncStatus === "error" ? "text-red-400" : "text-terminal-dim"}`}
+            >
+              {syncMessage}
+            </p>
+          )}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-stretch">

--- a/website/src/components/CliGuide.astro
+++ b/website/src/components/CliGuide.astro
@@ -62,7 +62,7 @@ const steps = variant === "sync" ? syncSteps : fullSteps;
   </div>
 
   <div class="space-y-4">
-    {steps.map((step, i) => (
+    {steps.map((step) => (
       <div class="flex gap-4 items-start">
         <div class="shrink-0 w-7 h-7 rounded-full bg-accent/15 flex items-center justify-center">
           <span class="text-xs font-bold font-mono text-accent">{step.num}</span>

--- a/website/src/components/CliGuide.astro
+++ b/website/src/components/CliGuide.astro
@@ -1,0 +1,105 @@
+---
+/**
+ * CliGuide — reusable step-by-step guide for getting started with vibe-replay CLI.
+ *
+ * Props:
+ *   heading    – title above the steps (default: "Get Started")
+ *   subheading – optional subtitle
+ *   variant    – "full" (install + scan + dashboard + sync) | "sync" (dashboard + sync only)
+ *                Defaults to "full". Use "sync" when the user is logged in but has no data.
+ */
+interface Props {
+  heading?: string;
+  subheading?: string;
+  variant?: "full" | "sync";
+}
+
+const {
+  heading = "Get Started",
+  subheading,
+  variant = "full",
+} = Astro.props;
+
+const fullSteps = [
+  {
+    num: "1",
+    title: "Run the CLI",
+    desc: "Scans your local Claude Code & Cursor sessions automatically.",
+    code: "npx vibe-replay",
+  },
+  {
+    num: "2",
+    title: "Open Dashboard",
+    desc: "Browse sessions, view replays, and explore local insights.",
+    code: "npx vibe-replay -d",
+  },
+  {
+    num: "3",
+    title: "Sync to Cloud",
+    desc: 'Click "Sync Insights" in the dashboard to push your data here.',
+    code: null,
+  },
+];
+
+const syncSteps = [
+  {
+    num: "1",
+    title: "Open Dashboard",
+    desc: "Launch the local dashboard to see all your sessions.",
+    code: "npx vibe-replay -d",
+  },
+  {
+    num: "2",
+    title: "Sync Insights",
+    desc: 'Click the "Sync Insights" button — your data appears here instantly.',
+    code: null,
+  },
+];
+
+const steps = variant === "sync" ? syncSteps : fullSteps;
+---
+
+<div class="max-w-lg mx-auto">
+  <div class="text-center mb-6">
+    <h2 class="text-lg font-bold text-text-primary mb-1">{heading}</h2>
+    {subheading && <p class="text-text-muted text-sm">{subheading}</p>}
+  </div>
+
+  <div class="space-y-4">
+    {steps.map((step, i) => (
+      <div class="flex gap-4 items-start">
+        <div class="shrink-0 w-7 h-7 rounded-full bg-accent/15 flex items-center justify-center">
+          <span class="text-xs font-bold font-mono text-accent">{step.num}</span>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-semibold text-text-primary">{step.title}</div>
+          <p class="text-text-muted text-xs mt-0.5">{step.desc}</p>
+          {step.code && (
+            <div class="mt-2 bg-surface-2 rounded-lg px-3 py-2 font-mono text-xs flex items-center gap-2 border border-border/50">
+              <span class="text-accent select-none">$</span>
+              <span class="text-text-secondary">{step.code}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    ))}
+  </div>
+
+  <!-- What you get -->
+  <div class="mt-6 pt-5 border-t border-border/30">
+    <div class="grid grid-cols-3 gap-3 text-center">
+      <div>
+        <div class="text-sm font-bold text-[#3fb950] font-mono">Sessions</div>
+        <div class="text-[10px] text-text-muted mt-0.5">Activity heatmap &amp; streaks</div>
+      </div>
+      <div>
+        <div class="text-sm font-bold text-[#d29922] font-mono">Costs</div>
+        <div class="text-[10px] text-text-muted mt-0.5">Spending trends by model</div>
+      </div>
+      <div>
+        <div class="text-sm font-bold text-[#79b8ff] font-mono">Projects</div>
+        <div class="text-[10px] text-text-muted mt-0.5">Per-project breakdowns</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/website/src/components/CliGuide.astro
+++ b/website/src/components/CliGuide.astro
@@ -14,11 +14,7 @@ interface Props {
   variant?: "full" | "sync";
 }
 
-const {
-  heading = "Get Started",
-  subheading,
-  variant = "full",
-} = Astro.props;
+const { heading = "Get Started", subheading, variant = "full" } = Astro.props;
 
 const fullSteps = [
   {

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -11,6 +11,11 @@ const linkClass = (page: string) =>
   page === active
     ? "text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-accent"
     : "text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent";
+
+const mobileLinkClass = (page: string) =>
+  page === active
+    ? "text-accent text-sm transition-colors"
+    : "text-text-secondary hover:text-accent text-sm transition-colors";
 ---
 
 <nav class="relative z-20 border-b border-border/50 px-6 py-3">
@@ -54,9 +59,9 @@ const linkClass = (page: string) =>
   <!-- Mobile dropdown -->
   <div id="nav-menu" class="hidden sm:hidden mt-3 pt-3 border-t border-border/50">
     <div class="flex flex-col gap-3">
-      <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors">Blog</a>
-      <a href="/explore" class="text-text-secondary hover:text-accent text-sm transition-colors">Explore Replays</a>
-      <a href="/insights" class="text-text-secondary hover:text-accent text-sm transition-colors">Insights</a>
+      <a href="/blog" class={mobileLinkClass("blog")}>Blog</a>
+      <a href="/explore" class={mobileLinkClass("explore")}>Explore Replays</a>
+      <a href="/insights" class={mobileLinkClass("insights")}>Insights</a>
       <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-secondary hover:text-accent text-sm transition-colors flex items-center gap-2">
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
@@ -113,14 +118,18 @@ const linkClass = (page: string) =>
     const show = (el: HTMLElement | null) => { if (el) el.style.display = ""; };
 
     const doSignIn = async () => {
-      const res = await fetch("/api/auth/sign-in/social", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ provider: "github", callbackURL: window.location.pathname }),
-      });
-      const data = await res.json();
-      if (data?.url) window.location.href = data.url;
+      try {
+        const res = await fetch("/api/auth/sign-in/social", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ provider: "github", callbackURL: window.location.pathname }),
+        });
+        const data = await res.json();
+        if (data?.url) window.location.href = data.url;
+      } catch {
+        window.location.href = "/auth/login?callback=" + window.location.pathname;
+      }
     };
 
     const doSignOut = async () => {
@@ -150,7 +159,10 @@ const linkClass = (page: string) =>
         username.textContent = data.user.name || data.user.email || "";
         show(userDiv);
         // Mobile
-        if (mobileAvatar) mobileAvatar.src = data.user.image || "";
+        if (mobileAvatar) {
+          mobileAvatar.src = data.user.image || "";
+          mobileAvatar.alt = data.user.name || "";
+        }
         show(mobileUser);
       } else {
         show(loginBtn);

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -37,6 +37,7 @@ const linkClass = (page: string) =>
           </button>
           <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
             <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
+            <a href="/profile" class="block px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-colors">Profile</a>
             <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
           </div>
         </div>
@@ -60,6 +61,18 @@ const linkClass = (page: string) =>
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
       </a>
+      <!-- Mobile auth -->
+      <div id="nav-mobile-auth" class="pt-3 border-t border-border/50" style="display:none">
+        <button id="nav-mobile-login" style="display:none" class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10">
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          Sign in
+        </button>
+        <div id="nav-mobile-user" style="display:none" class="flex items-center gap-3">
+          <img id="nav-mobile-avatar" class="w-6 h-6 rounded-full object-cover" alt="" />
+          <a href="/profile" class="text-text-secondary hover:text-accent text-sm transition-colors flex-1">Profile</a>
+          <button id="nav-mobile-logout" class="text-sm text-text-secondary hover:text-red-400 transition-colors cursor-pointer">Logout</button>
+        </div>
+      </div>
     </div>
   </div>
 </nav>
@@ -90,36 +103,16 @@ const linkClass = (page: string) =>
     const logoutBtn = document.getElementById("auth-logout");
     if (!container || !loginBtn || !userDiv || !avatarBtn || !avatar || !dropdown || !username || !logoutBtn) return;
 
-    const show = (el: HTMLElement) => { el.style.display = ""; };
+    // Mobile auth elements
+    const mobileAuth = document.getElementById("nav-mobile-auth");
+    const mobileLogin = document.getElementById("nav-mobile-login");
+    const mobileUser = document.getElementById("nav-mobile-user");
+    const mobileAvatar = document.getElementById("nav-mobile-avatar") as HTMLImageElement | null;
+    const mobileLogout = document.getElementById("nav-mobile-logout");
 
-    try {
-      const res = await fetch("/api/auth/get-session", { credentials: "include" });
-      const data = await res.json();
-      show(container);
+    const show = (el: HTMLElement | null) => { if (el) el.style.display = ""; };
 
-      if (data?.session && data?.user) {
-        avatar.src = data.user.image || "";
-        avatar.alt = data.user.name || "";
-        username.textContent = data.user.name || data.user.email || "";
-        show(userDiv);
-      } else {
-        show(loginBtn);
-      }
-    } catch {
-      show(container);
-      show(loginBtn);
-    }
-
-    avatarBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      dropdown.classList.toggle("hidden");
-    });
-
-    document.addEventListener("click", () => {
-      dropdown.classList.add("hidden");
-    });
-
-    loginBtn.addEventListener("click", async () => {
+    const doSignIn = async () => {
       const res = await fetch("/api/auth/sign-in/social", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -128,9 +121,9 @@ const linkClass = (page: string) =>
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;
-    });
+    };
 
-    logoutBtn.addEventListener("click", async () => {
+    const doSignOut = async () => {
       try {
         const res = await fetch("/api/auth/sign-out", {
           method: "POST",
@@ -143,6 +136,45 @@ const linkClass = (page: string) =>
         console.error("Sign-out error:", err);
       }
       window.location.reload();
+    };
+
+    try {
+      const res = await fetch("/api/auth/get-session", { credentials: "include" });
+      const data = await res.json();
+      show(container);
+      show(mobileAuth);
+
+      if (data?.session && data?.user) {
+        avatar.src = data.user.image || "";
+        avatar.alt = data.user.name || "";
+        username.textContent = data.user.name || data.user.email || "";
+        show(userDiv);
+        // Mobile
+        if (mobileAvatar) mobileAvatar.src = data.user.image || "";
+        show(mobileUser);
+      } else {
+        show(loginBtn);
+        show(mobileLogin);
+      }
+    } catch {
+      show(container);
+      show(loginBtn);
+      show(mobileAuth);
+      show(mobileLogin);
+    }
+
+    avatarBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      dropdown.classList.toggle("hidden");
     });
+
+    document.addEventListener("click", () => {
+      dropdown.classList.add("hidden");
+    });
+
+    loginBtn.addEventListener("click", doSignIn);
+    mobileLogin?.addEventListener("click", doSignIn);
+    logoutBtn.addEventListener("click", doSignOut);
+    mobileLogout?.addEventListener("click", doSignOut);
   })();
 </script>

--- a/website/src/pages/explore.astro
+++ b/website/src/pages/explore.astro
@@ -1,41 +1,12 @@
 ---
 import Footer from "../components/Footer.astro";
-import GitHubStar from "../components/GitHubStar.astro";
+import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Explore Replays - vibe-replay" description="Browse public AI coding session replays shared by the community. Watch Claude Code and Cursor sessions as interactive web replays.">
   <div class="min-h-screen flex flex-col">
-    <!-- Header (matches main page nav) -->
-    <nav class="border-b border-border/50 px-6 py-3">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <div class="flex items-center gap-4">
-          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
-          <span class="text-border hidden sm:inline">|</span>
-          <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Blog</a>
-          <span class="text-text-secondary text-sm hidden sm:inline">Explore</span>
-        </div>
-        <div class="flex items-center gap-3">
-          <GitHubStar />
-          <!-- Auth -->
-          <div id="auth-container" style="display:none">
-            <button id="auth-login" style="display:none" class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              Sign in
-            </button>
-            <div id="auth-user" style="display:none" class="relative">
-              <button id="auth-avatar-btn" class="flex items-center justify-center w-8 h-8 rounded-full border border-border/60 hover:border-accent/70 transition-all cursor-pointer overflow-hidden">
-                <img id="auth-avatar" class="w-full h-full rounded-full object-cover" alt="" />
-              </button>
-              <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
-                <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
-                <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
+    <Nav active="explore" />
 
     <!-- Main content -->
     <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-10">
@@ -233,73 +204,6 @@ import Layout from "../layouts/Layout.astro";
   // Initial load
   loadReplays("recent");
 
-  // --- Auth UI ---
-  (async () => {
-
-    const container = document.getElementById("auth-container");
-    const loginBtn = document.getElementById("auth-login");
-    const userDiv = document.getElementById("auth-user");
-    const avatarBtn = document.getElementById("auth-avatar-btn");
-    const avatar = document.getElementById("auth-avatar") as HTMLImageElement | null;
-    const dropdown = document.getElementById("auth-dropdown");
-    const username = document.getElementById("auth-username");
-    const logoutBtn = document.getElementById("auth-logout");
-    if (!container || !loginBtn || !userDiv || !avatarBtn || !avatar || !dropdown || !username || !logoutBtn) return;
-
-    const show = (el: HTMLElement) => { el.style.display = ""; };
-
-    try {
-      const res = await fetch("/api/auth/get-session", { credentials: "include" });
-      const data = await res.json();
-      show(container);
-
-      if (data?.session && data?.user) {
-        avatar.src = data.user.image || "";
-        avatar.alt = data.user.name || "";
-        username.textContent = data.user.name || data.user.email || "";
-        show(userDiv);
-      } else {
-        show(loginBtn);
-      }
-    } catch {
-      show(container);
-      show(loginBtn);
-    }
-
-    avatarBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      dropdown.classList.toggle("hidden");
-    });
-
-    document.addEventListener("click", () => {
-      dropdown.classList.add("hidden");
-    });
-
-    loginBtn.addEventListener("click", async () => {
-      const res = await fetch("/api/auth/sign-in/social", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ provider: "github", callbackURL: window.location.pathname }),
-      });
-      const data = await res.json();
-      if (data?.url) window.location.href = data.url;
-    });
-
-    logoutBtn.addEventListener("click", async () => {
-      try {
-        const res = await fetch("/api/auth/sign-out", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: "{}",
-        });
-        if (!res.ok) console.error("Sign-out failed:", res.status);
-      } catch (err) {
-        console.error("Sign-out error:", err);
-      }
-      window.location.reload();
-    });
-  })();
+  // Auth is handled by Nav component
 </script>
 

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1,4 +1,5 @@
 ---
+import CliGuide from "../components/CliGuide.astro";
 import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
@@ -19,15 +20,15 @@ import Layout from "../layouts/Layout.astro";
       <div id="signed-out" class="hidden">
         <div class="relative">
           <!-- Sign-in overlay -->
-          <div class="absolute inset-0 z-20 flex items-start justify-center pt-32 md:pt-40">
-            <div class="rounded-2xl border border-border bg-surface/95 backdrop-blur-sm p-8 max-w-sm text-center shadow-2xl shadow-black/30">
-              <h2 class="text-lg font-bold text-text-primary mb-2">Your AI Coding Dashboard</h2>
-              <p class="text-text-muted text-sm mb-1">Track sessions, costs, and productivity across all your machines.</p>
-              <p class="text-text-muted text-xs font-mono mb-5">Sync from CLI with <span class="text-accent">npx vibe-replay -d</span></p>
-              <button id="signin-btn" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-medium transition-colors cursor-pointer border border-white/10">
-                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-                Sign in with GitHub
-              </button>
+          <div class="absolute inset-0 z-20 flex items-start justify-center pt-12 md:pt-20">
+            <div class="rounded-2xl border border-border bg-surface/95 backdrop-blur-sm p-8 shadow-2xl shadow-black/30">
+              <CliGuide heading="Your AI Coding Dashboard" subheading="Track sessions, costs, and productivity across all your machines." variant="full" />
+              <div class="mt-6 text-center">
+                <button id="signin-btn" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-medium transition-colors cursor-pointer border border-white/10">
+                  <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                  Sign in with GitHub
+                </button>
+              </div>
             </div>
           </div>
 
@@ -206,17 +207,69 @@ import Layout from "../layouts/Layout.astro";
         </div>
       </div>
 
-      <!-- No data state -->
+      <!-- No data state — skeleton + getting started guide -->
       <div id="no-data" class="hidden">
-        <div class="flex items-center justify-center py-20">
-          <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md text-center">
-            <div class="text-4xl mb-4">&#128640;</div>
-            <h2 class="text-lg font-semibold text-text-primary mb-2">No insights synced yet</h2>
-            <p class="text-text-muted text-sm mb-4">Sync your local session insights from the CLI dashboard to see them here.</p>
-            <div class="bg-surface-2 rounded-lg p-4 text-left">
-              <p class="text-text-muted text-xs font-mono mb-1"># In the CLI dashboard, click "Sync Insights"</p>
-              <p class="text-text-muted text-xs font-mono mb-1"># Or use the API endpoint:</p>
-              <p class="text-accent text-xs font-mono">npx vibe-replay -d</p>
+        <div class="relative">
+          <!-- Guide overlay -->
+          <div class="absolute inset-0 z-20 flex items-start justify-center pt-16 md:pt-24">
+            <div class="rounded-2xl border border-border bg-surface/95 backdrop-blur-sm p-8 shadow-2xl shadow-black/30">
+              <CliGuide heading="Sync Your Insights" subheading="You're signed in — just sync from the CLI to see your dashboard." variant="sync" />
+            </div>
+          </div>
+
+          <!-- Blurred skeleton (same as signed-out) -->
+          <div class="space-y-6 select-none pointer-events-none blur-[6px] opacity-70" aria-hidden="true">
+            <div class="flex items-center justify-between">
+              <h1 class="text-lg font-bold text-text-primary">Your Insights</h1>
+            </div>
+            <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-surface-1 via-surface to-surface-1 border border-border p-6 md:p-8">
+              <div class="absolute -top-20 -right-20 w-64 h-64 bg-[#3fb950]/5 rounded-full blur-3xl"></div>
+              <div class="absolute -bottom-20 -left-20 w-48 h-48 bg-[#79b8ff]/5 rounded-full blur-3xl"></div>
+              <div class="relative z-10">
+                <div class="grid grid-cols-4 gap-x-6 gap-y-5 mb-6">
+                  <div><div class="text-2xl font-mono font-bold text-[#3fb950] tabular-nums">247</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Sessions</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-[#3fb950] tabular-nums">1,842</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Prompts</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-[#d29922] tabular-nums">5,621</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Tool Calls</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-text-primary tabular-nums">38h</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Coding</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-[#d29922] tabular-nums">$42.17</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Spent</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-[#79b8ff] tabular-nums">892</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">File Edits</div></div>
+                  <div><div class="text-2xl font-mono font-bold text-[#b392f0] tabular-nums">12</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Projects</div></div>
+                  <div></div>
+                </div>
+              </div>
+            </div>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5"><div class="flex items-start gap-3"><span class="text-lg leading-none mt-0.5">&#128293;</span><div><div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Current Streak</div><div class="text-lg font-mono font-bold text-text-primary mt-0.5">7 days</div></div></div></div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5"><div class="flex items-start gap-3"><span class="text-lg leading-none mt-0.5">&#9889;</span><div><div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Active Day</div><div class="text-lg font-mono font-bold text-text-primary mt-0.5">3.2 sessions</div></div></div></div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5"><div class="flex items-start gap-3"><span class="text-lg leading-none mt-0.5">&#128172;</span><div><div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Session</div><div class="text-lg font-mono font-bold text-text-primary mt-0.5">7 prompts</div></div></div></div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5"><div class="flex items-start gap-3"><span class="text-lg leading-none mt-0.5">&#127942;</span><div><div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Peak Day</div><div class="text-lg font-mono font-bold text-text-primary mt-0.5">11 sessions</div></div></div></div>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Weekly Trend</h3>
+                <div class="flex items-end gap-1.5 h-28">
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 35%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 52%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 65%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 78%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 45%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 82%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 90%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 72%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 100%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 55%; opacity: 0.7"></div></div>
+                </div>
+              </div>
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Day of Week</h3>
+                <div class="space-y-2">
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Mon</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 85%; opacity: 0.65"></div></div></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Tue</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 100%; opacity: 0.65"></div></div></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Wed</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 70%; opacity: 0.65"></div></div></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Thu</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 55%; opacity: 0.65"></div></div></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Fri</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 40%; opacity: 0.65"></div></div></div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1,41 +1,12 @@
 ---
 import Footer from "../components/Footer.astro";
-import GitHubStar from "../components/GitHubStar.astro";
+import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Insights - vibe-replay" description="Track your AI coding sessions across all machines. View cost, productivity trends, and project analytics.">
   <div class="min-h-screen flex flex-col">
-    <!-- Header -->
-    <nav class="border-b border-border/50 px-6 py-3">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <div class="flex items-center gap-4">
-          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
-          <span class="text-border hidden sm:inline">|</span>
-          <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Blog</a>
-          <span class="text-text-secondary text-sm hidden sm:inline">Insights</span>
-        </div>
-        <div class="flex items-center gap-3">
-          <GitHubStar />
-          <div id="auth-container" style="display:none">
-            <button id="auth-login" style="display:none" class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              Sign in
-            </button>
-            <div id="auth-user" style="display:none" class="relative">
-              <button id="auth-avatar-btn" class="flex items-center justify-center w-8 h-8 rounded-full border border-border/60 hover:border-accent/70 transition-all cursor-pointer overflow-hidden">
-                <img id="auth-avatar" class="w-full h-full rounded-full object-cover" alt="" />
-              </button>
-              <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
-                <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
-                <a href="/profile" class="block px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-colors">Profile</a>
-                <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
+    <Nav active="insights" />
 
     <!-- Main content -->
     <main class="flex-1 max-w-4xl mx-auto w-full px-4 md:px-6 py-10">
@@ -44,18 +15,193 @@ import Layout from "../layouts/Layout.astro";
         <div class="text-text-muted font-mono text-sm animate-pulse">Loading...</div>
       </div>
 
-      <!-- Not logged in state -->
+      <!-- Not logged in state — skeleton with fake data -->
       <div id="signed-out" class="hidden">
-        <div class="flex items-center justify-center py-20">
-          <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md text-center">
-            <div class="text-4xl mb-4">&#128202;</div>
-            <h2 class="text-lg font-semibold text-text-primary mb-2">Sign in to view Insights</h2>
-            <p class="text-text-muted text-sm mb-4">Track your AI coding sessions across all machines. Sync insights from the CLI to view cost trends, project analytics, and more.</p>
-            <p class="text-text-muted text-xs font-mono mb-6">npx vibe-replay &rarr; Dashboard &rarr; Sync Insights</p>
-            <button id="signin-btn" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-medium transition-colors cursor-pointer border border-white/10">
-              <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              Sign in with GitHub
-            </button>
+        <div class="relative">
+          <!-- Sign-in overlay -->
+          <div class="absolute inset-0 z-20 flex items-start justify-center pt-32 md:pt-40">
+            <div class="rounded-2xl border border-border bg-surface/95 backdrop-blur-sm p-8 max-w-sm text-center shadow-2xl shadow-black/30">
+              <h2 class="text-lg font-bold text-text-primary mb-2">Your AI Coding Dashboard</h2>
+              <p class="text-text-muted text-sm mb-1">Track sessions, costs, and productivity across all your machines.</p>
+              <p class="text-text-muted text-xs font-mono mb-5">Sync from CLI with <span class="text-accent">npx vibe-replay -d</span></p>
+              <button id="signin-btn" class="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-[#24292f] hover:bg-[#32383f] text-white text-sm font-medium transition-colors cursor-pointer border border-white/10">
+                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                Sign in with GitHub
+              </button>
+            </div>
+          </div>
+
+          <!-- Blurred skeleton dashboard -->
+          <div class="space-y-6 select-none pointer-events-none blur-[6px] opacity-70" aria-hidden="true">
+            <!-- Title -->
+            <div class="flex items-center justify-between">
+              <h1 class="text-lg font-bold text-text-primary">Your Insights</h1>
+            </div>
+
+            <!-- Stats card -->
+            <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-surface-1 via-surface to-surface-1 border border-border p-6 md:p-8">
+              <div class="absolute -top-20 -right-20 w-64 h-64 bg-[#3fb950]/5 rounded-full blur-3xl"></div>
+              <div class="absolute -bottom-20 -left-20 w-48 h-48 bg-[#79b8ff]/5 rounded-full blur-3xl"></div>
+              <div class="relative z-10">
+                <div class="grid grid-cols-4 gap-x-6 gap-y-5 mb-6">
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#3fb950] tabular-nums">247</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Sessions</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#3fb950] tabular-nums">1,842</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Prompts</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#d29922] tabular-nums">5,621</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Tool Calls</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-text-primary tabular-nums">38h</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Coding</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#d29922] tabular-nums">$42.17</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Spent</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#79b8ff] tabular-nums">892</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">File Edits</div>
+                  </div>
+                  <div>
+                    <div class="text-2xl font-mono font-bold text-[#b392f0] tabular-nums">12</div>
+                    <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Projects</div>
+                  </div>
+                  <div></div>
+                </div>
+                <!-- Fake mini heatmap -->
+                <div class="flex gap-[3px] flex-wrap mb-4" id="skeleton-mini-heatmap"></div>
+                <div class="flex items-center justify-between pt-4 border-t border-border/30">
+                  <div class="flex items-center gap-4">
+                    <span class="text-xs font-mono text-text-muted">7 day streak</span>
+                    <span class="text-xs font-mono text-text-muted">Most active: Tuesday</span>
+                  </div>
+                  <span class="text-[10px] font-mono text-text-muted">vibe-replay.com</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Highlight cards -->
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+                <div class="flex items-start gap-3">
+                  <span class="text-lg leading-none mt-0.5">&#128293;</span>
+                  <div class="min-w-0">
+                    <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Current Streak</div>
+                    <div class="text-lg font-mono font-bold text-text-primary mt-0.5">7 days</div>
+                    <div class="text-[10px] font-mono text-text-muted mt-0.5">Best: 14 days</div>
+                  </div>
+                </div>
+              </div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+                <div class="flex items-start gap-3">
+                  <span class="text-lg leading-none mt-0.5">&#9889;</span>
+                  <div class="min-w-0">
+                    <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Active Day</div>
+                    <div class="text-lg font-mono font-bold text-text-primary mt-0.5">3.2 sessions</div>
+                    <div class="text-[10px] font-mono text-text-muted mt-0.5">78 active days</div>
+                  </div>
+                </div>
+              </div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+                <div class="flex items-start gap-3">
+                  <span class="text-lg leading-none mt-0.5">&#128172;</span>
+                  <div class="min-w-0">
+                    <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Session</div>
+                    <div class="text-lg font-mono font-bold text-text-primary mt-0.5">7 prompts</div>
+                    <div class="text-[10px] font-mono text-text-muted mt-0.5">~9m each</div>
+                  </div>
+                </div>
+              </div>
+              <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+                <div class="flex items-start gap-3">
+                  <span class="text-lg leading-none mt-0.5">&#127942;</span>
+                  <div class="min-w-0">
+                    <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Peak Day</div>
+                    <div class="text-lg font-mono font-bold text-text-primary mt-0.5">11 sessions</div>
+                    <div class="text-[10px] font-mono text-text-muted mt-0.5">Mar 12, 2025</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Charts -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <!-- Weekly trend -->
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Weekly Trend</h3>
+                <div class="flex items-end gap-1.5 h-28">
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 35%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 52%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 28%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 65%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 78%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 45%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 82%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 60%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 90%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 72%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 100%; opacity: 0.7"></div></div>
+                  <div class="flex-1 flex justify-center items-end h-full"><div class="w-full rounded-md bg-[#3fb950]" style="height: 55%; opacity: 0.7"></div></div>
+                </div>
+              </div>
+              <!-- Day of week -->
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Day of Week</h3>
+                <div class="space-y-2">
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Sun</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 20%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">18</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Mon</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 85%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">62</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Tue</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 100%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">71</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Wed</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 70%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">48</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Thu</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 55%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">38</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Fri</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 40%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">28</span></div>
+                  <div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">Sat</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: 12%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">9</span></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Top Projects + Models -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Top Projects</h3>
+                <div class="space-y-2">
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary">vibe-replay</span><span class="text-[10px] font-mono text-text-muted tabular-nums">89 sessions &middot; $15.20</span></div>
+                    <div class="h-1.5 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full bg-gradient-to-r from-[#3fb950] to-[#79b8ff]" style="width: 100%; opacity: 0.65"></div></div>
+                  </div>
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary">my-saas-app</span><span class="text-[10px] font-mono text-text-muted tabular-nums">64 sessions &middot; $11.30</span></div>
+                    <div class="h-1.5 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full bg-gradient-to-r from-[#3fb950] to-[#79b8ff]" style="width: 72%; opacity: 0.65"></div></div>
+                  </div>
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary">dotfiles</span><span class="text-[10px] font-mono text-text-muted tabular-nums">35 sessions &middot; $5.80</span></div>
+                    <div class="h-1.5 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full bg-gradient-to-r from-[#3fb950] to-[#79b8ff]" style="width: 39%; opacity: 0.65"></div></div>
+                  </div>
+                  <div class="space-y-1">
+                    <div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary">blog</span><span class="text-[10px] font-mono text-text-muted tabular-nums">22 sessions &middot; $3.40</span></div>
+                    <div class="h-1.5 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full bg-gradient-to-r from-[#3fb950] to-[#79b8ff]" style="width: 25%; opacity: 0.65"></div></div>
+                  </div>
+                </div>
+              </div>
+              <div class="bg-surface-1 rounded-xl p-5">
+                <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Models</h3>
+                <div class="h-3 rounded-full bg-surface-2 overflow-hidden flex">
+                  <div class="h-full bg-[#3fb950]" style="width: 55%; opacity: 0.7"></div>
+                  <div class="h-full bg-[#79b8ff]" style="width: 30%; opacity: 0.7"></div>
+                  <div class="h-full bg-[#d29922]" style="width: 15%; opacity: 0.7"></div>
+                </div>
+                <div class="grid grid-cols-2 gap-2 mt-3">
+                  <div class="flex items-center gap-2"><div class="w-2.5 h-2.5 rounded-sm bg-[#3fb950] shrink-0" style="opacity: 0.7"></div><span class="text-[11px] font-mono text-text-muted truncate">c-sonnet-4</span><span class="text-[10px] font-mono text-text-muted tabular-nums ml-auto shrink-0">136</span></div>
+                  <div class="flex items-center gap-2"><div class="w-2.5 h-2.5 rounded-sm bg-[#79b8ff] shrink-0" style="opacity: 0.7"></div><span class="text-[11px] font-mono text-text-muted truncate">c-opus-4</span><span class="text-[10px] font-mono text-text-muted tabular-nums ml-auto shrink-0">74</span></div>
+                  <div class="flex items-center gap-2"><div class="w-2.5 h-2.5 rounded-sm bg-[#d29922] shrink-0" style="opacity: 0.7"></div><span class="text-[11px] font-mono text-text-muted truncate">c-haiku-4</span><span class="text-[10px] font-mono text-text-muted tabular-nums ml-auto shrink-0">37</span></div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -841,38 +987,24 @@ import Layout from "../layouts/Layout.astro";
     renderInsights(summary);
   }
 
-  // --- Auth UI (same pattern as profile page) ---
-  function initAuth(): void {
-    const container = document.getElementById("auth-container")!;
-    const loginBtn = document.getElementById("auth-login")!;
-    const userEl = document.getElementById("auth-user")!;
-    const avatarBtn = document.getElementById("auth-avatar-btn")!;
-    const avatar = document.getElementById("auth-avatar") as HTMLImageElement;
-    const dropdown = document.getElementById("auth-dropdown")!;
-    const username = document.getElementById("auth-username")!;
-    const logoutBtn = document.getElementById("auth-logout")!;
-    const signinBtn = document.getElementById("signin-btn");
+  // Auth is handled by Nav component
 
-    container.style.display = "";
+  // Render skeleton mini heatmap (28 fake cells)
+  const skeletonHeatmap = document.getElementById("skeleton-mini-heatmap");
+  if (skeletonHeatmap) {
+    const pattern = [0,1,0,2,3,1,0,0,2,1,3,2,0,1,0,3,2,1,0,0,1,2,3,1,2,0,1,3];
+    const opacities = [0, 0.45, 0.6, 0.9];
+    skeletonHeatmap.innerHTML = pattern.map((v) =>
+      v === 0
+        ? `<div class="w-[10px] h-[10px] rounded-[2px] bg-border/20"></div>`
+        : `<div class="w-[10px] h-[10px] rounded-[2px] bg-[#3fb950]" style="opacity: ${opacities[v]}"></div>`
+    ).join("");
+  }
 
-    fetch("/api/auth/get-session", { credentials: "include" })
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.session && data?.user) {
-          loginBtn.style.display = "none";
-          userEl.style.display = "";
-          if (data.user.image) avatar.src = data.user.image;
-          username.textContent = data.user.name || data.user.email || "User";
-        } else {
-          loginBtn.style.display = "";
-          userEl.style.display = "none";
-        }
-      })
-      .catch(() => {
-        loginBtn.style.display = "";
-      });
-
-    const doLogin = async () => {
+  // Sign-in button in the centered card
+  const signinBtn = document.getElementById("signin-btn");
+  if (signinBtn) {
+    signinBtn.addEventListener("click", async () => {
       try {
         const res = await fetch("/api/auth/sign-in/social", {
           method: "POST",
@@ -883,32 +1015,10 @@ import Layout from "../layouts/Layout.astro";
         const data = await res.json();
         if (data?.url) window.location.href = data.url;
       } catch {
-        // Fallback to redirect-based login
         window.location.href = "/auth/login?callback=/insights";
       }
-    };
-    loginBtn.addEventListener("click", doLogin);
-    signinBtn?.addEventListener("click", doLogin);
-
-    avatarBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      dropdown.classList.toggle("hidden");
-    });
-    document.addEventListener("click", () => dropdown.classList.add("hidden"));
-
-    logoutBtn.addEventListener("click", async () => {
-      try {
-        await fetch("/api/auth/sign-out", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: "{}",
-        });
-      } catch { /* ignore */ }
-      window.location.reload();
     });
   }
 
-  initAuth();
   initInsights();
 </script>

--- a/website/src/pages/profile.astro
+++ b/website/src/pages/profile.astro
@@ -1,41 +1,12 @@
 ---
 import Footer from "../components/Footer.astro";
-import GitHubStar from "../components/GitHubStar.astro";
+import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Profile - vibe-replay" description="Manage your shared AI coding session replays. View storage usage, cloud replays, and GitHub Gists.">
   <div class="min-h-screen flex flex-col">
-    <!-- Header (matches main page nav) -->
-    <nav class="border-b border-border/50 px-6 py-3">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <div class="flex items-center gap-4">
-          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
-          <span class="text-border hidden sm:inline">|</span>
-          <a href="/blog" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Blog</a>
-          <span class="text-text-secondary text-sm hidden sm:inline">Profile</span>
-        </div>
-        <div class="flex items-center gap-3">
-          <GitHubStar />
-          <!-- Auth -->
-          <div id="auth-container" style="display:none">
-            <button id="auth-login" style="display:none" class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-[#24292f] hover:bg-[#32383f] text-white text-xs font-medium transition-colors cursor-pointer border border-white/10">
-              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-              Sign in
-            </button>
-            <div id="auth-user" style="display:none" class="relative">
-              <button id="auth-avatar-btn" class="flex items-center justify-center w-8 h-8 rounded-full border border-border/60 hover:border-accent/70 transition-all cursor-pointer overflow-hidden">
-                <img id="auth-avatar" class="w-full h-full rounded-full object-cover" alt="" />
-              </button>
-              <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
-                <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
-                <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </nav>
+    <Nav active="profile" />
 
     <!-- Main content -->
     <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-10">
@@ -467,79 +438,22 @@ import Layout from "../layouts/Layout.astro";
     }
   }
 
-  // --- Auth UI (same as explore.astro) ---
-  (async () => {
-    const container = document.getElementById("auth-container");
-    const loginBtn = document.getElementById("auth-login");
-    const userDiv = document.getElementById("auth-user");
-    const avatarBtn = document.getElementById("auth-avatar-btn");
-    const avatar = document.getElementById("auth-avatar") as HTMLImageElement | null;
-    const dropdown = document.getElementById("auth-dropdown");
-    const username = document.getElementById("auth-username");
-    const logoutBtn = document.getElementById("auth-logout");
-    if (!container || !loginBtn || !userDiv || !avatarBtn || !avatar || !dropdown || !username || !logoutBtn) return;
+  // Auth is handled by Nav component
 
-    const show = (el: HTMLElement) => { el.style.display = ""; };
-
-    try {
-      const res = await fetch("/api/auth/get-session", { credentials: "include" });
-      const data = await res.json();
-      show(container);
-
-      if (data?.session && data?.user) {
-        avatar.src = data.user.image || "";
-        avatar.alt = data.user.name || "";
-        username.textContent = data.user.name || data.user.email || "";
-        show(userDiv);
-      } else {
-        show(loginBtn);
-      }
-    } catch {
-      show(container);
-      show(loginBtn);
-    }
-
-    avatarBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      dropdown.classList.toggle("hidden");
-    });
-
-    document.addEventListener("click", () => {
-      dropdown.classList.add("hidden");
-    });
-
-    const doSignIn = async () => {
+  // Sign-in button in the centered card
+  const signinBtn = document.getElementById("signin-btn");
+  if (signinBtn) {
+    signinBtn.addEventListener("click", async () => {
       const res = await fetch("/api/auth/sign-in/social", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ provider: "github", callbackURL: window.location.pathname }),
+        body: JSON.stringify({ provider: "github", callbackURL: "/profile" }),
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;
-    };
-
-    loginBtn.addEventListener("click", doSignIn);
-
-    // Sign-in button in the centered card
-    const signinBtn = document.getElementById("signin-btn");
-    if (signinBtn) signinBtn.addEventListener("click", doSignIn);
-
-    logoutBtn.addEventListener("click", async () => {
-      try {
-        const res = await fetch("/api/auth/sign-out", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: "{}",
-        });
-        if (!res.ok) console.error("Sign-out failed:", res.status);
-      } catch (err) {
-        console.error("Sign-out error:", err);
-      }
-      window.location.reload();
     });
-  })();
+  }
 
   // Init profile content
   initProfile();


### PR DESCRIPTION
## Summary
- **Nav unification**: Replace duplicated inline nav HTML + auth scripts in explore, insights, and profile pages with the shared `Nav.astro` component. All pages now show consistent navigation (Blog, Explore, Insights + GitHub Star + Auth).
- **Nav improvements**: Add Profile link to dropdown menu, add full mobile auth support (login/logout/avatar), highlight active page in mobile menu.
- **Insights skeleton**: Replace blank "Sign in to view Insights" card with a blurred skeleton dashboard showing fake demo data, guiding users on what insights offers and encouraging login. Uses reusable `CliGuide.astro` component with step-by-step CLI onboarding.
- **No-data state**: Logged-in users with no synced data see a 2-step sync guide (dashboard → sync) over the same blurred skeleton.
- **Sync to cloud button**: Add "↑ Sync to cloud" button next to "View personal insights" in the CLI dashboard. Shows persistent "✓ Synced Xm ago" after success. External-link icon always visible to open cloud insights.
- **Login modal upsell**: When syncing without auth, show a modal with 3 value props (cross-machine dashboard, cost tracking, shareable card) + GitHub sign-in. Auto-syncs after login completes.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test:e2e` — all 28 tests pass
- [x] Website build — all 11 pages built
- [x] Visual verification via Playwright screenshots
- [ ] Manual: nav links work on all pages (desktop + mobile)
- [ ] Manual: insights skeleton renders correctly signed-out and no-data states
- [ ] Manual: sync button → login modal → GitHub auth → auto-sync flow
- [ ] Manual: "✓ Synced Xm ago" persists and updates over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)