### PR TITLE
fix: search selection reset, abort cleanup, and accessibility improvements

### DIFF
--- a/packages/viewer/src/components/HelpOverlay.tsx
+++ b/packages/viewer/src/components/HelpOverlay.tsx
@@ -65,6 +65,9 @@ export default function HelpOverlay({ open, onClose }: Props) {
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-md animate-in fade-in duration-300"
       onClick={onClose}
+      role="dialog"
+      aria-label="Keyboard shortcuts"
+      aria-modal="true"
     >
       <div
         className="w-full max-w-lg bg-terminal-bg border border-terminal-border-subtle rounded-2xl shadow-layer-xl overflow-hidden animate-in zoom-in-95 duration-200"

--- a/packages/viewer/src/components/SearchOverlay.tsx
+++ b/packages/viewer/src/components/SearchOverlay.tsx
@@ -107,9 +107,6 @@ export default function SearchOverlay({ scenes, open, onClose, onSeek }: Props) 
     return matches;
   }, [scenes, query]);
 
-  // Reset selection when results change
-  useEffect(() => setSelectedIdx(0), []);
-
   // Scroll selected into view
   useEffect(() => {
     if (!listRef.current) return;
@@ -152,6 +149,9 @@ export default function SearchOverlay({ scenes, open, onClose, onSeek }: Props) 
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-[8vh] sm:pt-[15vh]"
       onClick={onClose}
+      role="dialog"
+      aria-label="Search scenes"
+      aria-modal="true"
     >
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
       <div
@@ -166,8 +166,12 @@ export default function SearchOverlay({ scenes, open, onClose, onSeek }: Props) 
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedIdx(0);
+            }}
             placeholder="Search scenes..."
+            aria-label="Search scenes"
             className="flex-1 bg-transparent text-sm font-sans font-medium text-terminal-text placeholder-terminal-dim outline-none"
           />
           <kbd className="text-[10px] font-mono text-terminal-dimmer bg-terminal-surface px-2 py-0.5 rounded-md">

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -94,12 +94,32 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
     return dots;
   }, [annotatedScenes, scenes.length]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+        e.preventDefault();
+        onSeek(Math.min(currentIndex + 1, scenes.length - 1));
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+        e.preventDefault();
+        onSeek(Math.max(currentIndex - 1, 0));
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        onSeek(0);
+      } else if (e.key === "End") {
+        e.preventDefault();
+        onSeek(scenes.length - 1);
+      }
+    },
+    [currentIndex, scenes.length, onSeek],
+  );
+
   if (scenes.length === 0) return null;
 
   return (
     <div
       className="px-4 pt-3 pb-1 cursor-pointer"
       onClick={handleSeekClick}
+      onKeyDown={handleKeyDown}
       role="slider"
       aria-label="Scene timeline"
       aria-valuemin={0}

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -97,7 +97,16 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
   if (scenes.length === 0) return null;
 
   return (
-    <div className="px-4 pt-3 pb-1 cursor-pointer" onClick={handleSeekClick}>
+    <div
+      className="px-4 pt-3 pb-1 cursor-pointer"
+      onClick={handleSeekClick}
+      role="slider"
+      aria-label="Scene timeline"
+      aria-valuemin={0}
+      aria-valuemax={scenes.length - 1}
+      aria-valuenow={currentIndex}
+      tabIndex={0}
+    >
       {/* Annotation dots above timeline */}
       {annotationDots.length > 0 && (
         <div className="relative h-2 mb-0.5">

--- a/packages/viewer/src/hooks/useOverlays.ts
+++ b/packages/viewer/src/hooks/useOverlays.ts
@@ -104,6 +104,13 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
       });
   }, [isEditor]);
 
+  // Abort in-flight studio operations on unmount
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
   // Detect tools
   useEffect(() => {
     if (!isEditor) return;

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -44,7 +44,7 @@ const linkClass = (page: string) =>
     </div>
 
     <!-- Mobile hamburger -->
-    <button id="nav-toggle" class="sm:hidden flex items-center justify-center w-9 h-9 rounded-lg bg-surface-1 border border-border text-text-primary hover:bg-surface-2 transition-colors" aria-label="Menu">
+    <button id="nav-toggle" class="sm:hidden flex items-center justify-center w-9 h-9 rounded-lg bg-surface-1 border border-border text-text-primary hover:bg-surface-2 transition-colors" aria-label="Menu" aria-expanded="false">
       <svg id="nav-open-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" /></svg>
       <svg id="nav-close-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
     </button>
@@ -72,9 +72,10 @@ const linkClass = (page: string) =>
   const closeIcon = document.getElementById("nav-close-icon");
   if (toggle && menu && openIcon && closeIcon) {
     toggle.addEventListener("click", () => {
-      const open = menu.classList.toggle("hidden");
-      openIcon.classList.toggle("hidden", !open);
-      closeIcon.classList.toggle("hidden", open);
+      const hidden = menu.classList.toggle("hidden");
+      openIcon.classList.toggle("hidden", !hidden);
+      closeIcon.classList.toggle("hidden", hidden);
+      toggle.setAttribute("aria-expanded", String(!hidden));
     });
   }
 

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -91,7 +91,7 @@ import Layout from "../layouts/Layout.astro";
 
           <div class="relative z-10">
             <!-- Stats grid: 4x2 -->
-            <div class="grid grid-cols-4 gap-x-6 gap-y-5 mb-6">
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-5 mb-6">
               <div>
                 <div id="stat-sessions" class="text-2xl font-mono font-bold text-[#3fb950] tabular-nums">0</div>
                 <div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">Sessions</div>


### PR DESCRIPTION
## Summary

Second round of quality and UX improvements from codebase audit:

- **Fix search selection bug** — SearchOverlay `selectedIdx` never reset when query changed (stale `useEffect` with empty deps), causing out-of-bounds selection. Now resets inline on input change.
- **Fix AbortController leak** — `useOverlays` translate/tone operations were not aborted on component unmount, leaving orphaned fetches that could update unmounted component state.
- **Responsive insights grid** — Stats grid was hardcoded `grid-cols-4`, cramped on mobile. Now `grid-cols-2 md:grid-cols-4`.
- **Nav accessibility** — Mobile hamburger button now tracks `aria-expanded` state for screen readers.
- **Dialog accessibility** — Search and help overlays now have `role="dialog"`, `aria-modal="true"`, and `aria-label` for assistive technology.
- **Timeline accessibility** — Timeline bar now has `role="slider"` with `aria-valuemin/max/now` and is focusable.

## Test plan

- [x] `pnpm test` — 694 unit tests pass
- [x] `pnpm build && pnpm test:e2e` — 68 E2E tests pass
- [x] Lint passes (pre-existing warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)