### PR TITLE
feat: add public insights sharing with privacy controls

### DIFF
--- a/cloudflare/drizzle/0008_add_insight_profiles.sql
+++ b/cloudflare/drizzle/0008_add_insight_profiles.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `insight_profiles` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`slug` text NOT NULL,
+	`display_name` text,
+	`avatar_url` text,
+	`enabled` integer DEFAULT true NOT NULL,
+	`config` text NOT NULL,
+	`view_count` integer DEFAULT 0,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `insight_profiles_user_id_unique` ON `insight_profiles` (`user_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `insight_profiles_slug_unique` ON `insight_profiles` (`slug`);
+--> statement-breakpoint
+CREATE INDEX `idx_insight_profiles_slug` ON `insight_profiles` (`slug`);
+--> statement-breakpoint
+CREATE INDEX `idx_insight_profiles_user` ON `insight_profiles` (`user_id`);

--- a/cloudflare/drizzle/meta/_journal.json
+++ b/cloudflare/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775800000000,
       "tag": "0007_replace_session_with_daily_insights",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1776000000000,
+      "tag": "0008_add_insight_profiles",
+      "breakpoints": true
     }
   ]
 }

--- a/cloudflare/src/db/schema.ts
+++ b/cloudflare/src/db/schema.ts
@@ -182,6 +182,36 @@ export const cloudReplays = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// Insight Profiles — public sharing of aggregated insights
+// ---------------------------------------------------------------------------
+
+export const insightProfiles = sqliteTable(
+  "insight_profiles",
+  {
+    id: text("id").primaryKey(), // nanoid(12)
+    userId: text("user_id")
+      .notNull()
+      .unique()
+      .references(() => user.id, { onDelete: "cascade" }),
+    slug: text("slug").notNull().unique(), // URL-friendly identifier for /i/:slug
+    displayName: text("display_name"), // optional display name override
+    avatarUrl: text("avatar_url"), // GitHub avatar
+    enabled: integer("enabled", { mode: "boolean" }).default(true).notNull(),
+    // JSON config: which sections to show/hide
+    // { showCost, showProjects, showModels, showProviders, showHeatmap, showStreak,
+    //   showWeeklyTrend, showDayOfWeek, blurProjectNames }
+    config: text("config").notNull(),
+    viewCount: integer("view_count").default(0),
+    createdAt: text("created_at").default(sql`(datetime('now'))`).notNull(),
+    updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("idx_insight_profiles_slug").on(table.slug),
+    index("idx_insight_profiles_user").on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Daily Insights — Prometheus-style time-series with (user, machine, date) labels
 // ---------------------------------------------------------------------------
 

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1586,6 +1586,7 @@ app.get("/api/public/insights/:slug", async (c) => {
   let topProjects: any[] = [];
   let models: Record<string, number> = {};
   let providers: Record<string, number> = {};
+  let projectCount = 0;
 
   if (config.showProjects || config.showModels || config.showProviders) {
     const cutoffDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
@@ -1664,6 +1665,7 @@ app.get("/api/public/insights/:slug", async (c) => {
     }
 
     if (config.showProjects) {
+      projectCount = Object.keys(projectsAgg).length;
       topProjects = Object.entries(projectsAgg)
         .map(([project, v]) => {
           const name = config.blurProjectNames ? project.replace(/[^/\\]/g, "*") : project;
@@ -1704,7 +1706,7 @@ app.get("/api/public/insights/:slug", async (c) => {
     avatarUrl: profile.avatarUrl,
     config: visibleSections,
     totalSessions: agg?.totalSessions || 0,
-    totalProjects: config.showProjects ? Object.keys(projectsAgg).length : undefined,
+    totalProjects: config.showProjects ? projectCount : undefined,
     totalDurationMs: agg?.totalDurationMs || 0,
     totalPrompts: agg?.totalPrompts || 0,
     totalToolCalls: agg?.totalToolCalls || 0,

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1445,7 +1445,14 @@ app.post("/api/insights/profile", async (c) => {
       updates.slug = slug;
     }
 
-    await db.update(insightProfiles).set(updates).where(eq(insightProfiles.id, existing.id));
+    try {
+      await db.update(insightProfiles).set(updates).where(eq(insightProfiles.id, existing.id));
+    } catch (e: any) {
+      if (e?.message?.includes("UNIQUE")) {
+        return c.json({ error: "Slug already taken" }, 409);
+      }
+      throw e;
+    }
 
     const finalEnabled = updates.enabled ?? existing.enabled;
     const finalSlug = updates.slug || existing.slug;
@@ -1677,12 +1684,14 @@ app.get("/api/public/insights/:slug", async (c) => {
     }
   }
 
-  // Increment view count (fire-and-forget)
-  db.update(insightProfiles)
-    .set({ viewCount: sql`${insightProfiles.viewCount} + 1` })
-    .where(eq(insightProfiles.id, profile.id))
-    .execute()
-    .catch(() => {});
+  // Increment view count (fire-and-forget, but survive Worker shutdown)
+  c.executionCtx.waitUntil(
+    db
+      .update(insightProfiles)
+      .set({ viewCount: sql`${insightProfiles.viewCount} + 1` })
+      .where(eq(insightProfiles.id, profile.id))
+      .catch(() => {}),
+  );
 
   // Only expose visibility flags that are true — don't reveal what's hidden
   const visibleSections: Record<string, boolean> = {};
@@ -1695,9 +1704,7 @@ app.get("/api/public/insights/:slug", async (c) => {
     avatarUrl: profile.avatarUrl,
     config: visibleSections,
     totalSessions: agg?.totalSessions || 0,
-    totalProjects: config.showProjects
-      ? new Set(topProjects.map((p: any) => p.project)).size
-      : undefined,
+    totalProjects: config.showProjects ? Object.keys(projectsAgg).length : undefined,
     totalDurationMs: agg?.totalDurationMs || 0,
     totalPrompts: agg?.totalPrompts || 0,
     totalToolCalls: agg?.totalToolCalls || 0,

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -5,7 +5,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { nanoid } from "nanoid";
 import { type AuthEnv, createAuth, DEV_ORIGINS, PROD_ORIGINS } from "./auth";
-import { cloudReplays, dailyInsights, replays, userFiles } from "./db/schema";
+import { cloudReplays, dailyInsights, insightProfiles, replays, userFiles } from "./db/schema";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1303,6 +1303,427 @@ app.get("/api/insights/summary", async (c) => {
     timeRange: { first: agg?.firstDate || "", last: agg?.lastDate || "" },
     sessionsPerDay,
   });
+});
+
+// ---------------------------------------------------------------------------
+// Insight Profiles — public sharing of aggregated insights
+// ---------------------------------------------------------------------------
+
+const SLUG_RE = /^[a-zA-Z0-9_-]{2,40}$/;
+
+const DEFAULT_PROFILE_CONFIG = {
+  showCost: false,
+  showProjects: true,
+  showModels: true,
+  showProviders: true,
+  showHeatmap: true,
+  showStreak: true,
+  showWeeklyTrend: true,
+  showDayOfWeek: true,
+  blurProjectNames: false,
+};
+
+type ProfileConfig = typeof DEFAULT_PROFILE_CONFIG;
+
+function parseProfileConfig(raw: string): ProfileConfig {
+  try {
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_PROFILE_CONFIG, ...parsed };
+  } catch {
+    return { ...DEFAULT_PROFILE_CONFIG };
+  }
+}
+
+/** Get current user's insight profile */
+app.get("/api/insights/profile", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const db = drizzle(c.env.DB);
+  const [profile] = await db
+    .select()
+    .from(insightProfiles)
+    .where(eq(insightProfiles.userId, userId))
+    .limit(1);
+
+  if (!profile) {
+    return c.json({ profile: null });
+  }
+
+  const baseUrl = getBaseUrl(c);
+  return c.json({
+    profile: {
+      id: profile.id,
+      slug: profile.slug,
+      displayName: profile.displayName,
+      avatarUrl: profile.avatarUrl,
+      enabled: profile.enabled,
+      config: parseProfileConfig(profile.config),
+      viewCount: profile.viewCount,
+      url: `${baseUrl}/i/${profile.slug}`,
+      createdAt: profile.createdAt,
+    },
+  });
+});
+
+/** Validate avatarUrl — only allow HTTPS URLs */
+function sanitizeAvatarUrl(url: unknown): string | null {
+  if (!url || typeof url !== "string") return null;
+  const trimmed = url.trim().slice(0, 500);
+  if (!trimmed.startsWith("https://")) return null;
+  return trimmed;
+}
+
+/** Create or update insight profile */
+app.post("/api/insights/profile", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId, user } = authResult;
+
+  let body: any;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const slug = body.slug ? String(body.slug).toLowerCase().trim() : null;
+  if (slug && !SLUG_RE.test(slug)) {
+    return c.json({ error: "Invalid slug (2-40 chars, alphanumeric, hyphens, underscores)" }, 400);
+  }
+
+  const config: ProfileConfig = {
+    ...DEFAULT_PROFILE_CONFIG,
+    ...(body.config && typeof body.config === "object" ? body.config : {}),
+  };
+  // Sanitize: only allow boolean values
+  for (const key of Object.keys(config) as (keyof ProfileConfig)[]) {
+    if (typeof config[key] !== "boolean") {
+      (config as any)[key] = DEFAULT_PROFILE_CONFIG[key];
+    }
+  }
+
+  const db = drizzle(c.env.DB);
+  const [existing] = await db
+    .select({
+      id: insightProfiles.id,
+      slug: insightProfiles.slug,
+      enabled: insightProfiles.enabled,
+    })
+    .from(insightProfiles)
+    .where(eq(insightProfiles.userId, userId))
+    .limit(1);
+
+  const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+  if (existing) {
+    // Update existing profile — only change enabled if explicitly provided
+    const updates: Record<string, any> = {
+      config: JSON.stringify(config),
+      updatedAt: now,
+    };
+    if (body.enabled !== undefined) {
+      updates.enabled = !!body.enabled;
+    }
+    if (body.displayName !== undefined) {
+      updates.displayName = body.displayName ? String(body.displayName).slice(0, 100) : null;
+    }
+    if (body.avatarUrl !== undefined) {
+      updates.avatarUrl = sanitizeAvatarUrl(body.avatarUrl);
+    }
+    // Allow changing slug if provided and different
+    if (slug && slug !== existing.slug) {
+      const [conflict] = await db
+        .select({ id: insightProfiles.id })
+        .from(insightProfiles)
+        .where(eq(insightProfiles.slug, slug))
+        .limit(1);
+      if (conflict) {
+        return c.json({ error: "Slug already taken" }, 409);
+      }
+      updates.slug = slug;
+    }
+
+    await db.update(insightProfiles).set(updates).where(eq(insightProfiles.id, existing.id));
+
+    const finalEnabled = updates.enabled ?? existing.enabled;
+    const finalSlug = updates.slug || existing.slug;
+    const baseUrl = getBaseUrl(c);
+    return c.json({
+      ok: true,
+      profile: {
+        id: existing.id,
+        slug: finalSlug,
+        enabled: finalEnabled,
+        config,
+        url: `${baseUrl}/i/${finalSlug}`,
+      },
+    });
+  }
+
+  // Create new profile
+  const finalSlug = slug || nanoid(8).toLowerCase();
+
+  // Always check slug uniqueness (including auto-generated)
+  const [conflict] = await db
+    .select({ id: insightProfiles.id })
+    .from(insightProfiles)
+    .where(eq(insightProfiles.slug, finalSlug))
+    .limit(1);
+  if (conflict) {
+    return c.json({ error: "Slug already taken" }, 409);
+  }
+
+  const id = nanoid(12);
+  try {
+    await db.insert(insightProfiles).values({
+      id,
+      userId,
+      slug: finalSlug,
+      displayName: body.displayName ? String(body.displayName).slice(0, 100) : user.name,
+      avatarUrl: sanitizeAvatarUrl(body.avatarUrl),
+      enabled: body.enabled !== false,
+      config: JSON.stringify(config),
+    });
+  } catch (e: any) {
+    if (e?.message?.includes("UNIQUE")) {
+      return c.json({ error: "Profile already exists" }, 409);
+    }
+    throw e;
+  }
+
+  const baseUrl = getBaseUrl(c);
+  return c.json({
+    ok: true,
+    created: true,
+    profile: {
+      id,
+      slug: finalSlug,
+      enabled: true,
+      config,
+      url: `${baseUrl}/i/${finalSlug}`,
+    },
+  });
+});
+
+/** Delete insight profile */
+app.delete("/api/insights/profile", async (c) => {
+  const authResult = await requireAuth(c);
+  if (authResult instanceof Response) return authResult;
+  const { userId } = authResult;
+
+  const db = drizzle(c.env.DB);
+  const deleted = await db
+    .delete(insightProfiles)
+    .where(eq(insightProfiles.userId, userId))
+    .returning({ id: insightProfiles.id });
+
+  return c.json({ ok: true, deleted: deleted.length > 0 });
+});
+
+/** Public insights data — unauthenticated, cached */
+app.get("/api/public/insights/:slug", async (c) => {
+  const slug = c.req.param("slug").toLowerCase();
+  if (!SLUG_RE.test(slug)) {
+    return c.json({ error: "Not found" }, 404);
+  }
+
+  const db = drizzle(c.env.DB);
+
+  // Look up profile
+  const [profile] = await db
+    .select()
+    .from(insightProfiles)
+    .where(eq(insightProfiles.slug, slug))
+    .limit(1);
+
+  if (!profile || !profile.enabled) {
+    return c.json({ error: "Not found" }, 404);
+  }
+
+  const config = parseProfileConfig(profile.config);
+  const userId = profile.userId;
+
+  // Aggregate counters
+  const [agg] = await db
+    .select({
+      totalSessions: sql<number>`coalesce(sum(${dailyInsights.sessions}), 0)`,
+      totalDurationMs: sql<number>`coalesce(sum(${dailyInsights.durationMs}), 0)`,
+      totalCost: sql<number>`coalesce(sum(${dailyInsights.cost}), 0)`,
+      totalPrompts: sql<number>`coalesce(sum(${dailyInsights.prompts}), 0)`,
+      totalToolCalls: sql<number>`coalesce(sum(${dailyInsights.toolCalls}), 0)`,
+      totalEdits: sql<number>`coalesce(sum(${dailyInsights.edits}), 0)`,
+      firstDate: sql<string>`min(${dailyInsights.date})`,
+      lastDate: sql<string>`max(${dailyInsights.date})`,
+    })
+    .from(dailyInsights)
+    .where(eq(dailyInsights.userId, userId));
+
+  // Sessions per day (for heatmap)
+  const sessionsPerDay: Record<string, number> = {};
+  if (config.showHeatmap) {
+    const dailyRows = await db
+      .select({
+        date: dailyInsights.date,
+        sessions: sql<number>`sum(${dailyInsights.sessions})`,
+      })
+      .from(dailyInsights)
+      .where(eq(dailyInsights.userId, userId))
+      .groupBy(dailyInsights.date)
+      .orderBy(dailyInsights.date);
+    for (const r of dailyRows) sessionsPerDay[r.date] = r.sessions;
+  }
+
+  // JSON breakdowns (last 365 days)
+  let topProjects: any[] = [];
+  let models: Record<string, number> = {};
+  let providers: Record<string, number> = {};
+
+  if (config.showProjects || config.showModels || config.showProviders) {
+    const cutoffDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const allRows = await db
+      .select({
+        projects: dailyInsights.projects,
+        models: dailyInsights.models,
+        providers: dailyInsights.providers,
+      })
+      .from(dailyInsights)
+      .where(and(eq(dailyInsights.userId, userId), gte(dailyInsights.date, cutoffDate)));
+
+    const projectsAgg: Record<
+      string,
+      {
+        sessions: number;
+        cost: number;
+        prompts: number;
+        toolCalls: number;
+        edits: number;
+        durationMs: number;
+      }
+    > = {};
+    const modelsAgg: Record<string, { sessions: number; cost: number }> = {};
+    const providersAgg: Record<string, { sessions: number; cost: number }> = {};
+
+    for (const row of allRows) {
+      if (config.showProjects && row.projects) {
+        try {
+          const p = JSON.parse(row.projects);
+          for (const [name, v] of Object.entries(p) as [string, any][]) {
+            if (!projectsAgg[name])
+              projectsAgg[name] = {
+                sessions: 0,
+                cost: 0,
+                prompts: 0,
+                toolCalls: 0,
+                edits: 0,
+                durationMs: 0,
+              };
+            projectsAgg[name].sessions += v.sessions || 0;
+            projectsAgg[name].cost += v.cost || 0;
+            projectsAgg[name].prompts += v.prompts || 0;
+            projectsAgg[name].toolCalls += v.toolCalls || 0;
+            projectsAgg[name].edits += v.edits || 0;
+            projectsAgg[name].durationMs += v.durationMs || 0;
+          }
+        } catch {
+          /* skip malformed */
+        }
+      }
+      if (config.showModels && row.models) {
+        try {
+          const m = JSON.parse(row.models);
+          for (const [name, v] of Object.entries(m) as [string, any][]) {
+            if (!modelsAgg[name]) modelsAgg[name] = { sessions: 0, cost: 0 };
+            modelsAgg[name].sessions += v.sessions || 0;
+            modelsAgg[name].cost += v.cost || 0;
+          }
+        } catch {
+          /* skip */
+        }
+      }
+      if (config.showProviders && row.providers) {
+        try {
+          const pr = JSON.parse(row.providers);
+          for (const [name, v] of Object.entries(pr) as [string, any][]) {
+            if (!providersAgg[name]) providersAgg[name] = { sessions: 0, cost: 0 };
+            providersAgg[name].sessions += v.sessions || 0;
+            providersAgg[name].cost += v.cost || 0;
+          }
+        } catch {
+          /* skip */
+        }
+      }
+    }
+
+    if (config.showProjects) {
+      topProjects = Object.entries(projectsAgg)
+        .map(([project, v]) => {
+          const name = config.blurProjectNames ? project.replace(/[^/\\]/g, "*") : project;
+          return {
+            project: name,
+            sessions: v.sessions,
+            ...(config.showCost ? { cost: v.cost } : {}),
+          };
+        })
+        .sort((a, b) => b.sessions - a.sessions)
+        .slice(0, 20);
+    }
+    if (config.showModels) {
+      models = Object.fromEntries(Object.entries(modelsAgg).map(([k, v]) => [k, v.sessions]));
+    }
+    if (config.showProviders) {
+      providers = Object.fromEntries(Object.entries(providersAgg).map(([k, v]) => [k, v.sessions]));
+    }
+  }
+
+  // Increment view count (fire-and-forget)
+  db.update(insightProfiles)
+    .set({ viewCount: sql`${insightProfiles.viewCount} + 1` })
+    .where(eq(insightProfiles.id, profile.id))
+    .execute()
+    .catch(() => {});
+
+  // Only expose visibility flags that are true — don't reveal what's hidden
+  const visibleSections: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(config)) {
+    if (v) visibleSections[k] = true;
+  }
+
+  const result: Record<string, any> = {
+    displayName: profile.displayName,
+    avatarUrl: profile.avatarUrl,
+    config: visibleSections,
+    totalSessions: agg?.totalSessions || 0,
+    totalProjects: config.showProjects
+      ? new Set(topProjects.map((p: any) => p.project)).size
+      : undefined,
+    totalDurationMs: agg?.totalDurationMs || 0,
+    totalPrompts: agg?.totalPrompts || 0,
+    totalToolCalls: agg?.totalToolCalls || 0,
+    totalEdits: agg?.totalEdits || 0,
+    timeRange: { first: agg?.firstDate || "", last: agg?.lastDate || "" },
+  };
+
+  if (config.showCost) result.totalCost = agg?.totalCost || 0;
+  if (config.showHeatmap) result.sessionsPerDay = sessionsPerDay;
+  if (config.showProjects) result.topProjects = topProjects;
+  if (config.showModels) result.models = models;
+  if (config.showProviders) result.providers = providers;
+
+  return c.json(result, 200, {
+    "Cache-Control": "public, max-age=3600, s-maxage=3600",
+  });
+});
+
+/** Short URL for public insight profiles */
+app.get("/i/:slug", (c) => {
+  const slug = c.req.param("slug").toLowerCase();
+  if (!SLUG_RE.test(slug)) {
+    return c.text("Not Found", 404);
+  }
+  const baseUrl = getBaseUrl(c);
+  return c.redirect(`${baseUrl}/shared-insights/?s=${slug}`);
 });
 
 // ---------------------------------------------------------------------------

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1296,7 +1296,7 @@ import Layout from "../layouts/Layout.astro";
           updateEnabledUI(true);
           toggleBtn.innerHTML = `<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 1 1 0-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 1 0 5.367-2.684 3 3 0 0 0-5.367 2.684Zm0 9.316a3 3 0 1 0 5.368 2.684 3 3 0 0 0-5.368-2.684Z" /></svg>Shared`;
         }
-      } else {
+      } else if (profileData) {
         // Update existing profile
         updateEnabledUI(newEnabled);
         const btnLabel = newEnabled ? "Shared" : "Share";

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -277,9 +277,94 @@ import Layout from "../layouts/Layout.astro";
 
       <!-- Insights content -->
       <div id="insights-content" class="hidden space-y-6">
-        <!-- Page title -->
+        <!-- Page title + Share button -->
         <div class="flex items-center justify-between">
           <h1 class="text-lg font-bold text-text-primary">Your Insights</h1>
+          <button id="share-toggle-btn" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-surface-1 border border-border text-text-secondary hover:text-accent hover:border-accent/40 transition-colors cursor-pointer">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 1 1 0-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 1 0 5.367-2.684 3 3 0 0 0-5.367 2.684Zm0 9.316a3 3 0 1 0 5.368 2.684 3 3 0 0 0-5.368-2.684Z" /></svg>
+            Share
+          </button>
+        </div>
+
+        <!-- Share settings panel -->
+        <div id="share-panel" class="hidden rounded-xl border border-accent/30 bg-surface-1 p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-text-primary">Share your insights</h3>
+            <button id="share-close-btn" class="text-text-muted hover:text-text-primary transition-colors cursor-pointer">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+
+          <!-- Enable toggle -->
+          <div class="flex items-center justify-between">
+            <div>
+              <div class="text-xs font-medium text-text-primary">Public profile</div>
+              <div class="text-[10px] text-text-muted">Anyone with the link can view your stats</div>
+            </div>
+            <button id="share-enabled-toggle" class="relative w-10 h-5 rounded-full bg-border transition-colors cursor-pointer" role="switch" aria-checked="false">
+              <span id="share-enabled-dot" class="absolute left-0.5 top-0.5 w-4 h-4 rounded-full bg-white transition-transform"></span>
+            </button>
+          </div>
+
+          <!-- Public URL (shown when enabled) -->
+          <div id="share-url-row" class="hidden flex items-center gap-2 bg-surface-2 rounded-lg px-3 py-2">
+            <input id="share-url-input" type="text" readonly class="flex-1 bg-transparent text-xs font-mono text-text-primary outline-none select-all" />
+            <button id="share-copy-btn" class="text-[10px] font-medium text-accent hover:text-accent/80 transition-colors cursor-pointer whitespace-nowrap">Copy</button>
+          </div>
+
+          <!-- Slug editor -->
+          <div id="share-slug-row" class="hidden">
+            <label class="text-[10px] font-medium text-text-muted block mb-1">Custom URL slug</label>
+            <div class="flex items-center gap-2">
+              <span class="text-[10px] font-mono text-text-muted">/i/</span>
+              <input id="share-slug-input" type="text" class="flex-1 bg-surface-2 border border-border rounded px-2 py-1 text-xs font-mono text-text-primary outline-none focus:border-accent/50" placeholder="my-custom-slug" maxlength="40" />
+              <button id="share-slug-save" class="text-[10px] font-medium text-accent hover:text-accent/80 transition-colors cursor-pointer whitespace-nowrap">Save</button>
+            </div>
+          </div>
+
+          <!-- Visibility toggles -->
+          <div id="share-config-section" class="hidden space-y-2.5 pt-2 border-t border-border/50">
+            <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest mb-2">What to show</div>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Cost / spending</span>
+              <input type="checkbox" data-config="showCost" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Activity heatmap</span>
+              <input type="checkbox" data-config="showHeatmap" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Streak & highlights</span>
+              <input type="checkbox" data-config="showStreak" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Weekly trend</span>
+              <input type="checkbox" data-config="showWeeklyTrend" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Day of week</span>
+              <input type="checkbox" data-config="showDayOfWeek" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Top projects</span>
+              <input type="checkbox" data-config="showProjects" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label id="blur-projects-row" class="flex items-center justify-between cursor-pointer group hidden">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors pl-4">Blur project names</span>
+              <input type="checkbox" data-config="blurProjectNames" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Models breakdown</span>
+              <input type="checkbox" data-config="showModels" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+            <label class="flex items-center justify-between cursor-pointer group">
+              <span class="text-xs text-text-secondary group-hover:text-text-primary transition-colors">Providers breakdown</span>
+              <input type="checkbox" data-config="showProviders" class="share-config-toggle w-4 h-4 rounded accent-[#3fb950] cursor-pointer" checked />
+            </label>
+          </div>
+
+          <!-- Status message -->
+          <div id="share-status" class="text-[10px] font-mono text-text-muted hidden"></div>
         </div>
 
         <!-- Stats card -->
@@ -1073,5 +1158,188 @@ import Layout from "../layouts/Layout.astro";
     });
   }
 
+  // --- Share panel ---
+  function initSharePanel(): void {
+    const toggleBtn = document.getElementById("share-toggle-btn")!;
+    const panel = document.getElementById("share-panel")!;
+    const closeBtn = document.getElementById("share-close-btn")!;
+    const enabledToggle = document.getElementById("share-enabled-toggle")!;
+    const enabledDot = document.getElementById("share-enabled-dot")!;
+    const urlRow = document.getElementById("share-url-row")!;
+    const urlInput = document.getElementById("share-url-input") as HTMLInputElement;
+    const copyBtn = document.getElementById("share-copy-btn")!;
+    const slugRow = document.getElementById("share-slug-row")!;
+    const slugInput = document.getElementById("share-slug-input") as HTMLInputElement;
+    const slugSave = document.getElementById("share-slug-save")!;
+    const configSection = document.getElementById("share-config-section")!;
+    const blurRow = document.getElementById("blur-projects-row")!;
+    const statusEl = document.getElementById("share-status")!;
+    const configToggles = document.querySelectorAll<HTMLInputElement>(".share-config-toggle");
+
+    let profileData: any = null;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function showStatus(msg: string, isError = false) {
+      statusEl.textContent = msg;
+      statusEl.className = `text-[10px] font-mono ${isError ? "text-red-400" : "text-accent"}`;
+      statusEl.classList.remove("hidden");
+      setTimeout(() => statusEl.classList.add("hidden"), 3000);
+    }
+
+    function updateEnabledUI(enabled: boolean) {
+      enabledToggle.setAttribute("aria-checked", String(enabled));
+      if (enabled) {
+        enabledToggle.classList.remove("bg-border");
+        enabledToggle.classList.add("bg-[#3fb950]");
+        enabledDot.style.transform = "translateX(20px)";
+        urlRow.classList.remove("hidden");
+        slugRow.classList.remove("hidden");
+        configSection.classList.remove("hidden");
+      } else {
+        enabledToggle.classList.add("bg-border");
+        enabledToggle.classList.remove("bg-[#3fb950]");
+        enabledDot.style.transform = "translateX(0)";
+        urlRow.classList.add("hidden");
+        slugRow.classList.add("hidden");
+        configSection.classList.add("hidden");
+      }
+    }
+
+    function updateConfigUI(config: Record<string, boolean>) {
+      configToggles.forEach((toggle) => {
+        const key = toggle.dataset.config;
+        if (key && config[key] !== undefined) {
+          toggle.checked = config[key];
+        }
+      });
+      // Show blur row only when showProjects is checked
+      const projectsToggle = document.querySelector<HTMLInputElement>('[data-config="showProjects"]');
+      blurRow.classList.toggle("hidden", !projectsToggle?.checked);
+    }
+
+    function getConfigFromUI(): Record<string, boolean> {
+      const config: Record<string, boolean> = {};
+      configToggles.forEach((toggle) => {
+        const key = toggle.dataset.config;
+        if (key) config[key] = toggle.checked;
+      });
+      return config;
+    }
+
+    async function saveProfile(body: any) {
+      try {
+        const res = await fetch("/api/insights/profile", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          showStatus(data.error || "Failed to save", true);
+          return null;
+        }
+        if (data.profile?.url) {
+          urlInput.value = data.profile.url;
+        }
+        if (data.profile?.slug) {
+          slugInput.value = data.profile.slug;
+        }
+        profileData = data.profile;
+        showStatus("Saved!");
+        return data;
+      } catch {
+        showStatus("Failed to save", true);
+        return null;
+      }
+    }
+
+    // Load existing profile
+    async function loadProfile() {
+      try {
+        const res = await fetch("/api/insights/profile", { credentials: "include" });
+        const data = await res.json();
+        if (data.profile) {
+          profileData = data.profile;
+          updateEnabledUI(data.profile.enabled);
+          urlInput.value = data.profile.url || "";
+          slugInput.value = data.profile.slug || "";
+          if (data.profile.config) {
+            updateConfigUI(data.profile.config);
+          }
+          // Update button text
+          toggleBtn.innerHTML = `<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 1 1 0-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 1 0 5.367-2.684 3 3 0 0 0-5.367 2.684Zm0 9.316a3 3 0 1 0 5.368 2.684 3 3 0 0 0-5.368-2.684Z" /></svg>${data.profile.enabled ? "Shared" : "Share"}`;
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Toggle panel visibility
+    let profileLoaded = false;
+    toggleBtn.addEventListener("click", () => {
+      panel.classList.toggle("hidden");
+      if (!panel.classList.contains("hidden") && !profileLoaded) {
+        profileLoaded = true;
+        loadProfile();
+      }
+    });
+    closeBtn.addEventListener("click", () => panel.classList.add("hidden"));
+
+    // Enable/disable toggle
+    enabledToggle.addEventListener("click", async () => {
+      const currentlyEnabled = enabledToggle.getAttribute("aria-checked") === "true";
+      const newEnabled = !currentlyEnabled;
+
+      if (!profileData && newEnabled) {
+        // Create new profile
+        const result = await saveProfile({ enabled: true, config: getConfigFromUI() });
+        if (result) {
+          updateEnabledUI(true);
+          toggleBtn.innerHTML = `<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 1 1 0-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 1 0 5.367-2.684 3 3 0 0 0-5.367 2.684Zm0 9.316a3 3 0 1 0 5.368 2.684 3 3 0 0 0-5.368-2.684Z" /></svg>Shared`;
+        }
+      } else {
+        // Update existing profile
+        updateEnabledUI(newEnabled);
+        const btnLabel = newEnabled ? "Shared" : "Share";
+        toggleBtn.innerHTML = `<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 1 1 0-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 1 0 5.367-2.684 3 3 0 0 0-5.367 2.684Zm0 9.316a3 3 0 1 0 5.368 2.684 3 3 0 0 0-5.368-2.684Z" /></svg>${btnLabel}`;
+        await saveProfile({ enabled: newEnabled, config: getConfigFromUI() });
+      }
+    });
+
+    // Copy URL
+    copyBtn.addEventListener("click", () => {
+      navigator.clipboard.writeText(urlInput.value).then(() => {
+        copyBtn.textContent = "Copied!";
+        setTimeout(() => { copyBtn.textContent = "Copy"; }, 2000);
+      });
+    });
+
+    // Save custom slug
+    slugSave.addEventListener("click", async () => {
+      const slug = slugInput.value.trim().toLowerCase();
+      if (!slug || !/^[a-zA-Z0-9_-]{2,40}$/.test(slug)) {
+        showStatus("Invalid slug (2-40 chars, letters/numbers/hyphens)", true);
+        return;
+      }
+      await saveProfile({ slug, config: getConfigFromUI() });
+    });
+
+    // Config toggles — debounced auto-save
+    configToggles.forEach((toggle) => {
+      toggle.addEventListener("change", () => {
+        // Show/hide blur row based on showProjects
+        if (toggle.dataset.config === "showProjects") {
+          blurRow.classList.toggle("hidden", !toggle.checked);
+        }
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          saveProfile({ config: getConfigFromUI() });
+        }, 500);
+      });
+    });
+
+  }
+
+  initAuth();
   initInsights();
+  initSharePanel();
 </script>

--- a/website/src/pages/shared-insights.astro
+++ b/website/src/pages/shared-insights.astro
@@ -1,0 +1,511 @@
+---
+import Footer from "../components/Footer.astro";
+import GitHubStar from "../components/GitHubStar.astro";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Insights - vibe-replay" description="Vibe coding insights shared via vibe-replay">
+  <div class="min-h-screen flex flex-col">
+    <!-- Header -->
+    <nav class="border-b border-border/50 px-6 py-3">
+      <div class="max-w-6xl mx-auto flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
+          <span class="text-border hidden sm:inline">|</span>
+          <a href="/insights/" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Insights</a>
+        </div>
+        <div class="flex items-center gap-3">
+          <GitHubStar />
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main content -->
+    <main class="flex-1 max-w-4xl mx-auto w-full px-4 md:px-6 py-10">
+      <!-- Loading state -->
+      <div id="loading" class="text-center py-20">
+        <div class="text-text-muted font-mono text-sm animate-pulse">Loading...</div>
+      </div>
+
+      <!-- Not found state -->
+      <div id="not-found" class="hidden">
+        <div class="flex items-center justify-center py-20">
+          <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md text-center">
+            <div class="text-4xl mb-4">&#128566;</div>
+            <h2 class="text-lg font-semibold text-text-primary mb-2">Profile not found</h2>
+            <p class="text-text-muted text-sm mb-4">This insights profile doesn't exist or has been disabled.</p>
+            <a href="/" class="text-accent hover:underline text-sm">Back to home</a>
+          </div>
+        </div>
+      </div>
+
+      <!-- Insights content -->
+      <div id="insights-content" class="hidden space-y-6">
+        <!-- Profile header -->
+        <div class="flex items-center gap-4">
+          <img id="profile-avatar" class="w-12 h-12 rounded-full border-2 border-border/40 hidden" alt="" />
+          <div>
+            <h1 id="profile-name" class="text-lg font-bold text-text-primary"></h1>
+            <p class="text-xs font-mono text-text-muted">Vibe coding insights</p>
+          </div>
+        </div>
+
+        <!-- Stats card -->
+        <div class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-surface-1 via-surface to-surface-1 border border-border p-6 md:p-8">
+          <div class="absolute -top-20 -right-20 w-64 h-64 bg-[#3fb950]/5 rounded-full blur-3xl pointer-events-none"></div>
+          <div class="absolute -bottom-20 -left-20 w-48 h-48 bg-[#79b8ff]/5 rounded-full blur-3xl pointer-events-none"></div>
+
+          <div class="relative z-10">
+            <div id="stats-grid" class="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-5 mb-6"></div>
+
+            <!-- Mini heatmap -->
+            <div id="mini-heatmap" class="flex gap-[3px] flex-wrap mb-4"></div>
+
+            <!-- Footer highlights -->
+            <div class="flex items-center justify-between pt-4 border-t border-border/30">
+              <div class="flex items-center gap-4">
+                <span id="card-streak" class="text-xs font-mono text-text-muted hidden"></span>
+                <span id="card-bestday" class="text-xs font-mono text-text-muted hidden"></span>
+              </div>
+              <span class="text-[10px] font-mono text-text-muted">vibe-replay.com</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Activity heatmap -->
+        <div id="heatmap-section" class="bg-surface-1 rounded-xl p-5 hidden">
+          <div class="flex items-center justify-between mb-4">
+            <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider">Activity</h3>
+            <span class="text-[9px] font-mono text-text-muted">Last 52 weeks</span>
+          </div>
+          <div id="contribution-heatmap"></div>
+        </div>
+
+        <!-- Highlight cards -->
+        <div id="highlights-section" class="grid grid-cols-2 md:grid-cols-4 gap-3 hidden">
+          <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+            <div class="flex items-start gap-3">
+              <span class="text-lg leading-none mt-0.5">&#128293;</span>
+              <div class="min-w-0">
+                <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Current Streak</div>
+                <div id="hl-streak" class="text-lg font-mono font-bold text-text-primary mt-0.5">0 days</div>
+                <div id="hl-streak-sub" class="text-[10px] font-mono text-text-muted mt-0.5"></div>
+              </div>
+            </div>
+          </div>
+          <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+            <div class="flex items-start gap-3">
+              <span class="text-lg leading-none mt-0.5">&#9889;</span>
+              <div class="min-w-0">
+                <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Active Day</div>
+                <div id="hl-avg-day" class="text-lg font-mono font-bold text-text-primary mt-0.5">0 sessions</div>
+                <div id="hl-avg-day-sub" class="text-[10px] font-mono text-text-muted mt-0.5"></div>
+              </div>
+            </div>
+          </div>
+          <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+            <div class="flex items-start gap-3">
+              <span class="text-lg leading-none mt-0.5">&#128172;</span>
+              <div class="min-w-0">
+                <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Avg / Session</div>
+                <div id="hl-avg-session" class="text-lg font-mono font-bold text-text-primary mt-0.5">0 prompts</div>
+                <div id="hl-avg-session-sub" class="text-[10px] font-mono text-text-muted mt-0.5"></div>
+              </div>
+            </div>
+          </div>
+          <div class="bg-surface-1 rounded-xl px-4 py-3.5">
+            <div class="flex items-start gap-3">
+              <span class="text-lg leading-none mt-0.5">&#127942;</span>
+              <div class="min-w-0">
+                <div class="text-[10px] font-bold text-text-muted uppercase tracking-widest">Peak Day</div>
+                <div id="hl-peak" class="text-lg font-mono font-bold text-text-primary mt-0.5">-</div>
+                <div id="hl-peak-sub" class="text-[10px] font-mono text-text-muted mt-0.5"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Charts: Weekly Trend + Day of Week -->
+        <div id="charts-section" class="grid grid-cols-1 md:grid-cols-2 gap-3 hidden">
+          <div id="weekly-trend-wrapper" class="bg-surface-1 rounded-xl p-5 hidden">
+            <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Weekly Trend</h3>
+            <div id="weekly-trend"></div>
+          </div>
+          <div id="day-of-week-wrapper" class="bg-surface-1 rounded-xl p-5 hidden">
+            <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Day of Week</h3>
+            <div id="day-of-week"></div>
+          </div>
+        </div>
+
+        <!-- Top Projects + Models & Providers -->
+        <div id="breakdowns-section" class="grid grid-cols-1 md:grid-cols-2 gap-3 hidden">
+          <div id="projects-wrapper" class="bg-surface-1 rounded-xl p-5 hidden">
+            <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Top Projects</h3>
+            <div id="top-projects"></div>
+          </div>
+          <div id="models-providers-wrapper" class="bg-surface-1 rounded-xl p-5 space-y-5 hidden">
+            <div id="models-wrapper" class="hidden">
+              <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Models</h3>
+              <div id="models-section"></div>
+            </div>
+            <div id="providers-wrapper" class="hidden">
+              <h3 class="text-xs font-semibold text-text-primary uppercase tracking-wider mb-4">Providers</h3>
+              <div id="providers-section"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer banner -->
+        <div id="footer-banner" class="text-center py-4 hidden">
+          <span id="footer-text" class="text-[11px] font-mono text-text-muted"></span>
+        </div>
+      </div>
+    </main>
+
+    <Footer />
+  </div>
+</Layout>
+
+<script>
+  function escapeHtml(s: string): string {
+    const div = document.createElement("div");
+    div.textContent = s;
+    return div.innerHTML;
+  }
+
+  function formatDuration(ms: number): string {
+    if (!ms) return "0m";
+    const secs = Math.floor(ms / 1000);
+    if (secs < 60) return `${secs}s`;
+    const mins = Math.floor(secs / 60);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ${mins % 60}m`;
+    const days = Math.floor(hrs / 24);
+    return `${days}d ${hrs % 24}h`;
+  }
+
+  function formatCompactDuration(ms: number): string {
+    if (!ms) return "0m";
+    const mins = Math.round(ms / 60000);
+    if (mins < 60) return `${mins}m`;
+    const hrs = Math.floor(mins / 60);
+    const remMins = mins % 60;
+    if (hrs < 24) return remMins > 0 ? `${hrs}h ${remMins}m` : `${hrs}h`;
+    const days = Math.floor(hrs / 24);
+    const remHrs = hrs % 24;
+    return remHrs > 0 ? `${days}d ${remHrs}h` : `${days}d`;
+  }
+
+  function formatCost(cost: number): string {
+    if (cost === 0) return "$0";
+    if (cost < 0.01) return "<$0.01";
+    if (cost < 100) return `$${cost.toFixed(2)}`;
+    return `$${Math.round(cost)}`;
+  }
+
+  function formatNumber(n: number): string {
+    if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
+    return n.toLocaleString();
+  }
+
+  function projectName(path: string): string {
+    if (!path) return "Unknown";
+    const parts = path.replace(/\\/g, "/").split("/");
+    return parts[parts.length - 1] || parts[parts.length - 2] || path;
+  }
+
+  function dateKey(d: Date): string {
+    return d.toISOString().slice(0, 10);
+  }
+
+  const DAY_MS = 86400000;
+  const DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const DAYS_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+  interface PublicInsights {
+    displayName: string;
+    avatarUrl: string | null;
+    config: Record<string, boolean>;
+    totalSessions: number;
+    totalProjects?: number;
+    totalDurationMs: number;
+    totalCost?: number;
+    totalPrompts: number;
+    totalToolCalls: number;
+    totalEdits: number;
+    timeRange: { first: string; last: string };
+    sessionsPerDay?: Record<string, number>;
+    topProjects?: Array<{ project: string; sessions: number; cost?: number }>;
+    models?: Record<string, number>;
+    providers?: Record<string, number>;
+  }
+
+  function computeStreak(spd: Record<string, number>): { current: number; longest: number } {
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    let current = 0;
+    const d = new Date(today);
+    while (true) {
+      const key = dateKey(d);
+      if (spd[key] && spd[key] > 0) { current++; d.setDate(d.getDate() - 1); }
+      else if (current === 0) { d.setDate(d.getDate() - 1); if (spd[dateKey(d)] > 0) { current++; d.setDate(d.getDate() - 1); } else break; }
+      else break;
+    }
+    const sorted = Object.keys(spd).filter(k => spd[k] > 0).sort();
+    let longest = 0, len = 0;
+    for (let i = 0; i < sorted.length; i++) {
+      if (i === 0) { len = 1; }
+      else { const diff = (new Date(sorted[i]).getTime() - new Date(sorted[i-1]).getTime()) / DAY_MS; len = diff === 1 ? len + 1 : 1; }
+      if (len > longest) longest = len;
+    }
+    return { current, longest };
+  }
+
+  function computePeakDay(spd: Record<string, number>) {
+    let max = 0, maxDate = "";
+    for (const [k, v] of Object.entries(spd)) { if (v > max) { max = v; maxDate = k; } }
+    return max > 0 ? { date: maxDate, count: max } : null;
+  }
+
+  function computeWeeklyTrend(spd: Record<string, number>, weeks: number) {
+    const result: Array<{ weekLabel: string; sessions: number; startDate: string }> = [];
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const dow = today.getDay();
+    const monday = new Date(today.getTime() - ((dow === 0 ? 6 : dow - 1)) * DAY_MS);
+    for (let w = weeks - 1; w >= 0; w--) {
+      const ws = new Date(monday.getTime() - w * 7 * DAY_MS);
+      let s = 0;
+      for (let d = 0; d < 7; d++) s += spd[dateKey(new Date(ws.getTime() + d * DAY_MS))] || 0;
+      result.push({ weekLabel: ws.toLocaleDateString("en-US", { month: "short", day: "numeric" }), sessions: s, startDate: dateKey(ws) });
+    }
+    return result;
+  }
+
+  function computeDayOfWeek(spd: Record<string, number>) {
+    const counts = [0,0,0,0,0,0,0];
+    for (const [k, v] of Object.entries(spd)) { if (v > 0) counts[new Date(`${k}T00:00:00`).getDay()] += v; }
+    return counts.map((count, i) => ({ shortDay: DAYS_SHORT[i], count }));
+  }
+
+  function renderMiniHeatmap(spd: Record<string, number>): void {
+    const el = document.getElementById("mini-heatmap")!;
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const cells: Array<{ count: number }> = [];
+    let max = 0;
+    for (let i = 27; i >= 0; i--) { const c = spd[dateKey(new Date(today.getTime() - i * DAY_MS))] || 0; if (c > max) max = c; cells.push({ count: c }); }
+    el.innerHTML = cells.map(c => {
+      if (c.count === 0) return `<div class="w-[10px] h-[10px] rounded-[2px] bg-border/20"></div>`;
+      const r = max <= 1 ? 1 : c.count / max;
+      return `<div class="w-[10px] h-[10px] rounded-[2px] bg-[#3fb950]" style="opacity: ${r <= 0.33 ? 0.45 : r <= 0.66 ? 0.7 : 0.9}"></div>`;
+    }).join("");
+  }
+
+  function renderContributionHeatmap(spd: Record<string, number>): void {
+    const el = document.getElementById("contribution-heatmap")!;
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const endDate = new Date(today.getTime() + (6 - today.getDay()) * DAY_MS);
+    const totalDays = 52 * 7;
+    const startDate = new Date(endDate.getTime() - (totalDays - 1) * DAY_MS);
+    let maxVal = 0;
+    const cols: Array<Array<{ date: string; count: number }>> = [];
+    const months = new Map<number, string>();
+    let lastMonth = -1;
+    for (let i = 0; i < totalDays; i++) {
+      const d = new Date(startDate.getTime() + i * DAY_MS);
+      const key = dateKey(d), count = spd[key] || 0, wi = Math.floor(i / 7);
+      if (count > maxVal) maxVal = count;
+      if (!cols[wi]) cols[wi] = [];
+      cols[wi].push({ date: key, count });
+      const month = d.getMonth();
+      if (month !== lastMonth) { months.set(wi, d.toLocaleDateString("en-US", { month: "short" })); lastMonth = month; }
+    }
+    const cc = (count: number) => {
+      if (count === 0) return { cls: "bg-[#1a1a24]", style: "" };
+      const r = maxVal <= 1 ? 1 : count / maxVal;
+      return { cls: "bg-[#3fb950]", style: `opacity: ${r <= 0.25 ? 0.4 : r <= 0.5 ? 0.6 : r <= 0.75 ? 0.8 : 1}` };
+    };
+    let mr = `<div class="flex items-end gap-[3px]"><div class="shrink-0 w-7"></div><div class="flex-1 flex gap-[3px] min-w-0">`;
+    for (let wi = 0; wi < cols.length; wi++) { mr += `<div class="flex-1 min-w-0 overflow-visible">${months.has(wi) ? `<span class="text-[9px] font-mono text-text-muted whitespace-nowrap">${escapeHtml(months.get(wi)!)}</span>` : ""}</div>`; }
+    mr += `</div></div>`;
+    const dayLabels = ["", "Mon", "", "Wed", "", "Fri", ""];
+    let grid = `<div class="flex gap-[3px]"><div class="shrink-0 w-7 flex flex-col gap-[3px]">`;
+    for (const l of dayLabels) grid += `<div class="flex-1 flex items-center text-[9px] font-mono text-text-muted leading-none">${l}</div>`;
+    grid += `</div><div class="flex-1 flex gap-[3px] min-w-0">`;
+    for (const week of cols) { grid += `<div class="flex-1 flex flex-col gap-[3px] min-w-0">`; for (const cell of week) { const c = cc(cell.count); grid += `<div class="aspect-square rounded-sm ${c.cls}" style="${c.style}" title="${cell.date}: ${cell.count} session${cell.count !== 1 ? "s" : ""}"></div>`; } grid += `</div>`; }
+    grid += `</div></div>`;
+    const legend = `<div class="flex items-center justify-end gap-1.5 pt-1"><span class="text-[9px] font-mono text-text-muted">Less</span><div class="w-[10px] h-[10px] rounded-sm bg-[#1a1a24]"></div><div class="w-[10px] h-[10px] rounded-sm bg-[#3fb950]" style="opacity: 0.4"></div><div class="w-[10px] h-[10px] rounded-sm bg-[#3fb950]" style="opacity: 0.6"></div><div class="w-[10px] h-[10px] rounded-sm bg-[#3fb950]" style="opacity: 0.8"></div><div class="w-[10px] h-[10px] rounded-sm bg-[#3fb950]"></div><span class="text-[9px] font-mono text-text-muted">More</span></div>`;
+    el.innerHTML = `<div class="space-y-1">${mr}${grid}${legend}</div>`;
+  }
+
+  function renderWeeklyTrend(spd: Record<string, number>): void {
+    const el = document.getElementById("weekly-trend")!;
+    const data = computeWeeklyTrend(spd, 12);
+    const maxVal = Math.max(...data.map(d => d.sessions), 1);
+    if (!data.some(d => d.sessions > 0)) { el.innerHTML = `<div class="flex items-center justify-center h-28 text-text-muted text-xs font-mono">No activity</div>`; return; }
+    const recent = data.slice(-4), older = data.slice(-8, -4);
+    const rAvg = recent.reduce((a, b) => a + b.sessions, 0) / Math.max(recent.length, 1);
+    const oAvg = older.reduce((a, b) => a + b.sessions, 0) / Math.max(older.length, 1);
+    const up = rAvg > oAvg, flat = Math.abs(rAvg - oAvg) < 0.5;
+    let bars = `<div class="flex items-end gap-1.5 h-28">`;
+    for (const w of data) { const h = Math.max((w.sessions / maxVal) * 100, w.sessions > 0 ? 6 : 0); bars += `<div class="flex-1 flex flex-col items-center justify-end h-full" title="${w.weekLabel}: ${w.sessions} sessions"><div class="w-full rounded-md bg-[#3fb950]" style="height: ${h}%; min-height: ${w.sessions > 0 ? "4px" : "0"}; opacity: ${w.sessions > 0 ? 0.7 : 0}"></div></div>`; }
+    bars += `</div>`;
+    let x = `<div class="flex items-center justify-between mt-3"><div class="flex gap-1.5 overflow-hidden">`;
+    data.filter((_, i) => i % 2 === 0).forEach(w => { x += `<span class="text-[9px] font-mono text-text-muted">${escapeHtml(w.weekLabel)}</span>`; });
+    x += `</div>`;
+    if (!flat) x += `<span class="text-[10px] font-mono font-bold ${up ? "text-[#3fb950]" : "text-[#d29922]"}">${up ? "\u2191 Trending up" : "\u2193 Slowing down"}</span>`;
+    x += `</div>`;
+    el.innerHTML = `<div class="space-y-0">${bars}${x}</div>`;
+  }
+
+  function renderDayOfWeek(spd: Record<string, number>): void {
+    const el = document.getElementById("day-of-week")!;
+    const data = computeDayOfWeek(spd);
+    const maxVal = Math.max(...data.map(d => d.count), 1);
+    let html = `<div class="space-y-2">`;
+    for (const d of data) { const pct = maxVal > 0 ? (d.count / maxVal) * 100 : 0; html += `<div class="flex items-center gap-2"><span class="text-[10px] font-mono text-text-muted w-7 text-right shrink-0">${d.shortDay}</span><div class="flex-1 h-4 rounded bg-surface-2 overflow-hidden"><div class="h-full rounded bg-[#3fb950]" style="width: ${Math.max(pct, d.count > 0 ? 3 : 0)}%; opacity: 0.65"></div></div><span class="text-[10px] font-mono text-text-muted w-6 text-right tabular-nums shrink-0">${d.count}</span></div>`; }
+    html += `</div>`;
+    el.innerHTML = html;
+  }
+
+  function renderTopProjects(projects: PublicInsights["topProjects"], showCost: boolean): void {
+    const el = document.getElementById("top-projects")!;
+    if (!projects || projects.length === 0) { el.innerHTML = `<div class="text-text-muted text-xs font-mono py-4 text-center">No project data</div>`; return; }
+    const maxS = Math.max(...projects.map(p => p.sessions), 1);
+    let html = `<div class="space-y-2">`;
+    for (const p of projects.slice(0, 8)) {
+      const name = projectName(p.project), pct = (p.sessions / maxS) * 100;
+      const costStr = showCost && p.cost && p.cost > 0 ? ` \u00b7 ${formatCost(p.cost)}` : "";
+      html += `<div class="space-y-1"><div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary truncate max-w-[60%]" title="${escapeHtml(p.project)}">${escapeHtml(name)}</span><span class="text-[10px] font-mono text-text-muted tabular-nums">${p.sessions} session${p.sessions !== 1 ? "s" : ""}${costStr}</span></div><div class="h-1.5 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full bg-gradient-to-r from-[#3fb950] to-[#79b8ff]" style="width: ${Math.max(pct, 3)}%; opacity: 0.65"></div></div></div>`;
+    }
+    html += `</div>`;
+    el.innerHTML = html;
+  }
+
+  function shortModelName(model: string): string {
+    return model.replace(/^anthropic\//, "").replace(/^openai\//, "").replace(/-\d{8}$/, "").replace(/^claude-/, "c-");
+  }
+
+  function renderModels(models: Record<string, number>): void {
+    const el = document.getElementById("models-section")!;
+    const map = new Map<string, number>();
+    for (const [m, c] of Object.entries(models)) { for (const l of [...new Set(m.split(",").map(p => p.trim()).filter(Boolean))]) { const s = shortModelName(l); map.set(s, (map.get(s) ?? 0) + c); } }
+    const entries = [...map.entries()].map(([model, count]) => ({ model, count })).sort((a, b) => b.count - a.count);
+    const total = entries.reduce((a, b) => a + b.count, 0);
+    if (entries.length === 0) { el.innerHTML = `<div class="text-text-muted text-xs font-mono py-4 text-center">No model data</div>`; return; }
+    const colors = ["bg-[#3fb950]", "bg-[#79b8ff]", "bg-[#d29922]", "bg-[#b392f0]", "bg-[#f97583]", "bg-text-muted"];
+    let bar = `<div class="h-3 rounded-full bg-surface-2 overflow-hidden flex">`;
+    entries.forEach((e, i) => { bar += `<div class="h-full ${colors[i % colors.length]}" style="width: ${(e.count / total) * 100}%; opacity: 0.7"></div>`; });
+    bar += `</div>`;
+    let legend = `<div class="grid grid-cols-2 gap-2 mt-3">`;
+    entries.forEach((e, i) => { legend += `<div class="flex items-center gap-2"><div class="w-2.5 h-2.5 rounded-sm ${colors[i % colors.length]} shrink-0" style="opacity: 0.7"></div><span class="text-[11px] font-mono text-text-muted truncate">${escapeHtml(e.model)}</span><span class="text-[10px] font-mono text-text-muted tabular-nums ml-auto shrink-0">${e.count}</span></div>`; });
+    legend += `</div>`;
+    el.innerHTML = `<div class="space-y-3">${bar}${legend}</div>`;
+  }
+
+  function renderProviders(providers: Record<string, number>): void {
+    const el = document.getElementById("providers-section")!;
+    const entries = Object.entries(providers).map(([p, c]) => ({ provider: p, label: p === "claude-code" ? "Claude Code" : p === "cursor" ? "Cursor" : p, count: c })).sort((a, b) => b.count - a.count);
+    if (entries.length <= 1) return;
+    const total = entries.reduce((a, b) => a + b.count, 0);
+    const colors: Record<string, string> = { "claude-code": "bg-[#d29922]", cursor: "bg-[#79b8ff]" };
+    let html = `<div class="space-y-3">`;
+    for (const e of entries) { const pct = total > 0 ? (e.count / total) * 100 : 0; html += `<div class="space-y-1.5"><div class="flex items-center justify-between"><span class="text-xs font-medium text-text-primary">${escapeHtml(e.label)}</span><span class="text-xs font-mono text-text-muted tabular-nums">${e.count} (${Math.round(pct)}%)</span></div><div class="h-2 rounded-full bg-surface-2 overflow-hidden"><div class="h-full rounded-full ${colors[e.provider] || "bg-text-muted"}" style="width: ${pct}%; opacity: 0.7"></div></div></div>`; }
+    html += `</div>`;
+    el.innerHTML = html;
+  }
+
+  function renderInsights(data: PublicInsights): void {
+    const cfg = data.config;
+    const spd = data.sessionsPerDay || {};
+
+    if (data.displayName) document.getElementById("profile-name")!.textContent = data.displayName;
+    if (data.avatarUrl) { const a = document.getElementById("profile-avatar") as HTMLImageElement; a.src = data.avatarUrl; a.classList.remove("hidden"); }
+    if (data.displayName) document.title = `${data.displayName}'s Insights - vibe-replay`;
+
+    // Stats grid
+    const statsGrid = document.getElementById("stats-grid")!;
+    const stats: Array<{ value: string; label: string; color: string }> = [
+      { value: formatNumber(data.totalSessions), label: "Sessions", color: "text-[#3fb950]" },
+      { value: formatNumber(data.totalPrompts), label: "Prompts", color: "text-[#3fb950]" },
+      { value: formatNumber(data.totalToolCalls), label: "Tool Calls", color: "text-[#d29922]" },
+      { value: formatDuration(data.totalDurationMs), label: "Coding", color: "text-text-primary" },
+    ];
+    if (cfg.showCost && data.totalCost !== undefined) stats.push({ value: formatCost(data.totalCost), label: "Spent", color: "text-[#d29922]" });
+    stats.push({ value: formatNumber(data.totalEdits), label: "File Edits", color: "text-[#79b8ff]" });
+    if (cfg.showProjects && data.totalProjects !== undefined) stats.push({ value: formatNumber(data.totalProjects), label: "Projects", color: "text-[#b392f0]" });
+    statsGrid.innerHTML = stats.map(s => `<div><div class="text-2xl font-mono font-bold ${s.color} tabular-nums">${s.value}</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">${s.label}</div></div>`).join("");
+
+    // Mini heatmap
+    if (cfg.showHeatmap) renderMiniHeatmap(spd);
+    else document.getElementById("mini-heatmap")!.style.display = "none";
+
+    // Full heatmap
+    if (cfg.showHeatmap && Object.keys(spd).length > 0) { document.getElementById("heatmap-section")!.classList.remove("hidden"); renderContributionHeatmap(spd); }
+
+    // Highlights
+    if (cfg.showStreak && Object.keys(spd).length > 0) {
+      document.getElementById("highlights-section")!.classList.remove("hidden");
+      const streak = computeStreak(spd), peak = computePeakDay(spd);
+      const active = Object.values(spd).filter(v => v > 0).length;
+      if (streak.current > 0) { const el2 = document.getElementById("card-streak")!; el2.textContent = `${streak.current} day streak`; el2.classList.remove("hidden"); }
+      document.getElementById("hl-streak")!.textContent = `${streak.current} day${streak.current !== 1 ? "s" : ""}`;
+      const sub = document.getElementById("hl-streak-sub")!;
+      if (streak.longest > streak.current) sub.textContent = `Best: ${streak.longest} days`;
+      else if (streak.current > 0) sub.textContent = "Personal best!";
+      document.getElementById("hl-avg-day")!.textContent = `${active > 0 ? (data.totalSessions / active).toFixed(1) : "0"} sessions`;
+      document.getElementById("hl-avg-day-sub")!.textContent = `${active} active day${active !== 1 ? "s" : ""}`;
+      const avgP = data.totalSessions > 0 ? Math.round(data.totalPrompts / data.totalSessions) : 0;
+      document.getElementById("hl-avg-session")!.textContent = `${avgP} prompts`;
+      if (data.totalSessions > 0) document.getElementById("hl-avg-session-sub")!.textContent = `~${formatCompactDuration(data.totalDurationMs / data.totalSessions)} each`;
+      if (peak) { document.getElementById("hl-peak")!.textContent = `${peak.count} sessions`; document.getElementById("hl-peak-sub")!.textContent = new Date(`${peak.date}T00:00:00`).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }); }
+      const dow = computeDayOfWeek(spd), best = [...dow].sort((a, b) => b.count - a.count)[0];
+      if (best?.count > 0) { const bd = document.getElementById("card-bestday")!; bd.textContent = `Most active: ${DAYS_FULL[DAYS_SHORT.indexOf(best.shortDay)] || best.shortDay}`; bd.classList.remove("hidden"); }
+    }
+
+    // Charts
+    const cs = document.getElementById("charts-section")!;
+    let showC = false;
+    if (cfg.showWeeklyTrend && Object.keys(spd).length > 0) { document.getElementById("weekly-trend-wrapper")!.classList.remove("hidden"); renderWeeklyTrend(spd); showC = true; }
+    if (cfg.showDayOfWeek && Object.keys(spd).length > 0) { document.getElementById("day-of-week-wrapper")!.classList.remove("hidden"); renderDayOfWeek(spd); showC = true; }
+    if (showC) cs.classList.remove("hidden");
+
+    // Breakdowns
+    const bs = document.getElementById("breakdowns-section")!;
+    let showB = false;
+    if (cfg.showProjects && data.topProjects?.length) { document.getElementById("projects-wrapper")!.classList.remove("hidden"); renderTopProjects(data.topProjects, !!cfg.showCost); showB = true; }
+    const hasModels = cfg.showModels && data.models && Object.keys(data.models).length > 0;
+    const hasProv = cfg.showProviders && data.providers && Object.keys(data.providers).length > 1;
+    if (hasModels || hasProv) { document.getElementById("models-providers-wrapper")!.classList.remove("hidden"); showB = true; if (hasModels) { document.getElementById("models-wrapper")!.classList.remove("hidden"); renderModels(data.models!); } if (hasProv) { document.getElementById("providers-wrapper")!.classList.remove("hidden"); renderProviders(data.providers!); } }
+    if (showB) bs.classList.remove("hidden");
+
+    // Footer
+    if (data.timeRange.first) { const days = Math.floor((Date.now() - new Date(data.timeRange.first).getTime()) / DAY_MS); if (days > 0) { document.getElementById("footer-banner")!.classList.remove("hidden"); document.getElementById("footer-text")!.textContent = `Vibe coding for ${days} day${days !== 1 ? "s" : ""} \u00b7 ${formatDuration(data.totalDurationMs)} total \u00b7 ${formatNumber(data.totalToolCalls)} tool calls`; } }
+  }
+
+  async function init(): Promise<void> {
+    const loading = document.getElementById("loading")!;
+    const notFound = document.getElementById("not-found")!;
+    const content = document.getElementById("insights-content")!;
+
+    const slug = new URLSearchParams(window.location.search).get("s");
+    if (!slug || !/^[a-zA-Z0-9_-]{2,40}$/.test(slug)) {
+      loading.classList.add("hidden");
+      notFound.classList.remove("hidden");
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/public/insights/${slug}`);
+      if (!res.ok) { loading.classList.add("hidden"); notFound.classList.remove("hidden"); return; }
+      const data: PublicInsights = await res.json();
+      loading.classList.add("hidden");
+      content.classList.remove("hidden");
+      renderInsights(data);
+    } catch {
+      loading.classList.add("hidden");
+      notFound.classList.remove("hidden");
+    }
+  }
+
+  init();
+</script>


### PR DESCRIPTION
## Summary

- Allow logged-in users to share their aggregated coding insights via a public URL (`/i/:slug`)
- Users can configure which sections to show/hide (cost, projects, models, heatmap, streaks, weekly trend, day of week) and optionally blur project names
- Share settings panel integrated into the existing insights page with debounced auto-save
- Public viewer page renders the same visualizations with sections conditionally shown based on profile config
- Data served with 1-hour cache headers for CDN caching

### Key changes

| Area | What |
|------|------|
| DB | New `insight_profiles` table (slug, config JSON, enabled toggle, view count) |
| API | `GET/POST/DELETE /api/insights/profile` (authenticated) |
| API | `GET /api/public/insights/:slug` (public, cached 1hr) |
| API | `GET /i/:slug` short URL redirect |
| Website | Share panel in `insights.astro` with 9 visibility toggles |
| Website | `shared-insights.astro` public viewer page |
| Migration | `0008_add_insight_profiles.sql` |

### Security measures
- `avatarUrl` validated to HTTPS only
- Config sanitized to boolean-only values
- UNIQUE constraint race conditions handled
- Public API only exposes `true` config flags (doesn't reveal what's hidden)
- `displayName` rendered via `textContent` (not `innerHTML`)
- Project names escaped with `escapeHtml()` in all `innerHTML` contexts
- `enabled=false` profiles return 404 on public endpoint

## Test plan
- [x] All 68 E2E tests pass
- [x] All 87 unit tests pass
- [x] Lint check passes (no new warnings)
- [x] Build succeeds (viewer bundle still under 800KB)
- [ ] Manual test: create profile via API, verify public page renders
- [ ] Manual test: toggle sections on/off, verify public page updates
- [ ] Manual test: custom slug, verify redirect works
- [ ] Deploy migration to D1

🤖 Generated with [Claude Code](https://claude.com/claude-code)