### PR TITLE
fix(cloud): batch insights sync below D1 limits

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -18,6 +18,18 @@ import { cloudReplays, dailyInsights, insightProfiles, replays, userFiles } from
 const CLOUD_REPLAY_ID_RE = /^[a-zA-Z0-9_-]{10,16}$/;
 const GIST_ID_RE = /^[a-f0-9]{20,40}$/;
 const VALID_VISIBILITY = new Set(["public", "unlisted", "private"]);
+// D1 starts failing once this lookup goes past ~100 bound params (user + machine + dates),
+// so keep all sync DB work comfortably below that ceiling.
+const SAFE_DAILY_SYNC_DB_CHUNK = 90;
+
+function chunkItems<T>(items: T[], maxItems: number): T[][] {
+  if (maxItems <= 0) return [items.slice()];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += maxItems) {
+    chunks.push(items.slice(i, i + maxItems));
+  }
+  return chunks;
+}
 
 function isDev(env: { BETTER_AUTH_URL?: string }): boolean {
   return !!env.BETTER_AUTH_URL?.startsWith("http://localhost");
@@ -1070,15 +1082,18 @@ app.post("/api/insights/sync", async (c) => {
   if (!machineId) return c.json({ error: "machineId required" }, 400);
 
   const dates = body.days.map((d: any) => String(d.date)).filter(Boolean);
-  const existingRows =
-    dates.length > 0
-      ? await c.env.DB.prepare(
-          `SELECT id, date FROM daily_insights WHERE user_id = ? AND machine_id = ? AND date IN (${dates.map(() => "?").join(",")})`,
-        )
-          .bind(userId, machineId, ...dates)
-          .all<{ id: string; date: string }>()
-      : { results: [] };
-  const existingMap = new Map((existingRows.results || []).map((r) => [r.date, r.id]));
+  const existingMap = new Map<string, string>();
+  for (const dateChunk of chunkItems(dates, SAFE_DAILY_SYNC_DB_CHUNK)) {
+    if (dateChunk.length === 0) continue;
+    const existingRows = await c.env.DB.prepare(
+      `SELECT id, date FROM daily_insights WHERE user_id = ? AND machine_id = ? AND date IN (${dateChunk.map(() => "?").join(",")})`,
+    )
+      .bind(userId, machineId, ...dateChunk)
+      .all<{ id: string; date: string }>();
+    for (const row of existingRows.results || []) {
+      existingMap.set(row.date, row.id);
+    }
+  }
 
   // Build batch statements
   const statements: D1PreparedStatement[] = [];
@@ -1141,7 +1156,9 @@ app.post("/api/insights/sync", async (c) => {
 
   if (statements.length > 0) {
     try {
-      await c.env.DB.batch(statements);
+      for (const statementChunk of chunkItems(statements, SAFE_DAILY_SYNC_DB_CHUNK)) {
+        await c.env.DB.batch(statementChunk);
+      }
     } catch (e) {
       console.error("Daily insights batch sync failed:", e);
       return c.json({ error: "Sync failed", synced: 0 }, 500);

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -18,8 +18,9 @@ import { cloudReplays, dailyInsights, insightProfiles, replays, userFiles } from
 const CLOUD_REPLAY_ID_RE = /^[a-zA-Z0-9_-]{10,16}$/;
 const GIST_ID_RE = /^[a-f0-9]{20,40}$/;
 const VALID_VISIBILITY = new Set(["public", "unlisted", "private"]);
-// D1 starts failing once this lookup goes past ~100 bound params (user + machine + dates),
-// so keep all sync DB work comfortably below that ceiling.
+// D1 starts failing once the user+machine+dates lookup goes past ~100 bound params.
+// Reuse the same conservative chunk size for both query and write paths so older clients
+// that still send large sync payloads stay under the database ceiling server-side too.
 const SAFE_DAILY_SYNC_DB_CHUNK = 90;
 
 function chunkItems<T>(items: T[], maxItems: number): T[][] {
@@ -1155,13 +1156,15 @@ app.post("/api/insights/sync", async (c) => {
   }
 
   if (statements.length > 0) {
+    let committedSynced = 0;
     try {
       for (const statementChunk of chunkItems(statements, SAFE_DAILY_SYNC_DB_CHUNK)) {
         await c.env.DB.batch(statementChunk);
+        committedSynced += statementChunk.length;
       }
     } catch (e) {
       console.error("Daily insights batch sync failed:", e);
-      return c.json({ error: "Sync failed", synced: 0 }, 500);
+      return c.json({ error: "Sync failed", synced: committedSynced }, 500);
     }
   }
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -92,6 +92,29 @@ function normalizeProjectPath(project: string): string {
   return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
 }
 
+// Keep cloud sync requests comfortably below the current D1 bind / batch ceiling.
+const MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST = 90;
+
+function chunkItems<T>(items: T[], maxItems: number): T[][] {
+  if (maxItems <= 0) return [items.slice()];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += maxItems) {
+    chunks.push(items.slice(i, i + maxItems));
+  }
+  return chunks;
+}
+
+function buildInsightsSyncBatches<T extends { date: string }>(
+  days: T[],
+  existingDates: Iterable<string>,
+  today: string,
+  maxDaysPerBatch = MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST,
+): T[][] {
+  const existing = new Set(existingDates);
+  const pending = days.filter((day) => !existing.has(day.date) || day.date === today);
+  return chunkItems(pending, maxDaysPerBatch);
+}
+
 interface GenerateRequestBody {
   provider: string;
   filePaths?: unknown;
@@ -1010,6 +1033,8 @@ export async function startServer(
     const apiUrl = getUrl();
     const cookieName = getCookie(apiUrl);
     const headers = { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` };
+    const today = new Date().toISOString().slice(0, 10);
+    let existingDates = new Set<string>();
 
     // Delta sync: fetch dates already on cloud, skip them
     try {
@@ -1019,49 +1044,54 @@ export async function startServer(
       );
       if (datesResp.ok) {
         const { dates } = (await datesResp.json()) as { dates: string[] };
-        const existing = new Set(dates);
-        const today = new Date().toISOString().slice(0, 10);
-        // Always re-sync today (may have new sessions since last sync)
-        daily.days = daily.days.filter((d) => !existing.has(d.date) || d.date === today);
-        if (daily.days.length === 0) return { synced: 0, total: 0 };
+        existingDates = new Set(dates);
       }
     } catch {
       // Failed to fetch dates — fall back to full sync (cloud will upsert)
     }
 
-    let resp: Response;
-    try {
-      resp = await fetch(`${apiUrl}/api/insights/sync`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(daily),
-        signal: AbortSignal.timeout(30_000),
-      });
-    } catch (e) {
-      return {
-        synced: 0,
-        total: daily.days.length,
-        error: e instanceof Error ? e.message : "Network error",
-      };
+    const batches = buildInsightsSyncBatches(daily.days, existingDates, today);
+    const totalDays = batches.reduce((sum, batch) => sum + batch.length, 0);
+    if (totalDays === 0) return { synced: 0, total: 0 };
+
+    let synced = 0;
+    for (const batch of batches) {
+      let resp: Response;
+      try {
+        resp = await fetch(`${apiUrl}/api/insights/sync`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ ...daily, days: batch }),
+          signal: AbortSignal.timeout(30_000),
+        });
+      } catch (e) {
+        return {
+          synced,
+          total: totalDays,
+          error: e instanceof Error ? e.message : "Network error",
+        };
+      }
+
+      if (resp.status === 401) {
+        await clearLocalAuthSession();
+        return { synced, total: totalDays, error: "Session expired" };
+      }
+      if (!resp.ok) {
+        const err = await resp.text().catch(() => `HTTP ${resp.status}`);
+        return { synced, total: totalDays, error: err };
+      }
+
+      let result: { synced: number };
+      try {
+        result = await resp.json();
+      } catch {
+        return { synced, total: totalDays, error: "Invalid response" };
+      }
+
+      synced += result.synced;
     }
 
-    if (resp.status === 401) {
-      await clearLocalAuthSession();
-      return { synced: 0, total: daily.days.length, error: "Session expired" };
-    }
-    if (!resp.ok) {
-      const err = await resp.text().catch(() => `HTTP ${resp.status}`);
-      return { synced: 0, total: daily.days.length, error: err };
-    }
-
-    let result: { synced: number };
-    try {
-      result = await resp.json();
-    } catch {
-      return { synced: 0, total: daily.days.length, error: "Invalid response" };
-    }
-
-    return { synced: result.synced, total: daily.days.length };
+    return { synced, total: totalDays };
   };
 
   /**
@@ -2850,6 +2880,7 @@ export async function startDashboard(
 }
 
 export const __testables = {
+  buildInsightsSyncBatches,
   countSessionStats,
   pickSourceRecordForSession,
   selectCursorEnrichmentCandidates,

--- a/packages/cli/test/server-insights-sync.test.ts
+++ b/packages/cli/test/server-insights-sync.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { __testables } from "../src/server.js";
+
+describe("buildInsightsSyncBatches", () => {
+  it("splits large daily sync payloads into stable batches", () => {
+    const days = Array.from({ length: 140 }, (_unused, index) => ({
+      date: `date-${index}`,
+      sessions: index,
+    }));
+
+    const batches = __testables.buildInsightsSyncBatches(days, [], "date-999", 90);
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toHaveLength(90);
+    expect(batches[1]).toHaveLength(50);
+    expect(batches[0][0]?.date).toBe("date-0");
+    expect(batches[0][89]?.date).toBe("date-89");
+    expect(batches[1][0]?.date).toBe("date-90");
+    expect(batches[1][49]?.date).toBe("date-139");
+  });
+
+  it("skips already-synced past days but always keeps today", () => {
+    const days = [
+      { date: "2026-04-07", sessions: 1 },
+      { date: "2026-04-08", sessions: 2 },
+      { date: "2026-04-09", sessions: 3 },
+    ];
+
+    const batches = __testables.buildInsightsSyncBatches(
+      days,
+      ["2026-04-07", "2026-04-08", "2026-04-09"],
+      "2026-04-09",
+      90,
+    );
+
+    expect(batches).toEqual([[{ date: "2026-04-09", sessions: 3 }]]);
+  });
+
+  it("returns no batches when every non-today day is already synced", () => {
+    const days = [
+      { date: "2026-04-07", sessions: 1 },
+      { date: "2026-04-08", sessions: 2 },
+    ];
+
+    const batches = __testables.buildInsightsSyncBatches(
+      days,
+      ["2026-04-07", "2026-04-08"],
+      "2026-04-09",
+      90,
+    );
+
+    expect(batches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- split CLI cloud insights uploads into safe request-sized batches so larger local histories no longer trip the current production D1 bind limit
- chunk the worker's daily insights lookup and D1 batch writes so both new and older clients stay below the same database ceiling
- add a targeted server test that locks in the batching behavior and preserves the existing delta-sync semantics for already-synced days

## Test plan
- [x] `pnpm --filter vibe-replay test -- server-insights-sync.test.ts server-generate.test.ts server-sources-enrichment.test.ts`
- [x] `pnpm lint:check`
- [x] `pnpm build`
- [x] manually verified local `POST /api/insights/sync` succeeds against production with a 140-day history that previously failed at 99+ days

Made with [Cursor](https://cursor.com)