### PR TITLE
fix: remove undefined initAuth() call that broke insights page

### DIFF
--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1339,7 +1339,6 @@ import Layout from "../layouts/Layout.astro";
 
   }
 
-  initAuth();
   initInsights();
   initSharePanel();
 </script>


### PR DESCRIPTION
## Summary
- Removed `initAuth()` call in `insights.astro` that was added in #143 but never defined
- This caused a `ReferenceError` that prevented `initInsights()` from executing, leaving the page stuck on "Loading..." forever
- Auth is already handled by the Nav component — no functionality lost

## Test plan
- [x] Verified production DB has data (171 rows in `daily_insights`)
- [x] Confirmed `initAuth` is not defined anywhere in the codebase
- [x] Built and deployed hotfix to Cloudflare — verified deployed JS no longer contains `initAuth`
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)