### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Patch version bump 0.1.4 → 0.1.5 for release

## Quality check
- Build: pass (viewer 752KB < 800KB limit)
- Lint: pass (159 files, 0 issues)
- Unit tests: 697 passed
- E2E tests: 68 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)