### PR TITLE
fix(cloud): always show project count in shared insights

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1608,7 +1608,8 @@ app.get("/api/public/insights/:slug", async (c) => {
   let providers: Record<string, number> = {};
   let projectCount = 0;
 
-  if (config.showProjects || config.showModels || config.showProviders) {
+  // Always fetch breakdowns — project count is always shown even when topProjects list is hidden
+  {
     const cutoffDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     const allRows = await db
       .select({
@@ -1634,7 +1635,7 @@ app.get("/api/public/insights/:slug", async (c) => {
     const providersAgg: Record<string, { sessions: number; cost: number }> = {};
 
     for (const row of allRows) {
-      if (config.showProjects && row.projects) {
+      if (row.projects) {
         try {
           const p = JSON.parse(row.projects);
           for (const [name, v] of Object.entries(p) as [string, any][]) {
@@ -1684,8 +1685,8 @@ app.get("/api/public/insights/:slug", async (c) => {
       }
     }
 
+    projectCount = Object.keys(projectsAgg).length;
     if (config.showProjects) {
-      projectCount = Object.keys(projectsAgg).length;
       topProjects = Object.entries(projectsAgg)
         .map(([project, v]) => {
           const name = config.blurProjectNames ? project.replace(/[^/\\]/g, "*") : project;
@@ -1726,7 +1727,7 @@ app.get("/api/public/insights/:slug", async (c) => {
     avatarUrl: profile.avatarUrl,
     config: visibleSections,
     totalSessions: agg?.totalSessions || 0,
-    totalProjects: config.showProjects ? projectCount : undefined,
+    totalProjects: projectCount,
     totalDurationMs: agg?.totalDurationMs || 0,
     totalPrompts: agg?.totalPrompts || 0,
     totalToolCalls: agg?.totalToolCalls || 0,

--- a/website/src/pages/shared-insights.astro
+++ b/website/src/pages/shared-insights.astro
@@ -432,7 +432,7 @@ import Layout from "../layouts/Layout.astro";
     ];
     if (cfg.showCost && data.totalCost !== undefined) stats.push({ value: formatCost(data.totalCost), label: "Spent", color: "text-[#d29922]" });
     stats.push({ value: formatNumber(data.totalEdits), label: "File Edits", color: "text-[#79b8ff]" });
-    if (cfg.showProjects && data.totalProjects !== undefined) stats.push({ value: formatNumber(data.totalProjects), label: "Projects", color: "text-[#b392f0]" });
+    if (data.totalProjects !== undefined) stats.push({ value: formatNumber(data.totalProjects), label: "Projects", color: "text-[#b392f0]" });
     statsGrid.innerHTML = stats.map(s => `<div><div class="text-2xl font-mono font-bold ${s.color} tabular-nums">${s.value}</div><div class="mt-0.5 text-[10px] uppercase text-text-muted tracking-wider">${s.label}</div></div>`).join("");
 
     // Mini heatmap


### PR DESCRIPTION
## Summary
- Decouple project count from `showProjects` toggle in shared insights
- When `showProjects` is disabled, the top projects list is hidden but the project count statistic remains visible in the stats grid
- Previously both disappeared together when toggling off top projects

## Test plan
- [ ] Open a shared insights page with `showProjects` disabled — verify "Projects" count still appears in stats
- [ ] Open a shared insights page with `showProjects` enabled — verify both count and top projects list appear
- [ ] Verify other config toggles (models, providers, cost) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)