### PR TITLE
fix(website): unify navigation across all pages

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -18,6 +18,9 @@
       <a href="/explore" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
         Explore
       </a>
+      <a href="/insights" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
+        Insights
+      </a>
       <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
         <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         GitHub

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -1,8 +1,10 @@
 ---
+import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Page not found - vibe-replay" description="The page you're looking for doesn't exist. Head back to vibe-replay to explore AI coding session replays.">
+  <Nav />
   <div class="min-h-screen flex items-center justify-center px-6">
     <div class="text-center max-w-md">
       <!-- Terminal-style 404 -->

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -4,34 +4,36 @@ import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Page not found - vibe-replay" description="The page you're looking for doesn't exist. Head back to vibe-replay to explore AI coding session replays.">
-  <Nav />
-  <div class="min-h-screen flex items-center justify-center px-6">
-    <div class="text-center max-w-md">
-      <!-- Terminal-style 404 -->
-      <div class="rounded-xl border border-border bg-surface-1 overflow-hidden mb-10 text-left">
-        <div class="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface-2/50">
-          <div class="flex gap-1.5">
-            <div class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></div>
-            <div class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></div>
-            <div class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></div>
+  <div class="flex flex-col min-h-screen">
+    <Nav />
+    <div class="flex-1 flex items-center justify-center px-6">
+      <div class="text-center max-w-md">
+        <!-- Terminal-style 404 -->
+        <div class="rounded-xl border border-border bg-surface-1 overflow-hidden mb-10 text-left">
+          <div class="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface-2/50">
+            <div class="flex gap-1.5">
+              <div class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></div>
+              <div class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></div>
+              <div class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></div>
+            </div>
+            <span class="text-[10px] text-text-muted font-mono ml-2">vibe-replay</span>
           </div>
-          <span class="text-[10px] text-text-muted font-mono ml-2">vibe-replay</span>
+          <div class="p-5 font-mono text-sm space-y-1.5">
+            <div><span class="text-accent">$</span> <span class="text-text-primary">curl {Astro.url.pathname}</span></div>
+            <div>&nbsp;</div>
+            <div class="text-[#f85149]">  error: page not found (404)</div>
+            <div class="text-text-muted">  This scene doesn't exist in the replay.</div>
+            <div>&nbsp;</div>
+            <div class="text-text-secondary">  Try one of these:</div>
+            <div class="text-accent">    /           <span class="text-text-muted">- home</span></div>
+            <div class="text-accent">    /view/      <span class="text-text-muted">- replay viewer</span></div>
+          </div>
         </div>
-        <div class="p-5 font-mono text-sm space-y-1.5">
-          <div><span class="text-accent">$</span> <span class="text-text-primary">curl {Astro.url.pathname}</span></div>
-          <div>&nbsp;</div>
-          <div class="text-[#f85149]">  error: page not found (404)</div>
-          <div class="text-text-muted">  This scene doesn't exist in the replay.</div>
-          <div>&nbsp;</div>
-          <div class="text-text-secondary">  Try one of these:</div>
-          <div class="text-accent">    /           <span class="text-text-muted">- home</span></div>
-          <div class="text-accent">    /view/      <span class="text-text-muted">- replay viewer</span></div>
-        </div>
-      </div>
 
-      <a href="/" class="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-mono text-accent border border-accent/30 rounded-lg hover:bg-accent/10 transition-colors">
-        <span>&larr;</span> Back to home
-      </a>
+        <a href="/" class="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-mono text-accent border border-accent/30 rounded-lg hover:bg-accent/10 transition-colors">
+          <span>&larr;</span> Back to home
+        </a>
+      </div>
     </div>
   </div>
 </Layout>

--- a/website/src/pages/shared-insights.astro
+++ b/website/src/pages/shared-insights.astro
@@ -1,24 +1,12 @@
 ---
 import Footer from "../components/Footer.astro";
-import GitHubStar from "../components/GitHubStar.astro";
+import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
 <Layout title="Insights - vibe-replay" description="Vibe coding insights shared via vibe-replay">
   <div class="min-h-screen flex flex-col">
-    <!-- Header -->
-    <nav class="border-b border-border/50 px-6 py-3">
-      <div class="max-w-6xl mx-auto flex items-center justify-between">
-        <div class="flex items-center gap-4">
-          <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
-          <span class="text-border hidden sm:inline">|</span>
-          <a href="/insights/" class="text-text-secondary hover:text-accent text-sm transition-colors hidden sm:inline underline underline-offset-4 decoration-text-muted hover:decoration-accent">Insights</a>
-        </div>
-        <div class="flex items-center gap-3">
-          <GitHubStar />
-        </div>
-      </div>
-    </nav>
+    <Nav active="insights" />
 
     <!-- Main content -->
     <main class="flex-1 max-w-4xl mx-auto w-full px-4 md:px-6 py-10">


### PR DESCRIPTION
## Summary
- **shared-insights**: replaced hand-written nav (missing links, auth, mobile menu) with shared `<Nav active="insights" />`
- **404**: added `<Nav />` so users can navigate away from error page
- **Footer**: added missing `/insights` link to match header nav

## Test plan
- [ ] Visit `/shared-insights/?s=tuo-lei` — should show full nav with Blog/Explore/Insights links, auth UI, mobile hamburger menu
- [ ] Visit a non-existent URL — 404 page should now have navigation bar
- [ ] Check footer on any page — should include Insights link between Explore and GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)