### PR TITLE
fix(cursor): use wall-clock turn duration in insights

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -132,6 +132,30 @@ describe("cursor sqlite metrics helpers", () => {
     expect(metrics.turnStats?.[1]?.tokenUsage).toBeUndefined();
   });
 
+  it("falls back to bubble-duration estimation when global-state timestamps are unavailable", () => {
+    const metrics = __testables.buildGlobalStateMetrics(
+      [
+        {
+          turn: { role: "user", blocks: [{ type: "text", text: "prompt" }] },
+          bubble: { type: 1, tokenCount: { inputTokens: 0, outputTokens: 0 } },
+        },
+        {
+          turn: { role: "assistant", blocks: [{ type: "text", text: "reply" }] },
+          bubble: {
+            type: 2,
+            tokenCount: { inputTokens: 500, outputTokens: 30 },
+            thinkingDurationMs: 2000,
+          },
+        },
+      ] as any,
+      undefined,
+    );
+
+    expect(metrics.turnStats?.[0]?.durationMs).toBe(2000);
+    expect(metrics.totalDurationMs).toBe(2000);
+    expect(metrics.usedWallClock).toBe(false);
+  });
+
   it("extracts Cursor branch metadata from composer payload", () => {
     const branchMeta = __testables.extractCursorBranchMetadata({
       createdOnBranch: "feature/start",

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -95,11 +95,19 @@ describe("cursor sqlite metrics helpers", () => {
     const metrics = __testables.buildGlobalStateMetrics(
       [
         {
-          turn: { role: "user", blocks: [{ type: "text", text: "first prompt" }] },
+          turn: {
+            role: "user",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            blocks: [{ type: "text", text: "first prompt" }],
+          },
           bubble: { type: 1, tokenCount: { inputTokens: 0, outputTokens: 0 } },
         },
         {
-          turn: { role: "assistant", blocks: [{ type: "text", text: "first reply" }] },
+          turn: {
+            role: "assistant",
+            timestamp: "2026-01-01T00:00:12.000Z",
+            blocks: [{ type: "text", text: "first reply" }],
+          },
           bubble: {
             type: 2,
             tokenCount: { inputTokens: 1000, outputTokens: 80 },
@@ -107,7 +115,11 @@ describe("cursor sqlite metrics helpers", () => {
           },
         },
         {
-          turn: { role: "user", blocks: [{ type: "text", text: "second prompt" }] },
+          turn: {
+            role: "user",
+            timestamp: "2026-01-01T00:00:20.000Z",
+            blocks: [{ type: "text", text: "second prompt" }],
+          },
           bubble: { type: 1, tokenCount: { inputTokens: 0, outputTokens: 0 } },
         },
       ] as any,
@@ -115,6 +127,7 @@ describe("cursor sqlite metrics helpers", () => {
     );
 
     expect(metrics.turnStats).toHaveLength(2);
+    expect(metrics.turnStats?.[0]?.durationMs).toBe(12_000);
     expect(metrics.turnStats?.[0]?.tokenUsage?.outputTokens).toBe(80);
     expect(metrics.turnStats?.[1]?.tokenUsage).toBeUndefined();
   });
@@ -585,6 +598,32 @@ describe("cursor sqlite metrics helpers", () => {
       hasWorkspaceRules: true,
     });
     expect(merged.dataSourceInfo?.supplements).toContain("cursor/user/globalStorage/state.vscdb");
+  });
+
+  it("prefers global-state wall-clock duration over store tool runtime when merging", () => {
+    const merged = __testables.mergeCursorParseResults(
+      {
+        sessionId: "sess-1",
+        slug: "sess-1",
+        cwd: "",
+        turns: [{ role: "user", blocks: [{ type: "text", text: "prompt" }] }],
+        dataSource: "sqlite",
+        totalDurationMs: 1200,
+        turnStats: [{ turnIndex: 0, durationMs: 1200 }],
+      },
+      {
+        sessionId: "sess-1",
+        slug: "sess-1",
+        cwd: "/workspace/project",
+        turns: [{ role: "assistant", blocks: [{ type: "text", text: "reply" }] }],
+        dataSource: "global-state",
+        totalDurationMs: 4200,
+        turnStats: [{ turnIndex: 0, durationMs: 4200 }],
+      },
+    );
+
+    expect(merged.totalDurationMs).toBe(4200);
+    expect(merged.turnStats?.[0]?.durationMs).toBe(4200);
   });
 
   it("does not add enrichment notes when primary metadata already exists", () => {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1474,16 +1474,23 @@ function mergeCursorParseResults(
   enrichment: ProviderParseResult,
 ): ProviderParseResult {
   const mergedModel = chooseMergedCursorModel(primary.model, enrichment.model);
-  const mergedTurnStats = mergeTurnStats(primary.turnStats, enrichment.turnStats);
+  const preferEnrichmentDuration =
+    enrichment.dataSource === "global-state" &&
+    (enrichment.totalDurationMs !== undefined ||
+      enrichment.turnStats?.some((stat) => stat.durationMs !== undefined) === true);
+  const mergedTurnStats = mergeTurnStats(primary.turnStats, enrichment.turnStats, {
+    preferEnrichmentDuration,
+  });
   const mergedTokenUsage = primary.tokenUsage || enrichment.tokenUsage;
   const mergedTokenUsageByModel = primary.tokenUsageByModel || enrichment.tokenUsageByModel;
   const mergedTotalDurationMs =
+    (preferEnrichmentDuration ? enrichment.totalDurationMs : undefined) ||
     primary.totalDurationMs ||
-    enrichment.totalDurationMs ||
+    (!preferEnrichmentDuration ? enrichment.totalDurationMs : undefined) ||
     (mergedTurnStats && mergedTurnStats.length > 0
       ? mergedTurnStats.reduce((sum, stat) => sum + (stat.durationMs || 0), 0) || undefined
       : undefined);
-  const mergedDuration = mergedTotalDurationMs !== undefined && !primary.totalDurationMs;
+  const mergedDuration = mergedTotalDurationMs !== primary.totalDurationMs;
   const mergedTokens =
     (!primary.tokenUsage && !!enrichment.tokenUsage) ||
     (!primary.tokenUsageByModel && !!enrichment.tokenUsageByModel);
@@ -1506,7 +1513,12 @@ function mergeCursorParseResults(
   const primaryNotes = (primary.dataSourceInfo?.notes || []).filter(
     (note) =>
       !(mergedTokens && /token usage is unavailable/i.test(note)) &&
-      !(mergedDuration && /per-turn duration metrics are unavailable/i.test(note)),
+      !(
+        mergedDuration &&
+        /per-turn duration metrics are unavailable|per-turn duration is estimated from cursor tool execution metadata|duration is estimated from cursor thinking and tool execution timing/i.test(
+          note,
+        )
+      ),
   );
   const notes = mergeUniqueStrings(
     primaryNotes,
@@ -1601,6 +1613,7 @@ function chooseMergedCursorModel(
 function mergeTurnStats(
   primary: TurnStat[] | undefined,
   enrichment: TurnStat[] | undefined,
+  options?: { preferEnrichmentDuration?: boolean },
 ): TurnStat[] | undefined {
   if (!primary?.length) return enrichment;
   if (!enrichment?.length) return primary;
@@ -1629,11 +1642,13 @@ function mergeTurnStats(
     merged.push({
       ...current,
       ...(current.model ? {} : extra.model ? { model: extra.model } : {}),
-      ...(current.durationMs !== undefined
-        ? {}
-        : extra.durationMs !== undefined
-          ? { durationMs: extra.durationMs }
-          : {}),
+      ...(options?.preferEnrichmentDuration && extra.durationMs !== undefined
+        ? { durationMs: extra.durationMs }
+        : current.durationMs !== undefined
+          ? {}
+          : extra.durationMs !== undefined
+            ? { durationMs: extra.durationMs }
+            : {}),
       ...(current.tokenUsage ? {} : extra.tokenUsage ? { tokenUsage: extra.tokenUsage } : {}),
       ...(current.contextTokens !== undefined
         ? {}
@@ -1671,6 +1686,77 @@ function extractBubbleDurationMs(bubble: Record<string, any>): number | undefine
   const toolMs = extractToolExecutionTimeMs((bubble.toolFormerData as any)?.result);
   if (thinkingMs !== undefined && toolMs !== undefined) return thinkingMs + toolMs;
   return thinkingMs ?? toolMs;
+}
+
+function timestampToMs(value: unknown): number | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function applyGlobalStateWallClockDurations(
+  entries: GlobalStateTurnEntry[],
+  turnStats: TurnStat[],
+): { turnStats: TurnStat[]; totalDurationMs?: number; usedWallClock: boolean } {
+  if (entries.length === 0 || turnStats.length === 0) {
+    return { turnStats, usedWallClock: false };
+  }
+
+  const durationsByTurn = new Map<number, number>();
+  let currentTurnIndex = -1;
+  let currentUserAt: number | undefined;
+  let currentAssistantAt: number | undefined;
+
+  const finalizeTurn = () => {
+    if (
+      currentTurnIndex >= 0 &&
+      currentUserAt !== undefined &&
+      currentAssistantAt !== undefined &&
+      currentAssistantAt > currentUserAt
+    ) {
+      durationsByTurn.set(currentTurnIndex, currentAssistantAt - currentUserAt);
+    }
+  };
+
+  for (const entry of entries) {
+    const bubbleTimestamp =
+      timestampToMs(entry.turn.timestamp) ||
+      timestampToMs(entry.bubble.createdAt) ||
+      timestampToMs(entry.bubble.lastUpdatedAt);
+    if (entry.turn.role === "user") {
+      finalizeTurn();
+      currentTurnIndex++;
+      currentUserAt = bubbleTimestamp;
+      currentAssistantAt = undefined;
+      continue;
+    }
+    if (currentTurnIndex < 0 || bubbleTimestamp === undefined) continue;
+    if (currentAssistantAt === undefined || bubbleTimestamp > currentAssistantAt) {
+      currentAssistantAt = bubbleTimestamp;
+    }
+  }
+  finalizeTurn();
+
+  if (durationsByTurn.size === 0) {
+    return {
+      turnStats,
+      totalDurationMs:
+        turnStats.reduce((sum, stat) => sum + (stat.durationMs || 0), 0) || undefined,
+      usedWallClock: false,
+    };
+  }
+
+  const mergedTurnStats = turnStats.map((stat) => {
+    const wallClockDuration = durationsByTurn.get(stat.turnIndex);
+    return wallClockDuration !== undefined ? { ...stat, durationMs: wallClockDuration } : stat;
+  });
+
+  return {
+    turnStats: mergedTurnStats,
+    totalDurationMs:
+      mergedTurnStats.reduce((sum, stat) => sum + (stat.durationMs || 0), 0) || undefined,
+    usedWallClock: true,
+  };
 }
 
 function buildGlobalStateMetrics(
@@ -1746,10 +1832,10 @@ function buildGlobalStateMetrics(
     }
   }
 
-  const totalDurationMs =
-    turnStats.length > 0
-      ? turnStats.reduce((sum, stat) => sum + (stat.durationMs || 0), 0) || undefined
-      : undefined;
+  const { turnStats: durationTurnStats, totalDurationMs } = applyGlobalStateWallClockDurations(
+    entries,
+    turnStats,
+  );
 
   const totalTokens =
     sessionTokenUsage && hasAnyTokens(sessionTokenUsage) ? sessionTokenUsage : totals;
@@ -1757,7 +1843,7 @@ function buildGlobalStateMetrics(
   return {
     ...(hasAnyTokens(totalTokens) ? { tokenUsage: totalTokens } : {}),
     ...(Object.keys(byModel).length > 0 ? { tokenUsageByModel: byModel } : {}),
-    ...(turnStats.length > 0 ? { turnStats } : {}),
+    ...(durationTurnStats.length > 0 ? { turnStats: durationTurnStats } : {}),
     ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
   };
 }
@@ -1882,7 +1968,9 @@ async function parseCursorGlobalStateDb(
       notes.push("Token usage is estimated from Cursor token snapshots.");
     }
     if (metrics.totalDurationMs !== undefined) {
-      notes.push("Duration is estimated from Cursor thinking and tool execution timing.");
+      notes.push(
+        "Per-turn duration is inferred from Cursor bubble timestamps (user prompt to final assistant bubble).",
+      );
     } else {
       notes.push("Duration is unavailable for this Cursor global-state session.");
     }
@@ -2462,6 +2550,7 @@ function extractModel(msg: CursorMessage): string | undefined {
 }
 
 export const __testables = {
+  applyGlobalStateWallClockDurations,
   buildGlobalStateMetrics,
   buildStoreTurnStats,
   createRetryableInit,

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1768,6 +1768,7 @@ function buildGlobalStateMetrics(
   tokenUsageByModel?: Record<string, TokenUsage>;
   turnStats?: TurnStat[];
   totalDurationMs?: number;
+  usedWallClock?: boolean;
 } {
   if (entries.length === 0) return {};
 
@@ -1832,10 +1833,11 @@ function buildGlobalStateMetrics(
     }
   }
 
-  const { turnStats: durationTurnStats, totalDurationMs } = applyGlobalStateWallClockDurations(
-    entries,
-    turnStats,
-  );
+  const {
+    turnStats: durationTurnStats,
+    totalDurationMs,
+    usedWallClock,
+  } = applyGlobalStateWallClockDurations(entries, turnStats);
 
   const totalTokens =
     sessionTokenUsage && hasAnyTokens(sessionTokenUsage) ? sessionTokenUsage : totals;
@@ -1845,6 +1847,7 @@ function buildGlobalStateMetrics(
     ...(Object.keys(byModel).length > 0 ? { tokenUsageByModel: byModel } : {}),
     ...(durationTurnStats.length > 0 ? { turnStats: durationTurnStats } : {}),
     ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
+    ...(totalDurationMs !== undefined ? { usedWallClock } : {}),
   };
 }
 
@@ -1969,7 +1972,9 @@ async function parseCursorGlobalStateDb(
     }
     if (metrics.totalDurationMs !== undefined) {
       notes.push(
-        "Per-turn duration is inferred from Cursor bubble timestamps (user prompt to final assistant bubble).",
+        metrics.usedWallClock
+          ? "Per-turn duration is inferred from Cursor bubble timestamps (user prompt to final assistant bubble)."
+          : "Duration is estimated from Cursor thinking and tool execution timing.",
       );
     } else {
       notes.push("Duration is unavailable for this Cursor global-state session.");

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -145,8 +145,8 @@ export function transformToReplay(
     costEstimate = estimateCostSimple(parsed.tokenUsage, parsed.model || "");
   }
 
-  // Duration: parser now provides totalDurationMs from turn_duration events
-  // or active-duration estimation — no wall-clock fallback needed.
+  // Duration comes from provider-specific parsing. For Cursor this can be
+  // prompt-to-turn-end wall time inferred from local bubble timestamps.
   const durationMs =
     parsed.totalDurationMs && parsed.totalDurationMs > 0 ? parsed.totalDurationMs : undefined;
 


### PR DESCRIPTION
## Summary
- derive Cursor turn durations from local bubble timestamps so insights reflect prompt-to-turn-end wall time instead of only active thinking or tool runtime
- prefer global-state timing metadata when it enriches store-backed Cursor sessions, and keep the duration note accurate when wall-clock timestamps are unavailable
- add parser coverage for both the wall-clock path and the fallback estimation path for Cursor global-state sessions

## Test plan
- [x] `pnpm --filter vibe-replay test -- src/providers/cursor/sqlite-reader.test.ts`
- [x] `pnpm --filter vibe-replay build`
- [x] `pnpm lint:check`
- [x] re-scan local Cursor data in a fresh dashboard instance and verify the updated turn duration distribution shifts from active-time to wall-clock timing