### PR TITLE
fix: correct marketplace.json schema for plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "description": "Turn AI coding sessions into animated, interactive web replays",
   "owner": {
     "name": "Tuo Lei",
-    "email": "github@tuo-lei"
+    "email": "hi@vibe-replay.com"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "description": "Turn AI coding sessions into animated, interactive web replays",
   "owner": {
     "name": "Tuo Lei",
-    "url": "https://github.com/tuo-lei"
+    "email": "github@tuo-lei"
   },
   "plugins": [
     {
@@ -12,10 +12,9 @@
       "description": "Generate interactive HTML replays and GitHub PR artifacts from AI coding sessions",
       "version": "1.0.0",
       "author": {
-        "name": "Tuo Lei",
-        "url": "https://github.com/tuo-lei"
+        "name": "Tuo Lei"
       },
-      "source": ".",
+      "source": "./",
       "category": "productivity",
       "homepage": "https://vibe-replay.com",
       "tags": ["replay", "session-recording", "visualization", "sharing"]


### PR DESCRIPTION
## Summary

- Fix `source` field: `"."` → `"./"` (matches playwright-skill and official marketplaces)
- Fix `owner` field: `url` → `email` (required by schema)
- Remove `url` from `author` (not in schema)

Tested against working marketplaces: `lackeyjb/playwright-skill`, `anthropics/claude-plugins-official`, `anthropics/claude-code`.

## Test plan

- [ ] `/plugin marketplace add tuo-lei/vibe-replay` succeeds without schema error
- [ ] `/plugin install vibe-replay@vibe-replay` installs the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)