### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump CLI version to 0.1.6 for release

## Test plan
- [x] `pnpm build` passes
- [x] `node packages/cli/dist/index.js --version` outputs `0.1.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)