### PR TITLE
docs(readme): add plugin teaser line at the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Turn Claude Code and Cursor sessions into shareable, interactive replays.
 npx vibe-replay
 ```
 
+> Also available as a [Claude Code plugin](#claude-code-plugin) — your agent generates replays automatically during PR creation.
+
 > **[Watch a live demo &rarr;](https://vibe-replay.com/view/?gist=c40137e4c224dc883fe2eaa668e2d8ba)**
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Add a one-liner below the install command linking to the Claude Code Plugin section
- Helps visitors immediately see that vibe-replay is also a plugin

## Test plan

- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)