### PR TITLE
feat(viewer): add context window fill visualization and enhanced analytics

### DIFF
--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -98,14 +98,15 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
 
 /**
  * Resolve context window limit for a model ID string.
- * Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
+ * This returns the default context limit for the runtime environment (e.g. Claude Code
+ * uses 200K even for models that support up to 1M via the API).
  * Returns undefined if model is unknown.
  */
 export function getModelContextLimit(model: string): number | undefined {
   const lower = model.toLowerCase();
-  // Opus 4.6 and Sonnet 4.6: 1M context window
-  if (lower.includes("opus-4-6") || lower.includes("sonnet-4-6")) return 1_000_000;
-  // All other Claude models (Opus 4.5/4.1/4, Sonnet 4.5/4/3.x, Haiku): 200K
+  // Claude Code uses 200K context windows for all Claude models.
+  // The model capability may be higher (e.g. Opus 4.6 supports 1M via the API),
+  // but in practice sessions compact around 200K.
   if (lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) {
     return 200_000;
   }

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -96,17 +96,18 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   deepseek: 128_000,
 };
 
+// Known context window tiers (sorted ascending) for snapping inferred limits.
+const CONTEXT_TIERS = [8_192, 128_000, 200_000, 1_000_000];
+
 /**
- * Resolve context window limit for a model ID string.
- * This returns the default context limit for the runtime environment (e.g. Claude Code
- * uses 200K even for models that support up to 1M via the API).
- * Returns undefined if model is unknown.
+ * Resolve the model's maximum context window capability.
+ * Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
  */
 export function getModelContextLimit(model: string): number | undefined {
   const lower = model.toLowerCase();
-  // Claude Code uses 200K context windows for all Claude models.
-  // The model capability may be higher (e.g. Opus 4.6 supports 1M via the API),
-  // but in practice sessions compact around 200K.
+  // Opus 4.6, Sonnet 4.6: 1M
+  if (lower.includes("opus-4-6") || lower.includes("sonnet-4-6")) return 1_000_000;
+  // All other Claude models: 200K
   if (lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) {
     return 200_000;
   }
@@ -114,6 +115,27 @@ export function getModelContextLimit(model: string): number | undefined {
     if (lower.includes(key)) return limit;
   }
   return undefined;
+}
+
+/**
+ * Infer the effective context limit from session data.
+ * If compaction data exists, the preTokens value reveals the actual limit
+ * (e.g. compacting at ~170K means the limit is 200K, not the model's max of 1M).
+ * Falls back to the model's maximum capability.
+ */
+export function inferContextLimit(
+  model: string,
+  compactions?: Array<{ preTokens?: number }>,
+): number | undefined {
+  const modelMax = getModelContextLimit(model);
+  if (!compactions?.length || !modelMax) return modelMax;
+  // Find the highest preTokens — snap to the nearest known tier above it
+  const maxPre = Math.max(...compactions.map((c) => c.preTokens || 0));
+  if (maxPre <= 0) return modelMax;
+  for (const tier of CONTEXT_TIERS) {
+    if (maxPre < tier) return tier;
+  }
+  return modelMax;
 }
 
 /** Calculate cost in USD for a single token usage bucket at a given pricing. */

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -98,12 +98,15 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
 
 /**
  * Resolve context window limit for a model ID string.
+ * Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
  * Returns undefined if model is unknown.
  */
 export function getModelContextLimit(model: string): number | undefined {
   const lower = model.toLowerCase();
+  // Opus 4.6 and Sonnet 4.6: 1M context window
+  if (lower.includes("opus-4-6") || lower.includes("sonnet-4-6")) return 1_000_000;
+  // All other Claude models (Opus 4.5/4.1/4, Sonnet 4.5/4/3.x, Haiku): 200K
   if (lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) {
-    // All Claude models: 200K
     return 200_000;
   }
   for (const [key, limit] of Object.entries(MODEL_CONTEXT_LIMITS)) {

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -96,18 +96,14 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   deepseek: 128_000,
 };
 
-// Known context window tiers (sorted ascending) for snapping inferred limits.
-const CONTEXT_TIERS = [8_192, 128_000, 200_000, 1_000_000];
-
 /**
- * Resolve the model's maximum context window capability.
- * Source: https://docs.anthropic.com/en/docs/about-claude/models/overview
+ * Resolve context window limit for a model ID string.
+ * Returns 200K for all Claude models as a baseline. The viewer dynamically
+ * switches to 1M if any turn's token usage exceeds 200K.
+ * Returns undefined if model is unknown.
  */
 export function getModelContextLimit(model: string): number | undefined {
   const lower = model.toLowerCase();
-  // Opus 4.6, Sonnet 4.6: 1M
-  if (lower.includes("opus-4-6") || lower.includes("sonnet-4-6")) return 1_000_000;
-  // All other Claude models: 200K
   if (lower.includes("opus") || lower.includes("sonnet") || lower.includes("haiku")) {
     return 200_000;
   }
@@ -115,27 +111,6 @@ export function getModelContextLimit(model: string): number | undefined {
     if (lower.includes(key)) return limit;
   }
   return undefined;
-}
-
-/**
- * Infer the effective context limit from session data.
- * If compaction data exists, the preTokens value reveals the actual limit
- * (e.g. compacting at ~170K means the limit is 200K, not the model's max of 1M).
- * Falls back to the model's maximum capability.
- */
-export function inferContextLimit(
-  model: string,
-  compactions?: Array<{ preTokens?: number }>,
-): number | undefined {
-  const modelMax = getModelContextLimit(model);
-  if (!compactions?.length || !modelMax) return modelMax;
-  // Find the highest preTokens — snap to the nearest known tier above it
-  const maxPre = Math.max(...compactions.map((c) => c.preTokens || 0));
-  if (maxPre <= 0) return modelMax;
-  for (const tier of CONTEXT_TIERS) {
-    if (maxPre < tier) return tier;
-  }
-  return modelMax;
 }
 
 /** Calculate cost in USD for a single token usage bucket at a given pricing. */

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { estimateCost, estimateCostSimple, inferContextLimit } from "./pricing.js";
+import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type {
   ContentBlock,
@@ -174,9 +174,7 @@ export function transformToReplay(
         costEstimate,
         ...(parsed.turnStats ? { turnStats: parsed.turnStats } : {}),
       },
-      ...(parsed.model
-        ? { contextLimit: inferContextLimit(parsed.model, parsed.compactions) }
-        : {}),
+      ...(parsed.model ? { contextLimit: getModelContextLimit(parsed.model) } : {}),
       ...(parsed.tokenUsageByModel ? { tokenUsageByModel: parsed.tokenUsageByModel } : {}),
       ...(parsed.prLinks && parsed.prLinks.length > 0 ? { prLinks: parsed.prLinks } : {}),
       compactions: parsed.compactions,

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
+import { estimateCost, estimateCostSimple, inferContextLimit } from "./pricing.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type {
   ContentBlock,
@@ -174,7 +174,9 @@ export function transformToReplay(
         costEstimate,
         ...(parsed.turnStats ? { turnStats: parsed.turnStats } : {}),
       },
-      ...(parsed.model ? { contextLimit: getModelContextLimit(parsed.model) } : {}),
+      ...(parsed.model
+        ? { contextLimit: inferContextLimit(parsed.model, parsed.compactions) }
+        : {}),
       ...(parsed.tokenUsageByModel ? { tokenUsageByModel: parsed.tokenUsageByModel } : {}),
       ...(parsed.prLinks && parsed.prLinks.length > 0 ? { prLinks: parsed.prLinks } : {}),
       compactions: parsed.compactions,

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -22,7 +22,6 @@ interface Props {
   state?: string;
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
-  contextLimit?: number;
 }
 
 interface TurnGroup {
@@ -64,7 +63,6 @@ export default function ConversationView({
   state,
   overlayActions,
   turnStats,
-  contextLimit,
 }: Props & { onSeek?: (index: number) => void }) {
   // Pre-compute ALL groups once — stable across playback ticks
   const allGroups = useMemo(() => {
@@ -174,7 +172,6 @@ export default function ConversationView({
             onComment={onComment}
             overlayActions={overlayActions}
             turnStats={turnStats}
-            contextLimit={contextLimit}
           />
         </LazyGroup>
       ))}
@@ -349,7 +346,6 @@ const GroupCard = memo(function GroupCard({
   onComment,
   overlayActions,
   turnStats,
-  contextLimit,
 }: {
   group: TurnGroup;
   currentIndex: number;
@@ -361,7 +357,6 @@ const GroupCard = memo(function GroupCard({
   onComment?: (sceneIndex: number) => void;
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
-  contextLimit?: number;
 }) {
   const [hovered, setHovered] = useState(false);
 

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -31,10 +31,6 @@ interface TurnGroup {
   turnNumber?: number;
 }
 
-function fmtTokens(n: number): string {
-  return `${fmtNum(n)} tokens`;
-}
-
 function formatTime(iso?: string): string {
   if (!iso) return "";
   try {
@@ -592,9 +588,9 @@ const GroupCard = memo(function GroupCard({
           )}
           {compactionTokens && (
             <span className="text-[10px] font-mono text-terminal-green">
-              {fmtTokens(compactionTokens.before)} → {fmtTokens(compactionTokens.after)}
+              {fmtNum(compactionTokens.before)} → {fmtNum(compactionTokens.after)}
               <span className="text-terminal-green/70 ml-1">
-                (-{fmtTokens(compactionTokens.freed)})
+                (-{fmtNum(compactionTokens.freed)} freed)
               </span>
             </span>
           )}

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -461,13 +461,13 @@ const GroupCard = memo(function GroupCard({
           const pct = Math.min((ts.contextTokens / effectiveLimit) * 100, 100);
           return (
             <div className="mb-2 flex items-center gap-2">
-              <div className="flex-1 h-1 rounded-full bg-terminal-surface overflow-hidden">
+              <div className="flex-1 h-2 rounded-full bg-terminal-surface overflow-hidden">
                 <div
-                  className="h-full rounded-full bg-terminal-cyan transition-all duration-300"
+                  className="h-full rounded-full bg-terminal-green transition-all duration-300"
                   style={{ width: `${pct}%` }}
                 />
               </div>
-              <span className="text-[9px] font-mono tabular-nums text-terminal-dimmer">
+              <span className="text-[9px] font-mono tabular-nums text-terminal-dim">
                 {fmtNum(ts.contextTokens)}
               </span>
             </div>

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -465,7 +465,7 @@ const GroupCard = memo(function GroupCard({
               <span
                 className={`text-[9px] font-mono tabular-nums ${pct >= 90 ? "text-terminal-red" : pct >= 70 ? "text-terminal-orange" : "text-terminal-dimmer"}`}
               >
-                {Math.round(pct)}%
+                {fmtNum(ts.contextTokens)} ({Math.round(pct)}%)
               </span>
             </div>
           );

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -4,7 +4,7 @@ import type { EffectivePrefs } from "../hooks/useViewPrefs";
 import type { Scene, TurnStat } from "../types";
 import { displayToolName } from "../utils/toolName";
 import CompactionSummaryBlock from "./CompactionSummaryBlock";
-import { formatDuration } from "./StatsPanel";
+import { fmtNum, formatDuration } from "./StatsPanel";
 import TextResponseBlock from "./TextResponseBlock";
 import ThinkingBlock from "./ThinkingBlock";
 import ToolCallBlock from "./ToolCallBlock";
@@ -22,6 +22,7 @@ interface Props {
   state?: string;
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
+  contextLimit?: number;
 }
 
 interface TurnGroup {
@@ -29,6 +30,10 @@ interface TurnGroup {
   timestamp?: string;
   scenes: { scene: Scene; index: number }[];
   turnNumber?: number;
+}
+
+function fmtTokens(n: number): string {
+  return `${fmtNum(n)} tokens`;
 }
 
 function formatTime(iso?: string): string {
@@ -59,6 +64,7 @@ export default function ConversationView({
   state,
   overlayActions,
   turnStats,
+  contextLimit,
 }: Props & { onSeek?: (index: number) => void }) {
   // Pre-compute ALL groups once — stable across playback ticks
   const allGroups = useMemo(() => {
@@ -168,6 +174,7 @@ export default function ConversationView({
             onComment={onComment}
             overlayActions={overlayActions}
             turnStats={turnStats}
+            contextLimit={contextLimit}
           />
         </LazyGroup>
       ))}
@@ -342,6 +349,7 @@ const GroupCard = memo(function GroupCard({
   onComment,
   overlayActions,
   turnStats,
+  contextLimit,
 }: {
   group: TurnGroup;
   currentIndex: number;
@@ -353,6 +361,7 @@ const GroupCard = memo(function GroupCard({
   onComment?: (sceneIndex: number) => void;
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
+  contextLimit?: number;
 }) {
   const [hovered, setHovered] = useState(false);
 
@@ -437,6 +446,30 @@ const GroupCard = memo(function GroupCard({
             </span>
           )}
         </div>
+        {/* Context fill indicator */}
+        {(() => {
+          if (!contextLimit || !turnStats || group.turnNumber === undefined) return null;
+          const ts = turnStats[group.turnNumber - 1];
+          if (!ts?.contextTokens) return null;
+          const pct = Math.min((ts.contextTokens / contextLimit) * 100, 100);
+          const color =
+            pct >= 90 ? "bg-terminal-red" : pct >= 70 ? "bg-terminal-orange" : "bg-terminal-cyan";
+          return (
+            <div className="mb-2 flex items-center gap-2">
+              <div className="flex-1 h-1 rounded-full bg-terminal-surface overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${color} transition-all duration-300`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span
+                className={`text-[9px] font-mono tabular-nums ${pct >= 90 ? "text-terminal-red" : pct >= 70 ? "text-terminal-orange" : "text-terminal-dimmer"}`}
+              >
+                {Math.round(pct)}%
+              </span>
+            </div>
+          );
+        })()}
         <div className="text-left">
           {visibleScenes.map(({ scene, index }) => {
             const sceneOverlays = overlayActions?.getOverlays(index) ?? [];
@@ -489,6 +522,21 @@ const GroupCard = memo(function GroupCard({
   if (group.type === "compaction") {
     const scene = visibleScenes[0]?.scene;
     if (!scene || scene.type !== "compaction-summary") return null;
+
+    // Find compaction token impact from turnStats (context drop > 50%)
+    const compactionTokens = (() => {
+      if (!turnStats || turnStats.length < 2) return undefined;
+      // Find the turn pair where context dropped significantly around this scene
+      for (let i = 0; i < turnStats.length - 1; i++) {
+        const cur = turnStats[i]?.contextTokens || 0;
+        const next = turnStats[i + 1]?.contextTokens || 0;
+        if (cur > 0 && next > 0 && next < cur * 0.5) {
+          return { before: cur, after: next, freed: cur - next };
+        }
+      }
+      return undefined;
+    })();
+
     return (
       <div
         id={`scene-${firstIndex}`}
@@ -508,6 +556,14 @@ const GroupCard = memo(function GroupCard({
           {group.timestamp && (
             <span className="text-xs font-mono text-terminal-dimmer">
               {formatTime(group.timestamp)}
+            </span>
+          )}
+          {compactionTokens && (
+            <span className="text-[10px] font-mono text-terminal-green">
+              {fmtTokens(compactionTokens.before)} → {fmtTokens(compactionTokens.after)}
+              <span className="text-terminal-green/70 ml-1">
+                (-{fmtTokens(compactionTokens.freed)})
+              </span>
             </span>
           )}
         </div>

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -446,26 +446,29 @@ const GroupCard = memo(function GroupCard({
             </span>
           )}
         </div>
-        {/* Context fill indicator */}
+        {/* Context token indicator */}
         {(() => {
-          if (!contextLimit || !turnStats || group.turnNumber === undefined) return null;
+          if (!turnStats || group.turnNumber === undefined) return null;
           const ts = turnStats[group.turnNumber - 1];
           if (!ts?.contextTokens) return null;
-          const pct = Math.min((ts.contextTokens / contextLimit) * 100, 100);
-          const color =
-            pct >= 90 ? "bg-terminal-red" : pct >= 70 ? "bg-terminal-orange" : "bg-terminal-cyan";
+          // Default 200K, auto-switch to 1M if any turn exceeds 200K
+          const effectiveLimit =
+            contextLimit && contextLimit > 200_000
+              ? contextLimit
+              : ts.contextTokens > 200_000
+                ? 1_000_000
+                : 200_000;
+          const pct = Math.min((ts.contextTokens / effectiveLimit) * 100, 100);
           return (
             <div className="mb-2 flex items-center gap-2">
               <div className="flex-1 h-1 rounded-full bg-terminal-surface overflow-hidden">
                 <div
-                  className={`h-full rounded-full ${color} transition-all duration-300`}
+                  className="h-full rounded-full bg-terminal-cyan transition-all duration-300"
                   style={{ width: `${pct}%` }}
                 />
               </div>
-              <span
-                className={`text-[9px] font-mono tabular-nums ${pct >= 90 ? "text-terminal-red" : pct >= 70 ? "text-terminal-orange" : "text-terminal-dimmer"}`}
-              >
-                {fmtNum(ts.contextTokens)} ({Math.round(pct)}%)
+              <span className="text-[9px] font-mono tabular-nums text-terminal-dimmer">
+                {fmtNum(ts.contextTokens)}
               </span>
             </div>
           );

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -523,11 +523,13 @@ const GroupCard = memo(function GroupCard({
     const scene = visibleScenes[0]?.scene;
     if (!scene || scene.type !== "compaction-summary") return null;
 
-    // Find compaction token impact from turnStats (context drop > 50%)
+    // Find compaction token impact from turnStats (context drop > 50%) near this group's position
     const compactionTokens = (() => {
-      if (!turnStats || turnStats.length < 2) return undefined;
-      // Find the turn pair where context dropped significantly around this scene
-      for (let i = 0; i < turnStats.length - 1; i++) {
+      if (!turnStats || turnStats.length < 2 || group.turnNumber === undefined) return undefined;
+      const center = group.turnNumber - 1;
+      const start = Math.max(0, center - 2);
+      const end = Math.min(turnStats.length - 1, center + 2);
+      for (let i = start; i < end; i++) {
         const cur = turnStats[i]?.contextTokens || 0;
         const next = turnStats[i + 1]?.contextTokens || 0;
         if (cur > 0 && next > 0 && next < cur * 0.5) {

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -365,6 +365,29 @@ const GroupCard = memo(function GroupCard({
 }) {
   const [hovered, setHovered] = useState(false);
 
+  // Infer the effective context ceiling from peak tokens and compaction drops.
+  // If compaction is detected (>50% context drop), the pre-drop peak reveals the limit.
+  // Otherwise default to 200K, or 1M if any turn exceeds 200K.
+  const contextCeiling = useMemo(() => {
+    if (!turnStats?.length) return 200_000;
+    const peak = Math.max(...turnStats.map((t) => t.contextTokens || 0));
+    // Detect compaction: find the highest context value right before a >50% drop
+    let compactionPeak = 0;
+    for (let i = 0; i < turnStats.length - 1; i++) {
+      const cur = turnStats[i]?.contextTokens || 0;
+      const next = turnStats[i + 1]?.contextTokens || 0;
+      if (cur > 0 && next > 0 && next < cur * 0.5 && cur > compactionPeak) {
+        compactionPeak = cur;
+      }
+    }
+    if (compactionPeak > 0) {
+      // Compaction at ~170K → ceiling ~200K; at ~850K → ceiling ~1M
+      return compactionPeak > 200_000 ? 1_000_000 : 200_000;
+    }
+    // No compaction: if peak > 200K, must be 1M window
+    return peak > 200_000 ? 1_000_000 : 200_000;
+  }, [turnStats]);
+
   // Only include scenes that are visible so far
   const visibleScenes = useMemo(
     () => group.scenes.filter((s) => s.index < visibleCount),
@@ -447,32 +470,41 @@ const GroupCard = memo(function GroupCard({
           )}
         </div>
         {/* Context token indicator */}
-        {(() => {
-          if (!turnStats || group.turnNumber === undefined) return null;
-          const ts = turnStats[group.turnNumber - 1];
-          if (!ts?.contextTokens) return null;
-          // Default 200K, auto-switch to 1M if any turn exceeds 200K
-          const effectiveLimit =
-            contextLimit && contextLimit > 200_000
-              ? contextLimit
-              : ts.contextTokens > 200_000
-                ? 1_000_000
-                : 200_000;
-          const pct = Math.min((ts.contextTokens / effectiveLimit) * 100, 100);
-          return (
-            <div className="mb-2 flex items-center gap-2">
-              <div className="flex-1 h-2 rounded-full bg-terminal-surface overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-terminal-green transition-all duration-300"
-                  style={{ width: `${pct}%` }}
-                />
+        {group.turnNumber !== undefined &&
+          turnStats &&
+          (() => {
+            const ts = turnStats[group.turnNumber! - 1];
+            if (!ts?.contextTokens) return null;
+            const pct = Math.min((ts.contextTokens / contextCeiling) * 100, 100);
+            const ratio = ts.contextTokens / contextCeiling;
+            const barColor =
+              ratio >= 0.85
+                ? "bg-terminal-red"
+                : ratio >= 0.7
+                  ? "bg-terminal-orange"
+                  : ratio >= 0.5
+                    ? "bg-yellow-400"
+                    : "bg-terminal-green";
+            const textColor =
+              ratio >= 0.85
+                ? "text-terminal-red"
+                : ratio >= 0.7
+                  ? "text-terminal-orange"
+                  : "text-terminal-dim";
+            return (
+              <div className="mb-2 flex items-center gap-2">
+                <div className="flex-1 h-2 rounded-full bg-terminal-surface overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${barColor} transition-all duration-300`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className={`text-[9px] font-mono tabular-nums ${textColor}`}>
+                  {fmtNum(ts.contextTokens)}
+                </span>
               </div>
-              <span className="text-[9px] font-mono tabular-nums text-terminal-dim">
-                {fmtNum(ts.contextTokens)}
-              </span>
-            </div>
-          );
-        })()}
+            );
+          })()}
         <div className="text-left">
           {visibleScenes.map(({ scene, index }) => {
             const sceneOverlays = overlayActions?.getOverlays(index) ?? [];

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -739,7 +739,7 @@ export default function Player({
                                 </span>
                               </div>
                               <div className="text-[9px] text-terminal-dimmer mt-0.5">
-                                peak context
+                                peak {fmtNum(peak)} / {fmtNum(meta.contextLimit)}
                               </div>
                             </div>
                           );

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -704,6 +704,46 @@ export default function Player({
                             {fmtNum(meta.stats.tokenUsage.outputTokens)} out
                           </div>
                         )}
+                        {(() => {
+                          if (!meta.contextLimit || !meta.stats.turnStats?.length) return null;
+                          const peak = Math.max(
+                            ...meta.stats.turnStats.map((t) => t.contextTokens || 0),
+                          );
+                          if (peak <= 0) return null;
+                          const pct = Math.round((peak / meta.contextLimit) * 100);
+                          const color =
+                            pct >= 90
+                              ? "bg-terminal-red"
+                              : pct >= 70
+                                ? "bg-terminal-orange"
+                                : "bg-terminal-cyan";
+                          const textColor =
+                            pct >= 90
+                              ? "text-terminal-red"
+                              : pct >= 70
+                                ? "text-terminal-orange"
+                                : "text-terminal-cyan";
+                          return (
+                            <div className="mt-1">
+                              <div className="flex items-center gap-1.5">
+                                <div className="flex-1 h-1.5 rounded-full bg-terminal-surface overflow-hidden">
+                                  <div
+                                    className={`h-full rounded-full ${color}`}
+                                    style={{ width: `${Math.min(pct, 100)}%` }}
+                                  />
+                                </div>
+                                <span
+                                  className={`text-[10px] font-mono font-bold tabular-nums ${textColor}`}
+                                >
+                                  {pct}%
+                                </span>
+                              </div>
+                              <div className="text-[9px] text-terminal-dimmer mt-0.5">
+                                peak context
+                              </div>
+                            </div>
+                          );
+                        })()}
                       </div>
                     </div>
                   </div>

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -705,42 +705,14 @@ export default function Player({
                           </div>
                         )}
                         {(() => {
-                          if (!meta.contextLimit || !meta.stats.turnStats?.length) return null;
+                          if (!meta.stats.turnStats?.length) return null;
                           const peak = Math.max(
                             ...meta.stats.turnStats.map((t) => t.contextTokens || 0),
                           );
                           if (peak <= 0) return null;
-                          const pct = Math.round((peak / meta.contextLimit) * 100);
-                          const color =
-                            pct >= 90
-                              ? "bg-terminal-red"
-                              : pct >= 70
-                                ? "bg-terminal-orange"
-                                : "bg-terminal-cyan";
-                          const textColor =
-                            pct >= 90
-                              ? "text-terminal-red"
-                              : pct >= 70
-                                ? "text-terminal-orange"
-                                : "text-terminal-cyan";
                           return (
-                            <div className="mt-1">
-                              <div className="flex items-center gap-1.5">
-                                <div className="flex-1 h-1.5 rounded-full bg-terminal-surface overflow-hidden">
-                                  <div
-                                    className={`h-full rounded-full ${color}`}
-                                    style={{ width: `${Math.min(pct, 100)}%` }}
-                                  />
-                                </div>
-                                <span
-                                  className={`text-[10px] font-mono font-bold tabular-nums ${textColor}`}
-                                >
-                                  {pct}%
-                                </span>
-                              </div>
-                              <div className="text-[9px] text-terminal-dimmer mt-0.5">
-                                peak {fmtNum(peak)} / {fmtNum(meta.contextLimit)}
-                              </div>
+                            <div className="text-terminal-dim mt-0.5">
+                              peak ctx: <span className="text-terminal-cyan">{fmtNum(peak)}</span>
                             </div>
                           );
                         })()}

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -750,6 +750,7 @@ export default function Player({
                     state={state}
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
+                    contextLimit={session.meta.contextLimit}
                     onComment={
                       isReadOnly
                         ? undefined

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -762,7 +762,6 @@ export default function Player({
                     state={state}
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
-                    contextLimit={session.meta.contextLimit}
                     onComment={
                       isReadOnly
                         ? undefined

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -74,6 +74,11 @@ export default function StatsPanel({ session }: Props) {
       tokenUsage: meta.stats.tokenUsage,
       costEstimate: meta.stats.costEstimate,
       compactions: meta.compactions,
+      peakContextPct: (() => {
+        if (!meta.contextLimit || !meta.stats.turnStats?.length) return undefined;
+        const peak = Math.max(...meta.stats.turnStats.map((t) => t.contextTokens || 0));
+        return peak > 0 ? Math.round((peak / meta.contextLimit) * 100) : undefined;
+      })(),
       medianTurnDurationMs: (() => {
         const durations = meta.stats.turnStats
           ?.map((t) => t.durationMs)
@@ -239,6 +244,29 @@ export default function StatsPanel({ session }: Props) {
         </div>
       )}
 
+      {/* Context window fill */}
+      {stats.peakContextPct !== undefined && (
+        <div>
+          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
+            Context Window
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex-1 h-2 rounded-full bg-terminal-surface overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${stats.peakContextPct >= 90 ? "bg-terminal-red" : stats.peakContextPct >= 70 ? "bg-terminal-orange" : "bg-terminal-cyan"}`}
+                style={{ width: `${Math.min(stats.peakContextPct, 100)}%` }}
+              />
+            </div>
+            <span
+              className={`text-xs font-mono font-bold tabular-nums ${stats.peakContextPct >= 90 ? "text-terminal-red" : stats.peakContextPct >= 70 ? "text-terminal-orange" : "text-terminal-cyan"}`}
+            >
+              {stats.peakContextPct}%
+            </span>
+          </div>
+          <div className="text-terminal-dimmer text-[10px] mt-0.5">peak fill</div>
+        </div>
+      )}
+
       {/* Efficiency metrics */}
       {stats.medianTurnDurationMs != null && (
         <div className="text-terminal-dim">
@@ -334,11 +362,22 @@ export default function StatsPanel({ session }: Props) {
           </div>
           <div className="space-y-1">
             {stats.compactions.map((c, i) => (
-              <div key={i} className="text-terminal-dim text-xs flex items-baseline gap-1.5">
+              <div
+                key={i}
+                className="text-terminal-dim text-xs flex items-baseline gap-1.5 flex-wrap"
+              >
                 <span className="text-terminal-orange">●</span>
                 <span>{c.trigger}</span>
                 {c.preTokens && (
-                  <span className="text-terminal-text">{fmtNum(c.preTokens)} tokens</span>
+                  <span className="text-terminal-text">
+                    {fmtNum(c.preTokens)} tokens
+                    {meta.contextLimit && (
+                      <span className="text-terminal-dimmer">
+                        {" "}
+                        ({Math.round((c.preTokens / meta.contextLimit) * 100)}% full)
+                      </span>
+                    )}
+                  </span>
                 )}
               </div>
             ))}

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -74,10 +74,10 @@ export default function StatsPanel({ session }: Props) {
       tokenUsage: meta.stats.tokenUsage,
       costEstimate: meta.stats.costEstimate,
       compactions: meta.compactions,
-      peakContextPct: (() => {
-        if (!meta.contextLimit || !meta.stats.turnStats?.length) return undefined;
+      peakContextTokens: (() => {
+        if (!meta.stats.turnStats?.length) return undefined;
         const peak = Math.max(...meta.stats.turnStats.map((t) => t.contextTokens || 0));
-        return peak > 0 ? Math.round((peak / meta.contextLimit) * 100) : undefined;
+        return peak > 0 ? peak : undefined;
       })(),
       medianTurnDurationMs: (() => {
         const durations = meta.stats.turnStats
@@ -244,26 +244,12 @@ export default function StatsPanel({ session }: Props) {
         </div>
       )}
 
-      {/* Context window fill */}
-      {stats.peakContextPct !== undefined && (
-        <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
-            Context Window
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex-1 h-2 rounded-full bg-terminal-surface overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all ${stats.peakContextPct >= 90 ? "bg-terminal-red" : stats.peakContextPct >= 70 ? "bg-terminal-orange" : "bg-terminal-cyan"}`}
-                style={{ width: `${Math.min(stats.peakContextPct, 100)}%` }}
-              />
-            </div>
-            <span
-              className={`text-xs font-mono font-bold tabular-nums ${stats.peakContextPct >= 90 ? "text-terminal-red" : stats.peakContextPct >= 70 ? "text-terminal-orange" : "text-terminal-cyan"}`}
-            >
-              {stats.peakContextPct}%
-            </span>
-          </div>
-          <div className="text-terminal-dimmer text-[10px] mt-0.5">peak fill</div>
+      {/* Peak context */}
+      {stats.peakContextTokens !== undefined && (
+        <div className="text-terminal-dim">
+          Peak context:{" "}
+          <span className="text-terminal-cyan">{fmtNum(stats.peakContextTokens)}</span>
+          <span className="text-terminal-dimmer"> tokens</span>
         </div>
       )}
 
@@ -369,15 +355,7 @@ export default function StatsPanel({ session }: Props) {
                 <span className="text-terminal-orange">●</span>
                 <span>{c.trigger}</span>
                 {c.preTokens && (
-                  <span className="text-terminal-text">
-                    {fmtNum(c.preTokens)} tokens
-                    {meta.contextLimit && (
-                      <span className="text-terminal-dimmer">
-                        {" "}
-                        ({Math.round((c.preTokens / meta.contextLimit) * 100)}% full)
-                      </span>
-                    )}
-                  </span>
+                  <span className="text-terminal-text">{fmtNum(c.preTokens)} tokens</span>
                 )}
               </div>
             ))}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1615,7 +1615,7 @@ function TurnTable({
               {hasDuration && (
                 <th className="px-2 py-1.5 font-semibold text-right w-16">Duration</th>
               )}
-              {hasContext && <th className="px-2 py-1.5 font-semibold text-right w-16">Context</th>}
+              {hasContext && <th className="px-2 py-1.5 font-semibold text-right w-28">Context</th>}
               {hasTokens && <th className="px-2 py-1.5 font-semibold text-right w-14">Output</th>}
             </tr>
           </thead>
@@ -1714,8 +1714,8 @@ function TurnRow({
           <td className="px-2 py-1 text-right tabular-nums">
             <HeatCell
               value={
-                r.contextPct !== undefined
-                  ? `${r.contextPct}%`
+                r.contextPct !== undefined && r.contextTokens
+                  ? `${fmtNum(r.contextTokens)} (${r.contextPct}%)`
                   : r.contextTokens
                     ? fmtNum(r.contextTokens)
                     : "—"

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1721,7 +1721,13 @@ function TurnRow({
                     : "—"
               }
               ratio={r.contextRatio}
-              color={r.contextPct !== undefined && r.contextPct >= 90 ? "--red" : "--cyan"}
+              color={
+                r.contextPct !== undefined && r.contextPct >= 90
+                  ? "--red"
+                  : r.contextPct !== undefined && r.contextPct >= 70
+                    ? "--orange"
+                    : "--cyan"
+              }
             />
           </td>
         )}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -679,11 +679,7 @@ export default function SummaryView({ session }: Props) {
 
         {/* Per-Turn Breakdown Table */}
         {stats.turns.length > 0 && (
-          <TurnTable
-            turns={stats.turns}
-            turnStats={meta.stats.turnStats}
-            contextLimit={meta.contextLimit}
-          />
+          <TurnTable turns={stats.turns} turnStats={meta.stats.turnStats} />
         )}
 
         {/* File Activity Heatmap */}
@@ -1112,9 +1108,10 @@ function ContextWindowChart({
   if (!contextSizes.some((c) => c > 0)) return null;
 
   const peak = Math.max(...contextSizes);
-  // Use contextLimit as the Y-axis max if available (so the chart shows fill %)
-  const max = contextLimit && contextLimit > peak ? contextLimit : peak;
-  const peakPct = contextLimit ? Math.round((peak / contextLimit) * 100) : undefined;
+  // Default 200K limit; auto-switch to 1M if any turn exceeds 200K
+  const effectiveLimit =
+    contextLimit && peak > 200_000 ? Math.max(contextLimit, 1_000_000) : contextLimit;
+  const max = effectiveLimit && effectiveLimit > peak ? effectiveLimit : peak;
   const h = 60;
   const w = 100;
 
@@ -1137,19 +1134,13 @@ function ContextWindowChart({
   const hoveredX = hovered !== null ? (n === 1 ? 0.5 : hovered / (n - 1)) : 0;
 
   // Context limit Y position for the limit line
-  const limitY = contextLimit ? h - (contextLimit / max) * (h - 6) - 3 : undefined;
+  const limitY = effectiveLimit ? h - (effectiveLimit / max) * (h - 6) - 3 : undefined;
 
   return (
     <div>
       <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1 flex items-center gap-2">
         <span>Context Window Usage</span>
-        {peakPct !== undefined && (
-          <span
-            className={`font-mono ${peakPct >= 90 ? "text-terminal-red" : peakPct >= 70 ? "text-terminal-orange" : "text-terminal-cyan"}`}
-          >
-            peak {peakPct}%
-          </span>
-        )}
+        <span className="font-mono text-terminal-cyan">peak {fmtNum(peak)}</span>
       </div>
       <div className="relative">
         <svg
@@ -1228,22 +1219,14 @@ function ContextWindowChart({
                   {turnLabels[hovered]}
                 </div>
               )}
-              <div>
-                {fmtNum(contextSizes[hovered])} tokens
-                {contextLimit && contextSizes[hovered] > 0 && (
-                  <span className="text-terminal-dimmer">
-                    {" "}
-                    ({Math.round((contextSizes[hovered] / contextLimit) * 100)}%)
-                  </span>
-                )}
-              </div>
+              <div>{fmtNum(contextSizes[hovered])} tokens</div>
             </>
           )}
         </ChartTooltip>
       </div>
       <div className="flex justify-between text-[10px] font-mono text-terminal-dimmer mt-0.5">
         <span>Turn 1</span>
-        <span>{contextLimit ? `limit ${fmtNum(contextLimit)}` : `peak ${fmtNum(peak)}`}</span>
+        <span>{effectiveLimit ? `limit ${fmtNum(effectiveLimit)}` : `peak ${fmtNum(peak)}`}</span>
         <span>Turn {n}</span>
       </div>
       {compactionTurns.length > 0 && (
@@ -1536,15 +1519,7 @@ function FileActivityHeatmap({
 
 const TURN_TABLE_COLLAPSE = 20;
 
-function TurnTable({
-  turns,
-  turnStats,
-  contextLimit,
-}: {
-  turns: TurnInfo[];
-  turnStats?: TurnStat[];
-  contextLimit?: number;
-}) {
+function TurnTable({ turns, turnStats }: { turns: TurnInfo[]; turnStats?: TurnStat[] }) {
   const [expanded, setExpanded] = useState(false);
 
   // Merge turn info with turnStats by index
@@ -1571,25 +1546,20 @@ function TurnTable({
 
     const mapped = turns.map((t, i) => {
       const ts = turnStats?.[i];
-      const ctxTokens = ts?.contextTokens || 0;
-      // When contextLimit is available, ratio = fill % of limit; otherwise relative to peak
-      const ctxRatio = contextLimit ? ctxTokens / contextLimit : ctxTokens / maxContext;
       return {
         ...t,
         durationMs: ts?.durationMs,
         contextTokens: ts?.contextTokens,
-        contextPct:
-          contextLimit && ctxTokens > 0 ? Math.round((ctxTokens / contextLimit) * 100) : undefined,
         outputTokens: ts?.tokenUsage?.outputTokens,
         toolRatio: t.toolCount / maxTools,
         durationRatio: (ts?.durationMs || 0) / maxDuration,
-        contextRatio: ctxRatio,
+        contextRatio: (ts?.contextTokens || 0) / maxContext,
         outputRatio: (ts?.tokenUsage?.outputTokens || 0) / maxOutput,
       };
     });
 
     return { rows: mapped, compactionAfter: compSet };
-  }, [turns, turnStats, contextLimit]);
+  }, [turns, turnStats]);
 
   const hasStats = turnStats && turnStats.length > 0;
   const hasDuration = hasStats && turnStats.some((t) => t.durationMs);
@@ -1615,7 +1585,7 @@ function TurnTable({
               {hasDuration && (
                 <th className="px-2 py-1.5 font-semibold text-right w-16">Duration</th>
               )}
-              {hasContext && <th className="px-2 py-1.5 font-semibold text-right w-28">Context</th>}
+              {hasContext && <th className="px-2 py-1.5 font-semibold text-right w-16">Context</th>}
               {hasTokens && <th className="px-2 py-1.5 font-semibold text-right w-14">Output</th>}
             </tr>
           </thead>
@@ -1671,7 +1641,6 @@ function TurnRow({
     errorCount: number;
     durationMs?: number;
     contextTokens?: number;
-    contextPct?: number;
     outputTokens?: number;
     toolRatio: number;
     durationRatio: number;
@@ -1713,21 +1682,9 @@ function TurnRow({
         {hasContext && (
           <td className="px-2 py-1 text-right tabular-nums">
             <HeatCell
-              value={
-                r.contextPct !== undefined && r.contextTokens
-                  ? `${fmtNum(r.contextTokens)} (${r.contextPct}%)`
-                  : r.contextTokens
-                    ? fmtNum(r.contextTokens)
-                    : "—"
-              }
+              value={r.contextTokens ? fmtNum(r.contextTokens) : "—"}
               ratio={r.contextRatio}
-              color={
-                r.contextPct !== undefined && r.contextPct >= 90
-                  ? "--red"
-                  : r.contextPct !== undefined && r.contextPct >= 70
-                    ? "--orange"
-                    : "--cyan"
-              }
+              color="--cyan"
             />
           </td>
         )}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -548,7 +548,11 @@ export default function SummaryView({ session }: Props) {
               costEstimate={meta.stats.costEstimate}
               turnLabels={turnLabels}
             />
-            <ContextWindowChart turnStats={meta.stats.turnStats!} turnLabels={turnLabels} />
+            <ContextWindowChart
+              turnStats={meta.stats.turnStats!}
+              turnLabels={turnLabels}
+              contextLimit={meta.contextLimit}
+            />
             {stats.turns.length >= 2 && (
               <ToolActivityChart turns={stats.turns} turnLabels={turnLabels} />
             )}
@@ -675,7 +679,11 @@ export default function SummaryView({ session }: Props) {
 
         {/* Per-Turn Breakdown Table */}
         {stats.turns.length > 0 && (
-          <TurnTable turns={stats.turns} turnStats={meta.stats.turnStats} />
+          <TurnTable
+            turns={stats.turns}
+            turnStats={meta.stats.turnStats}
+            contextLimit={meta.contextLimit}
+          />
         )}
 
         {/* File Activity Heatmap */}
@@ -715,6 +723,9 @@ export default function SummaryView({ session }: Props) {
           <div>
             <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
               Top Tools
+              <span className="text-terminal-dimmer ml-2 normal-case tracking-normal font-mono">
+                {stats.totalTools} total
+              </span>
             </div>
             <div className="space-y-1.5">
               {stats.topTools.map(([name, count]) => (
@@ -731,8 +742,11 @@ export default function SummaryView({ session }: Props) {
                       style={{ width: `${(count / stats.topTools[0][1]) * 100}%` }}
                     />
                   </div>
-                  <span className="text-terminal-dim shrink-0 w-6 text-right tabular-nums">
-                    {count}
+                  <span className="text-terminal-dim shrink-0 w-16 text-right tabular-nums">
+                    {count}{" "}
+                    <span className="text-terminal-dimmer">
+                      ({Math.round((count / stats.totalTools) * 100)}%)
+                    </span>
                   </span>
                 </div>
               ))}
@@ -1085,9 +1099,11 @@ function CacheEfficiencyLine({ turnStats }: { turnStats: TurnStat[] }) {
 function ContextWindowChart({
   turnStats,
   turnLabels,
+  contextLimit,
 }: {
   turnStats: TurnStat[];
   turnLabels?: string[];
+  contextLimit?: number;
 }) {
   const contextSizes = turnStats.map((t) => t.contextTokens || 0);
   const n = contextSizes.length;
@@ -1096,7 +1112,9 @@ function ContextWindowChart({
   if (!contextSizes.some((c) => c > 0)) return null;
 
   const peak = Math.max(...contextSizes);
-  const max = peak;
+  // Use contextLimit as the Y-axis max if available (so the chart shows fill %)
+  const max = contextLimit && contextLimit > peak ? contextLimit : peak;
+  const peakPct = contextLimit ? Math.round((peak / contextLimit) * 100) : undefined;
   const h = 60;
   const w = 100;
 
@@ -1118,10 +1136,20 @@ function ContextWindowChart({
 
   const hoveredX = hovered !== null ? (n === 1 ? 0.5 : hovered / (n - 1)) : 0;
 
+  // Context limit Y position for the limit line
+  const limitY = contextLimit ? h - (contextLimit / max) * (h - 6) - 3 : undefined;
+
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-        Context Window Usage
+      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1 flex items-center gap-2">
+        <span>Context Window Usage</span>
+        {peakPct !== undefined && (
+          <span
+            className={`font-mono ${peakPct >= 90 ? "text-terminal-red" : peakPct >= 70 ? "text-terminal-orange" : "text-terminal-cyan"}`}
+          >
+            peak {peakPct}%
+          </span>
+        )}
       </div>
       <div className="relative">
         <svg
@@ -1132,6 +1160,20 @@ function ContextWindowChart({
           onMouseMove={onMouseMove}
           onMouseLeave={onMouseLeave}
         >
+          {/* Context limit line (100% mark) */}
+          {limitY !== undefined && (
+            <line
+              x1="0"
+              y1={limitY}
+              x2={w}
+              y2={limitY}
+              style={{ stroke: "var(--dim)" }}
+              strokeWidth="0.5"
+              strokeDasharray="3,2"
+              vectorEffect="non-scaling-stroke"
+              opacity="0.4"
+            />
+          )}
           <polygon
             points={`0,${h} ${points.join(" ")} ${w},${h}`}
             style={{ fill: "var(--cyan-subtle)" }}
@@ -1186,14 +1228,22 @@ function ContextWindowChart({
                   {turnLabels[hovered]}
                 </div>
               )}
-              <div>{fmtNum(contextSizes[hovered])} tokens</div>
+              <div>
+                {fmtNum(contextSizes[hovered])} tokens
+                {contextLimit && contextSizes[hovered] > 0 && (
+                  <span className="text-terminal-dimmer">
+                    {" "}
+                    ({Math.round((contextSizes[hovered] / contextLimit) * 100)}%)
+                  </span>
+                )}
+              </div>
             </>
           )}
         </ChartTooltip>
       </div>
       <div className="flex justify-between text-[10px] font-mono text-terminal-dimmer mt-0.5">
         <span>Turn 1</span>
-        <span>peak {fmtNum(peak)}</span>
+        <span>{contextLimit ? `limit ${fmtNum(contextLimit)}` : `peak ${fmtNum(peak)}`}</span>
         <span>Turn {n}</span>
       </div>
       {compactionTurns.length > 0 && (
@@ -1486,7 +1536,15 @@ function FileActivityHeatmap({
 
 const TURN_TABLE_COLLAPSE = 20;
 
-function TurnTable({ turns, turnStats }: { turns: TurnInfo[]; turnStats?: TurnStat[] }) {
+function TurnTable({
+  turns,
+  turnStats,
+  contextLimit,
+}: {
+  turns: TurnInfo[];
+  turnStats?: TurnStat[];
+  contextLimit?: number;
+}) {
   const [expanded, setExpanded] = useState(false);
 
   // Merge turn info with turnStats by index
@@ -1513,20 +1571,25 @@ function TurnTable({ turns, turnStats }: { turns: TurnInfo[]; turnStats?: TurnSt
 
     const mapped = turns.map((t, i) => {
       const ts = turnStats?.[i];
+      const ctxTokens = ts?.contextTokens || 0;
+      // When contextLimit is available, ratio = fill % of limit; otherwise relative to peak
+      const ctxRatio = contextLimit ? ctxTokens / contextLimit : ctxTokens / maxContext;
       return {
         ...t,
         durationMs: ts?.durationMs,
         contextTokens: ts?.contextTokens,
+        contextPct:
+          contextLimit && ctxTokens > 0 ? Math.round((ctxTokens / contextLimit) * 100) : undefined,
         outputTokens: ts?.tokenUsage?.outputTokens,
         toolRatio: t.toolCount / maxTools,
         durationRatio: (ts?.durationMs || 0) / maxDuration,
-        contextRatio: (ts?.contextTokens || 0) / maxContext,
+        contextRatio: ctxRatio,
         outputRatio: (ts?.tokenUsage?.outputTokens || 0) / maxOutput,
       };
     });
 
     return { rows: mapped, compactionAfter: compSet };
-  }, [turns, turnStats]);
+  }, [turns, turnStats, contextLimit]);
 
   const hasStats = turnStats && turnStats.length > 0;
   const hasDuration = hasStats && turnStats.some((t) => t.durationMs);
@@ -1608,6 +1671,7 @@ function TurnRow({
     errorCount: number;
     durationMs?: number;
     contextTokens?: number;
+    contextPct?: number;
     outputTokens?: number;
     toolRatio: number;
     durationRatio: number;
@@ -1649,9 +1713,15 @@ function TurnRow({
         {hasContext && (
           <td className="px-2 py-1 text-right tabular-nums">
             <HeatCell
-              value={r.contextTokens ? fmtNum(r.contextTokens) : "—"}
+              value={
+                r.contextPct !== undefined
+                  ? `${r.contextPct}%`
+                  : r.contextTokens
+                    ? fmtNum(r.contextTokens)
+                    : "—"
+              }
               ratio={r.contextRatio}
-              color="--cyan"
+              color={r.contextPct !== undefined && r.contextPct >= 90 ? "--red" : "--cyan"}
             />
           </td>
         )}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -548,11 +548,7 @@ export default function SummaryView({ session }: Props) {
               costEstimate={meta.stats.costEstimate}
               turnLabels={turnLabels}
             />
-            <ContextWindowChart
-              turnStats={meta.stats.turnStats!}
-              turnLabels={turnLabels}
-              contextLimit={meta.contextLimit}
-            />
+            <ContextWindowChart turnStats={meta.stats.turnStats!} turnLabels={turnLabels} />
             {stats.turns.length >= 2 && (
               <ToolActivityChart turns={stats.turns} turnLabels={turnLabels} />
             )}
@@ -1095,11 +1091,9 @@ function CacheEfficiencyLine({ turnStats }: { turnStats: TurnStat[] }) {
 function ContextWindowChart({
   turnStats,
   turnLabels,
-  contextLimit,
 }: {
   turnStats: TurnStat[];
   turnLabels?: string[];
-  contextLimit?: number;
 }) {
   const contextSizes = turnStats.map((t) => t.contextTokens || 0);
   const n = contextSizes.length;

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1108,10 +1108,20 @@ function ContextWindowChart({
   if (!contextSizes.some((c) => c > 0)) return null;
 
   const peak = Math.max(...contextSizes);
-  // Default 200K limit; auto-switch to 1M if any turn exceeds 200K
-  const effectiveLimit =
-    contextLimit && peak > 200_000 ? Math.max(contextLimit, 1_000_000) : contextLimit;
-  const max = effectiveLimit && effectiveLimit > peak ? effectiveLimit : peak;
+
+  // Infer ceiling from compaction data and peak
+  let compactionPeak = 0;
+  for (let i = 0; i < contextSizes.length - 1; i++) {
+    if (
+      contextSizes[i] > 0 &&
+      contextSizes[i + 1] > 0 &&
+      contextSizes[i + 1] < contextSizes[i] * 0.5
+    ) {
+      compactionPeak = Math.max(compactionPeak, contextSizes[i]);
+    }
+  }
+  const effectiveLimit = compactionPeak > 200_000 || peak > 200_000 ? 1_000_000 : 200_000;
+  const max = effectiveLimit > peak ? effectiveLimit : peak;
   const h = 60;
   const w = 100;
 


### PR DESCRIPTION
## Summary
- Add context window token usage visualization across the viewer
- Show per-turn context token counts in conversation view, charts, and tables
- Enhance compaction scenes with before/after token counts when data is available
- Add percentage labels and total count to Top Tools breakdown

## Changes

### Context Window Token Visualization
- **ConversationView**: Each user prompt card shows a context token bar with absolute count (e.g. "167.0K"). Bar scales to 200K by default, auto-switches to 1M if any turn exceeds 200K.
- **ContextWindowChart**: Shows "peak XXK" label, context limit dashed line, compaction markers
- **TurnTable**: Context column shows token counts with heatmap coloring relative to session peak
- **StatsPanel**: Shows peak context token count
- **Sidebar Stats**: Shows peak context token count inline

### Enhanced Compaction Display
- Compaction scenes in conversation view show before/after token counts with freed tokens (scoped to ±2 turns around the compaction)
- StatsPanel compaction entries show token counts

### Tool Usage Analytics
- Top Tools section shows total tool count and per-tool percentage labels

## Design decisions
- **No percentages**: JSONL data doesn't record the effective context limit. Claude Code sessions can use 200K or 1M depending on user configuration, so showing fill % would be misleading.
- **Dynamic bar scaling**: Progress bars default to 200K. If any turn exceeds 200K, the scale switches to 1M automatically.
- **Token counts are always accurate**: Unlike percentages, absolute token counts are reliable regardless of the context window configuration.

## Test plan
- [x] `pnpm lint:check` passes
- [x] `pnpm test` — all 699 unit tests pass
- [x] `pnpm build` — viewer bundle 759KB (under 800KB limit)
- [x] `pnpm test:e2e` — all 68 E2E tests pass
- [x] Playwright verification with real sessions (4-turn, 46-turn, 227-turn)
- [x] Zero console errors across all tested sessions
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)