### PR TITLE
fix(cli): resolve TypeScript compilation errors across multiple files

### DIFF
--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -533,7 +533,7 @@ export function parseFeedbackResponse(
 
   let frictionPoints: FrictionPoint[] | undefined;
   if (Array.isArray(parsed.frictionPoints) && parsed.frictionPoints.length > 0) {
-    frictionPoints = parsed.frictionPoints
+    const filtered: FrictionPoint[] = parsed.frictionPoints
       .filter(
         (f: any) =>
           f &&
@@ -543,7 +543,7 @@ export function parseFeedbackResponse(
           typeof f.turn === "number",
       )
       .map((f: any) => ({ type: f.type, description: f.description, turn: f.turn }));
-    if (frictionPoints.length === 0) frictionPoints = undefined;
+    frictionPoints = filtered.length > 0 ? filtered : undefined;
   }
 
   let aiPerformance: FeedbackResult["aiPerformance"];

--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -205,8 +205,9 @@ function shortToolName(name: string): string {
 /** Find the last meaningful text-response in a list of scenes */
 function findLastTextResponse(scenes: Scene[]): string | null {
   for (let i = scenes.length - 1; i >= 0; i--) {
-    if (scenes[i].type === "text-response") {
-      const text = scenes[i].content.trim();
+    const scene = scenes[i];
+    if (scene.type === "text-response") {
+      const text = scene.content.trim();
       if (text.length > 10) return text;
     }
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,7 +21,12 @@ import {
   removeAuthTokenSync,
   saveAuthTokenSync,
 } from "./publishers/cloud.js";
-import { checkPublishStatus, loadSavedGistInfo, publishGist } from "./publishers/gist.js";
+import {
+  checkPublishStatus,
+  loadSavedGistInfo,
+  publishGist,
+  type SavedGistInfo,
+} from "./publishers/gist.js";
 import { publishLocal } from "./publishers/local.js";
 import { scanForSecrets } from "./scan.js";
 import { startDashboard, startServer } from "./server.js";
@@ -599,7 +604,7 @@ program
           const title = replay.meta.title || slug;
           const savedGist = await loadSavedGistInfo(outputDir);
           let shouldPublish = true;
-          let overwriteGist: string | undefined;
+          let overwriteGist: SavedGistInfo | undefined;
           if (savedGist) {
             const publishMode = await select<"overwrite" | "create" | "cancel">({
               message: `Previous gist found (${savedGist.gistId}). How to publish this replay?`,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -8,7 +8,7 @@ import { serve } from "@hono/node-server";
 import chalk from "chalk";
 import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import type { StatusCode } from "hono/utils/http-status";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText } from "./clean-prompt.js";
@@ -1858,7 +1858,7 @@ export async function startServer(
       const proxied = await fetchCloudApiWithLocalAuth(cloudPath, init);
       if (proxied.unauthorized) return c.json({ error: "Unauthorized" }, 401);
       const contentType = proxied.response.headers.get("content-type") || "";
-      const status = proxied.response.status as StatusCode;
+      const status = proxied.response.status as ContentfulStatusCode;
       if (!contentType.includes("application/json")) {
         const text = await proxied.response.text();
         return c.body(text, status, { "Content-Type": contentType || "text/plain" });
@@ -2479,7 +2479,9 @@ export async function startServer(
     if ("error" in result) return c.json({ error: result.error }, 400);
 
     try {
-      const body = await c.req.json<{ toolName?: string }>().catch(() => ({}));
+      const body: { toolName?: string } = await c.req
+        .json<{ toolName?: string }>()
+        .catch(() => ({}));
       const requestedToolName = typeof body.toolName === "string" ? body.toolName : undefined;
       const detected = await detectFeedbackTools();
       if (detected.tools.length === 0) {
@@ -2604,7 +2606,7 @@ export async function startServer(
     if ("error" in result) return c.json({ error: result.error }, 400);
 
     try {
-      const body = await c.req
+      const body: { toolName?: string; targetLang?: string; sourceLang?: string } = await c.req
         .json<{ toolName?: string; targetLang?: string; sourceLang?: string }>()
         .catch(() => ({}));
       const detected = await detectFeedbackTools();
@@ -2660,7 +2662,9 @@ export async function startServer(
     if ("error" in result) return c.json({ error: result.error }, 400);
 
     try {
-      const body = await c.req.json<{ toolName?: string; style?: string }>().catch(() => ({}));
+      const body: { toolName?: string; style?: string } = await c.req
+        .json<{ toolName?: string; style?: string }>()
+        .catch(() => ({}));
       const detected = await detectFeedbackTools();
       if (detected.tools.length === 0) {
         return c.json({ error: "No AI CLI tool available (claude, agent, or opencode)" }, 400);

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,16 +4,22 @@ export type {
   DataSource,
   DataSourceInfo,
   InsightsStore,
+  OverlaySource,
   PrLink,
   ReplaySession,
   Scene,
+  SceneOverlay,
   SessionInsight,
+  SessionOverlays,
   SubAgent,
   TokenUsage,
   TurnStat,
 } from "@vibe-replay/types";
 
 export { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
+
+// Re-import SubAgent for local use in this file (re-export above doesn't add to local scope)
+import type { SubAgent } from "@vibe-replay/types";
 
 // CLI-only types below
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,8 @@
 // Shared types — single source of truth
+// SubAgent is imported separately so it can be referenced locally in this file;
+// a `export type { ... } from` re-export alone does not add names to local scope.
+import type { SubAgent } from "@vibe-replay/types";
+
 export type {
   Annotation,
   DataSource,
@@ -17,9 +21,6 @@ export type {
 } from "@vibe-replay/types";
 
 export { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
-
-// Re-import SubAgent for local use in this file (re-export above doesn't add to local scope)
-import type { SubAgent } from "@vibe-replay/types";
 
 // CLI-only types below
 


### PR DESCRIPTION
## Summary

- **Add missing type re-exports** in `packages/cli/src/types.ts`: `OverlaySource`, `SceneOverlay`, and `SessionOverlays` were defined in `@vibe-replay/types` but not re-exported from the CLI types barrel, causing import failures in `feedback.ts` and `server.ts`
- **Fix `SubAgent` local scope** in `types.ts`: re-export doesn't add to local scope, so `EnrichedToolUseBlock` couldn't reference it — added separate import
- **Fix `SavedGistInfo` type mismatch** in `index.ts`: `overwriteGist` was typed as `string` but assigned/consumed as `SavedGistInfo`
- **Fix Hono `StatusCode` → `ContentfulStatusCode`** in `server.ts`: proxy responses used `StatusCode` (includes informational 1xx) where Hono's `c.body()`/`c.json()` require `ContentfulStatusCode`
- **Fix union type narrowing** in `server.ts`: `.json<T>().catch(() => ({}))` returns `T | {}` — added explicit type annotations on `body` variables so property access type-checks correctly
- **Fix `Scene` union narrowing** in `github.ts`: `scenes[i].content` after type guard on `scenes[i].type` didn't narrow — extracted to local variable
- **Fix `frictionPoints` possibly-undefined** in `feedback.ts`: used intermediate `filtered` variable to avoid TS18048

Reduces TypeScript strict-mode errors from **30+ down to 1** (pre-existing external `sql.js` missing type declaration).

## Test plan

- [x] `pnpm lint:check` — passes (161 files, no issues)
- [x] `pnpm test` — all 700 tests pass (613 CLI + 87 viewer)
- [x] `pnpm build` — succeeds (viewer 759KB, CLI 375KB)
- [x] `pnpm test:e2e` — CLI smoke tests pass (browser tests skip in cloud env, no Playwright binary)
- [x] TypeScript strict check confirms only 1 remaining error (pre-existing `sql.js` declaration)

https://claude.ai/code/session_01FZAdLSXEsGAzsCFFh5D7nk