### PR TITLE
fix(viewer,cli): fix vim-k navigation, play() race, and silent save failures

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1749,8 +1749,8 @@ export async function startServer(
     }
     try {
       await saveAnnotations(baseDir, result.slug, body);
-    } catch {
-      /* ignore */
+    } catch (err) {
+      return c.json({ error: `Failed to save annotations: ${getErrorMessage(err)}` }, 500);
     }
     return c.json({ ok: true });
   });
@@ -2591,8 +2591,8 @@ export async function startServer(
     }
     try {
       await saveOverlays(baseDir, result.slug, body);
-    } catch {
-      /* ignore */
+    } catch (err) {
+      return c.json({ error: `Failed to save overlays: ${getErrorMessage(err)}` }, 500);
     }
     return c.json({ ok: true });
   });

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -119,7 +119,9 @@ export function useAnnotations(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(annotations),
         })
-          .then(() => {
+          .then((res) => {
+            // fetch() only rejects on network failure, not HTTP errors — guard explicitly
+            if (!res.ok) return;
             setSavedSnapshot(annotations);
           })
           .catch(() => {

--- a/packages/viewer/src/hooks/usePlayback.ts
+++ b/packages/viewer/src/hooks/usePlayback.ts
@@ -70,6 +70,8 @@ export function usePlayback(scenes: Scene[], prefs: EffectivePrefs, enabled = tr
   const play = useCallback(() => {
     if (scenes.length === 0) return;
 
+    clearTimer();
+
     if (stateRef.current === "ended") {
       setCurrentIndex(-1);
       setVisibleCount(0);
@@ -92,7 +94,7 @@ export function usePlayback(scenes: Scene[], prefs: EffectivePrefs, enabled = tr
         }
       }
     }, 50);
-  }, [scenes, advanceScene]);
+  }, [scenes, advanceScene, clearTimer]);
 
   const pause = useCallback(() => {
     clearTimer();
@@ -160,7 +162,7 @@ export function usePlayback(scenes: Scene[], prefs: EffectivePrefs, enabled = tr
       // Do not hijack keys while user is typing in search/input controls.
       if (isEditableTarget(e.target)) return;
       // Space — play/pause
-      if (e.key === " " || e.key === "k") {
+      if (e.key === " ") {
         e.preventDefault();
         togglePlayPause();
       }

--- a/packages/viewer/src/hooks/usePlayback.ts
+++ b/packages/viewer/src/hooks/usePlayback.ts
@@ -78,7 +78,8 @@ export function usePlayback(scenes: Scene[], prefs: EffectivePrefs, enabled = tr
     }
 
     setState("playing");
-    setTimeout(() => {
+    // Store bootstrap timer in ref so rapid play() calls cannot stack multiple bootstraps
+    timerRef.current = setTimeout(() => {
       if (indexRef.current < 0) {
         // Starting fresh — check if first scene starts a batch
         const endIdx = findBatchEnd(scenes, 0);


### PR DESCRIPTION
## Summary

- **Fix broken vim `k` navigation**: The `k` key was bound to both play/pause (line 163) and previous scene (line 175) in the `else if` chain. Since play/pause came first, `k` always toggled play/pause — the "prev scene" binding was dead code. Now `k` correctly navigates to the previous scene (consistent with `j` for next scene), and Space remains the play/pause key.

- **Fix play() timer race condition**: `play()` scheduled a 50ms bootstrap `setTimeout` without first canceling any existing timer. Rapidly calling `play()` (e.g. double-clicking) could create multiple concurrent timers advancing scenes simultaneously. Now `clearTimer()` is called at the start of `play()`.

- **Fix silent data loss on annotation/overlay save**: The `POST /api/annotations` and `POST /api/overlays` endpoints caught save errors and returned `{ ok: true }` regardless. Users' edits were silently lost on disk errors with no feedback. Now these endpoints return a 500 error with a message when the save fails.

## Test plan

- [x] All 614 CLI unit tests pass
- [x] All 87 viewer unit tests pass
- [x] CLI smoke E2E tests pass
- [x] Lint check passes (Biome)
- [x] Build succeeds (viewer 759KB, under 800KB limit)
- [ ] Verify `k` key navigates to previous scene in browser (Playwright unavailable in cloud)
- [ ] Verify rapid play/pause doesn't cause double-advance (Playwright unavailable in cloud)

https://claude.ai/code/session_017RZRajWbqSVrP7QhnZQzxv