### PR TITLE
refactor(scanner): replace `as any[]` with typed EnrichedToolUseBlock cast

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -19,7 +19,7 @@ import { estimateCost, estimateCostSimple } from "./pricing.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { getCursorSessionCachePaths } from "./providers/cursor/sqlite-reader.js";
 import type { ProviderParseResult } from "./providers/types.js";
-import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
+import type { DataSource, EnrichedToolUseBlock, PrLink, SessionInfo, TokenUsage } from "./types.js";
 import { extractToolFilePath, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
@@ -654,22 +654,23 @@ function buildScanResultFromParsed(
       if (hasText || hasImages) promptCount++;
     }
 
-    for (const block of turn.blocks as any[]) {
-      if (block?.type !== "tool_use") continue;
+    for (const block of turn.blocks) {
+      if (block.type !== "tool_use") continue;
+      const toolBlock = block as EnrichedToolUseBlock;
       toolCallCount++;
 
       if (
         parsedSubAgentCount === 0 &&
-        block.name === "Agent" &&
-        block.input &&
-        typeof block.input.subagent_type === "string"
+        toolBlock.name === "Agent" &&
+        toolBlock.input &&
+        typeof toolBlock.input.subagent_type === "string"
       ) {
         derivedSubAgentCount++;
       }
 
       // Count file modifications from sub-agent scenes
-      if (block.name === "Agent" && block._subAgent?.scenes) {
-        for (const saScene of block._subAgent.scenes) {
+      if (toolBlock.name === "Agent" && toolBlock._subAgent?.scenes) {
+        for (const saScene of toolBlock._subAgent.scenes) {
           if (saScene.type !== "tool-call") continue;
           const saTool = saScene.toolName;
           if (
@@ -689,15 +690,15 @@ function buildScanResultFromParsed(
       }
 
       if (
-        block.name !== "Edit" &&
-        block.name !== "Write" &&
-        block.name !== "NotebookEdit" &&
-        block.name !== "Delete"
+        toolBlock.name !== "Edit" &&
+        toolBlock.name !== "Write" &&
+        toolBlock.name !== "NotebookEdit" &&
+        toolBlock.name !== "Delete"
       ) {
         continue;
       }
 
-      const rawPath = extractToolFilePath(block.input);
+      const rawPath = extractToolFilePath(toolBlock.input);
       if (!rawPath) continue;
       editCount++;
       const short = shortenPath(rawPath);


### PR DESCRIPTION
## Summary

The loop in `buildScanResultFromParsed` used `as any[]` to iterate `turn.blocks` and access enrichment fields (`_subAgent`) on `tool_use` blocks. The broad `any` cast defeated TypeScript's type narrowing and silently accepted any property access on the block — a footgun if a field is renamed or removed.

Replaced with the same pattern already used in `transform.ts:95`:

1. Narrow via `block.type === "tool_use"` (TypeScript discriminated union).
2. Cast the narrowed block to `EnrichedToolUseBlock` — a localized cast that covers only the parser-added enrichment fields (`_subAgent`, `_result`, etc.), while preserving type checking on `name`, `input`, and the rest.

This is the last `as any` in `packages/cli/src/scanner.ts`, and it was the broadest one — the remaining `as any` casts in the codebase are in provider parsers where they guard parsing of untyped JSON/SQLite rows (a reasonable boundary).

## Why

- Type safety: catches typos/renames on `EnrichedToolUseBlock` fields at compile time.
- Consistency: matches the established pattern in `transform.ts`.
- No behavior change — purely a type refactor.

## Test plan

- [x] `pnpm lint:check` — clean
- [x] `pnpm test` — 613/613 CLI + 87/87 viewer unit tests pass
- [x] `pnpm build` — viewer + CLI build successfully
- [ ] `pnpm test:e2e` — skipped (Playwright browsers not available in this environment); safe to skip since this is a pure type refactor with no runtime change

https://claude.ai/code/session_01KZ2eYP87geivBeo1ccZ4AW