### PR TITLE
fix(cli): add sql.js module declaration to eliminate TS7016

### DIFF
--- a/packages/cli/src/sql-js.d.ts
+++ b/packages/cli/src/sql-js.d.ts
@@ -7,7 +7,9 @@ declare module "sql.js" {
   interface Statement {
     bind(params?: any[]): boolean;
     step(): boolean;
+    get(): any[];
     getAsObject(): Record<string, any>;
+    reset(): void;
     free(): void;
   }
 

--- a/packages/cli/src/sql-js.d.ts
+++ b/packages/cli/src/sql-js.d.ts
@@ -1,0 +1,25 @@
+declare module "sql.js" {
+  interface QueryExecResult {
+    columns: string[];
+    values: any[][];
+  }
+
+  interface Statement {
+    bind(params?: any[]): boolean;
+    step(): boolean;
+    getAsObject(): Record<string, any>;
+    free(): void;
+  }
+
+  interface Database {
+    exec(sql: string, params?: any[]): QueryExecResult[];
+    prepare(sql: string): Statement;
+    close(): void;
+  }
+
+  interface SqlJsStatic {
+    Database: new (data?: ArrayLike<number> | Buffer | null) => Database;
+  }
+
+  export default function initSqlJs(config?: Record<string, unknown>): Promise<SqlJsStatic>;
+}


### PR DESCRIPTION
## Summary

Adds a local module declaration for `sql.js` so imports type-check. Previously the import fell back to `any` and emitted TS7016 since sql.js ships no types and no `@types/sql.js` exists. Covers the `Database`, `Statement`, and `QueryExecResult` shapes we actually use.

## Context

This PR was originally a broader TypeScript error cleanup, but the other fixes overlapped with already-merged #172, #174, #175, and #176 (and would have regressed them). Reset the branch to just the unique, non-overlapping change: the `sql-js.d.ts` declaration file.

## Test plan

- [x] `pnpm lint:check` — clean
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — no errors (previously 1 TS7016)
- [x] `pnpm build` — CLI/viewer build clean
- [x] `pnpm test` — all unit tests pass