### PR TITLE
fix(viewer): resolve 20 TypeScript errors in Minimap and ToolCallBlock

### DIFF
--- a/packages/viewer/src/components/Minimap.tsx
+++ b/packages/viewer/src/components/Minimap.tsx
@@ -105,7 +105,7 @@ export default function Minimap({
         const isActive = i === activeIdx;
         const isPast = i < activeIdx;
 
-        if (item.kind === "compaction" || item.kind === "injection") {
+        if (item.kind !== "turn") {
           const label = item.kind === "injection" ? "System context" : "Context compacted";
           const icon = item.kind === "injection" ? "⚡" : "⟳";
           return (

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -9,6 +9,7 @@ export type {
   Scene,
   SceneOverlay,
   SessionOverlays,
+  SubAgent,
   TokenUsage,
   TurnStat,
 } from "@vibe-replay/types";


### PR DESCRIPTION
## Summary

- **Minimap.tsx**: Fix discriminated union narrowing by changing `item.kind === "compaction" || item.kind === "injection"` to `item.kind !== "turn"`. TypeScript couldn't narrow the `OutlineItem` union after the early return because `CompactionOutline.kind` is itself a union of literals (`"compaction" | "injection"`). The negative check lets TS properly narrow to `TurnOutline` in the remaining code path — eliminating **17 property-access errors**.
- **types.ts**: Add missing `SubAgent` re-export from `@vibe-replay/types`, fixing **3 errors** in `ToolCallBlock.tsx` (failed import + cascading implicit `any` on `.map()` params).

No behavioral changes — the logic is semantically identical.

## Test plan

- [x] `pnpm lint:check` — passes (0 issues)
- [x] `pnpm test` — all 701 unit tests pass
- [x] `pnpm build` — both viewer and CLI build successfully
- [x] `npx tsc --noEmit -p packages/viewer/tsconfig.json` — 20 errors eliminated (5 remaining are pre-existing Vite-specific `import.meta.env` / CSS import issues unrelated to this change)
- [x] E2E CLI smoke tests pass (Playwright browser tests skipped — not available in cloud env)

https://claude.ai/code/session_01SKKaLjjGpVx5AQ7mi7Hqcc