### PR TITLE
refactor(cli): eliminate `as any` casts on turn.blocks with proper typing

### DIFF
--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { PrLink, TurnStat } from "@vibe-replay/types";
+import type { PrLink, SubAgent, TurnStat } from "@vibe-replay/types";
 import { isSystemGeneratedMessage } from "../../clean-prompt.js";
 import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, RawMessage } from "../../types.js";
@@ -387,7 +387,9 @@ export async function parseClaudeCodeSession(
           _result: result,
           _images: images,
           ...(isError ? { _isError: true } : {}),
-          ...(subAgent ? { _subAgent: subAgent } : {}),
+          // SubAgentParsed.scenes widens Scene.type to string during parsing;
+          // the final attached shape matches SubAgent after scanSubAgent post-processing.
+          ...(subAgent ? { _subAgent: subAgent as unknown as SubAgent } : {}),
           ...(toolDurationMs ? { _durationMs: toolDurationMs } : {}),
         };
       }

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -175,10 +175,9 @@ async function parseCursorJsonl(
           for (const imagePath of extracted.paths) imageFilePaths.add(imagePath);
           if (text) textParts.push(text);
         } else if (block.type === "image") {
-          const source = (block as any).source;
-          if (source?.data) {
-            const mediaType = source.media_type || "image/png";
-            userImages.push(`data:${mediaType};base64,${source.data}`);
+          if (block.source?.data) {
+            const mediaType = block.source.media_type || "image/png";
+            userImages.push(`data:${mediaType};base64,${block.source.data}`);
           }
         }
       }
@@ -191,7 +190,7 @@ async function parseCursorJsonl(
       if (role === "user" && textParts.length === 0 && userImages.length === 0) continue;
 
       if (role === "user") {
-        const blocks: any[] = [];
+        const blocks: ContentBlock[] = [];
         const fullText = textParts.join("\n");
         if (fullText) blocks.push({ type: "text", text: fullText });
         const dedupedImages = [...new Set(userImages)];
@@ -205,7 +204,7 @@ async function parseCursorJsonl(
       }
 
       const hasInlineToolUse = contentBlocks.some((block) => block?.type === "tool_use");
-      const blocks: any[] = [];
+      const blocks: ContentBlock[] = [];
       for (const block of contentBlocks as ContentBlock[]) {
         if (block.type === "text" && block.text) {
           const cleanedText = sanitizeAssistantTextForReplay(block.text, hasInlineToolUse);
@@ -261,10 +260,8 @@ async function parseCursorJsonl(
 
   // Try to extract a meaningful title from first user prompt
   const firstUser = allTurns.find((t) => t.role === "user");
-  const firstText =
-    firstUser?.blocks[0]?.type === "text"
-      ? (firstUser.blocks[0] as any).text?.slice(0, 80)
-      : undefined;
+  const firstBlock = firstUser?.blocks[0];
+  const firstText = firstBlock?.type === "text" ? firstBlock.text?.slice(0, 80) : undefined;
 
   const hasToolData = toolPaths.length > 0;
   return {
@@ -339,33 +336,32 @@ async function readImageFileAsDataUrl(pathValue: string): Promise<string | null>
 
 function collectThinkingTexts(turn: ParsedTurn): string[] {
   const texts: string[] = [];
-  for (const block of turn.blocks as any[]) {
-    if (block?.type !== "thinking") continue;
-    const text = typeof block.thinking === "string" ? block.thinking.trim() : "";
+  for (const block of turn.blocks) {
+    if (block.type !== "thinking") continue;
+    const text = block.thinking.trim();
     if (text) texts.push(text);
   }
   return texts;
 }
 
-function buildThinkingBlocks(texts: string[]): any[] {
-  return texts.map((thinking) => ({ type: "thinking", thinking }));
+function buildThinkingBlocks(texts: string[]): ContentBlock[] {
+  return texts.map((thinking) => ({ type: "thinking" as const, thinking }));
 }
 
 function countThinkingBlocks(turns: ParsedTurn[]): number {
   let count = 0;
   for (const turn of turns) {
-    for (const block of turn.blocks as any[]) {
-      if (block?.type === "thinking") count++;
+    for (const block of turn.blocks) {
+      if (block.type === "thinking") count++;
     }
   }
   return count;
 }
 
 function collectUserImages(turn: ParsedTurn): string[] {
-  const imageBlocks = (turn.blocks as any[]).filter((block) => block?.type === "_user_images");
   const images: string[] = [];
-  for (const block of imageBlocks) {
-    if (!Array.isArray(block.images)) continue;
+  for (const block of turn.blocks) {
+    if (block.type !== "_user_images") continue;
     for (const image of block.images) {
       if (typeof image === "string" && image.trim()) images.push(image);
     }
@@ -386,9 +382,8 @@ function extractToolResultText(block: Extract<ContentBlock, { type: "tool_result
   if (!Array.isArray(block.content)) return "";
   return block.content
     .map((item) => {
-      if (!item || typeof item !== "object") return "";
-      if (typeof (item as any).text === "string") return (item as any).text;
-      if (typeof (item as any).content === "string") return (item as any).content;
+      if (item.type === "text") return item.text;
+      if (item.type === "tool_result") return item.content;
       return "";
     })
     .filter(Boolean)
@@ -415,8 +410,8 @@ function attachToolResults(
 ): void {
   for (const turn of turns) {
     if (turn.role !== "assistant") continue;
-    for (const block of turn.blocks as any[]) {
-      if (block?.type !== "tool_use" || typeof block.id !== "string") continue;
+    for (const block of turn.blocks) {
+      if (block.type !== "tool_use" || typeof block.id !== "string") continue;
       const result = toolResults.get(block.id);
       if (result !== undefined) block._result = result;
       const images = toolImages.get(block.id);
@@ -457,7 +452,7 @@ export function mergeJsonlThinkingIntoCursorTurns(
     const missingThinking = candidateThinking.filter((text) => !existingThinking.has(text));
     if (missingThinking.length === 0) continue;
 
-    targetTurn.blocks = [...buildThinkingBlocks(missingThinking), ...targetTurn.blocks] as any;
+    targetTurn.blocks = [...buildThinkingBlocks(missingThinking), ...targetTurn.blocks];
   }
 
   // If JSONL has extra assistant thinking turns (common with marker-only lines),
@@ -468,7 +463,7 @@ export function mergeJsonlThinkingIntoCursorTurns(
     merged.push({
       role: "assistant",
       timestamp: jsonlAssistantTurns[i].timestamp,
-      blocks: buildThinkingBlocks(extraThinking) as any,
+      blocks: buildThinkingBlocks(extraThinking),
     });
   }
 
@@ -658,13 +653,15 @@ function inferToolName(result: string): string {
   return "ToolOutput";
 }
 
+type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+
 function attachToolEvents(turns: ParsedTurn[], tools: ToolEvent[]): void {
-  const markerBlocks: Array<{ block: any; turn: ParsedTurn; blockIndex: number }> = [];
+  const markerBlocks: Array<{ block: ToolUseBlock; turn: ParsedTurn; blockIndex: number }> = [];
   for (const turn of turns) {
     if (turn.role !== "assistant") continue;
     for (let bi = 0; bi < turn.blocks.length; bi++) {
-      const block = turn.blocks[bi] as any;
-      if (block?._isPendingMarker) {
+      const block = turn.blocks[bi];
+      if (block.type === "tool_use" && block._isPendingMarker) {
         markerBlocks.push({ block, turn, blockIndex: bi });
       }
     }
@@ -681,7 +678,7 @@ function attachToolEvents(turns: ParsedTurn[], tools: ToolEvent[]): void {
       ...(tool.input || {}),
     };
     marker.block._result = tool.result;
-    delete marker.block._isPendingMarker;
+    marker.block._isPendingMarker = undefined;
     if (!marker.turn.timestamp && tool.timestamp) {
       marker.turn.timestamp = tool.timestamp;
     }
@@ -690,11 +687,12 @@ function attachToolEvents(turns: ParsedTurn[], tools: ToolEvent[]): void {
   // Unpaired markers → convert to thinking (they're just status text, not tool calls)
   for (let i = paired; i < markerBlocks.length; i++) {
     const { turn, blockIndex, block } = markerBlocks[i];
-    const thinkingBlock = {
+    const markerText = typeof block.input?.marker === "string" ? block.input.marker : "";
+    const thinkingBlock: ContentBlock = {
       type: "thinking",
-      thinking: block.name || block.input?.marker || "",
+      thinking: block.name || markerText,
     };
-    (turn.blocks as any[])[blockIndex] = thinkingBlock;
+    turn.blocks[blockIndex] = thinkingBlock;
   }
 
   // Extra tool outputs with no matching marker → append as real tool calls
@@ -703,12 +701,12 @@ function attachToolEvents(turns: ParsedTurn[], tools: ToolEvent[]): void {
     turns.push({
       role: "assistant",
       timestamp: tool.timestamp,
-      blocks: [toToolUseBlock(tool) as any],
+      blocks: [toToolUseBlock(tool)],
     });
   }
 }
 
-function toToolUseBlock(tool: ToolEvent) {
+function toToolUseBlock(tool: ToolEvent): ContentBlock {
   return {
     type: "tool_use",
     id: tool.id,

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2186,8 +2186,8 @@ function buildStoreTurnStats(turns: ParsedTurn[]): TurnStat[] {
     const current = turnStats[currentTurnIndex];
     if (!current.model && turn.model) current.model = turn.model;
 
-    for (const block of turn.blocks as any[]) {
-      if (block?.type !== "tool_use") continue;
+    for (const block of turn.blocks) {
+      if (block.type !== "tool_use") continue;
       const ms = toPositiveMs(block._durationMs);
       if (ms !== undefined) {
         current.durationMs = (current.durationMs || 0) + ms;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -655,7 +655,7 @@ function buildScanResultFromParsed(
     }
 
     for (const block of turn.blocks) {
-      if (block?.type !== "tool_use") continue;
+      if (block.type !== "tool_use") continue;
       toolCallCount++;
 
       if (

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -19,7 +19,7 @@ import { estimateCost, estimateCostSimple } from "./pricing.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { getCursorSessionCachePaths } from "./providers/cursor/sqlite-reader.js";
 import type { ProviderParseResult } from "./providers/types.js";
-import type { DataSource, EnrichedToolUseBlock, PrLink, SessionInfo, TokenUsage } from "./types.js";
+import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 import { extractToolFilePath, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
@@ -655,22 +655,21 @@ function buildScanResultFromParsed(
     }
 
     for (const block of turn.blocks) {
-      if (block.type !== "tool_use") continue;
-      const toolBlock = block as EnrichedToolUseBlock;
+      if (block?.type !== "tool_use") continue;
       toolCallCount++;
 
       if (
         parsedSubAgentCount === 0 &&
-        toolBlock.name === "Agent" &&
-        toolBlock.input &&
-        typeof toolBlock.input.subagent_type === "string"
+        block.name === "Agent" &&
+        block.input &&
+        typeof block.input.subagent_type === "string"
       ) {
         derivedSubAgentCount++;
       }
 
       // Count file modifications from sub-agent scenes
-      if (toolBlock.name === "Agent" && toolBlock._subAgent?.scenes) {
-        for (const saScene of toolBlock._subAgent.scenes) {
+      if (block.name === "Agent" && block._subAgent?.scenes) {
+        for (const saScene of block._subAgent.scenes) {
           if (saScene.type !== "tool-call") continue;
           const saTool = saScene.toolName;
           if (
@@ -690,15 +689,15 @@ function buildScanResultFromParsed(
       }
 
       if (
-        toolBlock.name !== "Edit" &&
-        toolBlock.name !== "Write" &&
-        toolBlock.name !== "NotebookEdit" &&
-        toolBlock.name !== "Delete"
+        block.name !== "Edit" &&
+        block.name !== "Write" &&
+        block.name !== "NotebookEdit" &&
+        block.name !== "Delete"
       ) {
         continue;
       }
 
-      const rawPath = extractToolFilePath(toolBlock.input);
+      const rawPath = extractToolFilePath(block.input);
       if (!rawPath) continue;
       editCount++;
       const short = shortenPath(rawPath);

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -1,13 +1,7 @@
 import { homedir } from "node:os";
 import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
 import type { ProviderParseResult } from "./providers/types.js";
-import type {
-  ContentBlock,
-  EnrichedToolUseBlock,
-  ReplaySession,
-  Scene,
-  SubAgent,
-} from "./types.js";
+import type { ContentBlock, ReplaySession, Scene, SubAgent } from "./types.js";
 
 type ToolCallScene = Extract<Scene, { type: "tool-call" }>;
 
@@ -92,19 +86,18 @@ export function transformToReplay(
           });
         }
       } else if (block.type === "tool_use") {
-        const toolBlock = block as EnrichedToolUseBlock;
         const scene = buildToolScene(
-          toolBlock.name,
-          toolBlock.input || {},
-          toolBlock._result || "",
-          toolBlock._images,
+          block.name,
+          block.input || {},
+          block._result || "",
+          block._images,
         );
         scene.timestamp = turn.timestamp;
-        scene.isError = !!toolBlock._isError;
-        if (toolBlock._durationMs) scene.durationMs = toolBlock._durationMs;
+        scene.isError = !!block._isError;
+        if (block._durationMs) scene.durationMs = block._durationMs;
         // Attach subagent data for Agent tool calls
-        if (toolBlock.name === "Agent" && toolBlock._subAgent) {
-          const sa = toolBlock._subAgent;
+        if (block.name === "Agent" && block._subAgent) {
+          const sa = block._subAgent;
           scene.subAgent = {
             agentId: sa.agentId,
             agentType: sa.agentType,
@@ -117,8 +110,8 @@ export function transformToReplay(
             model: sa.model,
             scenes: (sa.scenes || []).map((s: Scene) => redactSubAgentScene(s)),
           } satisfies SubAgent;
-        } else if (provider === "cursor" && toolBlock.name === "Agent") {
-          const minimal = buildMinimalCursorSubAgent(toolBlock);
+        } else if (provider === "cursor" && block.name === "Agent") {
+          const minimal = buildMinimalCursorSubAgent(block);
           if (minimal) {
             scene.subAgent = minimal;
             syntheticSubAgentSummary.push({
@@ -278,7 +271,9 @@ function truncate(s: string, max: number): string {
   return `${redacted.slice(0, max)}\n... (truncated, ${redacted.length} chars total)`;
 }
 
-function buildMinimalCursorSubAgent(toolBlock: EnrichedToolUseBlock): SubAgent | null {
+function buildMinimalCursorSubAgent(
+  toolBlock: Extract<ContentBlock, { type: "tool_use" }>,
+): SubAgent | null {
   const input = toolBlock.input;
   if (!input || typeof input !== "object") return null;
   const rawAgentType =

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -124,7 +124,18 @@ export interface RawMessage {
 export type ContentBlock =
   | { type: "thinking"; thinking: string; signature?: string }
   | { type: "text"; text: string }
-  | { type: "tool_use"; id: string; name: string; input: Record<string, any> }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: Record<string, any>;
+      _result?: string;
+      _images?: string[];
+      _isError?: boolean;
+      _subAgent?: SubAgent;
+      _durationMs?: number;
+      _isPendingMarker?: boolean;
+    }
   | { type: "tool_result"; tool_use_id: string; content: string | ToolResultContent[] }
   | { type: "image"; source: { type: string; media_type: string; data: string } }
   | { type: "_user_images"; images: string[] };
@@ -133,16 +144,3 @@ export type ToolResultContent =
   | { type: "text"; text: string }
   | { type: "tool_result"; tool_use_id: string; content: string }
   | { type: "image"; source: { type: string; media_type: string; data: string } };
-
-/** tool_use block enriched by parsers with matched result, images, and metadata */
-export interface EnrichedToolUseBlock {
-  type: "tool_use";
-  id: string;
-  name: string;
-  input: Record<string, any>;
-  _result: string;
-  _images?: string[];
-  _isError?: boolean;
-  _subAgent?: SubAgent;
-  _durationMs?: number;
-}


### PR DESCRIPTION
## Summary

- Add optional enrichment fields (`_result`, `_images`, `_isError`, `_subAgent`, `_durationMs`, `_isPendingMarker`) to `ContentBlock`'s `tool_use` variant so TypeScript discriminated union narrowing works naturally after `block.type === "tool_use"` checks
- Remove 15+ `as any[]` and `as any` casts across scanner, transform, cursor parser, and sqlite-reader — replaced with proper type narrowing
- Fix `buildThinkingBlocks`, `toToolUseBlock`, `collectUserImages`, `extractToolResultText` and other helpers to use typed parameters/returns instead of `any`
- Remove unused `EnrichedToolUseBlock` import from transform.ts

## Why

`ParsedTurn.blocks` is typed as `ContentBlock[]`, but after parser enrichment the `tool_use` blocks carry extra fields (`_result`, `_subAgent`, etc.). Code throughout the codebase worked around this with `turn.blocks as any[]` casts, losing all type safety. By adding the enrichment fields as optional properties on the `tool_use` variant, TypeScript narrowing handles everything naturally.

## Test plan

- [x] All 700 unit tests pass (`pnpm test`)
- [x] All E2E tests pass (`pnpm build && pnpm test:e2e`) — 17 passed including browser-based generated HTML tests
- [x] Lint clean (`pnpm lint:check`)
- [x] Build succeeds with no type errors

https://claude.ai/code/session_0116poFbb3rogAwRn41vMM3t