### PR TITLE
docs: prefer /plugin Discover tab for plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/
 
 ### Install (recommended)
 
+Open Claude Code, run `/plugin`, then search **vibe-replay** in the **Discover** tab and install.
+
+Or install via CLI:
+
 ```bash
 /plugin marketplace add tuo-lei/vibe-replay
 /plugin install vibe-replay@vibe-replay

--- a/skills/replay/README.md
+++ b/skills/replay/README.md
@@ -63,6 +63,10 @@ Generates a self-contained HTML file and opens it in the browser.
 
 ### As a Claude Code plugin (recommended)
 
+Open Claude Code, run `/plugin`, then search **vibe-replay** in the **Discover** tab and install.
+
+Or via CLI:
+
 ```
 /plugin marketplace add tuo-lei/vibe-replay
 /plugin install vibe-replay@vibe-replay

--- a/website/src/components/Plugin.astro
+++ b/website/src/components/Plugin.astro
@@ -59,8 +59,14 @@ const capabilities = [
       <!-- Right: install card -->
       <div class="md:w-1/2 w-full">
         <div class="rounded-2xl border border-border/50 bg-surface-1/40 p-6 md:p-8">
-          <!-- Install commands -->
-          <p class="text-text-muted text-xs font-mono uppercase tracking-wider mb-3">Install</p>
+          <!-- Install: Discover (recommended) -->
+          <p class="text-text-muted text-xs font-mono uppercase tracking-wider mb-3">Install <span class="text-accent/70 normal-case tracking-normal">&middot; recommended</span></p>
+          <div class="px-4 py-3 mb-2 bg-surface/80 border border-accent/30 rounded-lg text-sm leading-relaxed">
+            In Claude Code, run <code class="font-mono text-accent">/plugin</code>, open the <span class="font-semibold text-text-primary">Discover</span> tab, search <span class="font-mono text-text-primary">vibe-replay</span>, and install.
+          </div>
+
+          <!-- Install: CLI (alternative) -->
+          <p class="text-text-muted text-xs font-mono uppercase tracking-wider mt-5 mb-3">Or via CLI</p>
           <div class="space-y-2 mb-6">
             <button
               data-copy="/plugin marketplace add tuo-lei/vibe-replay"


### PR DESCRIPTION
## Summary

- vibe-replay is now discoverable directly in Claude Code via `/plugin` → **Discover** tab, so surface that as the primary install path.
- Keep the existing `/plugin marketplace add` + `/plugin install` snippet as an **Or via CLI** alternative.
- Applied consistently across README.md, skills/replay/README.md, and the website's Plugin section.

## Changes

| File | Change |
|---|---|
| `README.md` | Add Discover step above the CLI snippet in the Install section |
| `skills/replay/README.md` | Same pattern — Discover first, CLI as alternative |
| `website/src/components/Plugin.astro` | New highlighted Discover card (accent-border) with `Install · recommended` label; existing copy-button rows relabeled `Or via CLI`. No change to copy-button behavior or capabilities grid. |

## Test plan

- [x] `pnpm lint:check` passes
- [x] `pnpm --filter @vibe-replay/website dev` renders the Plugin section without layout breakage or console errors (screenshot verified via Playwright at localhost:4321)
- [x] README renders correctly on GitHub (new bullet + code fence, no formatting regressions)
- [ ] Maintainer: verify Discover-tab copy matches what a new user sees in `/plugin` Discover today

🤖 Generated with [Claude Code](https://claude.com/claude-code)