### PR TITLE
fix(dashboard): bucket sessionsPerDay by local timezone

### DIFF
--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -19,6 +19,7 @@ import type { InsightsStore, SessionInsight } from "@vibe-replay/types";
 import { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
 import { getMachineId, getMachineName } from "./machine-id.js";
 import type { SessionScanResult } from "./scanner.js";
+import { localDayKey } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
 const INSIGHTS_DIR = join(homedir(), ".vibe-replay", "insights");
@@ -221,7 +222,7 @@ export function aggregateDailyInsights(store: InsightsStore): {
   >();
 
   for (const s of store.sessions) {
-    const date = s.startTime?.slice(0, 10);
+    const date = localDayKey(s.startTime);
     if (!date) continue;
 
     let day = byDate.get(date);

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -20,7 +20,7 @@ import { parseCursorSession } from "./providers/cursor/parser.js";
 import { getCursorSessionCachePaths } from "./providers/cursor/sqlite-reader.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
-import { extractToolFilePath, shortenPath } from "./utils.js";
+import { extractToolFilePath, localDayKey, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
 const SCANNER_VERSION = 7;
@@ -987,9 +987,9 @@ export function aggregateProjectInsights(
     if (ts && (!first || ts < first)) first = ts;
     if (ts && (!last || ts > last)) last = ts;
 
-    // Sessions per day
-    if (ts) {
-      const day = ts.slice(0, 10);
+    // Sessions per day (local timezone — UTC bucketing misses evening sessions west of UTC)
+    const day = localDayKey(ts);
+    if (day) {
       sessionsPerDay[day] = (sessionsPerDay[day] || 0) + 1;
     }
   }
@@ -1132,8 +1132,8 @@ export function aggregateUserInsights(scans: SessionScanResult[]): UserInsights 
     if (ts && (!first || ts < first)) first = ts;
     if (ts && (!last || ts > last)) last = ts;
 
-    if (ts) {
-      const day = ts.slice(0, 10);
+    const day = localDayKey(ts);
+    if (day) {
       ps.sessionsPerDay[day] = (ps.sessionsPerDay[day] || 0) + 1;
       sessionsPerDay[day] = (sessionsPerDay[day] || 0) + 1;
     }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -61,7 +61,7 @@ import type {
   SessionInfo,
   SessionOverlays,
 } from "./types.js";
-import { normalizeTitle } from "./utils.js";
+import { localDayKey, normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
 /** Sanitize slug to prevent path traversal — rejects anything that isn't a simple name */
@@ -1050,7 +1050,7 @@ export async function startServer(
     const apiUrl = getUrl();
     const cookieName = getCookie(apiUrl);
     const headers = { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` };
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey(new Date()) || "";
     let existingDates = new Set<string>();
 
     // Delta sync: fetch dates already on cloud, skip them
@@ -1116,7 +1116,7 @@ export async function startServer(
    * Runs at most once per calendar day to avoid excessive writes.
    */
   const autoSyncInsights = (): Promise<void> => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = localDayKey(new Date()) || "";
     if (lastAutoSyncDate === today) return Promise.resolve();
     // Serialize through syncLock to prevent concurrent read-modify-write on the store
     const job = syncLock.then(async () => {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1050,7 +1050,7 @@ export async function startServer(
     const apiUrl = getUrl();
     const cookieName = getCookie(apiUrl);
     const headers = { "Content-Type": "application/json", Cookie: `${cookieName}=${auth.token}` };
-    const today = localDayKey(new Date()) || "";
+    const today = localDayKey(new Date())!;
     let existingDates = new Set<string>();
 
     // Delta sync: fetch dates already on cloud, skip them
@@ -1116,7 +1116,7 @@ export async function startServer(
    * Runs at most once per calendar day to avoid excessive writes.
    */
   const autoSyncInsights = (): Promise<void> => {
-    const today = localDayKey(new Date()) || "";
+    const today = localDayKey(new Date())!;
     if (lastAutoSyncDate === today) return Promise.resolve();
     // Serialize through syncLock to prevent concurrent read-modify-write on the store
     const job = syncLock.then(async () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -22,3 +22,18 @@ export function extractToolFilePath(
   const fp = input?.file_path ?? input?.filePath ?? input?.path ?? input?.relativeWorkspacePath;
   return typeof fp === "string" && fp.trim() ? fp : undefined;
 }
+
+/**
+ * Format a timestamp as YYYY-MM-DD in the local timezone.
+ * Critical for day-bucketing: slicing an ISO string gives UTC, which shifts
+ * evening activity to the next day for users west of UTC.
+ */
+export function localDayKey(input: string | Date | number | undefined | null): string | undefined {
+  if (input == null || input === "") return undefined;
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return undefined;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/packages/cli/test/local-day-key.test.ts
+++ b/packages/cli/test/local-day-key.test.ts
@@ -7,12 +7,15 @@ import { localDayKey } from "../src/utils.js";
 const tzOffsetMin = new Date().getTimezoneOffset();
 
 describe("localDayKey", () => {
-  it("buckets late-evening PST activity into the local day, not the UTC next-day", () => {
-    // 2026-03-04 04:28 UTC is 2026-03-03 20:28 PST. Slicing the ISO string gave 2026-03-04;
-    // the helper must return the local day when running in a negative-offset zone.
-    if (tzOffsetMin <= 0) return;
-    expect(localDayKey("2026-03-04T04:28:17.516Z")).toBe("2026-03-03");
-  });
+  // 2026-03-04 04:28 UTC is 2026-03-03 20:28 PST. Slicing the ISO string gave 2026-03-04;
+  // the helper must return the local day when running in a negative-offset zone.
+  // `skipIf` rather than early-return so the reporter shows an explicit skip in UTC CI.
+  it.skipIf(tzOffsetMin <= 0)(
+    "buckets late-evening PST activity into the local day, not the UTC next-day",
+    () => {
+      expect(localDayKey("2026-03-04T04:28:17.516Z")).toBe("2026-03-03");
+    },
+  );
 
   it("accepts a Date instance", () => {
     const d = new Date(2026, 2, 3, 20, 28); // Mar 3 2026 20:28 local

--- a/packages/cli/test/local-day-key.test.ts
+++ b/packages/cli/test/local-day-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { localDayKey } from "../src/utils.js";
+
+// The timezone-sensitive rollover tests only mean something when the runner's
+// local zone is west of UTC (e.g. CI defaulting to UTC would flip the invariant).
+// Guard them so the suite is stable regardless of where it runs.
+const tzOffsetMin = new Date().getTimezoneOffset();
+
+describe("localDayKey", () => {
+  it("buckets late-evening PST activity into the local day, not the UTC next-day", () => {
+    // 2026-03-04 04:28 UTC is 2026-03-03 20:28 PST. Slicing the ISO string gave 2026-03-04;
+    // the helper must return the local day when running in a negative-offset zone.
+    if (tzOffsetMin <= 0) return;
+    expect(localDayKey("2026-03-04T04:28:17.516Z")).toBe("2026-03-03");
+  });
+
+  it("accepts a Date instance", () => {
+    const d = new Date(2026, 2, 3, 20, 28); // Mar 3 2026 20:28 local
+    expect(localDayKey(d)).toBe("2026-03-03");
+  });
+
+  it("accepts a unix ms number", () => {
+    const d = new Date(2026, 0, 15, 9, 0);
+    expect(localDayKey(d.getTime())).toBe("2026-01-15");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(localDayKey(new Date(2026, 0, 1))).toBe("2026-01-01");
+    expect(localDayKey(new Date(2026, 8, 9))).toBe("2026-09-09");
+  });
+
+  it("returns undefined for null, undefined, or empty input", () => {
+    expect(localDayKey(null)).toBeUndefined();
+    expect(localDayKey(undefined)).toBeUndefined();
+    expect(localDayKey("")).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable string", () => {
+    expect(localDayKey("not a date")).toBeUndefined();
+  });
+});

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatedValue } from "../hooks/useAnimatedNumber";
 import type { SessionSummary, SourceSession } from "../types";
+import { localDayKey } from "../utils/date";
 import { SessionDetailPopup } from "./Dashboard";
 import {
   formatCompactDuration,
@@ -279,7 +280,7 @@ function computeInsights(sources: SourceSession[], replays: SessionSummary[]): I
   // even while richer scan insights are still refreshing in the background.
   const sessionsPerDay: Record<string, number> = {};
   for (const s of sources) {
-    const day = s.timestamp?.slice(0, 10);
+    const day = localDayKey(s.timestamp);
     if (!day) continue;
     sessionsPerDay[day] = (sessionsPerDay[day] || 0) + 1;
   }

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -62,7 +62,11 @@ const DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DAYS_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
 function dateKey(d: Date): string {
-  return d.toISOString().slice(0, 10);
+  // Local timezone — must match the keys produced by scanner/insights.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 function rangeDays(range: TimeRange): number {

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -10,6 +10,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatedValue } from "../hooks/useAnimatedNumber";
 import type { SessionSummary, SourceSession } from "../types";
+import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
 import {
   formatCompactAge,
@@ -61,12 +62,10 @@ const DAY_MS = 86400000;
 const DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const DAYS_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
+// `dateKey` is a viewer-local alias that delegates to the shared helper.
+// Keeps callsites terse while guaranteeing a string return (Date input is always valid).
 function dateKey(d: Date): string {
-  // Local timezone — must match the keys produced by scanner/insights.
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
+  return localDayKey(d)!;
 }
 
 function rangeDays(range: TimeRange): number {

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -17,6 +17,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
 import { CACHE_REFRESH_TTL_MS, isCacheFresh, shortModelName } from "./dashboard-utils";
 import { formatDuration } from "./StatsPanel";
@@ -402,7 +403,7 @@ function ActivitySparkline({ sessionsPerDay }: { sessionsPerDay: Record<string, 
     const result: { day: string; count: number }[] = [];
     const cursor = new Date(start);
     while (cursor <= end) {
-      const key = cursor.toISOString().slice(0, 10);
+      const key = localDayKey(cursor)!;
       result.push({ day: key, count: sessionsPerDay[key] || 0 });
       cursor.setDate(cursor.getDate() + 1);
     }
@@ -951,7 +952,7 @@ export function TitleInsightsHeader({
               const bars: { day: string; count: number }[] = [];
               const cursor = new Date(start);
               while (cursor <= end) {
-                const key = cursor.toISOString().slice(0, 10);
+                const key = localDayKey(cursor)!;
                 bars.push({ day: key, count: sessionsPerDay[key] || 0 });
                 cursor.setDate(cursor.getDate() + 1);
               }

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useMemo, useState } from "react";
+import { localDayKey } from "../utils/date";
 import { navigateTo } from "./dashboard-utils";
 import { useScanInsightsContext } from "./InsightsPanel";
 import { formatDuration } from "./StatsPanel";
@@ -21,7 +22,7 @@ function MiniSparkline({ sessionsPerDay }: { sessionsPerDay: Record<string, numb
     const result: number[] = [];
     const cursor = new Date(start);
     while (cursor <= end) {
-      const key = cursor.toISOString().slice(0, 10);
+      const key = localDayKey(cursor)!;
       result.push(sessionsPerDay[key] || 0);
       cursor.setDate(cursor.getDate() + 1);
     }

--- a/packages/viewer/src/utils/date.ts
+++ b/packages/viewer/src/utils/date.ts
@@ -1,0 +1,14 @@
+/**
+ * Format a timestamp as YYYY-MM-DD in the local timezone.
+ * Critical for day-bucketing: slicing an ISO string gives UTC, which shifts
+ * evening activity to the next day for users west of UTC.
+ */
+export function localDayKey(input: string | Date | number | undefined | null): string | undefined {
+  if (input == null || input === "") return undefined;
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return undefined;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## Summary

- `sessionsPerDay` keys came from `ts.slice(0, 10)` on ISO timestamps, which produces a **UTC** date. For users west of UTC this pushes evening activity into the next calendar day (e.g. a session started at 20:28 PST was counted as the following day), breaking streaks, heatmaps, and the earliest-active-day label.
- Added a shared `localDayKey(ts)` helper in both CLI (`packages/cli/src/utils.ts`) and viewer (`packages/viewer/src/utils/date.ts`) and routed every day-bucket **producer** (`aggregateProjectInsights`, `aggregateUserInsights`, `aggregateDailyInsights`, `autoSyncInsights`) and **consumer** (`InsightsPage.dateKey`, `DashboardHome`, `InsightsPanel` ×2, `ProjectsPanel`) through it.
- Verified against a 37-file JSONL corpus on a machine in PST: first active day moves from `2026-03-04` → `2026-03-03` (correct), and Active Days total now matches the official Claude Code desktop stats (35).

## Test plan

- [x] `pnpm lint:check` on changed files — clean
- [x] `pnpm build` — viewer + CLI build green
- [x] `pnpm test` — 614 passed
- [x] `pnpm test:e2e` — 68 passed
- [x] Manually verified via Playwright on `http://localhost:13456?view=dashboard`: `/api/insights` returns `sessionsPerDay` starting at `2026-03-03`, 35 active days, current streak 2d, longest 10d (matches Claude desktop stats screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)