### PR TITLE
fix(viewer): fix TypeScript config and deduplicate apiUrl

### DIFF
--- a/packages/cli/src/publishers/gist.ts
+++ b/packages/cli/src/publishers/gist.ts
@@ -88,7 +88,7 @@ export async function publishGist(
     });
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({ error: resp.statusText }));
-      if ((resp.status as number) === 401) {
+      if (resp.status === 401) {
         throw new Error("Session expired. Run `vibe-replay auth login` to re-authenticate.");
       }
       throw new Error(

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AnnotationActions } from "../hooks/useAnnotations";
 import type { ViewerMode } from "../hooks/useSessionLoader";
 import type { ReplaySession } from "../types";
+import { apiUrl } from "../utils/api";
 import { sanitizeHtml, sanitizeSvg } from "../utils/sanitize";
 
 // Sync with MAX_EXPORT_TURNS in packages/cli/src/formatters/github.ts
@@ -37,13 +38,6 @@ interface GhExportResult {
 }
 
 type Status = { type: "success" | "error"; text: string } | null;
-
-function apiUrl(path: string): string {
-  const slug = new URLSearchParams(window.location.search).get("session");
-  if (!slug) return path;
-  const sep = path.includes("?") ? "&" : "?";
-  return `${path}${sep}slug=${encodeURIComponent(slug)}`;
-}
 
 function SectionHeader({ title, color }: { title: string; color: string }) {
   return (

--- a/packages/viewer/src/globals.d.ts
+++ b/packages/viewer/src/globals.d.ts
@@ -1,2 +1,4 @@
+/// <reference types="vite/client" />
+
 /** Cloud API URL, baked at build time via vite.config.ts define */
 declare const __CLOUD_API_URL__: string;

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -8,6 +8,7 @@ import {
   updateAnnotation,
 } from "../engine";
 import type { Annotation, ReplaySession } from "../types";
+import { apiUrl } from "../utils/api";
 import type { ViewerMode } from "./useSessionLoader";
 
 export interface AnnotationActions {
@@ -64,14 +65,6 @@ const LS_PREFIX = "vibe-replay-annotations-";
 
 function storageKey(sessionId: string): string {
   return LS_PREFIX + sessionId;
-}
-
-/** Build API URL with slug query param when viewing a different session */
-function apiUrl(path: string): string {
-  const slug = new URLSearchParams(window.location.search).get("session");
-  if (!slug) return path;
-  const sep = path.includes("?") ? "&" : "?";
-  return `${path}${sep}slug=${encodeURIComponent(slug)}`;
 }
 
 export function useAnnotations(

--- a/packages/viewer/src/hooks/useOverlays.ts
+++ b/packages/viewer/src/hooks/useOverlays.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReplaySession, SceneOverlay, SessionOverlays } from "../types";
+import { apiUrl } from "../utils/api";
 import type { ViewerMode } from "./useSessionLoader";
 
 export interface OverlayActions {
@@ -59,14 +60,6 @@ export interface OverlayActions {
 }
 
 const EMPTY_OVERLAYS: SessionOverlays = { version: 1, overlays: [] };
-
-/** Build API URL with slug query param */
-function apiUrl(path: string): string {
-  const slug = new URLSearchParams(window.location.search).get("session");
-  if (!slug) return path;
-  const sep = path.includes("?") ? "&" : "?";
-  return `${path}${sep}slug=${encodeURIComponent(slug)}`;
-}
 
 export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded"): OverlayActions {
   const isEditor = mode === "editor";

--- a/packages/viewer/src/utils/api.ts
+++ b/packages/viewer/src/utils/api.ts
@@ -1,0 +1,7 @@
+/** Build API URL with slug query param when viewing a different session */
+export function apiUrl(path: string): string {
+  const slug = new URLSearchParams(window.location.search).get("session");
+  if (!slug) return path;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}slug=${encodeURIComponent(slug)}`;
+}

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": false,


### PR DESCRIPTION
## Summary

- **Fix 8 TypeScript errors in viewer package** by adding `lib: ["ES2023", "DOM", "DOM.Iterable"]` to `tsconfig.json` and `/// <reference types="vite/client" />` to `globals.d.ts`. This resolves `toReversed` not found (ES2023), `import.meta.env` not typed (Vite), and CSS import errors.
- **Deduplicate `apiUrl()` utility** — identical function was copy-pasted in `useAnnotations.ts`, `useOverlays.ts`, and `ExportView.tsx`. Extracted to shared `utils/api.ts`.
- **Remove unnecessary `(resp.status as number)` cast** in `gist.ts` — `resp.status` is already `number`.

## Test plan

- [x] `tsc --noEmit` passes with 0 errors for both viewer and CLI packages (viewer had 8 errors before)
- [x] Full build succeeds — viewer 765KB (within 800KB limit)
- [x] All 717 unit tests pass (35 CLI + 4 viewer test files)
- [x] Lint + format checks pass
- [x] CLI smoke tests pass

https://claude.ai/code/session_01656H7vhb4Bs2Gi8GyGGLmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01656H7vhb4Bs2Gi8GyGGLmq)_