### PR TITLE
chore(cli): bump version to 0.1.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- Patch bump from 0.1.6 → 0.1.7
- Ships the Claude Desktop (Cowork) session support from #187 plus the claude-code discover streaming refactor (48× retained-heap reduction on 218-session collections)

## Test plan
- [x] `pnpm --filter vibe-replay build`
- [x] `node packages/cli/dist/index.js --version` → `0.1.7`
- [x] Smoke test: Cowork replay generation still works end-to-end

After this merges, I'll tag v0.1.7 + publish a GitHub release to trigger the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)