### PR TITLE
refactor(cli): extract FILE_EDIT_TOOLS constant to deduplicate tool name checks

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -20,7 +20,7 @@ import { parseCursorSession } from "./providers/cursor/parser.js";
 import { getCursorSessionCachePaths } from "./providers/cursor/sqlite-reader.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
-import { extractToolFilePath, localDayKey, shortenPath } from "./utils.js";
+import { FILE_EDIT_TOOLS, extractToolFilePath, localDayKey, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
 const SCANNER_VERSION = 7;
@@ -449,12 +449,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
               if (server) mcpServersUsed.add(server);
             }
             // Track file modifications
-            if (
-              block.name === "Edit" ||
-              block.name === "Write" ||
-              block.name === "NotebookEdit" ||
-              block.name === "Delete"
-            ) {
+            if (FILE_EDIT_TOOLS.has(block.name)) {
               const fp = extractToolFilePath(block.input);
               if (fp) {
                 editCount++;
@@ -499,12 +494,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
           if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
           for (const block of saMsg.content) {
             if (block.type !== "tool_use") continue;
-            if (
-              block.name === "Edit" ||
-              block.name === "Write" ||
-              block.name === "NotebookEdit" ||
-              block.name === "Delete"
-            ) {
+            if (FILE_EDIT_TOOLS.has(block.name)) {
               const fp = extractToolFilePath(block.input);
               if (fp) {
                 editCount++;
@@ -672,14 +662,7 @@ function buildScanResultFromParsed(
         for (const saScene of block._subAgent.scenes) {
           if (saScene.type !== "tool-call") continue;
           const saTool = saScene.toolName;
-          if (
-            saTool !== "Edit" &&
-            saTool !== "Write" &&
-            saTool !== "NotebookEdit" &&
-            saTool !== "Delete"
-          ) {
-            continue;
-          }
+          if (!FILE_EDIT_TOOLS.has(saTool)) continue;
           const saPath = extractToolFilePath(saScene.input);
           if (!saPath) continue;
           editCount++;
@@ -688,14 +671,7 @@ function buildScanResultFromParsed(
         }
       }
 
-      if (
-        block.name !== "Edit" &&
-        block.name !== "Write" &&
-        block.name !== "NotebookEdit" &&
-        block.name !== "Delete"
-      ) {
-        continue;
-      }
+      if (!FILE_EDIT_TOOLS.has(block.name)) continue;
 
       const rawPath = extractToolFilePath(block.input);
       if (!rawPath) continue;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -15,6 +15,14 @@ export function normalizeTitle(value?: string): string | undefined {
   return cleaned || undefined;
 }
 
+/** Tool names that modify files on disk. Used to count edits and track modified files. */
+export const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  "Edit",
+  "Write",
+  "NotebookEdit",
+  "Delete",
+]);
+
 /** Extract file path from tool input, handling different provider field names. */
 export function extractToolFilePath(
   input: Record<string, unknown> | undefined,


### PR DESCRIPTION
## Summary

- Extract a shared `FILE_EDIT_TOOLS` ReadonlySet constant in `utils.ts` containing the four file-editing tool names (`Edit`, `Write`, `NotebookEdit`, `Delete`)
- Replace 4 duplicated inline checks in `scanner.ts` with `FILE_EDIT_TOOLS.has()` calls
- Net result: -29 lines removed, +13 lines added — adding a new file-editing tool now requires updating only one location instead of four

## Motivation

The same set of tool names was checked in 4 separate places in `scanner.ts` using verbose `||` / `&&` chains. If a new file-editing tool were added, all 4 locations would need updating — easy to miss and a source of potential bugs.

## Test plan

- [x] `pnpm test` — all 757 unit tests pass (659 CLI + 98 viewer)
- [x] `pnpm build` — clean build, viewer 765KB (under 800KB limit)
- [x] `pnpm lint:check` — zero warnings, zero errors
- [x] TypeScript strict mode — `tsc --noEmit` passes with no errors
- [x] `pnpm test:e2e` — CLI smoke tests pass; browser-based tests skipped (no Playwright in cloud)

https://claude.ai/code/session_01K7PzUHXYJbzvDoEhf3h5QR

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7PzUHXYJbzvDoEhf3h5QR)_