### PR TITLE
chore: upgrade TypeScript to 6.0.3 and enable typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint:check
+      - run: pnpm typecheck
       - run: pnpm --filter @vibe-replay/website check
 
   test:

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { nanoid } from "nanoid";
 import { type AuthEnv, createAuth, DEV_ORIGINS, PROD_ORIGINS } from "./auth";
 import { cloudReplays, dailyInsights, insightProfiles, replays, userFiles } from "./db/schema";
@@ -128,16 +129,16 @@ app.on(["GET", "POST"], "/api/auth/*", async (c) => {
       method: req.method,
       headers,
       body: req.body,
-      duplex: "half" as any,
-    });
+      duplex: "half",
+    } as RequestInit);
   }
 
   // Validate callbackURL on social sign-in to prevent open redirect
   if (c.req.path === "/api/auth/sign-in/social" && c.req.method === "POST") {
     const cloned = req.clone();
     try {
-      const body = await cloned.json();
-      if (body.callbackURL && typeof body.callbackURL === "string") {
+      const body = (await cloned.json()) as { callbackURL?: unknown };
+      if (typeof body.callbackURL === "string") {
         if (!body.callbackURL.startsWith("/") || body.callbackURL.startsWith("//")) {
           return c.json({ error: "Invalid callbackURL" }, 400);
         }
@@ -745,7 +746,7 @@ app.post("/api/gists", async (c) => {
         : status === 422
           ? "GitHub rejected the request (content too large?)"
           : `GitHub API error (${status})`;
-    return c.json({ error: msg }, { status });
+    return c.json({ error: msg }, status as ContentfulStatusCode);
   }
 
   const gistData = (await gistResp.json()) as {
@@ -872,7 +873,7 @@ app.patch("/api/gists/:gistId", async (c) => {
           : status === 422
             ? "GitHub rejected the update (content too large?)"
             : `GitHub API error (${status})`;
-    return c.json({ error: msg }, { status });
+    return c.json({ error: msg }, status as ContentfulStatusCode);
   }
 
   const gistData = (await gistResp.json()) as {
@@ -2296,7 +2297,7 @@ async function importPrivateKey(pem: string): Promise<CryptoKey> {
     const pkcs8 = wrapPkcs1InPkcs8(bytes);
     return await crypto.subtle.importKey(
       "pkcs8",
-      pkcs8.buffer,
+      pkcs8,
       { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
       false,
       ["sign"],
@@ -2304,7 +2305,7 @@ async function importPrivateKey(pem: string): Promise<CryptoKey> {
   }
 }
 
-function wrapPkcs1InPkcs8(pkcs1: Uint8Array): Uint8Array {
+function wrapPkcs1InPkcs8(pkcs1: Uint8Array): Uint8Array<ArrayBuffer> {
   const rsaOid = new Uint8Array([
     0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
   ]);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "oxlint": "^1.61.0",
     "playwright": "^1.58.2",
     "tsx": "^4.21.0",
-    "typescript": "6.0.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "vitest run --config e2e/vitest.config.ts",
     "lint": "oxlint --fix packages/ website/src cloudflare/src && oxfmt packages/ website/src cloudflare/src",
     "lint:check": "oxlint packages/ website/src cloudflare/src && oxfmt --check packages/ website/src cloudflare/src",
+    "typecheck": "tsc --noEmit -p packages/types/tsconfig.json && tsc --noEmit -p packages/cli/tsconfig.json && tsc --noEmit -p packages/viewer/tsconfig.json && tsc --noEmit -p cloudflare/tsconfig.json",
     "fmt": "oxfmt packages/ website/src cloudflare/src",
     "prepare": "lefthook install"
   },
@@ -31,6 +32,7 @@
     "oxlint": "^1.61.0",
     "playwright": "^1.58.2",
     "tsx": "^4.21.0",
+    "typescript": "6.0.3",
     "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "@vitest/coverage-v8": "4.0.18",
     "tsup": "^8.3.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.18"
   },
   "engines": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -26,7 +26,7 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vite": "npm:rolldown-vite@^7.3.1",
     "vite-plugin-singlefile": "^2.0.3",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -105,13 +108,13 @@ importers:
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -164,8 +167,8 @@ importers:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: npm:rolldown-vite@^7.3.1
         version: rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.8.1)(@types/node@24.12.0)(esbuild@0.27.3)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
@@ -180,7 +183,7 @@ importers:
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.8
-        version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
+        version: 0.9.8(prettier@3.8.1)(typescript@6.0.3)
       '@astrojs/rss':
         specifier: ^4.0.17
         version: 4.0.17
@@ -195,13 +198,13 @@ importers:
         version: 4.2.1(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       astro:
         specifier: ^6.0.3
-        version: 6.0.3(@types/node@24.12.0)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 6.0.3(@types/node@24.12.0)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -3988,8 +3991,8 @@ packages:
   typescript-auto-import-cache@0.3.6:
     resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4428,12 +4431,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@astrojs/check@0.9.8(prettier@3.8.1)(typescript@5.9.3)':
+  '@astrojs/check@0.9.8(prettier@3.8.1)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.6(prettier@3.8.1)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.6(prettier@3.8.1)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - prettier
@@ -4447,12 +4450,12 @@ snapshots:
     dependencies:
       picomatch: 4.0.3
 
-  '@astrojs/language-server@2.16.6(prettier@3.8.1)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.6(prettier@3.8.1)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.3
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@volar/kit': 2.4.28(typescript@5.9.3)
+      '@volar/kit': 2.4.28(typescript@6.0.3)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -5771,12 +5774,12 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@volar/kit@2.4.28(typescript@5.9.3)':
+  '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 5.9.3
+      typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -5865,7 +5868,7 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  astro@6.0.3(@types/node@24.12.0)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@6.0.3(@types/node@24.12.0)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 3.0.0
       '@astrojs/internal-helpers': 0.8.0
@@ -5911,7 +5914,7 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -8057,14 +8060,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1:
     optional: true
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -8085,7 +8088,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.8
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -8110,7 +8113,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: 6.0.3
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.0.18

--- a/website/package.json
+++ b/website/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@vibe-replay/website",
-  "type": "module",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "bash ./scripts/run-with-required-node.sh dev",
     "build": "bash ./scripts/run-with-required-node.sh build",
@@ -17,6 +17,6 @@
     "@tailwindcss/vite": "^4.2.1",
     "astro": "^6.0.3",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- Bump `typescript` 5.9.3 → 6.0.3 across all packages
- Add root `typecheck` script covering `types` / `cli` / `viewer` / `cloudflare`
- Wire `pnpm typecheck` into CI `lint` job — type errors are now caught on every PR
- Fix pre-existing type errors in `cloudflare/src/worker.ts` that slipped in because typecheck was never run in CI

The TS 6.0 upgrade itself was a no-op for our code — zero breaking changes hit `cli` / `viewer` / `types` / `website`. The 9 errors fixed in `worker.ts` were latent issues that TS 5.9 also reported; they're surfaced now because typecheck is finally enforced.

## What changed in `worker.ts`

| Error | Fix |
|---|---|
| `duplex` not on cf `RequestInit<CfProperties>` | cast init `as RequestInit` |
| `body.callbackURL` on `unknown` body | `(await cloned.json()) as { callbackURL?: unknown }` + `typeof` narrow |
| `c.json(obj, { status: number })` not `ContentfulStatusCode` | `import type { ContentfulStatusCode } from "hono/utils/http-status"`; pass `status as ContentfulStatusCode` |
| `pkcs8.buffer: ArrayBufferLike` not `BufferSource` | return `Uint8Array<ArrayBuffer>` from `wrapPkcs1InPkcs8`, pass the view directly to `crypto.subtle.importKey` |

## Why not tsgo

Considered `@typescript/native-preview` (the Go port, ~5× faster). Skipped — preview-only, daily dev builds, and our typecheck is already <3s. Will revisit when TS 7 / tsgo ships GA.

## Test plan

- [x] `pnpm typecheck` passes (types / cli / viewer / cloudflare)
- [x] `pnpm --filter @vibe-replay/website check` passes (0 errors / 0 warnings)
- [x] `pnpm lint:check` passes
- [x] `pnpm test` — 661 + 98 unit tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm test:e2e` — 28 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)