### PR TITLE
refactor(viewer): make Projects Work Map first-class

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -216,6 +216,8 @@ export interface SessionScanWireData {
   filesModified: Array<{ file: string; count: number }>;
   costEstimate?: number;
   subAgentCount: number;
+  entrypoint?: string;
+  prLinks?: PrLink[];
 }
 
 export interface ReplaySession {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -218,6 +218,8 @@ export interface SessionScanWireData {
   subAgentCount: number;
   entrypoint?: string;
   prLinks?: PrLink[];
+  dataSource?: DataSource;
+  dataQualityNotes?: string[];
 }
 
 export interface ReplaySession {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -192,6 +192,32 @@ export interface InsightsStore {
   sessions: SessionInsight[];
 }
 
+/**
+ * Wire format for the per-session entries returned by `/api/scan/results`.
+ * This is the canonical client-facing subset of `SessionScanResult`
+ * (defined in `packages/cli/src/scanner.ts`). Keep in sync with that type
+ * when adding fields the viewer needs.
+ */
+export interface SessionScanWireData {
+  sessionId: string;
+  provider: string;
+  project: string;
+  slug: string;
+  title?: string;
+  firstPrompt?: string;
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+  gitBranch?: string;
+  model?: string;
+  promptCount: number;
+  toolCallCount: number;
+  editCount: number;
+  filesModified: Array<{ file: string; count: number }>;
+  costEstimate?: number;
+  subAgentCount: number;
+}
+
 export interface ReplaySession {
   meta: {
     sessionId: string;

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1295,17 +1295,31 @@ function SessionsPanel() {
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateError, setGenerateError] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
-  // When another panel (Projects → Timeline / Hot Files) routes us here with
-  // `?selected=<slug>`, open the popup for that session and strip the param
-  // so a refresh doesn't keep re-opening it.
+  // When another panel (Projects → Timeline / Hot Files) opens a session via
+  // the `vibe-open-session` event, route the slug into the popup. Two paths:
+  //   1. If SessionsPanel just mounted (e.g. tab switched from Projects),
+  //      Dashboard already pushed `?selected=<slug>` to the URL — read it.
+  //   2. If SessionsPanel is already mounted (user on Sessions tab clicked
+  //      from a still-rendered Projects view, or back-button), the URL push
+  //      doesn't trigger a re-mount, so listen for the event live.
+  // Strip `?selected` afterward so a refresh doesn't keep re-opening it.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const selected = params.get("selected");
-    if (!selected) return;
-    setSelectedSlug(selected);
-    const url = new URL(window.location.href);
-    url.searchParams.delete("selected");
-    window.history.replaceState(null, "", url);
+    const consumeUrl = () => {
+      const params = new URLSearchParams(window.location.search);
+      const selected = params.get("selected");
+      if (!selected) return;
+      setSelectedSlug(selected);
+      const url = new URL(window.location.href);
+      url.searchParams.delete("selected");
+      window.history.replaceState(null, "", url);
+    };
+    consumeUrl();
+    const handler = (e: Event) => {
+      const slug = (e as CustomEvent<{ slug: string }>).detail?.slug;
+      if (slug) setSelectedSlug(slug);
+    };
+    window.addEventListener("vibe-open-session", handler);
+    return () => window.removeEventListener("vibe-open-session", handler);
   }, []);
   const wasEnrichingRef = useRef(false);
   const [archivedSlugs, setArchivedSlugs] = useState<Set<string>>(new Set());

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1295,6 +1295,18 @@ function SessionsPanel() {
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateError, setGenerateError] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  // When another panel (Projects → Timeline / Hot Files) routes us here with
+  // `?selected=<slug>`, open the popup for that session and strip the param
+  // so a refresh doesn't keep re-opening it.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const selected = params.get("selected");
+    if (!selected) return;
+    setSelectedSlug(selected);
+    const url = new URL(window.location.href);
+    url.searchParams.delete("selected");
+    window.history.replaceState(null, "", url);
+  }, []);
   const wasEnrichingRef = useRef(false);
   const [archivedSlugs, setArchivedSlugs] = useState<Set<string>>(new Set());
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
@@ -2730,6 +2742,23 @@ export default function Dashboard({
     window.addEventListener("popstate", handler);
     return () => window.removeEventListener("popstate", handler);
   }, [getTabFromUrl]);
+
+  // Cross-panel "open this session in the Sessions popup" channel. Dispatched
+  // from Projects → Timeline / Hot Files when the user clicks a session that
+  // may or may not have a generated replay yet. We switch to Sessions tab and
+  // pass the slug via URL — SessionsPanel's mount effect picks it up and opens
+  // SessionDetailPopup, which handles both the "open replay" and "generate
+  // replay" cases uniformly.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const slug = (e as CustomEvent<{ slug: string }>).detail?.slug;
+      if (!slug) return;
+      setTab("sessions");
+      navigateTo({ tab: "sessions", selected: slug, project: null, q: null, archived: null });
+    };
+    window.addEventListener("vibe-open-session", handler);
+    return () => window.removeEventListener("vibe-open-session", handler);
+  }, []);
 
   const handleTabChange = (id: Tab) => {
     setTab(id);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -41,7 +41,7 @@ import {
 import ProjectsPanel from "./ProjectsPanel";
 import { formatDuration } from "./StatsPanel";
 
-type Tab = "home" | "sessions" | "replays" | "projects" | "insights";
+export type Tab = "home" | "sessions" | "replays" | "projects" | "insights";
 
 const MoreDotsIcon = () => (
   <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1316,7 +1316,14 @@ function SessionsPanel() {
     consumeUrl();
     const handler = (e: Event) => {
       const slug = (e as CustomEvent<{ slug: string }>).detail?.slug;
-      if (slug) setSelectedSlug(slug);
+      if (!slug) return;
+      setSelectedSlug(slug);
+      // Dashboard's root handler also writes `?selected=slug` for the
+      // cold-mount path. Strip it here so a tab round-trip after dismissing
+      // the popup doesn't reopen it on remount.
+      const url = new URL(window.location.href);
+      url.searchParams.delete("selected");
+      window.history.replaceState(null, "", url);
     };
     window.addEventListener("vibe-open-session", handler);
     return () => window.removeEventListener("vibe-open-session", handler);

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -263,7 +263,7 @@ function ProjectOverview({
         onClick={onOpenSessions}
         className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-terminal-green-subtle px-3 py-1.5 text-xs font-sans font-semibold text-terminal-green hover:bg-terminal-green-emphasis transition-colors"
       >
-        Open sessions →
+        View all sessions →
       </button>
     </div>
   );

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -8,18 +8,18 @@
  */
 
 import { useMemo, useState } from "react";
+import { ALL_PROJECTS } from "../hooks/usePanelFilters";
 import { localDayKey } from "../utils/date";
-import { timeAgo } from "../utils/format";
+import { plural, timeAgo } from "../utils/format";
+import type { Tab } from "./Dashboard";
 import { navigateTo, projectName, rollupTopProjects } from "./dashboard-utils";
 import { useScanInsightsContext } from "./InsightsPanel";
 import SessionRelationshipsView from "./SessionRelationshipsView";
-import { formatDuration } from "./StatsPanel";
+import { fmtNum, formatDuration } from "./StatsPanel";
 
 interface ProjectsPanelProps {
-  onNavigate: (view: "home" | "sessions" | "replays" | "projects") => void;
+  onNavigate: (view: Tab) => void;
 }
-
-const ALL_PROJECTS = "__all__";
 
 type PanelMode = "overview" | "timeline" | "files";
 
@@ -38,21 +38,23 @@ function MiniSparkline({
   sessionsPerDay: Record<string, number>;
   size?: "sm" | "md";
 }) {
-  const data = useMemo(() => {
+  const { data, max } = useMemo(() => {
     const end = new Date();
     const start = new Date(end);
     start.setDate(start.getDate() - 29);
     const result: number[] = [];
+    let m = 1;
     const cursor = new Date(start);
     while (cursor <= end) {
       const key = localDayKey(cursor)!;
-      result.push(sessionsPerDay[key] || 0);
+      const count = sessionsPerDay[key] || 0;
+      result.push(count);
+      if (count > m) m = count;
       cursor.setDate(cursor.getDate() + 1);
     }
-    return result;
+    return { data: result, max: m };
   }, [sessionsPerDay]);
 
-  const max = Math.max(...data, 1);
   const heightClass = size === "md" ? "h-8" : "h-4";
 
   return (
@@ -69,18 +71,6 @@ function MiniSparkline({
       ))}
     </div>
   );
-}
-
-// ─── Helpers ────────────────────────────────────────────────────────
-
-function fmtNum(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
-}
-
-function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
-  return count === 1 ? singular : pluralForm;
 }
 
 // ─── Project sidebar (left pane) ────────────────────────────────────
@@ -164,12 +154,10 @@ function ProjectSidebar({
                 </span>
               </div>
               {p.lastActivity && (
-                <div className="mt-1 ml-0.5">
-                  <span
-                    className={`text-xs font-mono truncate ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
-                  >
-                    {timeAgo(p.lastActivity, "long")}
-                  </span>
+                <div
+                  className={`mt-1 ml-0.5 text-xs font-mono truncate ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
+                >
+                  {timeAgo(p.lastActivity, "long")}
                 </div>
               )}
             </button>
@@ -195,91 +183,88 @@ function ProjectOverview({
 }) {
   const name = projectName(project);
   return (
-    <div className="space-y-4">
-      {/* Hero card */}
-      <div className="hover-lift relative overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-5 shadow-layer-md">
-        <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-60" />
-        <span className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-terminal-green/5 blur-2xl" />
+    <div className="hover-lift relative overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-5 shadow-layer-md">
+      <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-60" />
+      <span className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-terminal-green/5 blur-2xl" />
 
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="text-base font-sans font-semibold text-terminal-text truncate">
-              {name}
-            </div>
-            <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
-              {project}
-            </div>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-base font-sans font-semibold text-terminal-text truncate">
+            {name}
           </div>
-          {insight.lastActivity && (
-            <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
-              {timeAgo(insight.lastActivity, "long")}
-            </span>
-          )}
+          <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
+            {project}
+          </div>
         </div>
-
-        {/* Stats grid */}
-        <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs font-mono">
-          <Stat
-            label={plural(insight.sessions, "session")}
-            value={insight.sessions.toString()}
-            tone="text"
-          />
-          {insight.durationMs > 0 && (
-            <Stat label="active time" value={formatDuration(insight.durationMs)} tone="blue" />
-          )}
-          {insight.cost > 0 && (
-            <Stat label="cost" value={`$${insight.cost.toFixed(2)}`} tone="orange" />
-          )}
-          <Stat
-            label={plural(insight.prompts, "prompt")}
-            value={fmtNum(insight.prompts)}
-            tone="green"
-          />
-        </div>
-
-        {/* Secondary stats */}
-        <div className="mt-3 flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap">
-          {insight.toolCalls > 0 && (
-            <span>
-              {fmtNum(insight.toolCalls)} {plural(insight.toolCalls, "tool")}
-            </span>
-          )}
-          {insight.edits > 0 && (
-            <span>
-              {fmtNum(insight.edits)} {plural(insight.edits, "edit")}
-            </span>
-          )}
-          {insight.branchCount > 0 && (
-            <span>
-              {insight.branchCount} {plural(insight.branchCount, "branch", "branches")}
-            </span>
-          )}
-          {insight.prCount > 0 && (
-            <span>
-              {insight.prCount} {plural(insight.prCount, "PR")}
-            </span>
-          )}
-          {insight.memoryFileCount > 0 && (
-            <span>
-              {insight.memoryFileCount}{" "}
-              {insight.memoryFileCount === 1 ? "Claude memory" : "Claude memories"}
-            </span>
-          )}
-        </div>
-
-        {/* Sparkline */}
-        <div className="mt-4">
-          <MiniSparkline sessionsPerDay={insight.sessionsPerDay} size="md" />
-          <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">last 30 days</div>
-        </div>
-
-        <button
-          onClick={onOpenSessions}
-          className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-terminal-green-subtle px-3 py-1.5 text-xs font-sans font-semibold text-terminal-green hover:bg-terminal-green-emphasis transition-colors"
-        >
-          Open sessions →
-        </button>
+        {insight.lastActivity && (
+          <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
+            {timeAgo(insight.lastActivity, "long")}
+          </span>
+        )}
       </div>
+
+      {/* Stats grid */}
+      <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs font-mono">
+        <Stat
+          label={plural(insight.sessions, "session")}
+          value={insight.sessions.toString()}
+          tone="text"
+        />
+        {insight.durationMs > 0 && (
+          <Stat label="active time" value={formatDuration(insight.durationMs)} tone="blue" />
+        )}
+        {insight.cost > 0 && (
+          <Stat label="cost" value={`$${insight.cost.toFixed(2)}`} tone="orange" />
+        )}
+        <Stat
+          label={plural(insight.prompts, "prompt")}
+          value={fmtNum(insight.prompts)}
+          tone="green"
+        />
+      </div>
+
+      {/* Secondary stats */}
+      <div className="mt-3 flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap">
+        {insight.toolCalls > 0 && (
+          <span>
+            {fmtNum(insight.toolCalls)} {plural(insight.toolCalls, "tool")}
+          </span>
+        )}
+        {insight.edits > 0 && (
+          <span>
+            {fmtNum(insight.edits)} {plural(insight.edits, "edit")}
+          </span>
+        )}
+        {insight.branchCount > 0 && (
+          <span>
+            {insight.branchCount} {plural(insight.branchCount, "branch", "branches")}
+          </span>
+        )}
+        {insight.prCount > 0 && (
+          <span>
+            {insight.prCount} {plural(insight.prCount, "PR")}
+          </span>
+        )}
+        {insight.memoryFileCount > 0 && (
+          <span>
+            {insight.memoryFileCount}{" "}
+            {insight.memoryFileCount === 1 ? "Claude memory" : "Claude memories"}
+          </span>
+        )}
+      </div>
+
+      {/* Sparkline */}
+      <div className="mt-4">
+        <MiniSparkline sessionsPerDay={insight.sessionsPerDay} size="md" />
+        <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">last 30 days</div>
+      </div>
+
+      <button
+        onClick={onOpenSessions}
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-terminal-green-subtle px-3 py-1.5 text-xs font-sans font-semibold text-terminal-green hover:bg-terminal-green-emphasis transition-colors"
+      >
+        Open sessions →
+      </button>
     </div>
   );
 }
@@ -411,11 +396,10 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     return sorted;
   }, [userInsights]);
 
-  const selectedInsight = useMemo(
-    () =>
-      selectedProject === ALL_PROJECTS ? null : projects.find((p) => p.project === selectedProject),
-    [projects, selectedProject],
-  );
+  const selectedInsight =
+    selectedProject === ALL_PROJECTS
+      ? null
+      : (projects.find((p) => p.project === selectedProject) ?? null);
 
   const isScanning = scanStatus?.running && scanStatus.total > 0;
 
@@ -452,10 +436,8 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     lastActivity: p.lastActivity,
   }));
 
-  // Tabs: when a single project is selected, drop the standalone Timeline tab
-  // because Overview already embeds the timeline below the hero card. Hot Files
-  // is still its own tab — the file grid + detail layout takes too much space
-  // to live inside Overview.
+  // Single-project Overview already embeds the timeline; the standalone tab
+  // is redundant and dropped. Hot Files stays as its own tab.
   const isSingleProject = selectedProject !== ALL_PROJECTS;
   const visibleTabs = isSingleProject
     ? PROJECT_VIEW_TABS.filter((t) => t.id !== "timeline")
@@ -471,8 +453,6 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
         selected={selectedProject}
         onSelect={(project) => {
           setSelectedProject(project);
-          // Reset to overview when a new project is picked so users see the
-          // hero card first, not whatever inner tab was previously open.
           setMode("overview");
         }}
       />
@@ -544,9 +524,6 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 insight={selectedInsight}
                 onOpenSessions={() => openSessionsForProject(selectedProject)}
               />
-              {/* Single-project Overview embeds the timeline + Top Sessions
-                  inline so users see project info, when work happened, and
-                  which sessions mattered without switching tabs. */}
               <SessionRelationshipsView view="timeline" projectFilter={projectFilterArg} />
             </>
           )}

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -452,11 +452,16 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     lastActivity: p.lastActivity,
   }));
 
-  // Determine which tab is showing in the right pane.
-  // Default tab when "All projects" is selected: overview (= grid)
-  // Default when a single project is picked: overview (= hero card)
-  const activeMode = mode;
-  const projectFilterArg = selectedProject === ALL_PROJECTS ? undefined : selectedProject;
+  // Tabs: when a single project is selected, drop the standalone Timeline tab
+  // because Overview already embeds the timeline below the hero card. Hot Files
+  // is still its own tab — the file grid + detail layout takes too much space
+  // to live inside Overview.
+  const isSingleProject = selectedProject !== ALL_PROJECTS;
+  const visibleTabs = isSingleProject
+    ? PROJECT_VIEW_TABS.filter((t) => t.id !== "timeline")
+    : PROJECT_VIEW_TABS;
+  const activeMode = visibleTabs.some((t) => t.id === mode) ? mode : "overview";
+  const projectFilterArg = isSingleProject ? selectedProject : undefined;
 
   return (
     <div className="flex flex-1 min-h-0">
@@ -510,7 +515,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
             )}
           </div>
           <div className="inline-flex w-fit items-center rounded-xl bg-terminal-surface/80 p-0.5 shadow-layer-sm backdrop-blur-sm">
-            {PROJECT_VIEW_TABS.map((tab) => (
+            {visibleTabs.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setMode(tab.id)}
@@ -532,11 +537,17 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
             <ProjectsGrid projects={projects} onProjectClick={setSelectedProject} />
           )}
           {activeMode === "overview" && selectedInsight && (
-            <ProjectOverview
-              project={selectedProject}
-              insight={selectedInsight}
-              onOpenSessions={() => openSessionsForProject(selectedProject)}
-            />
+            <>
+              <ProjectOverview
+                project={selectedProject}
+                insight={selectedInsight}
+                onOpenSessions={() => openSessionsForProject(selectedProject)}
+              />
+              {/* Single-project Overview embeds the timeline + Top Sessions
+                  inline so users see project info, when work happened, and
+                  which sessions mattered without switching tabs. */}
+              <SessionRelationshipsView view="timeline" projectFilter={projectFilterArg} />
+            </>
           )}
           {activeMode === "timeline" && (
             <SessionRelationshipsView view="timeline" projectFilter={projectFilterArg} />

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -126,27 +126,27 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
       <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
         {/* Header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <h2 className="text-sm font-sans font-semibold text-terminal-text">
               All Projects
               <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
             </h2>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             {/* Visualize button */}
             <button
               onClick={() => setMode("relationships")}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-mono bg-terminal-purple/10 text-terminal-purple border border-terminal-purple/30 hover:bg-terminal-purple/20 transition-colors"
+              className="flex w-fit items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-mono bg-terminal-purple/10 text-terminal-purple border border-terminal-purple/30 hover:bg-terminal-purple/20 transition-colors"
               title="View session relationship visualizations"
             >
               <span>⟶</span>
               Visualize
             </button>
-            <div className="flex items-center gap-1 text-[10px] font-sans">
+            <div className="flex flex-wrap items-center gap-1 text-[10px] font-sans">
               <span className="text-terminal-dimmer mr-1">Sort:</span>
               {(
                 [

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -482,6 +482,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
         {/* Mobile project selector */}
         <div className="md:hidden px-3 pt-3">
           <select
+            aria-label="Select project"
             value={selectedProject}
             onChange={(e) => {
               setSelectedProject(e.target.value);

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -14,7 +14,13 @@ interface ProjectsPanelProps {
   onNavigate: (view: "home" | "sessions" | "replays" | "projects") => void;
 }
 
-type PanelMode = "grid" | "relationships";
+type PanelMode = "list" | "timeline" | "files";
+
+const PROJECT_VIEW_TABS: { id: PanelMode; label: string }[] = [
+  { id: "list", label: "List" },
+  { id: "timeline", label: "Timeline" },
+  { id: "files", label: "Files" },
+];
 
 // ─── Activity sparkline (compact) ───────────────────────────────────
 
@@ -63,32 +69,16 @@ function fmtNum(n: number): string {
 
 export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
   const { userInsights, scanStatus } = useScanInsightsContext();
-  const [mode, setMode] = useState<PanelMode>("grid");
-  const [sortBy, setSortBy] = useState<"lastActivity" | "sessions" | "cost" | "duration">(
-    "lastActivity",
-  );
+  const [mode, setMode] = useState<PanelMode>("list");
 
   const projects = useMemo(() => {
     if (!userInsights) return [];
     // Roll Claude agent worktrees up under their parent so the grid isn't
     // drowned by single-session sandbox dirs.
     const sorted = rollupTopProjects(userInsights.topProjects);
-    switch (sortBy) {
-      case "lastActivity":
-        sorted.sort((a, b) => (b.lastActivity || "").localeCompare(a.lastActivity || ""));
-        break;
-      case "sessions":
-        sorted.sort((a, b) => b.sessions - a.sessions);
-        break;
-      case "cost":
-        sorted.sort((a, b) => b.cost - a.cost);
-        break;
-      case "duration":
-        sorted.sort((a, b) => b.durationMs - a.durationMs);
-        break;
-    }
+    sorted.sort((a, b) => (b.lastActivity || "").localeCompare(a.lastActivity || ""));
     return sorted;
-  }, [userInsights, sortBy]);
+  }, [userInsights]);
 
   const isScanning = scanStatus?.running && scanStatus.total > 0;
 
@@ -121,10 +111,6 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     }, 50);
   };
 
-  if (mode === "relationships") {
-    return <SessionRelationshipsView onBack={() => setMode("grid")} />;
-  }
-
   return (
     <div className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
       <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
@@ -136,39 +122,20 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
               <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
             </h2>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            {/* Visualize button */}
-            <button
-              onClick={() => setMode("relationships")}
-              className="flex w-fit items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-mono bg-terminal-purple/10 text-terminal-purple border border-terminal-purple/30 hover:bg-terminal-purple/20 transition-colors"
-              title="View session relationship visualizations"
-            >
-              <span>⟶</span>
-              Visualize
-            </button>
-            <div className="flex flex-wrap items-center gap-1 text-[10px] font-sans">
-              <span className="text-terminal-dimmer mr-1">Sort:</span>
-              {(
-                [
-                  ["lastActivity", "Recent"],
-                  ["sessions", "Sessions"],
-                  ["cost", "Cost"],
-                  ["duration", "Duration"],
-                ] as const
-              ).map(([key, label]) => (
-                <button
-                  key={key}
-                  onClick={() => setSortBy(key)}
-                  className={`px-2 py-1 rounded-md transition-colors ${
-                    sortBy === key
-                      ? "bg-terminal-green-subtle text-terminal-green"
-                      : "text-terminal-dim hover:text-terminal-text"
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
-            </div>
+          <div className="flex flex-wrap items-center gap-1 text-[10px] font-sans">
+            {PROJECT_VIEW_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setMode(tab.id)}
+                className={`px-2.5 py-1.5 rounded-lg transition-colors ${
+                  mode === tab.id
+                    ? "bg-terminal-green-subtle text-terminal-green"
+                    : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-2"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
         </div>
 
@@ -181,81 +148,88 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
           </div>
         )}
 
+        {mode === "timeline" && <SessionRelationshipsView view="timeline" />}
+        {mode === "files" && <SessionRelationshipsView view="files" />}
+
         {/* Projects grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {projects.map((p) => {
-            const name = p.project.split("/").pop() || p.project;
-            return (
-              <button
-                key={p.project}
-                onClick={() => handleProjectClick(p.project)}
-                className="text-left bg-terminal-surface rounded-xl p-4 shadow-layer-sm hover:bg-terminal-surface-hover transition-all duration-200 group border-l-2 border-terminal-green/40 hover:border-terminal-green"
-              >
-                {/* Project name + last activity */}
-                <div className="flex items-start justify-between gap-2 mb-3">
-                  <div className="min-w-0">
-                    <div className="text-sm font-sans font-medium text-terminal-text truncate group-hover:text-terminal-green transition-colors">
-                      {name}
+        {mode === "list" && (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {projects.map((p) => {
+              const name = p.project.split("/").pop() || p.project;
+              return (
+                <button
+                  key={p.project}
+                  onClick={() => handleProjectClick(p.project)}
+                  className="text-left bg-terminal-surface rounded-xl p-4 shadow-layer-sm hover:bg-terminal-surface-hover transition-all duration-200 group border-l-2 border-terminal-green/40 hover:border-terminal-green"
+                >
+                  {/* Project name + last activity */}
+                  <div className="flex items-start justify-between gap-2 mb-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-sans font-medium text-terminal-text truncate group-hover:text-terminal-green transition-colors">
+                        {name}
+                      </div>
+                      <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
+                        {p.project}
+                      </div>
                     </div>
-                    <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
-                      {p.project}
-                    </div>
+                    {p.lastActivity && (
+                      <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
+                        {timeAgo(p.lastActivity, "long")}
+                      </span>
+                    )}
                   </div>
-                  {p.lastActivity && (
-                    <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
-                      {timeAgo(p.lastActivity, "long")}
-                    </span>
-                  )}
-                </div>
 
-                {/* Stats row */}
-                <div className="flex items-center gap-3 text-xs font-mono flex-wrap mb-3">
-                  <span className="text-terminal-text tabular-nums">
-                    {p.sessions}{" "}
-                    <span className="text-terminal-dimmer">
-                      session{p.sessions !== 1 ? "s" : ""}
+                  {/* Stats row */}
+                  <div className="flex items-center gap-3 text-xs font-mono flex-wrap mb-3">
+                    <span className="text-terminal-text tabular-nums">
+                      {p.sessions}{" "}
+                      <span className="text-terminal-dimmer">
+                        session{p.sessions !== 1 ? "s" : ""}
+                      </span>
                     </span>
-                  </span>
-                  {p.durationMs > 0 && (
-                    <span className="text-terminal-blue tabular-nums">
-                      {formatDuration(p.durationMs)}
+                    {p.durationMs > 0 && (
+                      <span className="text-terminal-blue tabular-nums">
+                        {formatDuration(p.durationMs)}
+                      </span>
+                    )}
+                    {p.cost > 0 && (
+                      <span className="text-terminal-orange tabular-nums">
+                        ${p.cost.toFixed(2)}
+                      </span>
+                    )}
+                    <span className="text-terminal-green tabular-nums">
+                      {fmtNum(p.prompts)} <span className="text-terminal-dimmer">prompts</span>
                     </span>
-                  )}
-                  {p.cost > 0 && (
-                    <span className="text-terminal-orange tabular-nums">${p.cost.toFixed(2)}</span>
-                  )}
-                  <span className="text-terminal-green tabular-nums">
-                    {fmtNum(p.prompts)} <span className="text-terminal-dimmer">prompts</span>
-                  </span>
-                </div>
+                  </div>
 
-                {/* Secondary stats */}
-                <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap mb-2">
-                  {p.toolCalls > 0 && <span>{fmtNum(p.toolCalls)} tools</span>}
-                  {p.edits > 0 && <span>{fmtNum(p.edits)} edits</span>}
-                  {p.branchCount > 0 && (
-                    <span>
-                      {p.branchCount} branch{p.branchCount !== 1 ? "es" : ""}
-                    </span>
-                  )}
-                  {p.prCount > 0 && (
-                    <span>
-                      {p.prCount} PR{p.prCount !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                  {p.memoryFileCount > 0 && (
-                    <span>
-                      {p.memoryFileCount} memory file{p.memoryFileCount !== 1 ? "s" : ""}
-                    </span>
-                  )}
-                </div>
+                  {/* Secondary stats */}
+                  <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap mb-2">
+                    {p.toolCalls > 0 && <span>{fmtNum(p.toolCalls)} tools</span>}
+                    {p.edits > 0 && <span>{fmtNum(p.edits)} edits</span>}
+                    {p.branchCount > 0 && (
+                      <span>
+                        {p.branchCount} branch{p.branchCount !== 1 ? "es" : ""}
+                      </span>
+                    )}
+                    {p.prCount > 0 && (
+                      <span>
+                        {p.prCount} PR{p.prCount !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                    {p.memoryFileCount > 0 && (
+                      <span>
+                        {p.memoryFileCount} memory file{p.memoryFileCount !== 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </div>
 
-                {/* Sparkline */}
-                <MiniSparkline sessionsPerDay={p.sessionsPerDay} />
-              </button>
-            );
-          })}
-        </div>
+                  {/* Sparkline */}
+                  <MiniSparkline sessionsPerDay={p.sessionsPerDay} />
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -5,7 +5,7 @@
 import { useMemo, useState } from "react";
 import { localDayKey } from "../utils/date";
 import { timeAgo } from "../utils/format";
-import { navigateTo, rollupTopProjects } from "./dashboard-utils";
+import { navigateTo, projectName, rollupTopProjects } from "./dashboard-utils";
 import { useScanInsightsContext } from "./InsightsPanel";
 import SessionRelationshipsView from "./SessionRelationshipsView";
 import { formatDuration } from "./StatsPanel";
@@ -19,7 +19,7 @@ type PanelMode = "list" | "timeline" | "files";
 const PROJECT_VIEW_TABS: { id: PanelMode; label: string }[] = [
   { id: "list", label: "List" },
   { id: "timeline", label: "Timeline" },
-  { id: "files", label: "Files" },
+  { id: "files", label: "Hot Files" },
 ];
 
 // ─── Activity sparkline (compact) ───────────────────────────────────
@@ -63,6 +63,10 @@ function fmtNum(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
 }
 
 // ─── Main Component ─────────────────────────────────────────────────
@@ -112,8 +116,12 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
   };
 
   return (
-    <div className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
-      <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
+    <div className="relative flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-x-0 top-0 h-56 bg-gradient-to-b from-terminal-green-subtle via-transparent to-transparent opacity-70" />
+        <div className="absolute inset-0 bg-dot-grid opacity-40" />
+      </div>
+      <div className="relative max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
         {/* Header */}
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
@@ -121,16 +129,19 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
               All Projects
               <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
             </h2>
+            <p className="mt-1 text-xs font-mono text-terminal-dimmer">
+              Recent work, timelines, and hotspots across your AI sessions.
+            </p>
           </div>
-          <div className="flex flex-wrap items-center gap-1 text-[10px] font-sans">
+          <div className="inline-flex w-fit items-center rounded-xl bg-terminal-surface/80 p-0.5 shadow-layer-sm backdrop-blur-sm">
             {PROJECT_VIEW_TABS.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setMode(tab.id)}
-                className={`px-2.5 py-1.5 rounded-lg transition-colors ${
+                className={`rounded-lg px-3.5 py-1.5 text-xs font-sans font-semibold transition-all duration-200 ease-material ${
                   mode === tab.id
-                    ? "bg-terminal-green-subtle text-terminal-green"
-                    : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-2"
+                    ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
+                    : "text-terminal-dim hover:text-terminal-text"
                 }`}
               >
                 {tab.label}
@@ -155,13 +166,15 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
         {mode === "list" && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {projects.map((p) => {
-              const name = p.project.split("/").pop() || p.project;
+              const name = projectName(p.project);
               return (
                 <button
                   key={p.project}
                   onClick={() => handleProjectClick(p.project)}
-                  className="text-left bg-terminal-surface rounded-xl p-4 shadow-layer-sm hover:bg-terminal-surface-hover transition-all duration-200 group border-l-2 border-terminal-green/40 hover:border-terminal-green"
+                  className="hover-lift group relative overflow-hidden rounded-xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-4 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover"
                 >
+                  <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-50 transition-opacity group-hover:opacity-100" />
+                  <span className="pointer-events-none absolute -right-10 -top-12 h-28 w-28 rounded-full bg-terminal-green/5 blur-2xl opacity-0 transition-opacity group-hover:opacity-100" />
                   {/* Project name + last activity */}
                   <div className="flex items-start justify-between gap-2 mb-3">
                     <div className="min-w-0">
@@ -183,9 +196,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                   <div className="flex items-center gap-3 text-xs font-mono flex-wrap mb-3">
                     <span className="text-terminal-text tabular-nums">
                       {p.sessions}{" "}
-                      <span className="text-terminal-dimmer">
-                        session{p.sessions !== 1 ? "s" : ""}
-                      </span>
+                      <span className="text-terminal-dimmer">{plural(p.sessions, "session")}</span>
                     </span>
                     {p.durationMs > 0 && (
                       <span className="text-terminal-blue tabular-nums">
@@ -198,27 +209,36 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                       </span>
                     )}
                     <span className="text-terminal-green tabular-nums">
-                      {fmtNum(p.prompts)} <span className="text-terminal-dimmer">prompts</span>
+                      {fmtNum(p.prompts)}{" "}
+                      <span className="text-terminal-dimmer">{plural(p.prompts, "prompt")}</span>
                     </span>
                   </div>
 
                   {/* Secondary stats */}
                   <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap mb-2">
-                    {p.toolCalls > 0 && <span>{fmtNum(p.toolCalls)} tools</span>}
-                    {p.edits > 0 && <span>{fmtNum(p.edits)} edits</span>}
+                    {p.toolCalls > 0 && (
+                      <span>
+                        {fmtNum(p.toolCalls)} {plural(p.toolCalls, "tool")}
+                      </span>
+                    )}
+                    {p.edits > 0 && (
+                      <span>
+                        {fmtNum(p.edits)} {plural(p.edits, "edit")}
+                      </span>
+                    )}
                     {p.branchCount > 0 && (
                       <span>
-                        {p.branchCount} branch{p.branchCount !== 1 ? "es" : ""}
+                        {p.branchCount} {plural(p.branchCount, "branch", "branches")}
                       </span>
                     )}
                     {p.prCount > 0 && (
                       <span>
-                        {p.prCount} PR{p.prCount !== 1 ? "s" : ""}
+                        {p.prCount} {plural(p.prCount, "PR")}
                       </span>
                     )}
                     {p.memoryFileCount > 0 && (
                       <span>
-                        {p.memoryFileCount} memory file{p.memoryFileCount !== 1 ? "s" : ""}
+                        {p.memoryFileCount} Claude {p.memoryFileCount !== 1 ? "memories" : "memory"}
                       </span>
                     )}
                   </div>

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -1,5 +1,10 @@
 /**
- * ProjectsPanel — Full-page Projects tab showing all projects from scan insights.
+ * ProjectsPanel — full-page Projects tab.
+ *
+ * Layout mirrors Sessions / Replays: a left sidebar listing projects, and a
+ * right pane showing the selected project's content. View tabs (Overview /
+ * Timeline / Hot Files) live in the right pane and adapt to whether one
+ * project is selected or "All projects".
  */
 
 import { useMemo, useState } from "react";
@@ -14,17 +19,25 @@ interface ProjectsPanelProps {
   onNavigate: (view: "home" | "sessions" | "replays" | "projects") => void;
 }
 
-type PanelMode = "list" | "timeline" | "files";
+const ALL_PROJECTS = "__all__";
+
+type PanelMode = "overview" | "timeline" | "files";
 
 const PROJECT_VIEW_TABS: { id: PanelMode; label: string }[] = [
-  { id: "list", label: "List" },
+  { id: "overview", label: "Overview" },
   { id: "timeline", label: "Timeline" },
   { id: "files", label: "Hot Files" },
 ];
 
 // ─── Activity sparkline (compact) ───────────────────────────────────
 
-function MiniSparkline({ sessionsPerDay }: { sessionsPerDay: Record<string, number> }) {
+function MiniSparkline({
+  sessionsPerDay,
+  size = "sm",
+}: {
+  sessionsPerDay: Record<string, number>;
+  size?: "sm" | "md";
+}) {
   const data = useMemo(() => {
     const end = new Date();
     const start = new Date(end);
@@ -40,9 +53,10 @@ function MiniSparkline({ sessionsPerDay }: { sessionsPerDay: Record<string, numb
   }, [sessionsPerDay]);
 
   const max = Math.max(...data, 1);
+  const heightClass = size === "md" ? "h-8" : "h-4";
 
   return (
-    <div className="flex items-end gap-px h-4">
+    <div className={`flex items-end gap-px ${heightClass}`}>
       {data.map((count, i) => (
         <div
           key={i}
@@ -69,20 +83,339 @@ function plural(count: number, singular: string, pluralForm = `${singular}s`): s
   return count === 1 ? singular : pluralForm;
 }
 
+// ─── Project sidebar (left pane) ────────────────────────────────────
+
+interface SidebarProject {
+  project: string;
+  sessions: number;
+  lastActivity?: string;
+}
+
+function ProjectSidebar({
+  projects,
+  selected,
+  onSelect,
+}: {
+  projects: SidebarProject[];
+  selected: string;
+  onSelect: (project: string) => void;
+}) {
+  const totalSessions = projects.reduce((sum, p) => sum + p.sessions, 0);
+  return (
+    <div className="hidden md:flex w-60 shrink-0 flex-col border-r border-terminal-border-subtle bg-terminal-surface/20">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-terminal-border-subtle">
+        <span className="text-[10px] font-sans text-terminal-dimmer uppercase tracking-widest font-semibold">
+          Projects
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2 space-y-0.5">
+        {/* All projects */}
+        <button
+          onClick={() => onSelect(ALL_PROJECTS)}
+          className={`w-full text-left px-3 py-2.5 text-xs font-sans rounded-lg transition-all duration-200 ease-material flex items-center justify-between ${
+            selected === ALL_PROJECTS
+              ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
+              : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface"
+          }`}
+        >
+          <span className="font-medium">All projects</span>
+          <span
+            className={`tabular-nums px-1.5 py-0.5 rounded-md text-xs ${
+              selected === ALL_PROJECTS
+                ? "bg-terminal-green-emphasis text-terminal-green"
+                : "bg-terminal-surface text-terminal-dimmer"
+            }`}
+          >
+            {totalSessions}
+          </span>
+        </button>
+
+        <div className="h-px bg-terminal-border-subtle mx-2 my-1.5" />
+
+        {/* Per-project items */}
+        {projects.map((p) => {
+          const isActive = selected === p.project;
+          const label = projectName(p.project);
+          return (
+            <button
+              key={p.project}
+              onClick={() => onSelect(p.project)}
+              title={p.project}
+              className={`w-full text-left px-3 py-2.5 rounded-lg transition-all duration-200 ease-material group ${
+                isActive ? "bg-terminal-green-subtle shadow-layer-sm" : "hover:bg-terminal-surface"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-1.5">
+                <span
+                  className={`text-xs font-sans truncate ${
+                    isActive ? "text-terminal-green font-medium" : "text-terminal-text"
+                  }`}
+                >
+                  {label}
+                </span>
+                <span
+                  className={`tabular-nums px-1.5 py-0.5 rounded-md text-xs shrink-0 ${
+                    isActive
+                      ? "bg-terminal-green-emphasis text-terminal-green"
+                      : "bg-terminal-surface text-terminal-dimmer"
+                  }`}
+                >
+                  {p.sessions}
+                </span>
+              </div>
+              {p.lastActivity && (
+                <div className="mt-1 ml-0.5">
+                  <span
+                    className={`text-xs font-mono truncate ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
+                  >
+                    {timeAgo(p.lastActivity, "long")}
+                  </span>
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Project Overview (single-project right pane content) ───────────
+
+type ProjectInsight = ReturnType<typeof rollupTopProjects>[number];
+
+function ProjectOverview({
+  project,
+  insight,
+  onOpenSessions,
+}: {
+  project: string;
+  insight: ProjectInsight;
+  onOpenSessions: () => void;
+}) {
+  const name = projectName(project);
+  return (
+    <div className="space-y-4">
+      {/* Hero card */}
+      <div className="hover-lift relative overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-5 shadow-layer-md">
+        <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-60" />
+        <span className="pointer-events-none absolute -right-10 -top-12 h-32 w-32 rounded-full bg-terminal-green/5 blur-2xl" />
+
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-base font-sans font-semibold text-terminal-text truncate">
+              {name}
+            </div>
+            <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
+              {project}
+            </div>
+          </div>
+          {insight.lastActivity && (
+            <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
+              {timeAgo(insight.lastActivity, "long")}
+            </span>
+          )}
+        </div>
+
+        {/* Stats grid */}
+        <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3 text-xs font-mono">
+          <Stat
+            label={plural(insight.sessions, "session")}
+            value={insight.sessions.toString()}
+            tone="text"
+          />
+          {insight.durationMs > 0 && (
+            <Stat label="active time" value={formatDuration(insight.durationMs)} tone="blue" />
+          )}
+          {insight.cost > 0 && (
+            <Stat label="cost" value={`$${insight.cost.toFixed(2)}`} tone="orange" />
+          )}
+          <Stat
+            label={plural(insight.prompts, "prompt")}
+            value={fmtNum(insight.prompts)}
+            tone="green"
+          />
+        </div>
+
+        {/* Secondary stats */}
+        <div className="mt-3 flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap">
+          {insight.toolCalls > 0 && (
+            <span>
+              {fmtNum(insight.toolCalls)} {plural(insight.toolCalls, "tool")}
+            </span>
+          )}
+          {insight.edits > 0 && (
+            <span>
+              {fmtNum(insight.edits)} {plural(insight.edits, "edit")}
+            </span>
+          )}
+          {insight.branchCount > 0 && (
+            <span>
+              {insight.branchCount} {plural(insight.branchCount, "branch", "branches")}
+            </span>
+          )}
+          {insight.prCount > 0 && (
+            <span>
+              {insight.prCount} {plural(insight.prCount, "PR")}
+            </span>
+          )}
+          {insight.memoryFileCount > 0 && (
+            <span>
+              {insight.memoryFileCount}{" "}
+              {insight.memoryFileCount === 1 ? "Claude memory" : "Claude memories"}
+            </span>
+          )}
+        </div>
+
+        {/* Sparkline */}
+        <div className="mt-4">
+          <MiniSparkline sessionsPerDay={insight.sessionsPerDay} size="md" />
+          <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">last 30 days</div>
+        </div>
+
+        <button
+          onClick={onOpenSessions}
+          className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-terminal-green-subtle px-3 py-1.5 text-xs font-sans font-semibold text-terminal-green hover:bg-terminal-green-emphasis transition-colors"
+        >
+          Open sessions →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone: "text" | "blue" | "orange" | "green";
+}) {
+  const toneClass = {
+    text: "text-terminal-text",
+    blue: "text-terminal-blue",
+    orange: "text-terminal-orange",
+    green: "text-terminal-green",
+  }[tone];
+  return (
+    <div className="rounded-lg bg-terminal-bg/40 p-2.5">
+      <div className={`text-sm font-sans font-semibold tabular-nums ${toneClass}`}>{value}</div>
+      <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">{label}</div>
+    </div>
+  );
+}
+
+// ─── All-projects grid (right pane content when "All projects" selected) ─
+
+function ProjectsGrid({
+  projects,
+  onProjectClick,
+}: {
+  projects: ProjectInsight[];
+  onProjectClick: (project: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-3">
+      {projects.map((p) => {
+        const name = projectName(p.project);
+        return (
+          <button
+            key={p.project}
+            onClick={() => onProjectClick(p.project)}
+            className="hover-lift group relative overflow-hidden rounded-xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-4 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover"
+          >
+            <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-50 transition-opacity group-hover:opacity-100" />
+            <span className="pointer-events-none absolute -right-10 -top-12 h-28 w-28 rounded-full bg-terminal-green/5 blur-2xl opacity-0 transition-opacity group-hover:opacity-100" />
+            <div className="flex items-start justify-between gap-2 mb-3">
+              <div className="min-w-0">
+                <div className="text-sm font-sans font-medium text-terminal-text truncate group-hover:text-terminal-green transition-colors">
+                  {name}
+                </div>
+                <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
+                  {p.project}
+                </div>
+              </div>
+              {p.lastActivity && (
+                <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
+                  {timeAgo(p.lastActivity, "long")}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-3 text-xs font-mono flex-wrap mb-3">
+              <span className="text-terminal-text tabular-nums">
+                {p.sessions}{" "}
+                <span className="text-terminal-dimmer">{plural(p.sessions, "session")}</span>
+              </span>
+              {p.durationMs > 0 && (
+                <span className="text-terminal-blue tabular-nums">
+                  {formatDuration(p.durationMs)}
+                </span>
+              )}
+              {p.cost > 0 && (
+                <span className="text-terminal-orange tabular-nums">${p.cost.toFixed(2)}</span>
+              )}
+              <span className="text-terminal-green tabular-nums">
+                {fmtNum(p.prompts)}{" "}
+                <span className="text-terminal-dimmer">{plural(p.prompts, "prompt")}</span>
+              </span>
+            </div>
+            <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap mb-2">
+              {p.toolCalls > 0 && (
+                <span>
+                  {fmtNum(p.toolCalls)} {plural(p.toolCalls, "tool")}
+                </span>
+              )}
+              {p.edits > 0 && (
+                <span>
+                  {fmtNum(p.edits)} {plural(p.edits, "edit")}
+                </span>
+              )}
+              {p.branchCount > 0 && (
+                <span>
+                  {p.branchCount} {plural(p.branchCount, "branch", "branches")}
+                </span>
+              )}
+              {p.prCount > 0 && (
+                <span>
+                  {p.prCount} {plural(p.prCount, "PR")}
+                </span>
+              )}
+              {p.memoryFileCount > 0 && (
+                <span>
+                  {p.memoryFileCount}{" "}
+                  {p.memoryFileCount === 1 ? "Claude memory" : "Claude memories"}
+                </span>
+              )}
+            </div>
+            <MiniSparkline sessionsPerDay={p.sessionsPerDay} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 // ─── Main Component ─────────────────────────────────────────────────
 
 export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
   const { userInsights, scanStatus } = useScanInsightsContext();
-  const [mode, setMode] = useState<PanelMode>("list");
+  const [selectedProject, setSelectedProject] = useState<string>(ALL_PROJECTS);
+  const [mode, setMode] = useState<PanelMode>("overview");
 
   const projects = useMemo(() => {
     if (!userInsights) return [];
-    // Roll Claude agent worktrees up under their parent so the grid isn't
-    // drowned by single-session sandbox dirs.
     const sorted = rollupTopProjects(userInsights.topProjects);
     sorted.sort((a, b) => (b.lastActivity || "").localeCompare(a.lastActivity || ""));
     return sorted;
   }, [userInsights]);
+
+  const selectedInsight = useMemo(
+    () =>
+      selectedProject === ALL_PROJECTS ? null : projects.find((p) => p.project === selectedProject),
+    [projects, selectedProject],
+  );
 
   const isScanning = scanStatus?.running && scanStatus.total > 0;
 
@@ -108,30 +441,73 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     );
   }
 
-  const handleProjectClick = (project: string) => {
+  const openSessionsForProject = (project: string) => {
     onNavigate("sessions");
-    setTimeout(() => {
-      navigateTo({ tab: "sessions", project });
-    }, 50);
+    setTimeout(() => navigateTo({ tab: "sessions", project }), 50);
   };
 
+  const sidebarProjects: SidebarProject[] = projects.map((p) => ({
+    project: p.project,
+    sessions: p.sessions,
+    lastActivity: p.lastActivity,
+  }));
+
+  // Determine which tab is showing in the right pane.
+  // Default tab when "All projects" is selected: overview (= grid)
+  // Default when a single project is picked: overview (= hero card)
+  const activeMode = mode;
+  const projectFilterArg = selectedProject === ALL_PROJECTS ? undefined : selectedProject;
+
   return (
-    <div className="relative flex-1 min-w-0 overflow-y-auto overflow-x-hidden">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute inset-x-0 top-0 h-56 bg-gradient-to-b from-terminal-green-subtle via-transparent to-transparent opacity-70" />
-        <div className="absolute inset-0 bg-dot-grid opacity-40" />
-      </div>
-      <div className="relative max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
-        {/* Header */}
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h2 className="text-sm font-sans font-semibold text-terminal-text">
-              All Projects
-              <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
+    <div className="flex flex-1 min-h-0">
+      {/* ─── Left sidebar: project navigation ─── */}
+      <ProjectSidebar
+        projects={sidebarProjects}
+        selected={selectedProject}
+        onSelect={(project) => {
+          setSelectedProject(project);
+          // Reset to overview when a new project is picked so users see the
+          // hero card first, not whatever inner tab was previously open.
+          setMode("overview");
+        }}
+      />
+
+      {/* ─── Right pane: header + tabs + content ─── */}
+      <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-y-auto">
+        {/* Mobile project selector */}
+        <div className="md:hidden px-3 pt-3">
+          <select
+            value={selectedProject}
+            onChange={(e) => {
+              setSelectedProject(e.target.value);
+              setMode("overview");
+            }}
+            className="w-full bg-terminal-surface rounded-lg px-3 py-2.5 text-sm font-sans text-terminal-text outline-none shadow-layer-sm"
+          >
+            <option value={ALL_PROJECTS}>All projects ({projects.length})</option>
+            {projects.map((p) => (
+              <option key={p.project} value={p.project}>
+                {projectName(p.project)} ({p.sessions})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Header: title + tabs */}
+        <div className="px-4 md:px-6 pt-5 pb-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="min-w-0">
+            <h2 className="text-sm font-sans font-semibold text-terminal-text truncate">
+              {selectedProject === ALL_PROJECTS ? "All Projects" : projectName(selectedProject)}
+              {selectedProject === ALL_PROJECTS && (
+                <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
+              )}
             </h2>
-            <p className="mt-1 text-xs font-mono text-terminal-dimmer">
-              Recent work, timelines, and hotspots across your AI sessions.
-            </p>
+            {isScanning && (
+              <div className="mt-1 flex items-center gap-1.5 text-[10px] font-mono text-terminal-dim">
+                <span className="w-1 h-1 rounded-full bg-terminal-purple animate-pulse" />
+                Analyzing... {scanStatus!.scanned}/{scanStatus!.total}
+              </div>
+            )}
           </div>
           <div className="inline-flex w-fit items-center rounded-xl bg-terminal-surface/80 p-0.5 shadow-layer-sm backdrop-blur-sm">
             {PROJECT_VIEW_TABS.map((tab) => (
@@ -139,7 +515,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 key={tab.id}
                 onClick={() => setMode(tab.id)}
                 className={`rounded-lg px-3.5 py-1.5 text-xs font-sans font-semibold transition-all duration-200 ease-material ${
-                  mode === tab.id
+                  activeMode === tab.id
                     ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
                     : "text-terminal-dim hover:text-terminal-text"
                 }`}
@@ -150,106 +526,25 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
           </div>
         </div>
 
-        {isScanning && (
-          <div className="flex items-center gap-2 px-1">
-            <span className="w-1.5 h-1.5 rounded-full bg-terminal-purple animate-pulse" />
-            <span className="text-xs font-mono text-terminal-dim">
-              Analyzing... {scanStatus!.scanned}/{scanStatus!.total}
-            </span>
-          </div>
-        )}
-
-        {mode === "timeline" && <SessionRelationshipsView view="timeline" />}
-        {mode === "files" && <SessionRelationshipsView view="files" />}
-
-        {/* Projects grid */}
-        {mode === "list" && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {projects.map((p) => {
-              const name = projectName(p.project);
-              return (
-                <button
-                  key={p.project}
-                  onClick={() => handleProjectClick(p.project)}
-                  className="hover-lift group relative overflow-hidden rounded-xl bg-gradient-to-br from-terminal-surface via-terminal-surface to-terminal-bg/70 p-4 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover"
-                >
-                  <span className="absolute inset-y-3 left-0 w-0.5 rounded-r-full bg-gradient-to-b from-terminal-green to-terminal-blue opacity-50 transition-opacity group-hover:opacity-100" />
-                  <span className="pointer-events-none absolute -right-10 -top-12 h-28 w-28 rounded-full bg-terminal-green/5 blur-2xl opacity-0 transition-opacity group-hover:opacity-100" />
-                  {/* Project name + last activity */}
-                  <div className="flex items-start justify-between gap-2 mb-3">
-                    <div className="min-w-0">
-                      <div className="text-sm font-sans font-medium text-terminal-text truncate group-hover:text-terminal-green transition-colors">
-                        {name}
-                      </div>
-                      <div className="text-[10px] font-mono text-terminal-dimmer truncate mt-0.5">
-                        {p.project}
-                      </div>
-                    </div>
-                    {p.lastActivity && (
-                      <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
-                        {timeAgo(p.lastActivity, "long")}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Stats row */}
-                  <div className="flex items-center gap-3 text-xs font-mono flex-wrap mb-3">
-                    <span className="text-terminal-text tabular-nums">
-                      {p.sessions}{" "}
-                      <span className="text-terminal-dimmer">{plural(p.sessions, "session")}</span>
-                    </span>
-                    {p.durationMs > 0 && (
-                      <span className="text-terminal-blue tabular-nums">
-                        {formatDuration(p.durationMs)}
-                      </span>
-                    )}
-                    {p.cost > 0 && (
-                      <span className="text-terminal-orange tabular-nums">
-                        ${p.cost.toFixed(2)}
-                      </span>
-                    )}
-                    <span className="text-terminal-green tabular-nums">
-                      {fmtNum(p.prompts)}{" "}
-                      <span className="text-terminal-dimmer">{plural(p.prompts, "prompt")}</span>
-                    </span>
-                  </div>
-
-                  {/* Secondary stats */}
-                  <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dimmer flex-wrap mb-2">
-                    {p.toolCalls > 0 && (
-                      <span>
-                        {fmtNum(p.toolCalls)} {plural(p.toolCalls, "tool")}
-                      </span>
-                    )}
-                    {p.edits > 0 && (
-                      <span>
-                        {fmtNum(p.edits)} {plural(p.edits, "edit")}
-                      </span>
-                    )}
-                    {p.branchCount > 0 && (
-                      <span>
-                        {p.branchCount} {plural(p.branchCount, "branch", "branches")}
-                      </span>
-                    )}
-                    {p.prCount > 0 && (
-                      <span>
-                        {p.prCount} {plural(p.prCount, "PR")}
-                      </span>
-                    )}
-                    {p.memoryFileCount > 0 && (
-                      <span>
-                        {p.memoryFileCount} Claude {p.memoryFileCount !== 1 ? "memories" : "memory"}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Sparkline */}
-                  <MiniSparkline sessionsPerDay={p.sessionsPerDay} />
-                </button>
-              );
-            })}
-          </div>
-        )}
+        {/* Tab content */}
+        <div className="px-4 md:px-6 pb-6 space-y-4">
+          {activeMode === "overview" && selectedProject === ALL_PROJECTS && (
+            <ProjectsGrid projects={projects} onProjectClick={setSelectedProject} />
+          )}
+          {activeMode === "overview" && selectedInsight && (
+            <ProjectOverview
+              project={selectedProject}
+              insight={selectedInsight}
+              onOpenSessions={() => openSessionsForProject(selectedProject)}
+            />
+          )}
+          {activeMode === "timeline" && (
+            <SessionRelationshipsView view="timeline" projectFilter={projectFilterArg} />
+          )}
+          {activeMode === "files" && (
+            <SessionRelationshipsView view="files" projectFilter={projectFilterArg} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -4,6 +4,7 @@
 
 import { useMemo, useState } from "react";
 import { localDayKey } from "../utils/date";
+import { timeAgo } from "../utils/format";
 import { navigateTo, rollupTopProjects } from "./dashboard-utils";
 import { useScanInsightsContext } from "./InsightsPanel";
 import SessionRelationshipsView from "./SessionRelationshipsView";
@@ -56,20 +57,6 @@ function fmtNum(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function timeAgo(iso: string): string {
-  if (!iso) return "";
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  const months = Math.floor(days / 30);
-  return `${months}mo ago`;
 }
 
 // ─── Main Component ─────────────────────────────────────────────────
@@ -216,7 +203,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                   </div>
                   {p.lastActivity && (
                     <span className="text-[10px] font-mono text-terminal-dimmer shrink-0">
-                      {timeAgo(p.lastActivity)}
+                      {timeAgo(p.lastActivity, "long")}
                     </span>
                   )}
                 </div>

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -6,11 +6,14 @@ import { useMemo, useState } from "react";
 import { localDayKey } from "../utils/date";
 import { navigateTo, rollupTopProjects } from "./dashboard-utils";
 import { useScanInsightsContext } from "./InsightsPanel";
+import SessionRelationshipsView from "./SessionRelationshipsView";
 import { formatDuration } from "./StatsPanel";
 
 interface ProjectsPanelProps {
   onNavigate: (view: "home" | "sessions" | "replays" | "projects") => void;
 }
+
+type PanelMode = "grid" | "relationships";
 
 // ─── Activity sparkline (compact) ───────────────────────────────────
 
@@ -73,6 +76,7 @@ function timeAgo(iso: string): string {
 
 export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
   const { userInsights, scanStatus } = useScanInsightsContext();
+  const [mode, setMode] = useState<PanelMode>("grid");
   const [sortBy, setSortBy] = useState<"lastActivity" | "sessions" | "cost" | "duration">(
     "lastActivity",
   );
@@ -130,6 +134,10 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     }, 50);
   };
 
+  if (mode === "relationships") {
+    return <SessionRelationshipsView onBack={() => setMode("grid")} />;
+  }
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-4">
@@ -141,28 +149,39 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
               <span className="ml-2 text-terminal-dimmer font-normal">({projects.length})</span>
             </h2>
           </div>
-          <div className="flex items-center gap-1 text-[10px] font-sans">
-            <span className="text-terminal-dimmer mr-1">Sort:</span>
-            {(
-              [
-                ["lastActivity", "Recent"],
-                ["sessions", "Sessions"],
-                ["cost", "Cost"],
-                ["duration", "Duration"],
-              ] as const
-            ).map(([key, label]) => (
-              <button
-                key={key}
-                onClick={() => setSortBy(key)}
-                className={`px-2 py-1 rounded-md transition-colors ${
-                  sortBy === key
-                    ? "bg-terminal-green-subtle text-terminal-green"
-                    : "text-terminal-dim hover:text-terminal-text"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
+          <div className="flex items-center gap-2">
+            {/* Visualize button */}
+            <button
+              onClick={() => setMode("relationships")}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[10px] font-mono bg-terminal-purple/10 text-terminal-purple border border-terminal-purple/30 hover:bg-terminal-purple/20 transition-colors"
+              title="View session relationship visualizations"
+            >
+              <span>⟶</span>
+              Visualize
+            </button>
+            <div className="flex items-center gap-1 text-[10px] font-sans">
+              <span className="text-terminal-dimmer mr-1">Sort:</span>
+              {(
+                [
+                  ["lastActivity", "Recent"],
+                  ["sessions", "Sessions"],
+                  ["cost", "Cost"],
+                  ["duration", "Duration"],
+                ] as const
+              ).map(([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => setSortBy(key)}
+                  className={`px-2 py-1 rounded-md transition-colors ${
+                    sortBy === key
+                      ? "bg-terminal-green-subtle text-terminal-green"
+                      : "text-terminal-dim hover:text-terminal-text"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -1179,6 +1179,20 @@ export default function SessionRelationshipsView({
     () => filteredSessions.filter((session) => sessionHasEstimatedTime(session)).length,
     [filteredSessions],
   );
+  // Totals are derived once per render — same reduce was previously running
+  // twice in the JSX (once for the value, once for plural). For a 300-session
+  // scan that's noticeable and pointless.
+  const totals = useMemo(() => {
+    let durationMs = 0;
+    let cost = 0;
+    let edits = 0;
+    for (const s of filteredSessions) {
+      durationMs += s.durationMs ?? 0;
+      cost += s.costEstimate ?? 0;
+      edits += s.editCount;
+    }
+    return { durationMs, cost, edits };
+  }, [filteredSessions]);
 
   if (loading) {
     return (
@@ -1222,50 +1236,42 @@ export default function SessionRelationshipsView({
     <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-bg to-terminal-surface shadow-layer-xl">
       <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-terminal-green/5 blur-3xl" />
       <div className="pointer-events-none absolute -bottom-24 -left-24 h-56 w-56 rounded-full bg-terminal-blue/5 blur-3xl" />
-      {/* Stats bar */}
-      <div className="relative z-10 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 text-[10px] font-mono text-terminal-dimmer md:px-6">
-        <span>
-          <span className="text-terminal-text">{filteredSessions.length}</span>{" "}
-          {plural(filteredSessions.length, "session")}
-        </span>
-        {!projectFilter && (
+      {/* Stats bar — hidden when projectFilter is set, because the parent
+          ProjectOverview already shows the project's all-time rollup. Showing
+          a window-filtered count beneath an all-time card was a UX trap (same
+          project, two visibly different "N sessions" numbers). */}
+      {!projectFilter && (
+        <div className="relative z-10 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 text-[10px] font-mono text-terminal-dimmer md:px-6">
+          <span>
+            <span className="text-terminal-text">{filteredSessions.length}</span>{" "}
+            {plural(filteredSessions.length, "session")}
+          </span>
           <span>
             <span className="text-terminal-text">{groups.length}</span>{" "}
             {plural(groups.length, "project")}
           </span>
-        )}
-        {providerSummary && (
-          <span>
-            <span className="text-terminal-purple">{providerSummary}</span>
-          </span>
-        )}
-        <span>
-          <span className="text-terminal-blue">
-            {fmtDuration(filteredSessions.reduce((s, x) => s + (x.durationMs ?? 0), 0))}
-          </span>{" "}
-          total time
-        </span>
-        <span>
-          <span className="text-terminal-orange">
-            ${filteredSessions.reduce((s, x) => s + (x.costEstimate ?? 0), 0).toFixed(2)}
-          </span>{" "}
-          total cost
-        </span>
-        <span>
-          <span className="text-terminal-green">
-            {filteredSessions.reduce((s, x) => s + x.editCount, 0).toLocaleString()}
-          </span>{" "}
-          {plural(
-            filteredSessions.reduce((s, x) => s + x.editCount, 0),
-            "edit",
+          {providerSummary && (
+            <span>
+              <span className="text-terminal-purple">{providerSummary}</span>
+            </span>
           )}
-        </span>
-        {estimatedTimingCount > 0 && (
           <span>
-            <span className="text-terminal-dimmer">{estimatedTimingCount}</span> estimated timing
+            <span className="text-terminal-blue">{fmtDuration(totals.durationMs)}</span> total time
           </span>
-        )}
-      </div>
+          <span>
+            <span className="text-terminal-orange">${totals.cost.toFixed(2)}</span> total cost
+          </span>
+          <span>
+            <span className="text-terminal-green">{totals.edits.toLocaleString()}</span>{" "}
+            {plural(totals.edits, "edit")}
+          </span>
+          {estimatedTimingCount > 0 && (
+            <span>
+              <span className="text-terminal-dimmer">{estimatedTimingCount}</span> estimated timing
+            </span>
+          )}
+        </div>
+      )}
 
       {/* View content */}
       <div className="relative z-10 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -1050,8 +1050,10 @@ function FileConnectionsView({
         </div>
       )}
 
-      {/* Project files + detail panel */}
-      <div className="min-w-0 flex-1 space-y-4 overflow-y-auto">
+      {/* Project files + detail panel — files grid on the left scrolls
+          independently; the detail panel is sticky on the right so clicking a
+          file shows its sessions immediately, no scrolling required. */}
+      <div className="min-w-0 flex-1 space-y-4">
         <div className="relative overflow-hidden rounded-2xl bg-terminal-bg/35 p-4 shadow-inner">
           <div className="pointer-events-none absolute -right-12 -top-12 h-28 w-28 rounded-full bg-terminal-green/5 blur-2xl" />
           <div className="relative">
@@ -1078,86 +1080,92 @@ function FileConnectionsView({
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
-          {selectedProjectGroup.files.map((cluster) => {
-            const isSelected = selectedFile === cluster.file;
-            return (
-              <button
-                key={cluster.file}
-                onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
-                className={`w-full rounded-xl px-3 py-2.5 text-left transition-all duration-200 ease-material ${
-                  isSelected
-                    ? "bg-terminal-green-subtle text-terminal-green shadow-layer-md"
-                    : "bg-terminal-bg/40 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
-                }`}
-              >
-                <div className="truncate text-xs font-mono">
-                  {cluster.displayName.split("/").pop()}
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          {/* Files grid — left column, scrolls independently */}
+          <div className="min-w-0 grid grid-cols-1 gap-2 xl:grid-cols-2 self-start">
+            {selectedProjectGroup.files.map((cluster) => {
+              const isSelected = selectedFile === cluster.file;
+              return (
+                <button
+                  key={cluster.file}
+                  onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
+                  className={`w-full rounded-xl px-3 py-2.5 text-left transition-all duration-200 ease-material ${
+                    isSelected
+                      ? "bg-terminal-green-subtle text-terminal-green shadow-layer-md"
+                      : "bg-terminal-bg/40 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
+                  }`}
+                >
+                  <div className="truncate text-xs font-mono">
+                    {cluster.displayName.split("/").pop()}
+                  </div>
+                  <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
+                    {cluster.displayName}
+                  </div>
+                  <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+                    {cluster.totalEdits.toLocaleString()} {plural(cluster.totalEdits, "edit")} ·{" "}
+                    {cluster.sessions.length} {plural(cluster.sessions.length, "session")}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Detail panel — right column, sticky so it stays visible while
+              the user scrolls the files grid */}
+          <div className="lg:sticky lg:top-3 lg:self-start lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto">
+            {selected ? (
+              <div className="space-y-3">
+                <div className="rounded-2xl bg-terminal-surface p-4 shadow-layer-sm">
+                  <div className="text-sm font-sans font-semibold text-terminal-text truncate">
+                    {selected.displayName.split("/").pop()}
+                  </div>
+                  <div className="text-xs font-mono text-terminal-dimmer mt-0.5 break-all">
+                    {selected.file}
+                  </div>
+                  <div className="text-xs font-mono text-terminal-dimmer mt-1">
+                    {selected.totalEdits.toLocaleString()} {plural(selected.totalEdits, "edit")}{" "}
+                    across {selected.sessions.length} {plural(selected.sessions.length, "session")}
+                  </div>
                 </div>
-                <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
-                  {cluster.displayName}
+
+                {/* Session list */}
+                <div className="space-y-2">
+                  {selected.sessions.map((s) => {
+                    const color = colorFor(s.colorIdx);
+                    return (
+                      <button
+                        type="button"
+                        key={s.session.sessionId}
+                        onClick={() => navigateTo({ view: null, session: s.session.slug })}
+                        className="flex w-full flex-col gap-2 rounded-xl bg-terminal-bg/45 p-3 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md sm:flex-row sm:items-start sm:gap-3"
+                      >
+                        <div
+                          className="hidden w-2 h-2 rounded-full mt-1.5 shrink-0 sm:block"
+                          style={{ backgroundColor: color.solid }}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs font-sans font-medium text-terminal-text truncate">
+                            {sessionTitle(s.session)}
+                          </div>
+                          <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5">
+                            {projectName(s.session.project)} · {fmtDate(s.session.startTime)}
+                          </div>
+                        </div>
+                        <div className="shrink-0 text-xs font-mono text-terminal-orange">
+                          {s.editCount} {plural(s.editCount, "edit")}
+                        </div>
+                      </button>
+                    );
+                  })}
                 </div>
-                <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-                  {cluster.totalEdits.toLocaleString()} {plural(cluster.totalEdits, "edit")} ·{" "}
-                  {cluster.sessions.length} {plural(cluster.sessions.length, "session")}
-                </div>
-              </button>
-            );
-          })}
+              </div>
+            ) : (
+              <div className="flex h-40 items-center justify-center rounded-2xl bg-terminal-bg/35 text-terminal-dimmer text-xs font-mono p-4 text-center">
+                Select a file to see the sessions that modified it
+              </div>
+            )}
+          </div>
         </div>
-
-        {selected ? (
-          <div className="space-y-3">
-            <div className="rounded-2xl bg-terminal-surface p-4 shadow-layer-sm">
-              <div className="text-sm font-sans font-semibold text-terminal-text truncate">
-                {selected.displayName.split("/").pop()}
-              </div>
-              <div className="text-xs font-mono text-terminal-dimmer mt-0.5 break-all">
-                {selected.file}
-              </div>
-              <div className="text-xs font-mono text-terminal-dimmer mt-1">
-                {selected.totalEdits.toLocaleString()} {plural(selected.totalEdits, "edit")} across{" "}
-                {selected.sessions.length} {plural(selected.sessions.length, "session")}
-              </div>
-            </div>
-
-            {/* Session list */}
-            <div className="space-y-2">
-              {selected.sessions.map((s) => {
-                const color = colorFor(s.colorIdx);
-                return (
-                  <button
-                    type="button"
-                    key={s.session.sessionId}
-                    onClick={() => navigateTo({ view: null, session: s.session.slug })}
-                    className="flex w-full flex-col gap-2 rounded-xl bg-terminal-bg/45 p-3 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md sm:flex-row sm:items-start sm:gap-3"
-                  >
-                    <div
-                      className="hidden w-2 h-2 rounded-full mt-1.5 shrink-0 sm:block"
-                      style={{ backgroundColor: color.solid }}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-xs font-sans font-medium text-terminal-text truncate">
-                        {sessionTitle(s.session)}
-                      </div>
-                      <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5">
-                        {projectName(s.session.project)} · {fmtDate(s.session.startTime)}
-                      </div>
-                    </div>
-                    <div className="shrink-0 text-xs font-mono text-terminal-orange">
-                      {s.editCount} {plural(s.editCount, "edit")}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-center h-40 text-terminal-dimmer text-xs font-mono">
-            Select a file in {projectName(selectedProjectGroup.project)} to see the sessions that
-            modified it
-          </div>
-        )}
       </div>
     </div>
   );

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -11,7 +11,6 @@ import { isAutomated, sessionScore } from "../utils/sessionSignals";
 import {
   cleanPrompt,
   formatDataSourceLabel,
-  navigateTo,
   normalizeTitleText,
   projectName,
   providerBadgeLabel,
@@ -61,6 +60,17 @@ function sessionBadges(s: ScanResultSession): string[] {
   if (source) badges.push(source);
   if (sessionHasEstimatedTime(s)) badges.push("estimated time");
   return badges;
+}
+
+/**
+ * Pop the Sessions tab's SessionDetailPopup for a session, regardless of
+ * whether a replay has been generated yet. Dashboard listens for this event,
+ * switches to the Sessions tab, and forwards the slug via URL so SessionsPanel
+ * can open the popup uniformly for both "open replay" and "generate replay"
+ * cases.
+ */
+function openSessionPopup(slug: string) {
+  window.dispatchEvent(new CustomEvent("vibe-open-session", { detail: { slug } }));
 }
 
 function rangeEmptyLabel(range: TimelineRange): string {
@@ -200,6 +210,13 @@ interface TimelineSession {
   fillAlpha: number;
   opacity: number;
   realDurationFraction: number;
+  /**
+   * True when the bar would overflow the lane's right edge if rendered from
+   * its leftPct. Right-anchored bars hug the right edge with their full
+   * minWidth and grow leftward — the bar's left edge no longer aligns with
+   * startTime, but the title stays readable. Tooltip carries the exact time.
+   */
+  rightAnchored: boolean;
 }
 
 interface TimelineProject {
@@ -392,15 +409,24 @@ function buildTimeline(
     const filtered = perGroup.get(g);
     if (!filtered || filtered.length === 0) continue;
 
+    // Build packing intervals using the bar's *visual* extent (after right-
+    // anchoring + min-width). Otherwise multiple late sessions all hugging the
+    // right edge get placed into the same lane and overlap each other.
     const intervals = filtered.map(({ session: s, startMs, endMs: realEndMs }) => {
       const score = sessionScore(s);
-      const visualWidthMs = Math.max(realEndMs - startMs, minWidthFor(score) * minMsPerPx);
+      const minWidthMs = minWidthFor(score) * minMsPerPx;
+      const naturalEndMs = Math.max(realEndMs, startMs + minWidthMs);
+      const rightAnchored = naturalEndMs > rangeEnd;
+      const visStartMs = rightAnchored ? Math.min(startMs, rangeEnd - minWidthMs) : startMs;
+      const visEndMs = rightAnchored ? rangeEnd : naturalEndMs;
       return {
-        startMs,
-        endMs: startMs + visualWidthMs, // visual end for packing
-        realEndMs, // for tooltip / display
+        startMs: visStartMs,
+        endMs: visEndMs,
+        realStartMs: startMs,
+        realEndMs,
         score,
         original: s,
+        rightAnchored,
       };
     });
 
@@ -413,16 +439,13 @@ function buildTimeline(
     for (const it of intervals) {
       const lane = laneAssignments.get(it.original.sessionId);
       if (lane == null) continue; // dropped due to lane cap
-      // Clip to viewport: if the bar starts before the visible window, push the
-      // left edge to 0 and shorten the width. Avoids "mid-string truncation"
-      // where the visible portion starts at some arbitrary character of the title.
-      const rawLeftPct = ((it.startMs - rangeStart) / rangeMs) * 100;
+      // Clip to viewport on the left so a bar starting before the window
+      // begins at 0% (no mid-string truncation).
+      const rawLeftPct = ((it.realStartMs - rangeStart) / rangeMs) * 100;
       const rawRightPct = ((it.realEndMs - rangeStart) / rangeMs) * 100;
       const leftPct = Math.max(0, rawLeftPct);
       const widthPct = Math.max(0, rawRightPct - leftPct);
       const minWidthPx = minWidthFor(it.score);
-      // Compare real-duration width vs. min-width-padded width to figure out
-      // how much of the rendered bar is actually "real time" vs. visual reach.
       const realWidthPx = (widthPct / 100) * APPROX_TIMELINE_WIDTH_PX;
       const visualWidthPx = Math.max(realWidthPx, minWidthPx);
       const realDurationFraction = visualWidthPx > 0 ? Math.min(1, realWidthPx / visualWidthPx) : 1;
@@ -437,6 +460,7 @@ function buildTimeline(
         fillAlpha: fillAlphaFor(it.score),
         opacity: opacityFor(it.score),
         realDurationFraction,
+        rightAnchored: it.rightAnchored,
       });
     }
 
@@ -709,13 +733,15 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                             key={ts.session.sessionId}
                             className="absolute overflow-hidden rounded-md text-left shadow-layer-sm transition-all duration-200 ease-material hover:z-10 hover:shadow-layer-md"
                             style={{
-                              left: `${ts.leftPct}%`,
-                              // Cap min-width to whatever space is left
-                              // between the bar's start and the lane's right
-                              // edge — otherwise bars near "today" overflow
-                              // the overflow-hidden lane container and get
-                              // visually truncated.
-                              width: `max(${ts.widthPct}%, min(${ts.minWidthPx}px, calc(100% - ${ts.leftPct}%)))`,
+                              ...(ts.rightAnchored
+                                ? // Hug the right edge with full minWidth so the
+                                  // title stays readable for sessions starting
+                                  // close to "now"; the bar grows leftward.
+                                  { right: 0, width: `${ts.minWidthPx}px` }
+                                : {
+                                    left: `${ts.leftPct}%`,
+                                    width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
+                                  }),
                               top,
                               height: ts.heightPx,
                               opacity,
@@ -723,7 +749,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                               backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
                             }}
                             aria-label={`Open ${sessionTitle(ts.session)}`}
-                            onClick={() => navigateTo({ view: null, session: ts.session.slug })}
+                            onClick={() => openSessionPopup(ts.session.slug)}
                             onMouseEnter={(e) => {
                               setTooltip({
                                 session: ts.session,
@@ -1093,7 +1119,7 @@ function FileConnectionsView({
                       <button
                         type="button"
                         key={s.session.sessionId}
-                        onClick={() => navigateTo({ view: null, session: s.session.slug })}
+                        onClick={() => openSessionPopup(s.session.slug)}
                         className="flex w-full flex-col gap-2 rounded-xl bg-terminal-bg/45 p-3 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md sm:flex-row sm:items-start sm:gap-3"
                       >
                         <div

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -188,6 +188,10 @@ const LANE_GAP_PX = 4;
 const MAX_LANES_PER_PROJECT = 5;
 const MIN_BAR_HEIGHT_PX = 10;
 const MAX_BAR_HEIGHT_PX = 72;
+// Floor for a project row's height so the project label (name + count line)
+// always has room. Without this, a project with one low-score session could
+// produce a row only ~16px tall and clip the second label line's descenders.
+const MIN_ROW_HEIGHT_PX = 40;
 const LABEL_VISIBLE_MIN_HEIGHT_PX = 14;
 const LABEL_LINE_HEIGHT_PX = 12;
 const LABEL_VERTICAL_PADDING_PX = 6;
@@ -479,7 +483,14 @@ function buildTimeline(
         laneTopsPx.push(cursor);
         cursor += h + LANE_GAP_PX;
       }
-      const totalRowHeightPx = cursor + 4;
+      const contentHeight = cursor + 4;
+      const totalRowHeightPx = Math.max(contentHeight, MIN_ROW_HEIGHT_PX);
+      // If row was floored above content height, push lane tops down so bars
+      // stay bottom-aligned within the now-taller row.
+      const verticalPadding = totalRowHeightPx - contentHeight;
+      if (verticalPadding > 0) {
+        for (let i = 0; i < laneTopsPx.length; i++) laneTopsPx[i] += verticalPadding;
+      }
 
       projects.push({
         project: g.project,
@@ -726,7 +737,10 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                             (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
                           ),
                         );
-                        const showWick = ts.realDurationFraction < 0.85;
+                        // Right-anchored bars no longer have their left edge
+                        // at startTime, so a left-aligned wick would be
+                        // misleading. Use the tooltip for exact timing instead.
+                        const showWick = !ts.rightAnchored && ts.realDurationFraction < 0.85;
                         return (
                           <button
                             type="button"

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -226,16 +226,21 @@ function ProjectGroupingView({ groups }: { groups: ProjectGroup[] }) {
 // Automated / scheduled sessions are hidden by default and surfaced via a toggle.
 // Per-project lane count is capped; overflow is rolled up into a "+N more" hint.
 
-// Each lane reserves LANE_TOTAL_HEIGHT_PX of vertical space. Within a lane,
-// bars are *bottom-aligned* so their tops form a skyline — height encodes
-// importance in addition to width and fill. The 6x height ratio (8 → 48)
-// makes top-tier sessions visibly tower over routine ones.
-const LANE_TOTAL_HEIGHT_PX = 48;
+// Bars are *bottom-aligned* within their lane so the lane tops form a skyline
+// — height encodes importance alongside width and fill. The 12x height ratio
+// (8 → 96) makes top-tier sessions visibly tower over routine ones, and tall
+// bars wrap their title onto multiple lines so the extra real-estate is useful.
+//
+// Per-lane height is *adaptive* — each lane sizes to its tallest bar (capped
+// at MAX_BAR_HEIGHT_PX) instead of every lane reserving the global maximum,
+// which previously left huge dead zones in lanes that only held short bars.
 const LANE_GAP_PX = 4;
 const MAX_LANES_PER_PROJECT = 5;
 const MIN_BAR_HEIGHT_PX = 8; // floor — low-score sessions are short ticks
-const MAX_BAR_HEIGHT_PX = LANE_TOTAL_HEIGHT_PX; // cap — top-tier sessions fill the lane
+const MAX_BAR_HEIGHT_PX = 96; // cap — top-tier sessions tower at this height
 const LABEL_VISIBLE_MIN_HEIGHT_PX = 14; // below this, render bar without label
+const TWO_LINE_LABEL_MIN_HEIGHT_PX = 32;
+const THREE_LINE_LABEL_MIN_HEIGHT_PX = 60;
 
 const MIN_BAR_MIN_WIDTH_PX = 6; // floor for low-importance sessions
 const MAX_BAR_MIN_WIDTH_PX = 160; // cap for the "important short session" widening
@@ -263,6 +268,11 @@ interface TimelineProject {
   project: string;
   sessions: TimelineSession[];
   laneCount: number;
+  /** Per-lane height in px — each lane sizes to its tallest bar. */
+  laneHeightsPx: number[];
+  /** Per-lane top offset (cumulative sum of preceding heights + gaps). */
+  laneTopsPx: number[];
+  totalRowHeightPx: number;
   hiddenInLanesCount: number; // sessions dropped because they exceeded MAX_LANES_PER_PROJECT
   colorIdx: number;
   importance: number;
@@ -467,10 +477,32 @@ function buildTimeline(
     if (tSessions.length > 0) {
       // Render high-score sessions last so their accent rim sits on top of overlaps
       tSessions.sort((a, b) => a.score - b.score);
+
+      // Per-lane heights: each lane sizes to its tallest bar (importance-biased
+      // packing means lane 0 holds the highest scores and is naturally the
+      // tallest). This avoids the dead vertical space when only the top lane
+      // has tall bars and lower lanes hold short routine sessions.
+      const laneHeightsPx: number[] = Array.from({ length: laneCount }, () => MIN_BAR_HEIGHT_PX);
+      for (const ts of tSessions) {
+        if (ts.heightPx > laneHeightsPx[ts.lane]) {
+          laneHeightsPx[ts.lane] = ts.heightPx;
+        }
+      }
+      const laneTopsPx: number[] = [];
+      let cursor = 3;
+      for (const h of laneHeightsPx) {
+        laneTopsPx.push(cursor);
+        cursor += h + LANE_GAP_PX;
+      }
+      const totalRowHeightPx = cursor + 3;
+
       projects.push({
         project: g.project,
         sessions: tSessions,
         laneCount,
+        laneHeightsPx,
+        laneTopsPx,
+        totalRowHeightPx,
         hiddenInLanesCount: dropped,
         colorIdx: g.colorIdx,
         importance: tSessions.reduce((sum, t) => sum + t.score, 0),
@@ -629,7 +661,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
               short ghosted ticks but still labeled and clickable. */}
           {projects.map((p) => {
             const color = colorFor(p.colorIdx);
-            const rowHeight = p.laneCount * (LANE_TOTAL_HEIGHT_PX + LANE_GAP_PX) + 6;
+            const rowHeight = p.totalRowHeightPx;
             const accentColor = color.solid;
             return (
               <div
@@ -672,11 +704,20 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                   {/* Session blocks — variable height (importance), bottom-aligned within lane */}
                   {p.sessions.map((ts) => {
                     const automated = isAutomated(ts.session);
-                    // Lane row spans LANE_TOTAL_HEIGHT_PX. Bar bottom aligns to
-                    // the lane's bottom; height varies up to that ceiling.
-                    const laneTop = 3 + ts.lane * (LANE_TOTAL_HEIGHT_PX + LANE_GAP_PX);
-                    const top = laneTop + (LANE_TOTAL_HEIGHT_PX - ts.heightPx);
+                    // Adaptive lanes: each lane's row height = its tallest bar.
+                    // Bars are bottom-aligned within their lane.
+                    const laneTop = p.laneTopsPx[ts.lane];
+                    const laneH = p.laneHeightsPx[ts.lane];
+                    const top = laneTop + (laneH - ts.heightPx);
                     const opacity = automated ? 0.4 : ts.opacity;
+                    // Multi-line label support: tall bars allow 2 or 3 lines so
+                    // the extra real estate actually carries information.
+                    const lineClamp =
+                      ts.heightPx >= THREE_LINE_LABEL_MIN_HEIGHT_PX
+                        ? 3
+                        : ts.heightPx >= TWO_LINE_LABEL_MIN_HEIGHT_PX
+                          ? 2
+                          : 1;
                     return (
                       <div
                         key={ts.session.sessionId}
@@ -706,14 +747,31 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                       >
                         {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
                           <div
-                            className={`relative h-full flex items-center text-[10px] font-mono ${color.text} pointer-events-none`}
+                            className={`relative h-full flex text-[10px] font-mono leading-tight ${color.text} pointer-events-none ${
+                              lineClamp === 1 ? "items-center" : "items-start pt-1"
+                            }`}
                             style={{
                               paddingLeft: ts.showAccent ? 7 : 4,
                               paddingRight: 4,
                               minWidth: 0,
                             }}
                           >
-                            <span className="block truncate min-w-0 flex-1">
+                            <span
+                              className={
+                                lineClamp === 1
+                                  ? "block truncate min-w-0 flex-1"
+                                  : "block min-w-0 flex-1 overflow-hidden"
+                              }
+                              style={
+                                lineClamp === 1
+                                  ? undefined
+                                  : {
+                                      display: "-webkit-box",
+                                      WebkitBoxOrient: "vertical",
+                                      WebkitLineClamp: lineClamp,
+                                    }
+                              }
+                            >
                               {ts.session.title ?? ts.session.firstPrompt ?? ""}
                             </span>
                           </div>

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -680,7 +680,12 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                               className="absolute overflow-hidden rounded-md text-left shadow-layer-sm transition-all duration-200 ease-material hover:z-10 hover:shadow-layer-md"
                               style={{
                                 left: `${ts.leftPct}%`,
-                                width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
+                                // Cap min-width to whatever space is left
+                                // between the bar's start and the lane's right
+                                // edge — otherwise bars near "today" overflow
+                                // the overflow-hidden lane container and get
+                                // visually truncated.
+                                width: `max(${ts.widthPct}%, min(${ts.minWidthPx}px, calc(100% - ${ts.leftPct}%)))`,
                                 top,
                                 height: ts.heightPx,
                                 opacity,

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -1,0 +1,945 @@
+/**
+ * SessionRelationshipsView — Four relationship visualizations for the Projects tab:
+ *   1. Project Grouping  — collapsible project rows with session lists
+ *   2. Timeline Swimlane — each project is a horizontal lane, sessions are time blocks
+ *   3. Dispatch Tree     — parent→child agent relationships
+ *   4. File Connections  — sessions linked by shared modified files
+ */
+
+import { useMemo, useState } from "react";
+import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
+
+// ─── Shared helpers ──────────────────────────────────────────────────
+
+function shortName(project: string): string {
+  return project.split("/").pop() || project;
+}
+
+function timeAgo(iso?: string): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return "now";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function fmtDate(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function fmtShortTime(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+function fmtDuration(ms?: number): string {
+  if (!ms || ms < 0) return "";
+  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
+  const h = Math.floor(ms / 3600000);
+  const m = Math.round((ms % 3600000) / 60000);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+// Stable project color palette — maps project index to a color class
+const PROJECT_COLORS = [
+  {
+    bg: "bg-terminal-green/20",
+    border: "border-terminal-green",
+    text: "text-terminal-green",
+    solid: "#22c55e",
+  },
+  {
+    bg: "bg-terminal-blue/20",
+    border: "border-terminal-blue",
+    text: "text-terminal-blue",
+    solid: "#3b82f6",
+  },
+  {
+    bg: "bg-terminal-purple/20",
+    border: "border-terminal-purple",
+    text: "text-terminal-purple",
+    solid: "#a855f7",
+  },
+  {
+    bg: "bg-terminal-orange/20",
+    border: "border-terminal-orange",
+    text: "text-terminal-orange",
+    solid: "#f97316",
+  },
+  { bg: "bg-pink-500/20", border: "border-pink-500", text: "text-pink-500", solid: "#ec4899" },
+  { bg: "bg-cyan-500/20", border: "border-cyan-500", text: "text-cyan-500", solid: "#06b6d4" },
+  {
+    bg: "bg-yellow-500/20",
+    border: "border-yellow-500",
+    text: "text-yellow-500",
+    solid: "#eab308",
+  },
+  { bg: "bg-red-500/20", border: "border-red-500", text: "text-red-500", solid: "#ef4444" },
+];
+
+function colorFor(idx: number) {
+  return PROJECT_COLORS[idx % PROJECT_COLORS.length];
+}
+
+// ─── Group sessions by project ───────────────────────────────────────
+
+interface ProjectGroup {
+  project: string;
+  sessions: ScanResultSession[];
+  totalDurationMs: number;
+  totalCost: number;
+  lastActivity?: string;
+  colorIdx: number;
+}
+
+function groupByProject(sessions: ScanResultSession[]): ProjectGroup[] {
+  const map = new Map<string, ScanResultSession[]>();
+  for (const s of sessions) {
+    if (!map.has(s.project)) map.set(s.project, []);
+    map.get(s.project)!.push(s);
+  }
+
+  const groups: ProjectGroup[] = [];
+  let idx = 0;
+  for (const [project, sess] of map) {
+    const sorted = [...sess].sort((a, b) => (b.startTime ?? "").localeCompare(a.startTime ?? ""));
+    groups.push({
+      project,
+      sessions: sorted,
+      totalDurationMs: sorted.reduce((s, x) => s + (x.durationMs ?? 0), 0),
+      totalCost: sorted.reduce((s, x) => s + (x.costEstimate ?? 0), 0),
+      lastActivity: sorted[0]?.endTime ?? sorted[0]?.startTime,
+      colorIdx: idx++,
+    });
+  }
+  return groups.sort((a, b) => (b.lastActivity ?? "").localeCompare(a.lastActivity ?? ""));
+}
+
+// ─── 1. Project Grouping View ────────────────────────────────────────
+
+function SessionRow({
+  session,
+  color,
+}: {
+  session: ScanResultSession;
+  color: (typeof PROJECT_COLORS)[0];
+}) {
+  const duration = session.durationMs ?? 0;
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 border-b border-terminal-border/30 hover:bg-terminal-surface-2/50 text-xs font-mono">
+      <div className="flex-1 min-w-0">
+        <div className="text-terminal-text truncate">
+          {session.title ?? session.firstPrompt ?? session.slug}
+        </div>
+        <div className="text-terminal-dimmer text-[10px] mt-0.5">
+          {fmtDate(session.startTime)} {fmtShortTime(session.startTime)}
+          {session.endTime && <span className="ml-2">{timeAgo(session.endTime)} ago</span>}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 shrink-0">
+        {duration > 0 && <span className={color.text}>{fmtDuration(duration)}</span>}
+        <span className="text-terminal-dimmer">{session.promptCount}p</span>
+        {session.editCount > 0 && (
+          <span className="text-terminal-orange">{session.editCount} edits</span>
+        )}
+        {(session.costEstimate ?? 0) > 0 && (
+          <span className="text-terminal-dimmer">${session.costEstimate!.toFixed(2)}</span>
+        )}
+        {session.gitBranch && (
+          <span className="text-terminal-purple truncate max-w-[80px]">{session.gitBranch}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectGroupRow({ group }: { group: ProjectGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  const color = colorFor(group.colorIdx);
+
+  return (
+    <div className={`rounded-xl overflow-hidden border border-terminal-border/40 ${color.bg}`}>
+      <button
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-terminal-surface-hover/30 transition-colors"
+        onClick={() => setExpanded((x) => !x)}
+      >
+        <span className={`text-xs ${expanded ? "rotate-90" : ""} transition-transform shrink-0`}>
+          ▶
+        </span>
+        <div
+          className={`w-1.5 h-1.5 rounded-full shrink-0`}
+          style={{ backgroundColor: color.solid }}
+        />
+        <div className="flex-1 min-w-0">
+          <span className={`font-sans font-semibold text-sm ${color.text}`}>
+            {shortName(group.project)}
+          </span>
+          <span className="text-[10px] font-mono text-terminal-dimmer ml-2 truncate">
+            {group.project}
+          </span>
+        </div>
+        <div className="flex items-center gap-4 shrink-0 text-xs font-mono">
+          <span className="text-terminal-text">
+            {group.sessions.length} <span className="text-terminal-dimmer">sessions</span>
+          </span>
+          {group.totalDurationMs > 0 && (
+            <span className="text-terminal-blue">{fmtDuration(group.totalDurationMs)}</span>
+          )}
+          {group.totalCost > 0 && (
+            <span className="text-terminal-orange">${group.totalCost.toFixed(2)}</span>
+          )}
+          {group.lastActivity && (
+            <span className="text-terminal-dimmer">{timeAgo(group.lastActivity)}</span>
+          )}
+        </div>
+      </button>
+      {expanded && (
+        <div className="border-t border-terminal-border/30 bg-terminal-surface/60">
+          {group.sessions.map((s) => (
+            <SessionRow key={s.sessionId} session={s} color={color} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectGroupingView({ groups }: { groups: ProjectGroup[] }) {
+  return (
+    <div className="space-y-2 p-4">
+      {groups.map((g) => (
+        <ProjectGroupRow key={g.project} group={g} />
+      ))}
+    </div>
+  );
+}
+
+// ─── 2. Timeline Swimlane View ───────────────────────────────────────
+
+interface Lane {
+  start: number;
+  end: number;
+}
+
+/** Simple lane packing: return the lane index for a session */
+function assignLane(lanes: Lane[], startMs: number, endMs: number): number {
+  for (let i = 0; i < lanes.length; i++) {
+    if (startMs >= lanes[i].end) {
+      lanes[i] = { start: startMs, end: endMs };
+      return i;
+    }
+  }
+  lanes.push({ start: startMs, end: endMs });
+  return lanes.length - 1;
+}
+
+const LANE_HEIGHT_PX = 20;
+const LANE_GAP_PX = 2;
+
+interface TimelineSession {
+  session: ScanResultSession;
+  leftPct: number;
+  widthPct: number;
+  lane: number;
+}
+
+interface TimelineProject {
+  project: string;
+  sessions: TimelineSession[];
+  laneCount: number;
+  colorIdx: number;
+}
+
+function buildTimeline(groups: ProjectGroup[]): {
+  projects: TimelineProject[];
+  ticks: { leftPct: number; label: string }[];
+  minMs: number;
+  maxMs: number;
+} {
+  // Determine time bounds from sessions with valid times
+  let minMs = Infinity;
+  let maxMs = -Infinity;
+  for (const g of groups) {
+    for (const s of g.sessions) {
+      if (s.startTime) minMs = Math.min(minMs, new Date(s.startTime).getTime());
+      const end = s.endTime
+        ? new Date(s.endTime).getTime()
+        : s.startTime
+          ? new Date(s.startTime).getTime() + (s.durationMs ?? 0)
+          : null;
+      if (end) maxMs = Math.max(maxMs, end);
+    }
+  }
+
+  if (!isFinite(minMs) || !isFinite(maxMs) || maxMs <= minMs) {
+    return { projects: [], ticks: [], minMs: 0, maxMs: 0 };
+  }
+
+  const totalMs = maxMs - minMs;
+  const paddingMs = totalMs * 0.01;
+  const rangeStart = minMs - paddingMs;
+  const rangeEnd = maxMs + paddingMs;
+  const rangeMs = rangeEnd - rangeStart;
+
+  const projects: TimelineProject[] = [];
+
+  for (const g of groups) {
+    const lanes: Lane[] = [];
+    const tSessions: TimelineSession[] = [];
+
+    // Sort by start time for lane packing
+    const sorted = [...g.sessions]
+      .filter((s) => s.startTime)
+      .sort((a, b) => new Date(a.startTime!).getTime() - new Date(b.startTime!).getTime());
+
+    for (const s of sorted) {
+      const startMs = new Date(s.startTime!).getTime();
+      const endMs = s.endTime ? new Date(s.endTime).getTime() : startMs + (s.durationMs ?? 60000);
+      const leftPct = ((startMs - rangeStart) / rangeMs) * 100;
+      const widthPct = Math.max(((endMs - startMs) / rangeMs) * 100, 0.3);
+      const lane = assignLane(lanes, startMs, endMs);
+      tSessions.push({ session: s, leftPct, widthPct, lane });
+    }
+
+    if (tSessions.length > 0) {
+      projects.push({
+        project: g.project,
+        sessions: tSessions,
+        laneCount: Math.max(...tSessions.map((s) => s.lane)) + 1,
+        colorIdx: g.colorIdx,
+      });
+    }
+  }
+
+  // Build time axis ticks (6-8 ticks)
+  const tickCount = 7;
+  const ticks: { leftPct: number; label: string }[] = [];
+  for (let i = 0; i <= tickCount; i++) {
+    const ms = rangeStart + (rangeMs * i) / tickCount;
+    const d = new Date(ms);
+    const leftPct = (i / tickCount) * 100;
+    // Smart label: show date if span > 1 day, else just time
+    const spanDays = rangeMs / 86400000;
+    let label: string;
+    if (spanDays > 60) {
+      label = d.toLocaleDateString("en-US", { month: "short", year: "2-digit" });
+    } else if (spanDays > 2) {
+      label = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    } else {
+      label = d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+    }
+    ticks.push({ leftPct, label });
+  }
+
+  return { projects, ticks, minMs, maxMs };
+}
+
+interface TooltipInfo {
+  session: ScanResultSession;
+  x: number;
+  y: number;
+}
+
+function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
+  const { projects, ticks } = useMemo(() => buildTimeline(groups), [groups]);
+  const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
+
+  if (projects.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-40 text-terminal-dimmer text-sm font-mono">
+        No sessions with timing data available.
+      </div>
+    );
+  }
+
+  const LABEL_WIDTH = 140;
+
+  return (
+    <div className="p-4 space-y-0 select-none">
+      {/* Time axis header */}
+      <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
+        <div className="relative flex-1 h-6 border-b border-terminal-border/40">
+          {ticks.map((t, i) => (
+            <div
+              key={i}
+              className="absolute flex flex-col items-center"
+              style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+            >
+              <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
+                {t.label}
+              </span>
+              <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Swimlanes */}
+      {projects.map((p) => {
+        const color = colorFor(p.colorIdx);
+        const rowHeight = p.laneCount * (LANE_HEIGHT_PX + LANE_GAP_PX) + 8;
+        return (
+          <div
+            key={p.project}
+            className="flex items-stretch border-b border-terminal-border/20 group"
+          >
+            {/* Project label */}
+            <div
+              className="flex flex-col justify-center shrink-0 py-1 pr-3"
+              style={{ width: LABEL_WIDTH }}
+            >
+              <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
+                {shortName(p.project)}
+              </div>
+              <div className="text-[9px] font-mono text-terminal-dimmer">
+                {p.sessions.length} sessions
+              </div>
+            </div>
+
+            {/* Lane area */}
+            <div
+              className="relative flex-1 bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
+              style={{ height: rowHeight }}
+            >
+              {/* Grid lines */}
+              {ticks.map((t, i) => (
+                <div
+                  key={i}
+                  className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
+                  style={{ left: `${t.leftPct}%` }}
+                />
+              ))}
+
+              {/* Session blocks */}
+              {p.sessions.map((ts) => {
+                const top = 4 + ts.lane * (LANE_HEIGHT_PX + LANE_GAP_PX);
+                return (
+                  <div
+                    key={ts.session.sessionId}
+                    className={`absolute rounded cursor-pointer hover:brightness-110 transition-all ${color.bg} border ${color.border} border-opacity-60`}
+                    style={{
+                      left: `${ts.leftPct}%`,
+                      width: `max(${ts.widthPct}%, 4px)`,
+                      top,
+                      height: LANE_HEIGHT_PX,
+                    }}
+                    onMouseEnter={(e) => {
+                      setTooltip({
+                        session: ts.session,
+                        x: e.clientX,
+                        y: e.clientY,
+                      });
+                    }}
+                    onMouseLeave={() => setTooltip(null)}
+                  >
+                    {ts.widthPct > 3 && (
+                      <span
+                        className={`absolute inset-0 flex items-center px-1 text-[8px] font-mono ${color.text} truncate opacity-80`}
+                      >
+                        {ts.session.title ?? ts.session.firstPrompt ?? ""}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="fixed z-50 pointer-events-none bg-terminal-surface border border-terminal-border rounded-lg shadow-xl p-3 text-xs font-mono max-w-xs"
+          style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
+        >
+          <div className="text-terminal-text font-medium mb-1 truncate">
+            {tooltip.session.title ?? tooltip.session.firstPrompt ?? tooltip.session.slug}
+          </div>
+          <div className="text-terminal-dimmer space-y-0.5">
+            {tooltip.session.startTime && (
+              <div>
+                {fmtDate(tooltip.session.startTime)} {fmtShortTime(tooltip.session.startTime)}
+                {tooltip.session.endTime && <span> → {fmtShortTime(tooltip.session.endTime)}</span>}
+              </div>
+            )}
+            {tooltip.session.durationMs && (
+              <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
+            )}
+            <div>
+              {tooltip.session.promptCount}p · {tooltip.session.editCount} edits ·{" "}
+              {tooltip.session.toolCallCount} tools
+            </div>
+            {tooltip.session.gitBranch && (
+              <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
+            )}
+            {(tooltip.session.costEstimate ?? 0) > 0 && (
+              <div className="text-terminal-orange">
+                ${tooltip.session.costEstimate!.toFixed(3)}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── 3. Dispatch Tree View ───────────────────────────────────────────
+
+interface DispatchNode {
+  session: ScanResultSession;
+  children: DispatchNode[];
+  depth: number;
+}
+
+function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
+  // Claude Code sub-agent detection: sessions with subAgentCount > 0 are parents.
+  // Without explicit parent-child IDs in the scan results, we infer relationships
+  // heuristically: sessions that started within a parent session's time range
+  // and have the same project are likely children.
+  const withSubAgents = sessions.filter((s) => s.subAgentCount > 0 && s.startTime);
+  const candidates = sessions.filter((s) => s.subAgentCount === 0 && s.startTime);
+
+  const roots: DispatchNode[] = [];
+  const usedIds = new Set<string>();
+
+  for (const parent of withSubAgents) {
+    const parentStart = new Date(parent.startTime!).getTime();
+    const parentEnd = parent.endTime
+      ? new Date(parent.endTime).getTime()
+      : parentStart + (parent.durationMs ?? 0);
+
+    // Find sessions that ran entirely within this parent's window
+    const children: DispatchNode[] = [];
+    for (const child of candidates) {
+      if (child.project !== parent.project) continue;
+      const childStart = new Date(child.startTime!).getTime();
+      const childEnd = child.endTime
+        ? new Date(child.endTime).getTime()
+        : childStart + (child.durationMs ?? 0);
+      if (childStart >= parentStart && childEnd <= parentEnd + 300000) {
+        children.push({ session: child, children: [], depth: 1 });
+        usedIds.add(child.sessionId);
+      }
+    }
+
+    if (children.length > 0) {
+      roots.push({ session: parent, children, depth: 0 });
+      usedIds.add(parent.sessionId);
+    }
+  }
+
+  // Sessions with subAgentCount > 0 but no children found — show as isolated
+  for (const s of withSubAgents) {
+    if (!usedIds.has(s.sessionId)) {
+      roots.push({ session: s, children: [], depth: 0 });
+    }
+  }
+
+  return roots;
+}
+
+function DispatchNodeRow({ node, colorIdx }: { node: DispatchNode; colorIdx: number }) {
+  const [expanded, setExpanded] = useState(true);
+  const color = colorFor(colorIdx);
+  const s = node.session;
+
+  return (
+    <div>
+      <div
+        className={`flex items-start gap-2 py-2 px-3 rounded-lg ${node.depth === 0 ? `${color.bg} border ${color.border}/40` : "hover:bg-terminal-surface-2/30"}`}
+        style={{ marginLeft: node.depth * 32 }}
+      >
+        {node.children.length > 0 && (
+          <button
+            className="shrink-0 mt-0.5 text-terminal-dimmer hover:text-terminal-text"
+            onClick={() => setExpanded((x) => !x)}
+          >
+            <span
+              className={`text-[10px] ${expanded ? "rotate-90" : ""} inline-block transition-transform`}
+            >
+              ▶
+            </span>
+          </button>
+        )}
+        {node.children.length === 0 && (
+          <span className="w-4 shrink-0 text-terminal-dimmer text-[10px]">
+            {node.depth > 0 ? "└" : "·"}
+          </span>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`text-xs font-mono ${node.depth === 0 ? color.text : "text-terminal-text"} truncate`}
+            >
+              {s.title ?? s.firstPrompt ?? s.slug}
+            </span>
+            {node.depth === 0 && s.subAgentCount > 0 && (
+              <span className="text-[9px] font-mono text-terminal-purple bg-terminal-purple/10 px-1.5 py-0.5 rounded">
+                {s.subAgentCount} subagents
+              </span>
+            )}
+          </div>
+          <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5 flex gap-2">
+            {s.startTime && <span>{fmtDate(s.startTime)}</span>}
+            {s.durationMs && (
+              <span className="text-terminal-blue">{fmtDuration(s.durationMs)}</span>
+            )}
+            <span>
+              {s.promptCount}p · {s.editCount} edits
+            </span>
+          </div>
+        </div>
+      </div>
+      {expanded &&
+        node.children.map((child) => (
+          <DispatchNodeRow key={child.session.sessionId} node={child} colorIdx={colorIdx} />
+        ))}
+    </div>
+  );
+}
+
+function DispatchTreeView({ groups }: { groups: ProjectGroup[] }) {
+  const trees = useMemo(() => {
+    const allSessions = groups.flatMap((g) => g.sessions);
+    return buildDispatchTree(allSessions);
+  }, [groups]);
+
+  if (trees.length === 0) {
+    return (
+      <div className="p-8 text-center space-y-2">
+        <div className="text-terminal-dimmer text-sm font-mono">
+          No dispatch relationships found.
+        </div>
+        <div className="text-terminal-dimmer/60 text-xs font-mono">
+          Sessions with sub-agents will appear here as parent→child trees.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-3">
+      <div className="text-xs font-mono text-terminal-dimmer mb-4">
+        {trees.length} dispatch group{trees.length !== 1 ? "s" : ""} found
+        {" · "}
+        {trees.reduce((s, t) => s + t.children.length, 0)} child sessions
+      </div>
+      {trees.map((node, i) => {
+        const colorIdx = groups.findIndex((g) => g.project === node.session.project);
+        return (
+          <div key={node.session.sessionId} className="space-y-1">
+            <DispatchNodeRow node={node} colorIdx={colorIdx >= 0 ? colorIdx : i} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── 4. File Connections View ────────────────────────────────────────
+
+interface FileCluster {
+  file: string;
+  sessions: Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>;
+}
+
+function buildFileClusters(groups: ProjectGroup[]): FileCluster[] {
+  const fileMap = new Map<
+    string,
+    Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>
+  >();
+
+  for (const g of groups) {
+    for (const s of g.sessions) {
+      for (const f of s.filesModified) {
+        // Normalize path to just the last 2-3 segments for readability
+        const parts = f.file.split("/");
+        const key = parts.slice(-3).join("/");
+        if (!fileMap.has(key)) fileMap.set(key, []);
+        fileMap.get(key)!.push({ session: s, editCount: f.count, colorIdx: g.colorIdx });
+      }
+    }
+  }
+
+  // Only show files touched by 2+ sessions
+  const clusters: FileCluster[] = [];
+  for (const [file, sessions] of fileMap) {
+    const uniqueSessions = [...new Map(sessions.map((s) => [s.session.sessionId, s])).values()];
+    if (uniqueSessions.length >= 2) {
+      clusters.push({ file, sessions: uniqueSessions });
+    }
+  }
+
+  return clusters.sort((a, b) => b.sessions.length - a.sessions.length).slice(0, 50);
+}
+
+function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
+  const clusters = useMemo(() => buildFileClusters(groups), [groups]);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+
+  if (clusters.length === 0) {
+    return (
+      <div className="p-8 text-center space-y-2">
+        <div className="text-terminal-dimmer text-sm font-mono">No shared files found.</div>
+        <div className="text-terminal-dimmer/60 text-xs font-mono">
+          Files edited by multiple sessions will appear here.
+        </div>
+      </div>
+    );
+  }
+
+  const selected = selectedFile ? clusters.find((c) => c.file === selectedFile) : null;
+
+  return (
+    <div className="flex gap-4 p-4 h-full">
+      {/* File list */}
+      <div className="w-64 shrink-0 space-y-1 overflow-y-auto">
+        <div className="text-[10px] font-mono text-terminal-dimmer mb-2 px-2">
+          {clusters.length} shared files
+        </div>
+        {clusters.map((cluster) => {
+          const isSelected = selectedFile === cluster.file;
+          const maxEdits = Math.max(...cluster.sessions.map((s) => s.editCount));
+          return (
+            <button
+              key={cluster.file}
+              onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
+              className={`w-full text-left px-3 py-2 rounded-lg text-xs font-mono transition-colors ${
+                isSelected
+                  ? "bg-terminal-green/20 border border-terminal-green text-terminal-green"
+                  : "hover:bg-terminal-surface-2 text-terminal-text border border-transparent"
+              }`}
+            >
+              <div className="truncate">{cluster.file.split("/").pop()}</div>
+              <div className="text-[9px] text-terminal-dimmer truncate">{cluster.file}</div>
+              <div className="flex items-center gap-2 mt-1">
+                <div className="flex gap-0.5">
+                  {cluster.sessions.slice(0, 8).map((s, i) => (
+                    <div
+                      key={i}
+                      className="w-2 h-2 rounded-full"
+                      style={{
+                        backgroundColor: colorFor(s.colorIdx).solid,
+                        opacity: 0.4 + (s.editCount / maxEdits) * 0.6,
+                      }}
+                    />
+                  ))}
+                </div>
+                <span className="text-[9px] text-terminal-dimmer">
+                  {cluster.sessions.length} sessions
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Detail panel */}
+      <div className="flex-1 overflow-y-auto">
+        {selected ? (
+          <div className="space-y-3">
+            <div>
+              <div className="text-sm font-mono text-terminal-text font-medium">
+                {selected.file.split("/").pop()}
+              </div>
+              <div className="text-xs font-mono text-terminal-dimmer mt-0.5">{selected.file}</div>
+              <div className="text-xs font-mono text-terminal-dimmer mt-1">
+                {selected.sessions.length} sessions modified this file
+              </div>
+            </div>
+
+            {/* SVG connection diagram */}
+            <div className="relative">
+              <svg
+                width="100%"
+                height={Math.max(120, selected.sessions.length * 50 + 40)}
+                className="overflow-visible"
+              >
+                {/* File node in center */}
+                <g transform={`translate(50%, ${Math.max(60, selected.sessions.length * 25)})`}>
+                  <circle r={20} fill="#374151" stroke="#6b7280" strokeWidth={1.5} />
+                  <text
+                    textAnchor="middle"
+                    dy="0.35em"
+                    fontSize={8}
+                    fill="#9ca3af"
+                    className="font-mono"
+                  >
+                    📄
+                  </text>
+                </g>
+              </svg>
+            </div>
+
+            {/* Session list */}
+            <div className="space-y-2">
+              {selected.sessions.map((s) => {
+                const color = colorFor(s.colorIdx);
+                return (
+                  <div
+                    key={s.session.sessionId}
+                    className={`flex items-start gap-3 p-3 rounded-lg border ${color.bg} ${color.border}/40`}
+                  >
+                    <div
+                      className="w-2 h-2 rounded-full mt-1.5 shrink-0"
+                      style={{ backgroundColor: color.solid }}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className={`text-xs font-mono ${color.text} truncate`}>
+                        {s.session.title ?? s.session.firstPrompt ?? s.session.slug}
+                      </div>
+                      <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5">
+                        {shortName(s.session.project)} · {fmtDate(s.session.startTime)}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-xs font-mono text-terminal-orange">
+                      {s.editCount} edit{s.editCount !== 1 ? "s" : ""}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-40 text-terminal-dimmer text-xs font-mono">
+            Select a file to see which sessions modified it
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Container ──────────────────────────────────────────────────
+
+type RelView = "timeline" | "group" | "tree" | "files";
+
+const VIEW_TABS: { id: RelView; label: string; icon: string; desc: string }[] = [
+  { id: "timeline", label: "Timeline", icon: "⟶", desc: "Sessions as time blocks per project" },
+  { id: "group", label: "Groups", icon: "≡", desc: "Sessions grouped by project" },
+  { id: "tree", label: "Dispatch", icon: "⤷", desc: "Parent → child agent relationships" },
+  { id: "files", label: "Files", icon: "⊕", desc: "Sessions linked by shared files" },
+];
+
+interface SessionRelationshipsViewProps {
+  onBack?: () => void;
+}
+
+export default function SessionRelationshipsView({ onBack }: SessionRelationshipsViewProps) {
+  const { sessions, loading, error } = useRelationshipData();
+  const [activeView, setActiveView] = useState<RelView>("timeline");
+
+  const groups = useMemo(() => groupByProject(sessions), [sessions]);
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex items-center gap-2 text-terminal-dim text-sm font-mono">
+          <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
+          Loading session data...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center space-y-2">
+          <div className="text-terminal-dimmer text-sm font-mono">Failed to load: {error}</div>
+          <div className="text-terminal-dimmer/60 text-xs font-mono">
+            Make sure the vibe-replay editor server is running.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-4 md:px-6 py-3 border-b border-terminal-border/40 shrink-0">
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="text-terminal-dimmer hover:text-terminal-text text-xs font-mono transition-colors"
+          >
+            ← Projects
+          </button>
+        )}
+        <div className="flex-1">
+          <h2 className="text-sm font-sans font-semibold text-terminal-text">
+            Session Relationships
+            <span className="ml-2 text-terminal-dimmer font-normal text-xs font-mono">
+              {sessions.length} sessions · {groups.length} projects
+            </span>
+          </h2>
+        </div>
+
+        {/* View tabs */}
+        <div className="flex items-center gap-1">
+          {VIEW_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveView(tab.id)}
+              title={tab.desc}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono transition-all ${
+                activeView === tab.id
+                  ? "bg-terminal-green/15 text-terminal-green border border-terminal-green/30"
+                  : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-2"
+              }`}
+            >
+              <span className="text-[11px]">{tab.icon}</span>
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      <div className="flex items-center gap-4 px-4 md:px-6 py-2 border-b border-terminal-border/20 text-[10px] font-mono text-terminal-dimmer shrink-0">
+        <span>
+          <span className="text-terminal-text">{sessions.length}</span> sessions
+        </span>
+        <span>
+          <span className="text-terminal-text">{groups.length}</span> projects
+        </span>
+        <span>
+          <span className="text-terminal-blue">
+            {fmtDuration(sessions.reduce((s, x) => s + (x.durationMs ?? 0), 0))}
+          </span>{" "}
+          total time
+        </span>
+        <span>
+          <span className="text-terminal-orange">
+            ${sessions.reduce((s, x) => s + (x.costEstimate ?? 0), 0).toFixed(2)}
+          </span>{" "}
+          total cost
+        </span>
+        <span>
+          <span className="text-terminal-green">
+            {sessions.reduce((s, x) => s + x.editCount, 0).toLocaleString()}
+          </span>{" "}
+          edits
+        </span>
+      </div>
+
+      {/* View content */}
+      <div className="flex-1 overflow-y-auto">
+        {activeView === "timeline" && <TimelineSwimlaneView groups={groups} />}
+        {activeView === "group" && <ProjectGroupingView groups={groups} />}
+        {activeView === "tree" && <DispatchTreeView groups={groups} />}
+        {activeView === "files" && <FileConnectionsView groups={groups} />}
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -9,6 +9,7 @@
 import { useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
 import { shortName, timeAgo } from "../utils/format";
+import { collapseWorktree, isAutomated, sessionScore } from "../utils/sessionSignals";
 
 // ─── Shared helpers ──────────────────────────────────────────────────
 
@@ -85,11 +86,15 @@ interface ProjectGroup {
   colorIdx: number;
 }
 
-function groupByProject(sessions: ScanResultSession[]): ProjectGroup[] {
+function groupByProject(
+  sessions: ScanResultSession[],
+  options: { collapseWorktrees?: boolean } = {},
+): ProjectGroup[] {
   const map = new Map<string, ScanResultSession[]>();
   for (const s of sessions) {
-    if (!map.has(s.project)) map.set(s.project, []);
-    map.get(s.project)!.push(s);
+    const key = options.collapseWorktrees ? collapseWorktree(s.project) : s.project;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(s);
   }
 
   const groups: ProjectGroup[] = [];
@@ -207,49 +212,150 @@ function ProjectGroupingView({ groups }: { groups: ProjectGroup[] }) {
   );
 }
 
-// ─── 2. Timeline Swimlane View ───────────────────────────────────────
+// ─── 2. Timeline View ────────────────────────────────────────────────
+//
+// One row per project. Sessions within a project are lane-packed (no overlap),
+// each at a uniform LANE_HEIGHT so labels are always readable. Importance is
+// encoded in three independent visual channels:
+//
+//   minWidthPx  — important short sessions get widened so labels fit
+//   fillIntensity — bg opacity (low score = ghosted outline, high score = solid)
+//   accentBar  — top-decile sessions get a 3px solid left rim
+//
+// Automated / scheduled sessions are hidden by default and surfaced via a toggle.
+// Per-project lane count is capped; overflow is rolled up into a "+N more" hint.
 
-interface Lane {
-  start: number;
-  end: number;
-}
+// Each lane reserves LANE_TOTAL_HEIGHT_PX of vertical space. Within a lane,
+// bars are *bottom-aligned* so their tops form a skyline — height encodes
+// importance in addition to width and fill. The 6x height ratio (8 → 48)
+// makes top-tier sessions visibly tower over routine ones.
+const LANE_TOTAL_HEIGHT_PX = 48;
+const LANE_GAP_PX = 4;
+const MAX_LANES_PER_PROJECT = 5;
+const MIN_BAR_HEIGHT_PX = 8; // floor — low-score sessions are short ticks
+const MAX_BAR_HEIGHT_PX = LANE_TOTAL_HEIGHT_PX; // cap — top-tier sessions fill the lane
+const LABEL_VISIBLE_MIN_HEIGHT_PX = 14; // below this, render bar without label
 
-/** Simple lane packing: return the lane index for a session */
-function assignLane(lanes: Lane[], startMs: number, endMs: number): number {
-  for (let i = 0; i < lanes.length; i++) {
-    if (startMs >= lanes[i].end) {
-      lanes[i] = { start: startMs, end: endMs };
-      return i;
-    }
-  }
-  lanes.push({ start: startMs, end: endMs });
-  return lanes.length - 1;
-}
-
-const LANE_HEIGHT_PX = 20;
-const LANE_GAP_PX = 2;
+const MIN_BAR_MIN_WIDTH_PX = 6; // floor for low-importance sessions
+const MAX_BAR_MIN_WIDTH_PX = 160; // cap for the "important short session" widening
+const TOP_ACCENT_SCORE_THRESHOLD = 60; // score >= this gets the left accent rim
+// Approximate width of the time-axis area (px) used to convert minWidthPx into
+// a visual end-time for lane packing. Real container is responsive; this is the
+// floor we design for. Slightly underestimating makes lanes pack more loosely
+// at narrow viewports — better than visual overlap.
+const APPROX_TIMELINE_WIDTH_PX = 1100;
 
 interface TimelineSession {
   session: ScanResultSession;
   leftPct: number;
   widthPct: number;
   lane: number;
+  score: number;
+  minWidthPx: number;
+  heightPx: number; // bar height (importance)
+  fillAlpha: number; // 0-1 background alpha applied to color.solid
+  showAccent: boolean;
+  opacity: number;
 }
 
 interface TimelineProject {
   project: string;
   sessions: TimelineSession[];
   laneCount: number;
+  hiddenInLanesCount: number; // sessions dropped because they exceeded MAX_LANES_PER_PROJECT
   colorIdx: number;
+  importance: number;
 }
 
-function buildTimeline(groups: ProjectGroup[]): {
+function fillAlphaFor(score: number): number {
+  // low = ghost, mid = soft, high = solid
+  if (score >= 60) return 0.45;
+  if (score >= 30) return 0.28;
+  return 0.12;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const m = hex.replace("#", "");
+  const r = parseInt(m.slice(0, 2), 16);
+  const g = parseInt(m.slice(2, 4), 16);
+  const b = parseInt(m.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function opacityFor(score: number): number {
+  // map score 0–100 → 0.55–1.0
+  return 0.55 + Math.min(1, score / 100) * 0.45;
+}
+
+function minWidthFor(score: number): number {
+  // sqrt curve so mid-importance sessions still get meaningful width
+  const t = Math.sqrt(Math.max(0, Math.min(100, score)) / 100);
+  return MIN_BAR_MIN_WIDTH_PX + t * (MAX_BAR_MIN_WIDTH_PX - MIN_BAR_MIN_WIDTH_PX);
+}
+
+function heightFor(score: number): number {
+  // Linear (not sqrt) so importance maps proportionally to height — the whole
+  // point of this channel is to make important sessions visibly larger.
+  const t = Math.max(0, Math.min(100, score)) / 100;
+  return MIN_BAR_HEIGHT_PX + t * (MAX_BAR_HEIGHT_PX - MIN_BAR_HEIGHT_PX);
+}
+
+/**
+ * Lane packing biased to importance: highest-scoring sessions claim the top
+ * lane first, so the most interesting work isn't pushed below the fold.
+ *
+ * Returns: per-session lane index, total lane count, and the number of sessions
+ * that couldn't fit within MAX_LANES_PER_PROJECT (rolled up as "+N hidden").
+ */
+function packLanesByImportance(
+  sessions: { startMs: number; endMs: number; score: number; original: ScanResultSession }[],
+): { laneAssignments: Map<string, number>; laneCount: number; dropped: number } {
+  const ordered = [...sessions].sort((a, b) => b.score - a.score);
+  const laneIntervals: Array<Array<{ startMs: number; endMs: number }>> = [];
+  const laneAssignments = new Map<string, number>();
+  let dropped = 0;
+
+  for (const s of ordered) {
+    let placed = -1;
+    for (let i = 0; i < laneIntervals.length; i++) {
+      const overlap = laneIntervals[i].some((iv) => s.startMs < iv.endMs && s.endMs > iv.startMs);
+      if (!overlap) {
+        placed = i;
+        break;
+      }
+    }
+
+    if (placed === -1) {
+      if (laneIntervals.length >= MAX_LANES_PER_PROJECT) {
+        dropped++;
+        continue;
+      }
+      placed = laneIntervals.length;
+      laneIntervals.push([]);
+    }
+
+    laneIntervals[placed].push({ startMs: s.startMs, endMs: s.endMs });
+    laneAssignments.set(s.original.sessionId, placed);
+  }
+
+  return { laneAssignments, laneCount: laneIntervals.length, dropped };
+}
+
+function buildTimeline(
+  groups: ProjectGroup[],
+  windowStart?: number,
+  windowEnd?: number,
+  includeAutomated = false,
+): {
   projects: TimelineProject[];
   ticks: { leftPct: number; label: string }[];
   minMs: number;
   maxMs: number;
+  totalSessions: number;
+  hiddenAutomatedCount: number;
 } {
-  // Determine time bounds from sessions with valid times
+  // Determine time bounds. If an explicit window is provided (range selector),
+  // use it. Otherwise fall back to min/max across all sessions ("All" view).
   let minMs = Infinity;
   let maxMs = -Infinity;
   for (const g of groups) {
@@ -265,44 +371,115 @@ function buildTimeline(groups: ProjectGroup[]): {
   }
 
   if (!isFinite(minMs) || !isFinite(maxMs) || maxMs <= minMs) {
-    return { projects: [], ticks: [], minMs: 0, maxMs: 0 };
+    return {
+      projects: [],
+      ticks: [],
+      minMs: 0,
+      maxMs: 0,
+      totalSessions: 0,
+      hiddenAutomatedCount: 0,
+    };
   }
 
-  const totalMs = maxMs - minMs;
-  const paddingMs = totalMs * 0.01;
-  const rangeStart = minMs - paddingMs;
-  const rangeEnd = maxMs + paddingMs;
+  let rangeStart: number;
+  let rangeEnd: number;
+  if (windowStart != null && windowEnd != null) {
+    rangeStart = windowStart;
+    rangeEnd = windowEnd;
+  } else {
+    const totalMs = maxMs - minMs;
+    const paddingMs = totalMs * 0.01;
+    rangeStart = minMs - paddingMs;
+    rangeEnd = maxMs + paddingMs;
+  }
   const rangeMs = rangeEnd - rangeStart;
 
   const projects: TimelineProject[] = [];
+  let totalSessions = 0;
+  let hiddenAutomatedCount = 0;
 
   for (const g of groups) {
-    const lanes: Lane[] = [];
-    const tSessions: TimelineSession[] = [];
+    // Filter to window + automated policy
+    const filtered = g.sessions.filter((s) => {
+      if (!s.startTime) return false;
+      const startMs = new Date(s.startTime).getTime();
+      const endMs = s.endTime ? new Date(s.endTime).getTime() : startMs + (s.durationMs ?? 0);
+      if (endMs < rangeStart || startMs > rangeEnd) return false;
+      if (!includeAutomated && isAutomated(s)) {
+        hiddenAutomatedCount++;
+        return false;
+      }
+      return true;
+    });
 
-    // Sort by start time for lane packing
-    const sorted = [...g.sessions]
-      .filter((s) => s.startTime)
-      .sort((a, b) => new Date(a.startTime!).getTime() - new Date(b.startTime!).getTime());
+    if (filtered.length === 0) continue;
 
-    for (const s of sorted) {
+    // Build interval list for lane packing. Crucially, the "interval" we hand
+    // to the packer is the VISUAL extent (max of duration and min-width
+    // converted back to time), not just the raw duration — otherwise widened
+    // short sessions overlap their neighbours visually even though the packer
+    // thought they were disjoint.
+    const minMsPerPx = rangeMs / APPROX_TIMELINE_WIDTH_PX;
+    const intervals = filtered.map((s) => {
       const startMs = new Date(s.startTime!).getTime();
-      const endMs = s.endTime ? new Date(s.endTime).getTime() : startMs + (s.durationMs ?? 60000);
-      const leftPct = ((startMs - rangeStart) / rangeMs) * 100;
-      const widthPct = Math.max(((endMs - startMs) / rangeMs) * 100, 0.3);
-      const lane = assignLane(lanes, startMs, endMs);
-      tSessions.push({ session: s, leftPct, widthPct, lane });
+      const realEndMs = s.endTime
+        ? new Date(s.endTime).getTime()
+        : startMs + (s.durationMs ?? 60000);
+      const score = sessionScore(s);
+      const visualWidthMs = Math.max(realEndMs - startMs, minWidthFor(score) * minMsPerPx);
+      return {
+        startMs,
+        endMs: startMs + visualWidthMs, // visual end for packing
+        realEndMs, // for tooltip / display
+        score,
+        original: s,
+      };
+    });
+
+    const { laneAssignments, laneCount, dropped } = packLanesByImportance(intervals);
+
+    const tSessions: TimelineSession[] = [];
+    for (const it of intervals) {
+      const lane = laneAssignments.get(it.original.sessionId);
+      if (lane == null) continue; // dropped due to lane cap
+      // Clip to viewport: if the bar starts before the visible window, push the
+      // left edge to 0 and shorten the width. Avoids "mid-string truncation"
+      // where the visible portion starts at some arbitrary character of the title.
+      const rawLeftPct = ((it.startMs - rangeStart) / rangeMs) * 100;
+      const rawRightPct = ((it.realEndMs - rangeStart) / rangeMs) * 100;
+      const leftPct = Math.max(0, rawLeftPct);
+      const widthPct = Math.max(0, rawRightPct - leftPct);
+      tSessions.push({
+        session: it.original,
+        leftPct,
+        widthPct,
+        lane,
+        score: it.score,
+        minWidthPx: minWidthFor(it.score),
+        heightPx: heightFor(it.score),
+        fillAlpha: fillAlphaFor(it.score),
+        showAccent: it.score >= TOP_ACCENT_SCORE_THRESHOLD,
+        opacity: opacityFor(it.score),
+      });
     }
 
     if (tSessions.length > 0) {
+      // Render high-score sessions last so their accent rim sits on top of overlaps
+      tSessions.sort((a, b) => a.score - b.score);
       projects.push({
         project: g.project,
         sessions: tSessions,
-        laneCount: tSessions.reduce((max, s) => Math.max(max, s.lane), 0) + 1,
+        laneCount,
+        hiddenInLanesCount: dropped,
         colorIdx: g.colorIdx,
+        importance: tSessions.reduce((sum, t) => sum + t.score, 0),
       });
+      totalSessions += tSessions.length;
     }
   }
+
+  // Order project lanes by total importance (most active first)
+  projects.sort((a, b) => b.importance - a.importance);
 
   // Build time axis ticks (6-8 ticks)
   const tickCount = 7;
@@ -324,7 +501,24 @@ function buildTimeline(groups: ProjectGroup[]): {
     ticks.push({ leftPct, label });
   }
 
-  return { projects, ticks, minMs, maxMs };
+  return { projects, ticks, minMs, maxMs, totalSessions, hiddenAutomatedCount };
+}
+
+type TimelineRange = "1d" | "7d" | "30d" | "all";
+
+const RANGE_OPTIONS: { value: TimelineRange; label: string; days?: number }[] = [
+  { value: "1d", label: "1D", days: 1 },
+  { value: "7d", label: "7D", days: 7 },
+  { value: "30d", label: "30D", days: 30 },
+  { value: "all", label: "All" },
+];
+
+function rangeWindow(range: TimelineRange): { start?: number; end?: number } {
+  const opt = RANGE_OPTIONS.find((o) => o.value === range);
+  if (!opt || opt.days == null) return {};
+  const end = Date.now();
+  const start = end - opt.days * 86400000;
+  return { start, end };
 }
 
 interface TooltipInfo {
@@ -334,122 +528,218 @@ interface TooltipInfo {
 }
 
 function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
-  const { projects, ticks } = useMemo(() => buildTimeline(groups), [groups]);
+  const [range, setRange] = useState<TimelineRange>("7d");
+  const [showAutomated, setShowAutomated] = useState(false);
   const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
-
-  if (projects.length === 0) {
-    return (
-      <div className="flex items-center justify-center h-40 text-terminal-dimmer text-sm font-mono">
-        No sessions with timing data available.
-      </div>
-    );
-  }
+  const { start, end } = useMemo(() => rangeWindow(range), [range]);
+  const { projects, ticks, totalSessions, hiddenAutomatedCount } = useMemo(
+    () => buildTimeline(groups, start, end, showAutomated),
+    [groups, start, end, showAutomated],
+  );
 
   const LABEL_WIDTH = 140;
 
   return (
     <div className="p-4 space-y-0 select-none">
-      {/* Time axis header */}
-      <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
-        <div className="relative flex-1 h-6 border-b border-terminal-border/40">
-          {ticks.map((t, i) => (
-            <div
-              key={i}
-              className="absolute flex flex-col items-center"
-              style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+      {/* Range selector + automated toggle */}
+      <div className="flex items-center justify-between mb-3 pl-1">
+        <div className="text-[11px] font-mono text-terminal-dimmer flex items-center gap-3">
+          <span>
+            {totalSessions} <span className="opacity-60">sessions</span>
+          </span>
+          <span className="opacity-50">·</span>
+          <span className="opacity-70">
+            row = project · height + width + fill = importance · time → x-axis
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-[10px] font-mono">
+          {hiddenAutomatedCount > 0 && !showAutomated && (
+            <button
+              onClick={() => setShowAutomated(true)}
+              className="text-terminal-dimmer hover:text-terminal-text transition-colors"
+              title="Scheduled / automated sessions are hidden by default"
             >
-              <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
-                {t.label}
-              </span>
-              <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
-            </div>
-          ))}
+              + {hiddenAutomatedCount} automated hidden ▸
+            </button>
+          )}
+          {showAutomated && (
+            <button
+              onClick={() => setShowAutomated(false)}
+              className="text-terminal-purple hover:underline"
+            >
+              hide automated
+            </button>
+          )}
+          <div className="flex items-center gap-1">
+            <span className="text-terminal-dimmer mr-1">Range:</span>
+            {RANGE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setRange(opt.value)}
+                className={`px-2 py-1 rounded-md transition-colors ${
+                  range === opt.value
+                    ? "bg-terminal-green-subtle text-terminal-green"
+                    : "text-terminal-dim hover:text-terminal-text"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
-      {/* Swimlanes */}
-      {projects.map((p) => {
-        const color = colorFor(p.colorIdx);
-        const rowHeight = p.laneCount * (LANE_HEIGHT_PX + LANE_GAP_PX) + 8;
-        return (
-          <div
-            key={p.project}
-            className="flex items-stretch border-b border-terminal-border/20 group"
-          >
-            {/* Project label */}
-            <div
-              className="flex flex-col justify-center shrink-0 py-1 pr-3"
-              style={{ width: LABEL_WIDTH }}
+      {projects.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-40 gap-2 text-terminal-dimmer text-sm font-mono">
+          <div>No sessions in the last {RANGE_OPTIONS.find((o) => o.value === range)?.label}.</div>
+          {range !== "all" && (
+            <button
+              onClick={() => setRange("all")}
+              className="text-terminal-green hover:underline text-xs"
             >
-              <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                {shortName(p.project)}
-              </div>
-              <div className="text-[9px] font-mono text-terminal-dimmer">
-                {p.sessions.length} sessions
-              </div>
-            </div>
-
-            {/* Lane area */}
-            <div
-              className="relative flex-1 bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
-              style={{ height: rowHeight }}
-            >
-              {/* Grid lines */}
+              Show all sessions →
+            </button>
+          )}
+        </div>
+      ) : (
+        <>
+          {/* Time axis header */}
+          <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
+            <div className="relative flex-1 h-6 border-b border-terminal-border/40">
               {ticks.map((t, i) => (
                 <div
                   key={i}
-                  className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
-                  style={{ left: `${t.leftPct}%` }}
-                />
+                  className="absolute flex flex-col items-center"
+                  style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+                >
+                  <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
+                    {t.label}
+                  </span>
+                  <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
+                </div>
               ))}
+            </div>
+          </div>
 
-              {/* Session blocks */}
-              {p.sessions.map((ts) => {
-                const top = 4 + ts.lane * (LANE_HEIGHT_PX + LANE_GAP_PX);
-                return (
-                  <div
-                    key={ts.session.sessionId}
-                    className={`absolute rounded cursor-pointer hover:brightness-110 transition-all ${color.bg} border ${color.border} border-opacity-60`}
-                    style={{
-                      left: `${ts.leftPct}%`,
-                      width: `max(${ts.widthPct}%, 4px)`,
-                      top,
-                      height: LANE_HEIGHT_PX,
-                    }}
-                    onMouseEnter={(e) => {
-                      setTooltip({
-                        session: ts.session,
-                        x: e.clientX,
-                        y: e.clientY,
-                      });
-                    }}
-                    onMouseLeave={() => setTooltip(null)}
-                  >
-                    {ts.widthPct > 3 && (
-                      <span
-                        className={`absolute inset-0 flex items-center px-1 text-[8px] font-mono ${color.text} truncate opacity-80`}
-                      >
-                        {ts.session.title ?? ts.session.firstPrompt ?? ""}
+          {/* Project rows — lane-packed, bottom-aligned skyline.
+              Per-bar HEIGHT, WIDTH (min-width by score), FILL alpha, and an
+              optional left ACCENT RIM all encode importance — important sessions
+              are visibly larger and more saturated, low-importance ones are
+              short ghosted ticks but still labeled and clickable. */}
+          {projects.map((p) => {
+            const color = colorFor(p.colorIdx);
+            const rowHeight = p.laneCount * (LANE_TOTAL_HEIGHT_PX + LANE_GAP_PX) + 6;
+            const accentColor = color.solid;
+            return (
+              <div
+                key={p.project}
+                className="flex items-stretch border-b border-terminal-border/20 group"
+              >
+                {/* Project label */}
+                <div
+                  className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
+                  style={{ width: LABEL_WIDTH, height: rowHeight }}
+                >
+                  <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
+                    {shortName(p.project)}
+                  </div>
+                  <div className="text-[9px] font-mono text-terminal-dimmer truncate">
+                    {p.sessions.length} session{p.sessions.length !== 1 ? "s" : ""}
+                    {p.hiddenInLanesCount > 0 && (
+                      <span className="text-terminal-orange/70">
+                        {" "}
+                        · +{p.hiddenInLanesCount} hidden
                       </span>
                     )}
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        );
-      })}
+                </div>
+
+                {/* Lane area */}
+                <div
+                  className="relative flex-1 overflow-hidden bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
+                  style={{ height: rowHeight }}
+                >
+                  {/* Grid lines */}
+                  {ticks.map((t, i) => (
+                    <div
+                      key={i}
+                      className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
+                      style={{ left: `${t.leftPct}%` }}
+                    />
+                  ))}
+
+                  {/* Session blocks — variable height (importance), bottom-aligned within lane */}
+                  {p.sessions.map((ts) => {
+                    const automated = isAutomated(ts.session);
+                    // Lane row spans LANE_TOTAL_HEIGHT_PX. Bar bottom aligns to
+                    // the lane's bottom; height varies up to that ceiling.
+                    const laneTop = 3 + ts.lane * (LANE_TOTAL_HEIGHT_PX + LANE_GAP_PX);
+                    const top = laneTop + (LANE_TOTAL_HEIGHT_PX - ts.heightPx);
+                    const opacity = automated ? 0.4 : ts.opacity;
+                    return (
+                      <div
+                        key={ts.session.sessionId}
+                        className={`absolute overflow-hidden rounded-sm cursor-pointer hover:brightness-125 hover:z-10 transition-all border ${color.border} border-opacity-50`}
+                        style={{
+                          left: `${ts.leftPct}%`,
+                          width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
+                          top,
+                          height: ts.heightPx,
+                          opacity,
+                          zIndex: Math.round(ts.score),
+                          backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
+                          ...(ts.showAccent
+                            ? {
+                                boxShadow: `inset 3px 0 0 ${accentColor}`,
+                              }
+                            : {}),
+                        }}
+                        onMouseEnter={(e) => {
+                          setTooltip({
+                            session: ts.session,
+                            x: e.clientX,
+                            y: e.clientY,
+                          });
+                        }}
+                        onMouseLeave={() => setTooltip(null)}
+                      >
+                        {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
+                          <div
+                            className={`relative h-full flex items-center text-[10px] font-mono ${color.text} pointer-events-none`}
+                            style={{
+                              paddingLeft: ts.showAccent ? 7 : 4,
+                              paddingRight: 4,
+                              minWidth: 0,
+                            }}
+                          >
+                            <span className="block truncate min-w-0 flex-1">
+                              {ts.session.title ?? ts.session.firstPrompt ?? ""}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </>
+      )}
 
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="fixed z-50 pointer-events-none bg-terminal-surface border border-terminal-border rounded-lg shadow-xl p-3 text-xs font-mono max-w-xs"
+          className="fixed pointer-events-none bg-terminal-surface border border-terminal-border rounded-lg shadow-xl p-3 text-xs font-mono w-80"
           style={{
-            left: Math.min(tooltip.x + 12, window.innerWidth - 280),
-            top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 160)),
+            // Bars use zIndex up to 100 (score-based), so the tooltip needs to
+            // stay well above that — z-50 was actually below high-score bars.
+            zIndex: 1000,
+            left: Math.min(tooltip.x + 12, window.innerWidth - 336),
+            top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
           }}
         >
-          <div className="text-terminal-text font-medium mb-1 truncate">
+          <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
             {tooltip.session.title ?? tooltip.session.firstPrompt ?? tooltip.session.slug}
           </div>
           <div className="text-terminal-dimmer space-y-0.5">
@@ -815,6 +1105,12 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
   const [activeView, setActiveView] = useState<RelView>("timeline");
 
   const groups = useMemo(() => groupByProject(sessions), [sessions]);
+  // Timeline collapses worktree paths back to their parent repo so the lanes
+  // reflect "real" projects instead of being polluted by every worktree.
+  const timelineGroups = useMemo(
+    () => groupByProject(sessions, { collapseWorktrees: true }),
+    [sessions],
+  );
 
   if (loading) {
     return (
@@ -911,7 +1207,7 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
 
       {/* View content */}
       <div className="flex-1 overflow-y-auto">
-        {activeView === "timeline" && <TimelineSwimlaneView groups={groups} />}
+        {activeView === "timeline" && <TimelineSwimlaneView groups={timelineGroups} />}
         {activeView === "group" && <ProjectGroupingView groups={groups} />}
         {activeView === "tree" && <DispatchTreeView groups={groups} />}
         {activeView === "files" && <FileConnectionsView groups={groups} />}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -965,7 +965,14 @@ function buildProjectFileGroups(groups: ProjectGroup[]): ProjectFileGroup[] {
   );
 }
 
-function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
+function FileConnectionsView({
+  groups,
+  hideProjectList,
+}: {
+  groups: ProjectGroup[];
+  /** True when the outer Projects sidebar already restricts us to one project. */
+  hideProjectList?: boolean;
+}) {
   const projectFileGroups = useMemo(() => buildProjectFileGroups(groups), [groups]);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
@@ -1001,43 +1008,47 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
 
   return (
     <div className="flex h-full min-w-0 flex-col gap-4 p-4 lg:flex-row">
-      {/* Project list */}
-      <div className="w-full shrink-0 space-y-2 overflow-y-auto lg:w-64">
-        <div className="px-1">
-          <div className="text-sm font-sans font-semibold text-terminal-text">Hot Files</div>
-          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
-            {projectFileGroups.length} {plural(projectFileGroups.length, "project")} with hot files
+      {/* Project list — hidden when the outer Projects sidebar already filters
+          us to a single project (avoids a redundant second-level project list) */}
+      {!hideProjectList && (
+        <div className="w-full shrink-0 space-y-2 overflow-y-auto lg:w-64">
+          <div className="px-1">
+            <div className="text-sm font-sans font-semibold text-terminal-text">Hot Files</div>
+            <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+              {projectFileGroups.length} {plural(projectFileGroups.length, "project")} with hot
+              files
+            </div>
           </div>
+          {projectFileGroups.map((group) => {
+            const isSelected = selectedProjectGroup.project === group.project;
+            return (
+              <button
+                key={group.project}
+                onClick={() => {
+                  setSelectedProject(group.project);
+                  setSelectedFile(null);
+                }}
+                className={`w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-200 ease-material ${
+                  isSelected
+                    ? "border-transparent bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
+                    : "border-transparent bg-terminal-bg/35 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
+                }`}
+              >
+                <div className="truncate text-xs font-sans font-semibold">
+                  {projectName(group.project)}
+                </div>
+                <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
+                  {group.project}
+                </div>
+                <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+                  {group.files.length} {plural(group.files.length, "file")} ·{" "}
+                  {group.totalEdits.toLocaleString()} {plural(group.totalEdits, "edit")}
+                </div>
+              </button>
+            );
+          })}
         </div>
-        {projectFileGroups.map((group) => {
-          const isSelected = selectedProjectGroup.project === group.project;
-          return (
-            <button
-              key={group.project}
-              onClick={() => {
-                setSelectedProject(group.project);
-                setSelectedFile(null);
-              }}
-              className={`w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-200 ease-material ${
-                isSelected
-                  ? "border-transparent bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
-                  : "border-transparent bg-terminal-bg/35 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
-              }`}
-            >
-              <div className="truncate text-xs font-sans font-semibold">
-                {projectName(group.project)}
-              </div>
-              <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
-                {group.project}
-              </div>
-              <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-                {group.files.length} {plural(group.files.length, "file")} ·{" "}
-                {group.totalEdits.toLocaleString()} {plural(group.totalEdits, "edit")}
-              </div>
-            </button>
-          );
-        })}
-      </div>
+      )}
 
       {/* Project files + detail panel */}
       <div className="min-w-0 flex-1 space-y-4 overflow-y-auto">
@@ -1158,17 +1169,34 @@ export type ProjectRelationshipView = "timeline" | "files";
 
 interface SessionRelationshipsViewProps {
   view: ProjectRelationshipView;
+  /**
+   * If set, restrict the view to a single project (post-rollup key).
+   * The outer Projects sidebar already shows the project list, so the inner
+   * Hot Files project list collapses to a single row when filter is active.
+   */
+  projectFilter?: string;
 }
 
-export default function SessionRelationshipsView({ view }: SessionRelationshipsViewProps) {
+export default function SessionRelationshipsView({
+  view,
+  projectFilter,
+}: SessionRelationshipsViewProps) {
   const { sessions, loading, error } = useRelationshipData();
 
   // Collapse agent worktrees back to the project the user recognizes. The
   // session rows still expose the original path when it matters.
-  const groups = useMemo(() => groupByProject(sessions, { collapseWorktrees: true }), [sessions]);
+  const filteredSessions = useMemo(
+    () =>
+      projectFilter ? sessions.filter((s) => rollupProject(s.project) === projectFilter) : sessions,
+    [sessions, projectFilter],
+  );
+  const groups = useMemo(
+    () => groupByProject(filteredSessions, { collapseWorktrees: true }),
+    [filteredSessions],
+  );
   const providerSummary = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const s of sessions) {
+    for (const s of filteredSessions) {
       const label = providerBadgeLabel(s.provider);
       counts.set(label, (counts.get(label) || 0) + 1);
     }
@@ -1177,10 +1205,10 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
       .slice(0, 3)
       .map(([label, count]) => `${label} ${count}`)
       .join(" · ");
-  }, [sessions]);
+  }, [filteredSessions]);
   const estimatedTimingCount = useMemo(
-    () => sessions.filter((session) => sessionHasEstimatedTime(session)).length,
-    [sessions],
+    () => filteredSessions.filter((session) => sessionHasEstimatedTime(session)).length,
+    [filteredSessions],
   );
 
   if (loading) {
@@ -1238,13 +1266,15 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
       {/* Stats bar */}
       <div className="relative z-10 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 text-[10px] font-mono text-terminal-dimmer md:px-6">
         <span>
-          <span className="text-terminal-text">{sessions.length}</span>{" "}
-          {plural(sessions.length, "session")}
+          <span className="text-terminal-text">{filteredSessions.length}</span>{" "}
+          {plural(filteredSessions.length, "session")}
         </span>
-        <span>
-          <span className="text-terminal-text">{groups.length}</span>{" "}
-          {plural(groups.length, "project")}
-        </span>
+        {!projectFilter && (
+          <span>
+            <span className="text-terminal-text">{groups.length}</span>{" "}
+            {plural(groups.length, "project")}
+          </span>
+        )}
         {providerSummary && (
           <span>
             <span className="text-terminal-purple">{providerSummary}</span>
@@ -1252,22 +1282,22 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
         )}
         <span>
           <span className="text-terminal-blue">
-            {fmtDuration(sessions.reduce((s, x) => s + (x.durationMs ?? 0), 0))}
+            {fmtDuration(filteredSessions.reduce((s, x) => s + (x.durationMs ?? 0), 0))}
           </span>{" "}
           total time
         </span>
         <span>
           <span className="text-terminal-orange">
-            ${sessions.reduce((s, x) => s + (x.costEstimate ?? 0), 0).toFixed(2)}
+            ${filteredSessions.reduce((s, x) => s + (x.costEstimate ?? 0), 0).toFixed(2)}
           </span>{" "}
           total cost
         </span>
         <span>
           <span className="text-terminal-green">
-            {sessions.reduce((s, x) => s + x.editCount, 0).toLocaleString()}
+            {filteredSessions.reduce((s, x) => s + x.editCount, 0).toLocaleString()}
           </span>{" "}
           {plural(
-            sessions.reduce((s, x) => s + x.editCount, 0),
+            filteredSessions.reduce((s, x) => s + x.editCount, 0),
             "edit",
           )}
         </span>
@@ -1281,7 +1311,9 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
       {/* View content */}
       <div className="relative z-10 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
         {view === "timeline" && <TimelineSwimlaneView groups={groups} />}
-        {view === "files" && <FileConnectionsView groups={groups} />}
+        {view === "files" && (
+          <FileConnectionsView groups={groups} hideProjectList={Boolean(projectFilter)} />
+        )}
       </div>
     </div>
   );

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -362,6 +362,29 @@ function packLanesByImportance(
   return { laneAssignments, laneCount: laneIntervals.length, dropped };
 }
 
+/**
+ * Active end of a session = startTime + durationMs.
+ *
+ * The raw `endTime` field on a JSONL session is the timestamp of the *last
+ * activity*, which can be days or weeks after the session's actual work
+ * concluded (Claude Code keeps writing keep-alive entries during long idle
+ * gaps). Using it as the visualization endpoint makes a 75-minute session
+ * that sat idle for 10 days look like a 10-day-long bar pinned to a window
+ * that doesn't actually contain any of its work.
+ *
+ * Prefer durationMs (real active time). Fall back to endTime - startTime
+ * only when duration isn't recorded, and even then cap at 12h to prevent
+ * pathological idle gaps from polluting the layout.
+ */
+function activeEndMs(startMs: number, s: ScanResultSession): number {
+  if (s.durationMs != null) return startMs + s.durationMs;
+  if (s.endTime) {
+    const wallClockMs = new Date(s.endTime).getTime() - startMs;
+    return startMs + Math.min(wallClockMs, 12 * 60 * 60 * 1000);
+  }
+  return startMs + 60_000; // unknown — assume ~1 minute
+}
+
 function buildTimeline(
   groups: ProjectGroup[],
   windowStart?: number,
@@ -377,17 +400,16 @@ function buildTimeline(
 } {
   // Determine time bounds. If an explicit window is provided (range selector),
   // use it. Otherwise fall back to min/max across all sessions ("All" view).
+  // Use the *active* end (start + durationMs), not raw endTime — see comment
+  // on activeEndMs.
   let minMs = Infinity;
   let maxMs = -Infinity;
   for (const g of groups) {
     for (const s of g.sessions) {
-      if (s.startTime) minMs = Math.min(minMs, new Date(s.startTime).getTime());
-      const end = s.endTime
-        ? new Date(s.endTime).getTime()
-        : s.startTime
-          ? new Date(s.startTime).getTime() + (s.durationMs ?? 0)
-          : null;
-      if (end) maxMs = Math.max(maxMs, end);
+      if (!s.startTime) continue;
+      const startMs = new Date(s.startTime).getTime();
+      minMs = Math.min(minMs, startMs);
+      maxMs = Math.max(maxMs, activeEndMs(startMs, s));
     }
   }
 
@@ -420,11 +442,13 @@ function buildTimeline(
   let hiddenAutomatedCount = 0;
 
   for (const g of groups) {
-    // Filter to window + automated policy
+    // Filter to window + automated policy. Use the *active* end so a session
+    // whose JSONL stayed open through 10 days of idle doesn't get pulled into
+    // any window its actual work didn't reach.
     const filtered = g.sessions.filter((s) => {
       if (!s.startTime) return false;
       const startMs = new Date(s.startTime).getTime();
-      const endMs = s.endTime ? new Date(s.endTime).getTime() : startMs + (s.durationMs ?? 0);
+      const endMs = activeEndMs(startMs, s);
       if (endMs < rangeStart || startMs > rangeEnd) return false;
       if (!includeAutomated && isAutomated(s)) {
         hiddenAutomatedCount++;
@@ -443,9 +467,7 @@ function buildTimeline(
     const minMsPerPx = rangeMs / APPROX_TIMELINE_WIDTH_PX;
     const intervals = filtered.map((s) => {
       const startMs = new Date(s.startTime!).getTime();
-      const realEndMs = s.endTime
-        ? new Date(s.endTime).getTime()
-        : startMs + (s.durationMs ?? 60000);
+      const realEndMs = activeEndMs(startMs, s);
       const score = sessionScore(s);
       const visualWidthMs = Math.max(realEndMs - startMs, minWidthFor(score) * minMsPerPx);
       return {
@@ -852,12 +874,26 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
             {tooltip.session.title ?? tooltip.session.firstPrompt ?? tooltip.session.slug}
           </div>
           <div className="text-terminal-dimmer space-y-0.5">
-            {tooltip.session.startTime && (
-              <div>
-                {fmtDate(tooltip.session.startTime)} {fmtShortTime(tooltip.session.startTime)}
-                {tooltip.session.endTime && <span> → {fmtShortTime(tooltip.session.endTime)}</span>}
-              </div>
-            )}
+            {tooltip.session.startTime &&
+              (() => {
+                const startMs = new Date(tooltip.session.startTime).getTime();
+                const endMs = activeEndMs(startMs, tooltip.session);
+                const startISO = tooltip.session.startTime;
+                const endISO = new Date(endMs).toISOString();
+                const sameDay = fmtDate(startISO) === fmtDate(endISO);
+                return (
+                  <div>
+                    {fmtDate(startISO)} {fmtShortTime(startISO)}
+                    {endMs !== startMs && (
+                      <span>
+                        {" → "}
+                        {sameDay ? "" : `${fmtDate(endISO)} `}
+                        {fmtShortTime(endISO)}
+                      </span>
+                    )}
+                  </div>
+                );
+              })()}
             {tooltip.session.durationMs && (
               <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
             )}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -1,14 +1,12 @@
 /**
- * SessionRelationshipsView — Four relationship visualizations for the Projects tab:
- *   1. Project Grouping  — collapsible project rows with session lists
- *   2. Timeline Swimlane — each project is a horizontal lane, sessions are time blocks
- *   3. Dispatch Tree     — parent→child agent relationships
- *   4. File Connections  — sessions linked by shared modified files
+ * SessionRelationshipsView — alternate Projects tab views:
+ *   1. Timeline Swimlane — each project is a horizontal lane, sessions are time blocks
+ *   2. File Hotspots     — project-scoped files sorted by repeated edits
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
-import { shortName, timeAgo } from "../utils/format";
+import { shortName } from "../utils/format";
 import { isAutomated, sessionScore } from "../utils/sessionSignals";
 import { rollupProject } from "./dashboard-utils";
 
@@ -114,108 +112,7 @@ function groupByProject(
   return groups.sort((a, b) => (b.lastActivity ?? "").localeCompare(a.lastActivity ?? ""));
 }
 
-// ─── 1. Project Grouping View ────────────────────────────────────────
-
-function SessionRow({
-  session,
-  color,
-}: {
-  session: ScanResultSession;
-  color: (typeof PROJECT_COLORS)[0];
-}) {
-  const duration = session.durationMs ?? 0;
-  return (
-    <div className="flex flex-col gap-2 px-4 py-2 border-b border-terminal-border/30 hover:bg-terminal-surface-2/50 text-xs font-mono sm:flex-row sm:items-center sm:gap-3">
-      <div className="flex-1 min-w-0">
-        <div className="text-terminal-text truncate">
-          {session.title ?? session.firstPrompt ?? session.slug}
-        </div>
-        <div className="text-terminal-dimmer text-[10px] mt-0.5">
-          {fmtDate(session.startTime)} {fmtShortTime(session.startTime)}
-          {session.endTime && <span className="ml-2">{timeAgo(session.endTime)} ago</span>}
-        </div>
-      </div>
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:shrink-0">
-        {duration > 0 && <span className={color.text}>{fmtDuration(duration)}</span>}
-        <span className="text-terminal-dimmer">{session.promptCount}p</span>
-        {session.editCount > 0 && (
-          <span className="text-terminal-orange">{session.editCount} edits</span>
-        )}
-        {(session.costEstimate ?? 0) > 0 && (
-          <span className="text-terminal-dimmer">${session.costEstimate!.toFixed(2)}</span>
-        )}
-        {session.gitBranch && (
-          <span className="text-terminal-purple truncate max-w-[80px]">{session.gitBranch}</span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function ProjectGroupRow({ group }: { group: ProjectGroup }) {
-  const [expanded, setExpanded] = useState(false);
-  const color = colorFor(group.colorIdx);
-
-  return (
-    <div className={`rounded-xl overflow-hidden border border-terminal-border/40 ${color.bg}`}>
-      <button
-        className="w-full flex flex-col gap-2 px-4 py-3 text-left hover:bg-terminal-surface-hover/30 transition-colors sm:flex-row sm:items-center sm:gap-3"
-        onClick={() => setExpanded((x) => !x)}
-      >
-        <div className="flex min-w-0 items-center gap-3">
-          <span className={`text-xs ${expanded ? "rotate-90" : ""} transition-transform shrink-0`}>
-            ▶
-          </span>
-          <div
-            className={`w-1.5 h-1.5 rounded-full shrink-0`}
-            style={{ backgroundColor: color.solid }}
-          />
-          <div className="min-w-0">
-            <span className={`font-sans font-semibold text-sm ${color.text}`}>
-              {shortName(group.project)}
-            </span>
-            <span className="block truncate text-[10px] font-mono text-terminal-dimmer sm:ml-2 sm:inline">
-              {group.project}
-            </span>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-7 text-xs font-mono sm:ml-auto sm:shrink-0 sm:pl-0">
-          <span className="text-terminal-text">
-            {group.sessions.length} <span className="text-terminal-dimmer">sessions</span>
-          </span>
-          {group.totalDurationMs > 0 && (
-            <span className="text-terminal-blue">{fmtDuration(group.totalDurationMs)}</span>
-          )}
-          {group.totalCost > 0 && (
-            <span className="text-terminal-orange">${group.totalCost.toFixed(2)}</span>
-          )}
-          {group.lastActivity && (
-            <span className="text-terminal-dimmer">{timeAgo(group.lastActivity)}</span>
-          )}
-        </div>
-      </button>
-      {expanded && (
-        <div className="border-t border-terminal-border/30 bg-terminal-surface/60">
-          {group.sessions.map((s) => (
-            <SessionRow key={s.sessionId} session={s} color={color} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ProjectGroupingView({ groups }: { groups: ProjectGroup[] }) {
-  return (
-    <div className="space-y-2 p-4">
-      {groups.map((g) => (
-        <ProjectGroupRow key={g.project} group={g} />
-      ))}
-    </div>
-  );
-}
-
-// ─── 2. Timeline View ────────────────────────────────────────────────
+// ─── 1. Timeline View ────────────────────────────────────────────────
 //
 // One row per project. Sessions within a project are lane-packed (no overlap),
 // each at a uniform LANE_HEIGHT so labels are always readable. Importance is
@@ -922,211 +819,95 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
   );
 }
 
-// ─── 3. Dispatch Tree View ───────────────────────────────────────────
-
-interface DispatchNode {
-  session: ScanResultSession;
-  children: DispatchNode[];
-  depth: number;
-}
-
-// Grace window for the heuristic: a child session may continue a few minutes
-// past the parent's recorded endTime due to async shutdown / clock skew between
-// parent and sub-agent JSONL writes. Wide enough to catch real children, small
-// enough to avoid pulling in unrelated later sessions.
-const DISPATCH_END_GRACE_MS = 5 * 60 * 1000;
-
-function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
-  // Claude Code sub-agent detection: sessions with subAgentCount > 0 are parents.
-  // Without explicit parent-child IDs in the scan results, we infer relationships
-  // heuristically: sessions that started within a parent session's time range
-  // and have the same project are likely children.
-  const withSubAgents = sessions.filter((s) => s.subAgentCount > 0 && s.startTime);
-  const candidates = sessions.filter((s) => s.subAgentCount === 0 && s.startTime);
-
-  const roots: DispatchNode[] = [];
-  const usedIds = new Set<string>();
-
-  for (const parent of withSubAgents) {
-    const parentStart = new Date(parent.startTime!).getTime();
-    const parentEnd = parent.endTime
-      ? new Date(parent.endTime).getTime()
-      : parentStart + (parent.durationMs ?? 0);
-
-    // Find sessions that ran entirely within this parent's window
-    const children: DispatchNode[] = [];
-    for (const child of candidates) {
-      if (usedIds.has(child.sessionId)) continue;
-      if (rollupProject(child.project) !== rollupProject(parent.project)) continue;
-      const childStart = new Date(child.startTime!).getTime();
-      const childEnd = child.endTime
-        ? new Date(child.endTime).getTime()
-        : childStart + (child.durationMs ?? 0);
-      if (childStart >= parentStart && childEnd <= parentEnd + DISPATCH_END_GRACE_MS) {
-        children.push({ session: child, children: [], depth: 1 });
-        usedIds.add(child.sessionId);
-      }
-    }
-
-    if (children.length > 0) {
-      roots.push({ session: parent, children, depth: 0 });
-      usedIds.add(parent.sessionId);
-    }
-  }
-
-  // Sessions with subAgentCount > 0 but no children found — show as isolated
-  for (const s of withSubAgents) {
-    if (!usedIds.has(s.sessionId)) {
-      roots.push({ session: s, children: [], depth: 0 });
-    }
-  }
-
-  return roots;
-}
-
-function DispatchNodeRow({ node, colorIdx }: { node: DispatchNode; colorIdx: number }) {
-  const [expanded, setExpanded] = useState(true);
-  const color = colorFor(colorIdx);
-  const s = node.session;
-
-  return (
-    <div>
-      <div
-        className={`flex items-start gap-2 py-2 px-3 rounded-lg ${node.depth === 0 ? `${color.bg} border ${color.border}/40` : "hover:bg-terminal-surface-2/30"}`}
-        style={{ marginLeft: node.depth * 32 }}
-      >
-        {node.children.length > 0 && (
-          <button
-            className="shrink-0 mt-0.5 text-terminal-dimmer hover:text-terminal-text"
-            onClick={() => setExpanded((x) => !x)}
-          >
-            <span
-              className={`text-[10px] ${expanded ? "rotate-90" : ""} inline-block transition-transform`}
-            >
-              ▶
-            </span>
-          </button>
-        )}
-        {node.children.length === 0 && (
-          <span className="w-4 shrink-0 text-terminal-dimmer text-[10px]">
-            {node.depth > 0 ? "└" : "·"}
-          </span>
-        )}
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-xs font-mono ${node.depth === 0 ? color.text : "text-terminal-text"} truncate`}
-            >
-              {s.title ?? s.firstPrompt ?? s.slug}
-            </span>
-            {node.depth === 0 && s.subAgentCount > 0 && (
-              <span className="text-[9px] font-mono text-terminal-purple bg-terminal-purple/10 px-1.5 py-0.5 rounded">
-                {s.subAgentCount} subagents
-              </span>
-            )}
-          </div>
-          <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5 flex gap-2">
-            {s.startTime && <span>{fmtDate(s.startTime)}</span>}
-            {s.durationMs && (
-              <span className="text-terminal-blue">{fmtDuration(s.durationMs)}</span>
-            )}
-            <span>
-              {s.promptCount}p · {s.editCount} edits
-            </span>
-          </div>
-        </div>
-      </div>
-      {expanded &&
-        node.children.map((child) => (
-          <DispatchNodeRow key={child.session.sessionId} node={child} colorIdx={colorIdx} />
-        ))}
-    </div>
-  );
-}
-
-function DispatchTreeView({ groups }: { groups: ProjectGroup[] }) {
-  const trees = useMemo(() => {
-    const allSessions = groups.flatMap((g) => g.sessions);
-    return buildDispatchTree(allSessions);
-  }, [groups]);
-
-  if (trees.length === 0) {
-    return (
-      <div className="p-8 text-center space-y-2">
-        <div className="text-terminal-dimmer text-sm font-mono">
-          No dispatch relationships found.
-        </div>
-        <div className="text-terminal-dimmer/60 text-xs font-mono">
-          Sessions with sub-agents will appear here as parent→child trees.
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="p-4 space-y-3">
-      <div className="text-xs font-mono text-terminal-dimmer mb-4">
-        {trees.length} dispatch group{trees.length !== 1 ? "s" : ""} found
-        {" · "}
-        {trees.reduce((s, t) => s + t.children.length, 0)} child sessions
-      </div>
-      {trees.map((node, i) => {
-        const colorIdx = groups.findIndex((g) => g.project === node.session.project);
-        return (
-          <div key={node.session.sessionId} className="space-y-1">
-            <DispatchNodeRow node={node} colorIdx={colorIdx >= 0 ? colorIdx : i} />
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-// ─── 4. File Connections View ────────────────────────────────────────
+// ─── 2. File Hotspots View ───────────────────────────────────────────
 
 interface FileCluster {
   file: string;
   displayName: string;
+  totalEdits: number;
   sessions: Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>;
 }
 
-function buildFileClusters(groups: ProjectGroup[]): FileCluster[] {
-  const fileMap = new Map<
-    string,
-    Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>
-  >();
+interface ProjectFileGroup {
+  project: string;
+  colorIdx: number;
+  files: FileCluster[];
+  totalEdits: number;
+  totalSessions: number;
+}
+
+function displayFileName(file: string, project: string): string {
+  const normalizedProject = project.replace(/\/$/, "");
+  if (normalizedProject && file.startsWith(`${normalizedProject}/`)) {
+    return file.slice(normalizedProject.length + 1);
+  }
+  const parts = file.split("/");
+  return parts.slice(-3).join("/");
+}
+
+function buildProjectFileGroups(groups: ProjectGroup[]): ProjectFileGroup[] {
+  const projectFileGroups: ProjectFileGroup[] = [];
 
   for (const g of groups) {
+    const fileMap = new Map<
+      string,
+      Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>
+    >();
+
     for (const s of g.sessions) {
       for (const f of s.filesModified) {
-        // Use full path as key to avoid false connections across projects
         const key = f.file;
         if (!fileMap.has(key)) fileMap.set(key, []);
         fileMap.get(key)!.push({ session: s, editCount: f.count, colorIdx: g.colorIdx });
       }
     }
-  }
 
-  // Only show files touched by 2+ sessions
-  const clusters: FileCluster[] = [];
-  for (const [file, sessions] of fileMap) {
-    const uniqueSessions = [...new Map(sessions.map((s) => [s.session.sessionId, s])).values()];
-    if (uniqueSessions.length >= 2) {
-      // Shortened display: last 3 path segments
-      const parts = file.split("/");
-      const displayName = parts.slice(-3).join("/");
-      clusters.push({ file, displayName, sessions: uniqueSessions });
+    const files: FileCluster[] = [];
+    for (const [file, sessions] of fileMap) {
+      const uniqueSessions = [...new Map(sessions.map((s) => [s.session.sessionId, s])).values()];
+      if (uniqueSessions.length < 2) continue;
+      files.push({
+        file,
+        displayName: displayFileName(file, g.project),
+        sessions: uniqueSessions.sort((a, b) => b.editCount - a.editCount),
+        totalEdits: uniqueSessions.reduce((sum, s) => sum + s.editCount, 0),
+      });
     }
+
+    if (files.length === 0) continue;
+    files.sort((a, b) => b.totalEdits - a.totalEdits || b.sessions.length - a.sessions.length);
+    projectFileGroups.push({
+      project: g.project,
+      colorIdx: g.colorIdx,
+      files,
+      totalEdits: files.reduce((sum, file) => sum + file.totalEdits, 0),
+      totalSessions: files.reduce((sum, file) => sum + file.sessions.length, 0),
+    });
   }
 
-  return clusters.sort((a, b) => b.sessions.length - a.sessions.length).slice(0, 50);
+  return projectFileGroups.sort(
+    (a, b) => b.totalEdits - a.totalEdits || b.totalSessions - a.totalSessions,
+  );
 }
 
 function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
-  const clusters = useMemo(() => buildFileClusters(groups), [groups]);
+  const projectFileGroups = useMemo(() => buildProjectFileGroups(groups), [groups]);
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
-  if (clusters.length === 0) {
+  useEffect(() => {
+    if (projectFileGroups.length === 0) {
+      setSelectedProject(null);
+      setSelectedFile(null);
+      return;
+    }
+    if (!selectedProject || !projectFileGroups.some((g) => g.project === selectedProject)) {
+      setSelectedProject(projectFileGroups[0].project);
+      setSelectedFile(null);
+    }
+  }, [projectFileGroups, selectedProject]);
+
+  if (projectFileGroups.length === 0) {
     return (
       <div className="p-8 text-center space-y-2">
         <div className="text-terminal-dimmer text-sm font-mono">No shared files found.</div>
@@ -1137,57 +918,85 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
     );
   }
 
-  const selected = selectedFile ? clusters.find((c) => c.file === selectedFile) : null;
+  const selectedProjectGroup =
+    projectFileGroups.find((g) => g.project === selectedProject) ?? projectFileGroups[0];
+  const selected = selectedFile
+    ? selectedProjectGroup.files.find((c) => c.file === selectedFile)
+    : null;
+  const selectedProjectColor = colorFor(selectedProjectGroup.colorIdx);
 
   return (
-    <div className="flex h-full min-w-0 flex-col gap-4 p-4 md:flex-row">
-      {/* File list */}
-      <div className="max-h-64 w-full shrink-0 space-y-1 overflow-y-auto md:max-h-none md:w-64">
+    <div className="flex h-full min-w-0 flex-col gap-4 p-4 lg:flex-row">
+      {/* Project list */}
+      <div className="w-full shrink-0 space-y-1 overflow-y-auto lg:w-64">
         <div className="text-[10px] font-mono text-terminal-dimmer mb-2 px-2">
-          {clusters.length} shared files
+          {projectFileGroups.length} projects with shared files
         </div>
-        {clusters.map((cluster) => {
-          const isSelected = selectedFile === cluster.file;
-          const maxEdits = cluster.sessions.reduce((max, s) => Math.max(max, s.editCount), 0);
+        {projectFileGroups.map((group) => {
+          const isSelected = selectedProjectGroup.project === group.project;
+          const color = colorFor(group.colorIdx);
           return (
             <button
-              key={cluster.file}
-              onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
+              key={group.project}
+              onClick={() => {
+                setSelectedProject(group.project);
+                setSelectedFile(null);
+              }}
               className={`w-full text-left px-3 py-2 rounded-lg text-xs font-mono transition-colors ${
                 isSelected
-                  ? "bg-terminal-green/20 border border-terminal-green text-terminal-green"
+                  ? `${color.bg} border ${color.border} ${color.text}`
                   : "hover:bg-terminal-surface-2 text-terminal-text border border-transparent"
               }`}
             >
-              <div className="truncate">{cluster.displayName.split("/").pop()}</div>
-              <div className="text-[9px] text-terminal-dimmer truncate">{cluster.displayName}</div>
-              <div className="flex items-center gap-2 mt-1">
-                <div className="flex gap-0.5">
-                  {cluster.sessions.slice(0, 8).map((s, i) => (
-                    <div
-                      key={i}
-                      className="w-2 h-2 rounded-full"
-                      style={{
-                        backgroundColor: colorFor(s.colorIdx).solid,
-                        opacity: 0.4 + (s.editCount / maxEdits) * 0.6,
-                      }}
-                    />
-                  ))}
-                </div>
-                <span className="text-[9px] text-terminal-dimmer">
-                  {cluster.sessions.length} sessions
-                </span>
+              <div className="truncate font-semibold">{shortName(group.project)}</div>
+              <div className="text-[9px] text-terminal-dimmer truncate">{group.project}</div>
+              <div className="mt-1 text-[9px] text-terminal-dimmer">
+                {group.files.length} files · {group.totalEdits.toLocaleString()} edits
               </div>
             </button>
           );
         })}
       </div>
 
-      {/* Detail panel */}
-      <div className="min-w-0 flex-1 overflow-y-auto">
+      {/* Project files + detail panel */}
+      <div className="min-w-0 flex-1 space-y-4 overflow-y-auto">
+        <div>
+          <div className={`text-sm font-sans font-semibold ${selectedProjectColor.text}`}>
+            {shortName(selectedProjectGroup.project)}
+          </div>
+          <div className="mt-0.5 truncate text-xs font-mono text-terminal-dimmer">
+            {selectedProjectGroup.project}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
+          {selectedProjectGroup.files.map((cluster) => {
+            const isSelected = selectedFile === cluster.file;
+            return (
+              <button
+                key={cluster.file}
+                onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
+                className={`w-full text-left px-3 py-2 rounded-lg text-xs font-mono transition-colors ${
+                  isSelected
+                    ? "bg-terminal-green/20 border border-terminal-green text-terminal-green"
+                    : "hover:bg-terminal-surface-2 text-terminal-text border border-terminal-border/30"
+                }`}
+              >
+                <div className="truncate">{cluster.displayName.split("/").pop()}</div>
+                <div className="text-[9px] text-terminal-dimmer truncate">
+                  {cluster.displayName}
+                </div>
+                <div className="mt-1 text-[9px] text-terminal-dimmer">
+                  {cluster.totalEdits.toLocaleString()} edits · {cluster.sessions.length} sessions
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
         {selected ? (
           <div className="space-y-3">
-            <div>
+            <div className="border-t border-terminal-border/30 pt-4">
               <div className="text-sm font-mono text-terminal-text font-medium truncate">
                 {selected.displayName.split("/").pop()}
               </div>
@@ -1195,7 +1004,8 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
                 {selected.file}
               </div>
               <div className="text-xs font-mono text-terminal-dimmer mt-1">
-                {selected.sessions.length} sessions modified this file
+                {selected.totalEdits.toLocaleString()} edits across {selected.sessions.length}{" "}
+                sessions
               </div>
             </div>
 
@@ -1230,7 +1040,8 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
           </div>
         ) : (
           <div className="flex items-center justify-center h-40 text-terminal-dimmer text-xs font-mono">
-            Select a file to see which sessions modified it
+            Select a file in {shortName(selectedProjectGroup.project)} to see the sessions that
+            modified it
           </div>
         )}
       </div>
@@ -1240,22 +1051,14 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
 
 // ─── Main Container ──────────────────────────────────────────────────
 
-type RelView = "timeline" | "group" | "tree" | "files";
-
-const VIEW_TABS: { id: RelView; label: string; icon: string; desc: string }[] = [
-  { id: "timeline", label: "Timeline", icon: "⟶", desc: "Sessions as time blocks per project" },
-  { id: "group", label: "Groups", icon: "≡", desc: "Sessions grouped by project" },
-  { id: "tree", label: "Dispatch", icon: "⤷", desc: "Parent → child agent relationships" },
-  { id: "files", label: "Files", icon: "⊕", desc: "Sessions linked by shared files" },
-];
+export type ProjectRelationshipView = "timeline" | "files";
 
 interface SessionRelationshipsViewProps {
-  onBack?: () => void;
+  view: ProjectRelationshipView;
 }
 
-export default function SessionRelationshipsView({ onBack }: SessionRelationshipsViewProps) {
+export default function SessionRelationshipsView({ view }: SessionRelationshipsViewProps) {
   const { sessions, loading, error } = useRelationshipData();
-  const [activeView, setActiveView] = useState<RelView>("timeline");
 
   // Collapse agent worktrees back to the project the user recognizes. The
   // session rows still expose the original path when it matters.
@@ -1286,46 +1089,7 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
   }
 
   return (
-    <div className="flex-1 flex min-w-0 flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex shrink-0 flex-col gap-3 border-b border-terminal-border/40 px-4 py-3 md:px-6 lg:flex-row lg:items-center">
-        {onBack && (
-          <button
-            onClick={onBack}
-            className="self-start text-terminal-dimmer hover:text-terminal-text text-xs font-mono transition-colors lg:shrink-0"
-          >
-            ← Projects
-          </button>
-        )}
-        <div className="min-w-0 flex-1">
-          <h2 className="text-sm font-sans font-semibold text-terminal-text">
-            Session Relationships
-            <span className="block text-terminal-dimmer font-normal text-xs font-mono sm:ml-2 sm:inline">
-              {sessions.length} sessions · {groups.length} projects
-            </span>
-          </h2>
-        </div>
-
-        {/* View tabs */}
-        <div className="flex max-w-full items-center gap-1 overflow-x-auto pb-1 lg:shrink-0 lg:pb-0">
-          {VIEW_TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveView(tab.id)}
-              title={tab.desc}
-              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono transition-all ${
-                activeView === tab.id
-                  ? "bg-terminal-green/15 text-terminal-green border border-terminal-green/30"
-                  : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-2"
-              }`}
-            >
-              <span className="text-[11px]">{tab.icon}</span>
-              {tab.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
+    <div className="flex min-w-0 flex-col overflow-hidden rounded-lg border border-terminal-border/30 bg-terminal-surface/20">
       {/* Stats bar */}
       <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-terminal-border/20 px-4 py-2 text-[10px] font-mono text-terminal-dimmer md:px-6">
         <span>
@@ -1356,10 +1120,8 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
 
       {/* View content */}
       <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
-        {activeView === "timeline" && <TimelineSwimlaneView groups={groups} />}
-        {activeView === "group" && <ProjectGroupingView groups={groups} />}
-        {activeView === "tree" && <DispatchTreeView groups={groups} />}
-        {activeView === "files" && <FileConnectionsView groups={groups} />}
+        {view === "timeline" && <TimelineSwimlaneView groups={groups} />}
+        {view === "files" && <FileConnectionsView groups={groups} />}
       </div>
     </div>
   );

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -8,23 +8,9 @@
 
 import { useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
+import { shortName, timeAgo } from "../utils/format";
 
 // ─── Shared helpers ──────────────────────────────────────────────────
-
-function shortName(project: string): string {
-  return project.split("/").pop() || project;
-}
-
-function timeAgo(iso?: string): string {
-  if (!iso) return "";
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return "now";
-  if (mins < 60) return `${mins}m`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h`;
-  return `${Math.floor(hours / 24)}d`;
-}
 
 function fmtDate(iso?: string): string {
   if (!iso) return "";
@@ -503,6 +489,12 @@ interface DispatchNode {
   depth: number;
 }
 
+// Grace window for the heuristic: a child session may continue a few minutes
+// past the parent's recorded endTime due to async shutdown / clock skew between
+// parent and sub-agent JSONL writes. Wide enough to catch real children, small
+// enough to avoid pulling in unrelated later sessions.
+const DISPATCH_END_GRACE_MS = 5 * 60 * 1000;
+
 function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
   // Claude Code sub-agent detection: sessions with subAgentCount > 0 are parents.
   // Without explicit parent-child IDs in the scan results, we infer relationships
@@ -529,7 +521,7 @@ function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
       const childEnd = child.endTime
         ? new Date(child.endTime).getTime()
         : childStart + (child.durationMs ?? 0);
-      if (childStart >= parentStart && childEnd <= parentEnd + 300000) {
+      if (childStart >= parentStart && childEnd <= parentEnd + DISPATCH_END_GRACE_MS) {
         children.push({ session: child, children: [], depth: 1 });
         usedIds.add(child.sessionId);
       }

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -6,9 +6,16 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
-import { shortName } from "../utils/format";
 import { isAutomated, sessionScore } from "../utils/sessionSignals";
-import { rollupProject } from "./dashboard-utils";
+import {
+  cleanPrompt,
+  formatDataSourceLabel,
+  navigateTo,
+  normalizeTitleText,
+  projectName,
+  providerBadgeLabel,
+  rollupProject,
+} from "./dashboard-utils";
 
 // ─── Shared helpers ──────────────────────────────────────────────────
 
@@ -33,7 +40,46 @@ function fmtDuration(ms?: number): string {
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
 }
 
-// Stable project color palette — maps project index to a color class
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
+function sessionTitle(s: ScanResultSession): string {
+  const title = normalizeTitleText(cleanPrompt(s.title || ""));
+  if (title) return title;
+  const firstPrompt = normalizeTitleText(cleanPrompt(s.firstPrompt || ""));
+  return firstPrompt || s.slug;
+}
+
+function sessionHasEstimatedTime(s: ScanResultSession): boolean {
+  if (s.durationMs == null) return true;
+  return (s.dataQualityNotes || []).some((note) =>
+    /duration is inferred|duration.*estimated|missing duration/i.test(note),
+  );
+}
+
+function sessionBadges(s: ScanResultSession): string[] {
+  const badges = [providerBadgeLabel(s.provider)];
+  const source = s.dataSource ? formatDataSourceLabel(false, s.dataSource) : "";
+  if (source) badges.push(source);
+  if (sessionHasEstimatedTime(s)) badges.push("estimated time");
+  return badges;
+}
+
+function rangeEmptyLabel(range: TimelineRange): string {
+  switch (range) {
+    case "1d":
+      return "the last 24 hours";
+    case "7d":
+      return "the last 7 days";
+    case "30d":
+      return "the last 30 days";
+    case "all":
+      return "this scan";
+  }
+}
+
+// Stable project palette using the same semantic accents as the rest of the dashboard.
 const PROJECT_COLORS = [
   {
     bg: "bg-terminal-green/20",
@@ -59,15 +105,12 @@ const PROJECT_COLORS = [
     text: "text-terminal-orange",
     solid: "#f97316",
   },
-  { bg: "bg-pink-500/20", border: "border-pink-500", text: "text-pink-500", solid: "#ec4899" },
-  { bg: "bg-cyan-500/20", border: "border-cyan-500", text: "text-cyan-500", solid: "#06b6d4" },
   {
-    bg: "bg-yellow-500/20",
-    border: "border-yellow-500",
-    text: "text-yellow-500",
-    solid: "#eab308",
+    bg: "bg-terminal-cyan/20",
+    border: "border-terminal-cyan",
+    text: "text-terminal-cyan",
+    solid: "#56d4dd",
   },
-  { bg: "bg-red-500/20", border: "border-red-500", text: "text-red-500", solid: "#ef4444" },
 ];
 
 function colorFor(idx: number) {
@@ -99,13 +142,23 @@ function groupByProject(
   const groups: ProjectGroup[] = [];
   let idx = 0;
   for (const [project, sess] of map) {
-    const sorted = [...sess].sort((a, b) => (b.startTime ?? "").localeCompare(a.startTime ?? ""));
+    const sorted = [...sess].sort((a, b) => {
+      const aStart = a.startTime ? new Date(a.startTime).getTime() : 0;
+      const bStart = b.startTime ? new Date(b.startTime).getTime() : 0;
+      return bStart - aStart;
+    });
+    const lastActivityMs = sorted.reduce((max, s) => {
+      if (!s.startTime) return max;
+      const startMs = new Date(s.startTime).getTime();
+      return Math.max(max, activeEndMs(startMs, s));
+    }, 0);
     groups.push({
       project,
       sessions: sorted,
       totalDurationMs: sorted.reduce((s, x) => s + (x.durationMs ?? 0), 0),
       totalCost: sorted.reduce((s, x) => s + (x.costEstimate ?? 0), 0),
-      lastActivity: sorted[0]?.endTime ?? sorted[0]?.startTime,
+      lastActivity:
+        lastActivityMs > 0 ? new Date(lastActivityMs).toISOString() : sorted[0]?.startTime,
       colorIdx: idx++,
     });
   }
@@ -114,39 +167,18 @@ function groupByProject(
 
 // ─── 1. Timeline View ────────────────────────────────────────────────
 //
-// One row per project. Sessions within a project are lane-packed (no overlap),
-// each at a uniform LANE_HEIGHT so labels are always readable. Importance is
-// encoded in three independent visual channels:
-//
-//   minWidthPx  — important short sessions get widened so labels fit
-//   fillIntensity — bg opacity (low score = ghosted outline, high score = solid)
-//   accentBar  — top-decile sessions get a 3px solid left rim
-//
-// Automated / scheduled sessions are hidden by default and surfaced via a toggle.
-// Per-project lane count is capped; overflow is rolled up into a "+N more" hint.
-
-// Bars are *bottom-aligned* within their lane so the lane tops form a skyline
-// — height encodes importance alongside width and fill. The 12x height ratio
-// (8 → 96) makes top-tier sessions visibly tower over routine ones, and tall
-// bars wrap their title onto multiple lines so the extra real-estate is useful.
-//
-// Per-lane height is *adaptive* — each lane sizes to its tallest bar (capped
-// at MAX_BAR_HEIGHT_PX) instead of every lane reserving the global maximum,
-// which previously left huge dead zones in lanes that only held short bars.
+// One row per project. X position and the bottom wick express active time;
+// project color identifies the row. Visual height and min-width make larger
+// sessions easier to inspect without also piling on heavy fill/accent channels.
 const LANE_GAP_PX = 4;
 const MAX_LANES_PER_PROJECT = 5;
-const MIN_BAR_HEIGHT_PX = 8; // floor — low-score sessions are short ticks
-const MAX_BAR_HEIGHT_PX = 96; // cap — top-tier sessions tower at this height
-const LABEL_VISIBLE_MIN_HEIGHT_PX = 14; // below this, render bar without label
-// Line metrics for the dynamic line-clamp calculation. text-[10px] with
-// leading-tight resolves to ~12px line-height; we reserve 6px of vertical
-// padding inside the bar so a 14px bar still fits one line.
+const MIN_BAR_HEIGHT_PX = 10;
+const MAX_BAR_HEIGHT_PX = 72;
+const LABEL_VISIBLE_MIN_HEIGHT_PX = 14;
 const LABEL_LINE_HEIGHT_PX = 12;
 const LABEL_VERTICAL_PADDING_PX = 6;
-
-const MIN_BAR_MIN_WIDTH_PX = 6; // floor for low-importance sessions
-const MAX_BAR_MIN_WIDTH_PX = 160; // cap for the "important short session" widening
-const TOP_ACCENT_SCORE_THRESHOLD = 60; // score >= this gets the left accent rim
+const MIN_BAR_MIN_WIDTH_PX = 8;
+const MAX_BAR_MIN_WIDTH_PX = 140;
 // Approximate width of the time-axis area (px) used to convert minWidthPx into
 // a visual end-time for lane packing. Real container is responsive; this is the
 // floor we design for. Slightly underestimating makes lanes pack more loosely
@@ -160,16 +192,9 @@ interface TimelineSession {
   lane: number;
   score: number;
   minWidthPx: number;
-  heightPx: number; // bar height (importance)
-  fillAlpha: number; // 0-1 background alpha applied to color.solid
-  showAccent: boolean;
+  heightPx: number;
+  fillAlpha: number;
   opacity: number;
-  /**
-   * Fraction of the rendered bar (0–1) that the *actual* session duration
-   * occupies. When < 1, the bar was widened by the min-width-by-importance
-   * floor; the remainder is visual padding. Drives the K-line "wick" strip
-   * along the bottom that recovers true-duration intuition.
-   */
   realDurationFraction: number;
 }
 
@@ -184,14 +209,11 @@ interface TimelineProject {
   totalRowHeightPx: number;
   hiddenInLanesCount: number; // sessions dropped because they exceeded MAX_LANES_PER_PROJECT
   colorIdx: number;
-  importance: number;
+  lastActivity?: string;
 }
 
 function fillAlphaFor(score: number): number {
-  // low = ghost, mid = soft, high = solid
-  if (score >= 60) return 0.45;
-  if (score >= 30) return 0.28;
-  return 0.12;
+  return score >= 60 ? 0.24 : 0.16;
 }
 
 function hexToRgba(hex: string, alpha: number): string {
@@ -203,34 +225,28 @@ function hexToRgba(hex: string, alpha: number): string {
 }
 
 function opacityFor(score: number): number {
-  // map score 0–100 → 0.55–1.0
-  return 0.55 + Math.min(1, score / 100) * 0.45;
+  return score >= 60 ? 0.95 : 0.78;
 }
 
 function minWidthFor(score: number): number {
-  // sqrt curve so mid-importance sessions still get meaningful width
   const t = Math.sqrt(Math.max(0, Math.min(100, score)) / 100);
   return MIN_BAR_MIN_WIDTH_PX + t * (MAX_BAR_MIN_WIDTH_PX - MIN_BAR_MIN_WIDTH_PX);
 }
 
 function heightFor(score: number): number {
-  // Linear (not sqrt) so importance maps proportionally to height — the whole
-  // point of this channel is to make important sessions visibly larger.
   const t = Math.max(0, Math.min(100, score)) / 100;
   return MIN_BAR_HEIGHT_PX + t * (MAX_BAR_HEIGHT_PX - MIN_BAR_HEIGHT_PX);
 }
 
 /**
- * Lane packing biased to importance: highest-scoring sessions claim the top
- * lane first, so the most interesting work isn't pushed below the fold.
- *
- * Returns: per-session lane index, total lane count, and the number of sessions
- * that couldn't fit within MAX_LANES_PER_PROJECT (rolled up as "+N hidden").
+ * Lane packing keeps sessions from overlapping visually while preserving time
+ * order. Returns per-session lane index, total lane count, and the number of
+ * sessions that couldn't fit within MAX_LANES_PER_PROJECT.
  */
-function packLanesByImportance(
+function packTimelineLanes(
   sessions: { startMs: number; endMs: number; score: number; original: ScanResultSession }[],
 ): { laneAssignments: Map<string, number>; laneCount: number; dropped: number } {
-  const ordered = [...sessions].sort((a, b) => b.score - a.score);
+  const ordered = [...sessions].sort((a, b) => a.startMs - b.startMs || b.score - a.score);
   const laneIntervals: Array<Array<{ startMs: number; endMs: number }>> = [];
   const laneAssignments = new Map<string, number>();
   let dropped = 0;
@@ -312,7 +328,7 @@ function buildTimeline(
     }
   }
 
-  if (!isFinite(minMs) || !isFinite(maxMs) || maxMs <= minMs) {
+  if (!Number.isFinite(minMs) || !Number.isFinite(maxMs) || maxMs <= minMs) {
     return {
       projects: [],
       ticks: [],
@@ -358,11 +374,8 @@ function buildTimeline(
 
     if (filtered.length === 0) continue;
 
-    // Build interval list for lane packing. Crucially, the "interval" we hand
-    // to the packer is the VISUAL extent (max of duration and min-width
-    // converted back to time), not just the raw duration — otherwise widened
-    // short sessions overlap their neighbours visually even though the packer
-    // thought they were disjoint.
+    // Build interval list for lane packing. The only visual floor is a small
+    // hit target for very short sessions; width otherwise tracks active time.
     const minMsPerPx = rangeMs / APPROX_TIMELINE_WIDTH_PX;
     const intervals = filtered.map((s) => {
       const startMs = new Date(s.startTime!).getTime();
@@ -378,7 +391,7 @@ function buildTimeline(
       };
     });
 
-    const { laneAssignments, laneCount, dropped } = packLanesByImportance(intervals);
+    const { laneAssignments, laneCount, dropped } = packTimelineLanes(intervals);
 
     const tSessions: TimelineSession[] = [];
     for (const it of intervals) {
@@ -406,20 +419,14 @@ function buildTimeline(
         minWidthPx,
         heightPx: heightFor(it.score),
         fillAlpha: fillAlphaFor(it.score),
-        showAccent: it.score >= TOP_ACCENT_SCORE_THRESHOLD,
         opacity: opacityFor(it.score),
         realDurationFraction,
       });
     }
 
     if (tSessions.length > 0) {
-      // Render high-score sessions last so their accent rim sits on top of overlaps
-      tSessions.sort((a, b) => a.score - b.score);
+      tSessions.sort((a, b) => a.leftPct - b.leftPct || b.score - a.score);
 
-      // Per-lane heights: each lane sizes to its tallest bar (importance-biased
-      // packing means lane 0 holds the highest scores and is naturally the
-      // tallest). This avoids the dead vertical space when only the top lane
-      // has tall bars and lower lanes hold short routine sessions.
       const laneHeightsPx: number[] = Array.from({ length: laneCount }, () => MIN_BAR_HEIGHT_PX);
       for (const ts of tSessions) {
         if (ts.heightPx > laneHeightsPx[ts.lane]) {
@@ -427,12 +434,12 @@ function buildTimeline(
         }
       }
       const laneTopsPx: number[] = [];
-      let cursor = 3;
+      let cursor = 4;
       for (const h of laneHeightsPx) {
         laneTopsPx.push(cursor);
         cursor += h + LANE_GAP_PX;
       }
-      const totalRowHeightPx = cursor + 3;
+      const totalRowHeightPx = cursor + 4;
 
       projects.push({
         project: g.project,
@@ -443,14 +450,13 @@ function buildTimeline(
         totalRowHeightPx,
         hiddenInLanesCount: dropped,
         colorIdx: g.colorIdx,
-        importance: tSessions.reduce((sum, t) => sum + t.score, 0),
+        lastActivity: g.lastActivity,
       });
       totalSessions += tSessions.length;
     }
   }
 
-  // Order project lanes by total importance (most active first)
-  projects.sort((a, b) => b.importance - a.importance);
+  projects.sort((a, b) => (b.lastActivity ?? "").localeCompare(a.lastActivity ?? ""));
 
   // Build time axis ticks (6-8 ticks)
   const tickCount = 7;
@@ -507,21 +513,39 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
     () => buildTimeline(groups, start, end, showAutomated),
     [groups, start, end, showAutomated],
   );
+  const timelineSessions = useMemo(
+    () =>
+      projects.flatMap((project) =>
+        project.sessions.map((session) => ({
+          ...session,
+          project: project.project,
+          colorIdx: project.colorIdx,
+        })),
+      ),
+    [projects],
+  );
+  const topSessions = useMemo(
+    () => [...timelineSessions].sort((a, b) => b.score - a.score).slice(0, 6),
+    [timelineSessions],
+  );
+  const estimatedTimingCount = useMemo(
+    () => timelineSessions.filter((ts) => sessionHasEstimatedTime(ts.session)).length,
+    [timelineSessions],
+  );
 
   const LABEL_WIDTH = 140;
 
   return (
-    <div className="p-4 space-y-3 select-none">
+    <div className="space-y-4 p-4 select-none">
       {/* Range selector + automated toggle */}
-      <div className="flex flex-col gap-2 pl-1 lg:flex-row lg:items-center lg:justify-between">
-        <div className="text-[11px] font-mono text-terminal-dimmer flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span>
-            {totalSessions} <span className="opacity-60">sessions</span>
-          </span>
-          <span className="opacity-50">·</span>
-          <span className="opacity-70">
-            row = project · height + width + fill = importance · time → x-axis
-          </span>
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-1">
+          <div className="text-sm font-sans font-semibold text-terminal-text">Work Timeline</div>
+          <div className="text-xs font-mono text-terminal-dimmer">
+            {totalSessions} {plural(totalSessions, "session")} · rows are projects · bar position
+            and width show active time
+            {estimatedTimingCount > 0 ? ` · ${estimatedTimingCount} estimated` : ""}
+          </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[10px] font-mono">
           {hiddenAutomatedCount > 0 && !showAutomated && (
@@ -541,15 +565,14 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
               hide automated
             </button>
           )}
-          <div className="flex items-center gap-1">
-            <span className="text-terminal-dimmer mr-1">Range:</span>
+          <div className="inline-flex items-center rounded-xl bg-terminal-surface p-0.5 shadow-layer-sm">
             {RANGE_OPTIONS.map((opt) => (
               <button
                 key={opt.value}
                 onClick={() => setRange(opt.value)}
-                className={`px-2 py-1 rounded-md transition-colors ${
+                className={`rounded-lg px-2.5 py-1 text-xs font-sans font-semibold transition-all duration-200 ease-material ${
                   range === opt.value
-                    ? "bg-terminal-green-subtle text-terminal-green"
+                    ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
                     : "text-terminal-dim hover:text-terminal-text"
                 }`}
               >
@@ -562,7 +585,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
 
       {projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-40 gap-2 text-terminal-dimmer text-sm font-mono">
-          <div>No sessions in the last {RANGE_OPTIONS.find((o) => o.value === range)?.label}.</div>
+          <div>No sessions in {rangeEmptyLabel(range)}.</div>
           {range !== "all" && (
             <button
               onClick={() => setRange("all")}
@@ -573,208 +596,245 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           )}
         </div>
       ) : (
-        <div className="overflow-x-auto pb-2">
-          <div className="min-w-[760px]">
-            {/* Time axis header */}
-            <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
-              <div className="relative flex-1 h-6 border-b border-terminal-border/40">
-                {ticks.map((t, i) => (
-                  <div
-                    key={i}
-                    className="absolute flex flex-col items-center"
-                    style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
-                  >
-                    <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
-                      {t.label}
-                    </span>
-                    <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
-                  </div>
-                ))}
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+            <div className="min-w-[760px]">
+              {/* Time axis header */}
+              <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
+                <div className="relative flex-1 h-6">
+                  {ticks.map((t, i) => (
+                    <div
+                      key={i}
+                      className="absolute flex flex-col items-center"
+                      style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+                    >
+                      <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
+                        {t.label}
+                      </span>
+                      <div className="w-px h-1.5 bg-terminal-border/20 mt-0.5" />
+                    </div>
+                  ))}
+                  <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-terminal-border/25 to-transparent" />
+                </div>
               </div>
-            </div>
 
-            {/* Project rows — lane-packed, bottom-aligned skyline.
-              Per-bar HEIGHT, WIDTH (min-width by score), FILL alpha, and an
-              optional left ACCENT RIM all encode importance — important sessions
-              are visibly larger and more saturated, low-importance ones are
-              short ghosted ticks but still labeled and clickable. */}
-            {projects.map((p) => {
-              const color = colorFor(p.colorIdx);
-              const rowHeight = p.totalRowHeightPx;
-              const accentColor = color.solid;
-              return (
-                <div
-                  key={p.project}
-                  className="flex items-stretch border-b border-terminal-border/20 group"
-                >
-                  {/* Project label */}
-                  <div
-                    className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
-                    style={{ width: LABEL_WIDTH, height: rowHeight }}
-                  >
-                    <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                      {shortName(p.project)}
-                    </div>
-                    <div className="text-[9px] font-mono text-terminal-dimmer truncate">
-                      {p.sessions.length} session{p.sessions.length !== 1 ? "s" : ""}
-                      {p.hiddenInLanesCount > 0 && (
-                        <span className="text-terminal-orange/70">
-                          {" "}
-                          · +{p.hiddenInLanesCount} hidden
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Lane area */}
-                  <div
-                    className="relative flex-1 overflow-hidden bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
-                    style={{ height: rowHeight }}
-                  >
-                    {/* Grid lines */}
-                    {ticks.map((t, i) => (
+              {/* Project rows: time stays on x-axis; project color identifies the lane. */}
+              <div className="space-y-1.5">
+                {projects.map((p) => {
+                  const color = colorFor(p.colorIdx);
+                  const rowHeight = p.totalRowHeightPx;
+                  const accentColor = color.solid;
+                  return (
+                    <div key={p.project} className="flex items-stretch rounded-xl group">
+                      {/* Project label */}
                       <div
-                        key={i}
-                        className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
-                        style={{ left: `${t.leftPct}%` }}
-                      />
-                    ))}
-
-                    {/* Session blocks — variable height (importance), bottom-aligned within lane */}
-                    {p.sessions.map((ts) => {
-                      const automated = isAutomated(ts.session);
-                      // Adaptive lanes: each lane's row height = its tallest bar.
-                      // Bars are bottom-aligned within their lane.
-                      const laneTop = p.laneTopsPx[ts.lane];
-                      const laneH = p.laneHeightsPx[ts.lane];
-                      const top = laneTop + (laneH - ts.heightPx);
-                      const opacity = automated ? 0.4 : ts.opacity;
-                      // Multi-line label support: clamp to whatever number of
-                      // lines actually fits in the bar's height, so we use the
-                      // full vertical real estate without growing the bar.
-                      const lineClamp = Math.max(
-                        1,
-                        Math.floor(
-                          (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
-                        ),
-                      );
-                      // K-line "wick": when the bar is widened by min-width, mark
-                      // the actual session duration as a thin strip along the
-                      // bottom so true duration is still readable.
-                      const showWick = ts.realDurationFraction < 0.85;
-                      return (
-                        <div
-                          key={ts.session.sessionId}
-                          className={`absolute overflow-hidden rounded-sm cursor-pointer hover:brightness-125 hover:z-10 transition-all border ${color.border} border-opacity-50`}
-                          style={{
-                            left: `${ts.leftPct}%`,
-                            width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
-                            top,
-                            height: ts.heightPx,
-                            opacity,
-                            zIndex: Math.round(ts.score),
-                            backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
-                            ...(ts.showAccent
-                              ? {
-                                  boxShadow: `inset 3px 0 0 ${accentColor}`,
-                                }
-                              : {}),
-                          }}
-                          onMouseEnter={(e) => {
-                            setTooltip({
-                              session: ts.session,
-                              x: e.clientX,
-                              y: e.clientY,
-                            });
-                          }}
-                          onMouseLeave={() => setTooltip(null)}
-                        >
-                          {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
-                            <div
-                              className={`relative h-full flex text-[10px] font-mono leading-tight ${color.text} pointer-events-none ${
-                                lineClamp === 1 ? "items-center" : "items-start pt-1"
-                              }`}
-                              style={{
-                                paddingLeft: ts.showAccent ? 7 : 4,
-                                paddingRight: 4,
-                                minWidth: 0,
-                              }}
-                            >
-                              <span
-                                className={
-                                  lineClamp === 1
-                                    ? "block truncate min-w-0 flex-1"
-                                    : "block min-w-0 flex-1 overflow-hidden"
-                                }
-                                style={
-                                  lineClamp === 1
-                                    ? undefined
-                                    : {
-                                        display: "-webkit-box",
-                                        WebkitBoxOrient: "vertical",
-                                        WebkitLineClamp: lineClamp,
-                                      }
-                                }
-                              >
-                                {ts.session.title ?? ts.session.firstPrompt ?? ""}
-                              </span>
-                            </div>
-                          )}
-                          {showWick && (
-                            <>
-                              {/* K-line wick: bright strip along the bottom marks
-                                the actual session duration within the widened
-                                bar. Uses a near-white color so it contrasts
-                                against the bar's saturated fill. */}
-                              <div
-                                className="absolute bottom-0 left-0 pointer-events-none"
-                                style={{
-                                  width: `${ts.realDurationFraction * 100}%`,
-                                  height: 3,
-                                  backgroundColor: "rgba(255, 255, 255, 0.85)",
-                                }}
-                                title="actual duration"
-                              />
-                              {/* End-of-real-time tick: a 2px-wide × 7px-tall mark
-                                at the wick's right edge so the end-position
-                                stays visible even when the wick itself is just
-                                a few pixels wide. */}
-                              <div
-                                className="absolute bottom-0 pointer-events-none"
-                                style={{
-                                  left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
-                                  width: 2,
-                                  height: 7,
-                                  backgroundColor: "rgba(255, 255, 255, 0.95)",
-                                }}
-                              />
-                            </>
+                        className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
+                        style={{ width: LABEL_WIDTH, height: rowHeight }}
+                      >
+                        <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
+                          {projectName(p.project)}
+                        </div>
+                        <div className="text-[9px] font-mono text-terminal-dimmer truncate">
+                          {p.sessions.length} {plural(p.sessions.length, "session")}
+                          {p.hiddenInLanesCount > 0 && (
+                            <span className="text-terminal-orange/70">
+                              {" "}
+                              · +{p.hiddenInLanesCount} hidden
+                            </span>
                           )}
                         </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
+                      </div>
+
+                      {/* Lane area */}
+                      <div
+                        className="relative flex-1 overflow-hidden rounded-xl bg-terminal-surface/45 shadow-layer-sm transition-colors group-hover:bg-terminal-surface-hover/70"
+                        style={{ height: rowHeight }}
+                      >
+                        {/* Grid lines */}
+                        {ticks.map((t, i) => (
+                          <div
+                            key={i}
+                            className="absolute top-0 bottom-0 w-px bg-terminal-border/[0.06]"
+                            style={{ left: `${t.leftPct}%` }}
+                          />
+                        ))}
+
+                        {/* Session blocks */}
+                        {p.sessions.map((ts) => {
+                          const automated = isAutomated(ts.session);
+                          const laneTop = p.laneTopsPx[ts.lane];
+                          const laneH = p.laneHeightsPx[ts.lane];
+                          const top = laneTop + (laneH - ts.heightPx);
+                          const opacity = automated ? 0.4 : ts.opacity;
+                          const lineClamp = Math.max(
+                            1,
+                            Math.floor(
+                              (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
+                            ),
+                          );
+                          const showWick = ts.realDurationFraction < 0.85;
+                          return (
+                            <button
+                              type="button"
+                              key={ts.session.sessionId}
+                              className="absolute overflow-hidden rounded-md text-left shadow-layer-sm transition-all duration-200 ease-material hover:z-10 hover:shadow-layer-md"
+                              style={{
+                                left: `${ts.leftPct}%`,
+                                width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
+                                top,
+                                height: ts.heightPx,
+                                opacity,
+                                zIndex: automated ? 1 : 2,
+                                backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
+                              }}
+                              aria-label={`Open ${sessionTitle(ts.session)}`}
+                              onClick={() => navigateTo({ view: null, session: ts.session.slug })}
+                              onMouseEnter={(e) => {
+                                setTooltip({
+                                  session: ts.session,
+                                  x: e.clientX,
+                                  y: e.clientY,
+                                });
+                              }}
+                              onMouseLeave={() => setTooltip(null)}
+                            >
+                              {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
+                                <span
+                                  className={`pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
+                                    lineClamp === 1
+                                      ? "truncate leading-[18px]"
+                                      : "overflow-hidden pt-1"
+                                  }`}
+                                  style={
+                                    lineClamp === 1
+                                      ? undefined
+                                      : {
+                                          display: "-webkit-box",
+                                          WebkitBoxOrient: "vertical",
+                                          WebkitLineClamp: lineClamp,
+                                        }
+                                  }
+                                >
+                                  {sessionTitle(ts.session)}
+                                </span>
+                              )}
+                              {showWick && (
+                                <>
+                                  <span
+                                    className="pointer-events-none absolute bottom-0 left-0 h-0.5 rounded-r-full bg-terminal-text/70"
+                                    style={{ width: `${ts.realDurationFraction * 100}%` }}
+                                    title="actual duration"
+                                  />
+                                  <span
+                                    className="pointer-events-none absolute bottom-0 h-1.5 w-px bg-terminal-text/80"
+                                    style={{
+                                      left: `calc(${ts.realDurationFraction * 100}% - 1px)`,
+                                    }}
+                                  />
+                                </>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
           </div>
+
+          <aside className="relative overflow-hidden rounded-2xl bg-terminal-surface p-4 shadow-layer-lg">
+            <div className="pointer-events-none absolute -right-16 -top-16 h-36 w-36 rounded-full bg-terminal-blue/5 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-16 -left-16 h-36 w-36 rounded-full bg-terminal-green/5 blur-3xl" />
+            <div className="relative">
+              <div className="mb-3">
+                <div className="text-sm font-sans font-semibold text-terminal-text">
+                  Top Sessions
+                </div>
+                <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+                  Ranked by activity signals. Badges show provider and Cursor data source.
+                </div>
+              </div>
+              <div className="space-y-2">
+                {topSessions.map((ts) => {
+                  const color = colorFor(ts.colorIdx);
+                  return (
+                    <button
+                      type="button"
+                      key={ts.session.sessionId}
+                      onClick={() => navigateTo({ view: null, session: ts.session.slug })}
+                      className="w-full rounded-xl bg-terminal-bg/45 p-2.5 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md"
+                    >
+                      <div className="flex items-start gap-2">
+                        <span
+                          className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: color.solid }}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-xs font-sans font-medium text-terminal-text">
+                            {sessionTitle(ts.session)}
+                          </div>
+                          <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
+                            {projectName(ts.project)}
+                          </div>
+                          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] font-mono">
+                            <span className="rounded-md bg-terminal-green-subtle px-1.5 py-0.5 text-terminal-green">
+                              score {Math.round(ts.score)}
+                            </span>
+                            {sessionBadges(ts.session).map((badge) => (
+                              <span
+                                key={badge}
+                                className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-terminal-dim"
+                              >
+                                {badge}
+                              </span>
+                            ))}
+                            {ts.session.durationMs ? (
+                              <span className="text-terminal-blue">
+                                {fmtDuration(ts.session.durationMs)}
+                              </span>
+                            ) : null}
+                            {ts.session.editCount > 0 ? (
+                              <span className="text-terminal-dimmer">
+                                {ts.session.editCount} {plural(ts.session.editCount, "edit")}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </aside>
         </div>
       )}
 
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="fixed pointer-events-none bg-terminal-surface border border-terminal-border rounded-lg shadow-xl p-3 text-xs font-mono w-80"
+          className="fixed pointer-events-none w-80 rounded-xl border border-terminal-border bg-terminal-surface p-3 text-xs font-mono shadow-layer-xl"
           style={{
-            // Bars use zIndex up to 100 (score-based), so the tooltip needs to
-            // stay well above that — z-50 was actually below high-score bars.
+            // Keep the tooltip above hovered timeline bars.
             zIndex: 1000,
             left: Math.min(tooltip.x + 12, window.innerWidth - 336),
             top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
           }}
         >
           <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
-            {tooltip.session.title ?? tooltip.session.firstPrompt ?? tooltip.session.slug}
+            {sessionTitle(tooltip.session)}
+          </div>
+          <div className="mb-2 flex flex-wrap gap-1">
+            {sessionBadges(tooltip.session).map((badge) => (
+              <span
+                key={badge}
+                className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] text-terminal-dim"
+              >
+                {badge}
+              </span>
+            ))}
           </div>
           <div className="text-terminal-dimmer space-y-0.5">
             {tooltip.session.startTime &&
@@ -801,8 +861,9 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
               <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
             )}
             <div>
-              {tooltip.session.promptCount}p · {tooltip.session.editCount} edits ·{" "}
-              {tooltip.session.toolCallCount} tools
+              {tooltip.session.promptCount}p · {tooltip.session.editCount}{" "}
+              {plural(tooltip.session.editCount, "edit")} · {tooltip.session.toolCallCount}{" "}
+              {plural(tooltip.session.toolCallCount, "tool")}
             </div>
             {tooltip.session.gitBranch && (
               <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
@@ -865,12 +926,13 @@ function buildProjectFileGroups(groups: ProjectGroup[]): ProjectFileGroup[] {
     const files: FileCluster[] = [];
     for (const [file, sessions] of fileMap) {
       const uniqueSessions = [...new Map(sessions.map((s) => [s.session.sessionId, s])).values()];
-      if (uniqueSessions.length < 2) continue;
+      const totalEdits = uniqueSessions.reduce((sum, s) => sum + s.editCount, 0);
+      if (uniqueSessions.length < 2 && totalEdits < 3) continue;
       files.push({
         file,
         displayName: displayFileName(file, g.project),
         sessions: uniqueSessions.sort((a, b) => b.editCount - a.editCount),
-        totalEdits: uniqueSessions.reduce((sum, s) => sum + s.editCount, 0),
+        totalEdits,
       });
     }
 
@@ -910,9 +972,9 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
   if (projectFileGroups.length === 0) {
     return (
       <div className="p-8 text-center space-y-2">
-        <div className="text-terminal-dimmer text-sm font-mono">No shared files found.</div>
+        <div className="text-terminal-dimmer text-sm font-mono">No hot files found.</div>
         <div className="text-terminal-dimmer/60 text-xs font-mono">
-          Files edited by multiple sessions will appear here.
+          Cursor sessions without file edits are still shown in List and Timeline.
         </div>
       </div>
     );
@@ -923,18 +985,19 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
   const selected = selectedFile
     ? selectedProjectGroup.files.find((c) => c.file === selectedFile)
     : null;
-  const selectedProjectColor = colorFor(selectedProjectGroup.colorIdx);
 
   return (
     <div className="flex h-full min-w-0 flex-col gap-4 p-4 lg:flex-row">
       {/* Project list */}
-      <div className="w-full shrink-0 space-y-1 overflow-y-auto lg:w-64">
-        <div className="text-[10px] font-mono text-terminal-dimmer mb-2 px-2">
-          {projectFileGroups.length} projects with shared files
+      <div className="w-full shrink-0 space-y-2 overflow-y-auto lg:w-64">
+        <div className="px-1">
+          <div className="text-sm font-sans font-semibold text-terminal-text">Hot Files</div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+            {projectFileGroups.length} {plural(projectFileGroups.length, "project")} with hot files
+          </div>
         </div>
         {projectFileGroups.map((group) => {
           const isSelected = selectedProjectGroup.project === group.project;
-          const color = colorFor(group.colorIdx);
           return (
             <button
               key={group.project}
@@ -942,16 +1005,21 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
                 setSelectedProject(group.project);
                 setSelectedFile(null);
               }}
-              className={`w-full text-left px-3 py-2 rounded-lg text-xs font-mono transition-colors ${
+              className={`w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-200 ease-material ${
                 isSelected
-                  ? `${color.bg} border ${color.border} ${color.text}`
-                  : "hover:bg-terminal-surface-2 text-terminal-text border border-transparent"
+                  ? "border-transparent bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
+                  : "border-transparent bg-terminal-bg/35 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
               }`}
             >
-              <div className="truncate font-semibold">{shortName(group.project)}</div>
-              <div className="text-[9px] text-terminal-dimmer truncate">{group.project}</div>
-              <div className="mt-1 text-[9px] text-terminal-dimmer">
-                {group.files.length} files · {group.totalEdits.toLocaleString()} edits
+              <div className="truncate text-xs font-sans font-semibold">
+                {projectName(group.project)}
+              </div>
+              <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
+                {group.project}
+              </div>
+              <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+                {group.files.length} {plural(group.files.length, "file")} ·{" "}
+                {group.totalEdits.toLocaleString()} {plural(group.totalEdits, "edit")}
               </div>
             </button>
           );
@@ -960,12 +1028,29 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
 
       {/* Project files + detail panel */}
       <div className="min-w-0 flex-1 space-y-4 overflow-y-auto">
-        <div>
-          <div className={`text-sm font-sans font-semibold ${selectedProjectColor.text}`}>
-            {shortName(selectedProjectGroup.project)}
-          </div>
-          <div className="mt-0.5 truncate text-xs font-mono text-terminal-dimmer">
-            {selectedProjectGroup.project}
+        <div className="relative overflow-hidden rounded-2xl bg-terminal-bg/35 p-4 shadow-inner">
+          <div className="pointer-events-none absolute -right-12 -top-12 h-28 w-28 rounded-full bg-terminal-green/5 blur-2xl" />
+          <div className="relative">
+            <div className="text-sm font-sans font-semibold text-terminal-text">
+              {projectName(selectedProjectGroup.project)}
+            </div>
+            <div className="mt-0.5 truncate text-xs font-mono text-terminal-dimmer">
+              {selectedProjectGroup.project}
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] font-mono text-terminal-dimmer">
+              <span className="rounded-md bg-terminal-green-subtle px-1.5 py-0.5 text-terminal-green">
+                {selectedProjectGroup.files.length}{" "}
+                {plural(selectedProjectGroup.files.length, "hot file")}
+              </span>
+              <span>
+                {selectedProjectGroup.totalEdits.toLocaleString()}{" "}
+                {plural(selectedProjectGroup.totalEdits, "edit")}
+              </span>
+              <span>
+                {selectedProjectGroup.totalSessions.toLocaleString()}{" "}
+                {plural(selectedProjectGroup.totalSessions, "session")}
+              </span>
+            </div>
           </div>
         </div>
 
@@ -976,18 +1061,21 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
               <button
                 key={cluster.file}
                 onClick={() => setSelectedFile(isSelected ? null : cluster.file)}
-                className={`w-full text-left px-3 py-2 rounded-lg text-xs font-mono transition-colors ${
+                className={`w-full rounded-xl px-3 py-2.5 text-left transition-all duration-200 ease-material ${
                   isSelected
-                    ? "bg-terminal-green/20 border border-terminal-green text-terminal-green"
-                    : "hover:bg-terminal-surface-2 text-terminal-text border border-terminal-border/30"
+                    ? "bg-terminal-green-subtle text-terminal-green shadow-layer-md"
+                    : "bg-terminal-bg/40 text-terminal-text shadow-layer-sm hover:bg-terminal-surface-hover hover:shadow-layer-md"
                 }`}
               >
-                <div className="truncate">{cluster.displayName.split("/").pop()}</div>
-                <div className="text-[9px] text-terminal-dimmer truncate">
+                <div className="truncate text-xs font-mono">
+                  {cluster.displayName.split("/").pop()}
+                </div>
+                <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
                   {cluster.displayName}
                 </div>
-                <div className="mt-1 text-[9px] text-terminal-dimmer">
-                  {cluster.totalEdits.toLocaleString()} edits · {cluster.sessions.length} sessions
+                <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+                  {cluster.totalEdits.toLocaleString()} {plural(cluster.totalEdits, "edit")} ·{" "}
+                  {cluster.sessions.length} {plural(cluster.sessions.length, "session")}
                 </div>
               </button>
             );
@@ -996,16 +1084,16 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
 
         {selected ? (
           <div className="space-y-3">
-            <div className="border-t border-terminal-border/30 pt-4">
-              <div className="text-sm font-mono text-terminal-text font-medium truncate">
+            <div className="rounded-2xl bg-terminal-surface p-4 shadow-layer-sm">
+              <div className="text-sm font-sans font-semibold text-terminal-text truncate">
                 {selected.displayName.split("/").pop()}
               </div>
               <div className="text-xs font-mono text-terminal-dimmer mt-0.5 break-all">
                 {selected.file}
               </div>
               <div className="text-xs font-mono text-terminal-dimmer mt-1">
-                {selected.totalEdits.toLocaleString()} edits across {selected.sessions.length}{" "}
-                sessions
+                {selected.totalEdits.toLocaleString()} {plural(selected.totalEdits, "edit")} across{" "}
+                {selected.sessions.length} {plural(selected.sessions.length, "session")}
               </div>
             </div>
 
@@ -1014,33 +1102,35 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
               {selected.sessions.map((s) => {
                 const color = colorFor(s.colorIdx);
                 return (
-                  <div
+                  <button
+                    type="button"
                     key={s.session.sessionId}
-                    className={`flex flex-col gap-2 p-3 rounded-lg border sm:flex-row sm:items-start sm:gap-3 ${color.bg} ${color.border}/40`}
+                    onClick={() => navigateTo({ view: null, session: s.session.slug })}
+                    className="flex w-full flex-col gap-2 rounded-xl bg-terminal-bg/45 p-3 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md sm:flex-row sm:items-start sm:gap-3"
                   >
                     <div
                       className="hidden w-2 h-2 rounded-full mt-1.5 shrink-0 sm:block"
                       style={{ backgroundColor: color.solid }}
                     />
                     <div className="flex-1 min-w-0">
-                      <div className={`text-xs font-mono ${color.text} truncate`}>
-                        {s.session.title ?? s.session.firstPrompt ?? s.session.slug}
+                      <div className="text-xs font-sans font-medium text-terminal-text truncate">
+                        {sessionTitle(s.session)}
                       </div>
                       <div className="text-[9px] font-mono text-terminal-dimmer mt-0.5">
-                        {shortName(s.session.project)} · {fmtDate(s.session.startTime)}
+                        {projectName(s.session.project)} · {fmtDate(s.session.startTime)}
                       </div>
                     </div>
                     <div className="shrink-0 text-xs font-mono text-terminal-orange">
-                      {s.editCount} edit{s.editCount !== 1 ? "s" : ""}
+                      {s.editCount} {plural(s.editCount, "edit")}
                     </div>
-                  </div>
+                  </button>
                 );
               })}
             </div>
           </div>
         ) : (
           <div className="flex items-center justify-center h-40 text-terminal-dimmer text-xs font-mono">
-            Select a file in {shortName(selectedProjectGroup.project)} to see the sessions that
+            Select a file in {projectName(selectedProjectGroup.project)} to see the sessions that
             modified it
           </div>
         )}
@@ -1063,13 +1153,53 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
   // Collapse agent worktrees back to the project the user recognizes. The
   // session rows still expose the original path when it matters.
   const groups = useMemo(() => groupByProject(sessions, { collapseWorktrees: true }), [sessions]);
+  const providerSummary = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const s of sessions) {
+      const label = providerBadgeLabel(s.provider);
+      counts.set(label, (counts.get(label) || 0) + 1);
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([label, count]) => `${label} ${count}`)
+      .join(" · ");
+  }, [sessions]);
+  const estimatedTimingCount = useMemo(
+    () => sessions.filter((session) => sessionHasEstimatedTime(session)).length,
+    [sessions],
+  );
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="flex items-center gap-2 text-terminal-dim text-sm font-mono">
-          <span className="w-1.5 h-1.5 rounded-full bg-terminal-green animate-pulse" />
-          Loading session data...
+      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-bg to-terminal-surface p-4 shadow-layer-xl">
+        <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-terminal-green/5 blur-3xl" />
+        <div className="relative space-y-4 animate-pulse">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="h-3 w-20 rounded bg-terminal-surface-2" />
+            <div className="h-3 w-24 rounded bg-terminal-surface-2 opacity-70" />
+            <div className="h-3 w-32 rounded bg-terminal-surface-2 opacity-50" />
+          </div>
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
+            <div className="rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+              <div className="space-y-2">
+                {Array.from({ length: 5 }, (_, i) => (
+                  <div key={i} className="flex items-center gap-3">
+                    <div className="h-8 w-32 rounded bg-terminal-surface-2 opacity-60" />
+                    <div className="h-9 flex-1 rounded-xl bg-terminal-surface/60 shadow-layer-sm" />
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-2xl bg-terminal-surface p-4 shadow-layer-lg">
+              <div className="mb-3 h-4 w-24 rounded bg-terminal-surface-2" />
+              <div className="space-y-2">
+                {Array.from({ length: 4 }, (_, i) => (
+                  <div key={i} className="h-16 rounded-xl bg-terminal-bg/45 shadow-layer-sm" />
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -1089,15 +1219,24 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
   }
 
   return (
-    <div className="flex min-w-0 flex-col overflow-hidden rounded-lg border border-terminal-border/30 bg-terminal-surface/20">
+    <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-bg to-terminal-surface shadow-layer-xl">
+      <div className="pointer-events-none absolute -right-24 -top-24 h-64 w-64 rounded-full bg-terminal-green/5 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 -left-24 h-56 w-56 rounded-full bg-terminal-blue/5 blur-3xl" />
       {/* Stats bar */}
-      <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-terminal-border/20 px-4 py-2 text-[10px] font-mono text-terminal-dimmer md:px-6">
+      <div className="relative z-10 flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 text-[10px] font-mono text-terminal-dimmer md:px-6">
         <span>
-          <span className="text-terminal-text">{sessions.length}</span> sessions
+          <span className="text-terminal-text">{sessions.length}</span>{" "}
+          {plural(sessions.length, "session")}
         </span>
         <span>
-          <span className="text-terminal-text">{groups.length}</span> projects
+          <span className="text-terminal-text">{groups.length}</span>{" "}
+          {plural(groups.length, "project")}
         </span>
+        {providerSummary && (
+          <span>
+            <span className="text-terminal-purple">{providerSummary}</span>
+          </span>
+        )}
         <span>
           <span className="text-terminal-blue">
             {fmtDuration(sessions.reduce((s, x) => s + (x.durationMs ?? 0), 0))}
@@ -1114,12 +1253,20 @@ export default function SessionRelationshipsView({ view }: SessionRelationshipsV
           <span className="text-terminal-green">
             {sessions.reduce((s, x) => s + x.editCount, 0).toLocaleString()}
           </span>{" "}
-          edits
+          {plural(
+            sessions.reduce((s, x) => s + x.editCount, 0),
+            "edit",
+          )}
         </span>
+        {estimatedTimingCount > 0 && (
+          <span>
+            <span className="text-terminal-dimmer">{estimatedTimingCount}</span> estimated timing
+          </span>
+        )}
       </div>
 
       {/* View content */}
-      <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
+      <div className="relative z-10 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
         {view === "timeline" && <TimelineSwimlaneView groups={groups} />}
         {view === "files" && <FileConnectionsView groups={groups} />}
       </div>

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -9,7 +9,8 @@
 import { useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
 import { shortName, timeAgo } from "../utils/format";
-import { collapseWorktree, isAutomated, sessionScore } from "../utils/sessionSignals";
+import { isAutomated, sessionScore } from "../utils/sessionSignals";
+import { rollupProject } from "./dashboard-utils";
 
 // ─── Shared helpers ──────────────────────────────────────────────────
 
@@ -92,7 +93,7 @@ function groupByProject(
 ): ProjectGroup[] {
   const map = new Map<string, ScanResultSession[]>();
   for (const s of sessions) {
-    const key = options.collapseWorktrees ? collapseWorktree(s.project) : s.project;
+    const key = options.collapseWorktrees ? rollupProject(s.project) : s.project;
     if (!map.has(key)) map.set(key, []);
     map.get(key)!.push(s);
   }

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -312,7 +312,7 @@ function buildTimeline(groups: ProjectGroup[]): {
       projects.push({
         project: g.project,
         sessions: tSessions,
-        laneCount: Math.max(...tSessions.map((s) => s.lane)) + 1,
+        laneCount: tSessions.reduce((max, s) => Math.max(max, s.lane), 0) + 1,
         colorIdx: g.colorIdx,
       });
     }
@@ -458,7 +458,10 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       {tooltip && (
         <div
           className="fixed z-50 pointer-events-none bg-terminal-surface border border-terminal-border rounded-lg shadow-xl p-3 text-xs font-mono max-w-xs"
-          style={{ left: tooltip.x + 12, top: tooltip.y - 8 }}
+          style={{
+            left: Math.min(tooltip.x + 12, window.innerWidth - 280),
+            top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 160)),
+          }}
         >
           <div className="text-terminal-text font-medium mb-1 truncate">
             {tooltip.session.title ?? tooltip.session.firstPrompt ?? tooltip.session.slug}
@@ -520,6 +523,7 @@ function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
     // Find sessions that ran entirely within this parent's window
     const children: DispatchNode[] = [];
     for (const child of candidates) {
+      if (usedIds.has(child.sessionId)) continue;
       if (child.project !== parent.project) continue;
       const childStart = new Date(child.startTime!).getTime();
       const childEnd = child.endTime
@@ -649,6 +653,7 @@ function DispatchTreeView({ groups }: { groups: ProjectGroup[] }) {
 
 interface FileCluster {
   file: string;
+  displayName: string;
   sessions: Array<{ session: ScanResultSession; editCount: number; colorIdx: number }>;
 }
 
@@ -661,9 +666,8 @@ function buildFileClusters(groups: ProjectGroup[]): FileCluster[] {
   for (const g of groups) {
     for (const s of g.sessions) {
       for (const f of s.filesModified) {
-        // Normalize path to just the last 2-3 segments for readability
-        const parts = f.file.split("/");
-        const key = parts.slice(-3).join("/");
+        // Use full path as key to avoid false connections across projects
+        const key = f.file;
         if (!fileMap.has(key)) fileMap.set(key, []);
         fileMap.get(key)!.push({ session: s, editCount: f.count, colorIdx: g.colorIdx });
       }
@@ -675,7 +679,10 @@ function buildFileClusters(groups: ProjectGroup[]): FileCluster[] {
   for (const [file, sessions] of fileMap) {
     const uniqueSessions = [...new Map(sessions.map((s) => [s.session.sessionId, s])).values()];
     if (uniqueSessions.length >= 2) {
-      clusters.push({ file, sessions: uniqueSessions });
+      // Shortened display: last 3 path segments
+      const parts = file.split("/");
+      const displayName = parts.slice(-3).join("/");
+      clusters.push({ file, displayName, sessions: uniqueSessions });
     }
   }
 
@@ -708,7 +715,7 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
         </div>
         {clusters.map((cluster) => {
           const isSelected = selectedFile === cluster.file;
-          const maxEdits = Math.max(...cluster.sessions.map((s) => s.editCount));
+          const maxEdits = cluster.sessions.reduce((max, s) => Math.max(max, s.editCount), 0);
           return (
             <button
               key={cluster.file}
@@ -719,8 +726,8 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
                   : "hover:bg-terminal-surface-2 text-terminal-text border border-transparent"
               }`}
             >
-              <div className="truncate">{cluster.file.split("/").pop()}</div>
-              <div className="text-[9px] text-terminal-dimmer truncate">{cluster.file}</div>
+              <div className="truncate">{cluster.displayName.split("/").pop()}</div>
+              <div className="text-[9px] text-terminal-dimmer truncate">{cluster.displayName}</div>
               <div className="flex items-center gap-2 mt-1">
                 <div className="flex gap-0.5">
                   {cluster.sessions.slice(0, 8).map((s, i) => (
@@ -749,35 +756,12 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
           <div className="space-y-3">
             <div>
               <div className="text-sm font-mono text-terminal-text font-medium">
-                {selected.file.split("/").pop()}
+                {selected.displayName.split("/").pop()}
               </div>
               <div className="text-xs font-mono text-terminal-dimmer mt-0.5">{selected.file}</div>
               <div className="text-xs font-mono text-terminal-dimmer mt-1">
                 {selected.sessions.length} sessions modified this file
               </div>
-            </div>
-
-            {/* SVG connection diagram */}
-            <div className="relative">
-              <svg
-                width="100%"
-                height={Math.max(120, selected.sessions.length * 50 + 40)}
-                className="overflow-visible"
-              >
-                {/* File node in center */}
-                <g transform={`translate(50%, ${Math.max(60, selected.sessions.length * 25)})`}>
-                  <circle r={20} fill="#374151" stroke="#6b7280" strokeWidth={1.5} />
-                  <text
-                    textAnchor="middle"
-                    dy="0.35em"
-                    fontSize={8}
-                    fill="#9ca3af"
-                    className="font-mono"
-                  >
-                    📄
-                  </text>
-                </g>
-              </svg>
             </div>
 
             {/* Session list */}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
+import { plural } from "../utils/format";
 import { isAutomated, sessionScore } from "../utils/sessionSignals";
 import {
   cleanPrompt,
@@ -38,10 +39,6 @@ function fmtDuration(ms?: number): string {
   const h = Math.floor(ms / 3600000);
   const m = Math.round((ms % 3600000) / 60000);
   return m > 0 ? `${h}h ${m}m` : `${h}h`;
-}
-
-function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
-  return count === 1 ? singular : pluralForm;
 }
 
 function sessionTitle(s: ScanResultSession): string {
@@ -147,16 +144,23 @@ function groupByProject(
       const bStart = b.startTime ? new Date(b.startTime).getTime() : 0;
       return bStart - aStart;
     });
-    const lastActivityMs = sorted.reduce((max, s) => {
-      if (!s.startTime) return max;
-      const startMs = new Date(s.startTime).getTime();
-      return Math.max(max, activeEndMs(startMs, s));
-    }, 0);
+    let totalDurationMs = 0;
+    let totalCost = 0;
+    let lastActivityMs = 0;
+    for (const s of sorted) {
+      totalDurationMs += s.durationMs ?? 0;
+      totalCost += s.costEstimate ?? 0;
+      if (s.startTime) {
+        const startMs = new Date(s.startTime).getTime();
+        const endMs = activeEndMs(startMs, s);
+        if (endMs > lastActivityMs) lastActivityMs = endMs;
+      }
+    }
     groups.push({
       project,
       sessions: sorted,
-      totalDurationMs: sorted.reduce((s, x) => s + (x.durationMs ?? 0), 0),
-      totalCost: sorted.reduce((s, x) => s + (x.costEstimate ?? 0), 0),
+      totalDurationMs,
+      totalCost,
       lastActivity:
         lastActivityMs > 0 ? new Date(lastActivityMs).toISOString() : sorted[0]?.startTime,
       colorIdx: idx++,
@@ -250,35 +254,38 @@ function packTimelineLanes(
   unlimited: boolean = false,
 ): { laneAssignments: Map<string, number>; laneCount: number; dropped: number } {
   const ordered = [...sessions].sort((a, b) => a.startMs - b.startMs || b.score - a.score);
-  const laneIntervals: Array<Array<{ startMs: number; endMs: number }>> = [];
+  // Sessions are processed in start-time order, so each lane's only relevant
+  // overlap candidate is the last interval placed in it — anything earlier
+  // ended even sooner. Track only that single end timestamp per lane.
+  const laneEnds: number[] = [];
   const laneAssignments = new Map<string, number>();
   let dropped = 0;
   const cap = unlimited ? Infinity : MAX_LANES_PER_PROJECT;
 
   for (const s of ordered) {
     let placed = -1;
-    for (let i = 0; i < laneIntervals.length; i++) {
-      const overlap = laneIntervals[i].some((iv) => s.startMs < iv.endMs && s.endMs > iv.startMs);
-      if (!overlap) {
+    for (let i = 0; i < laneEnds.length; i++) {
+      if (s.startMs >= laneEnds[i]) {
         placed = i;
         break;
       }
     }
 
     if (placed === -1) {
-      if (laneIntervals.length >= cap) {
+      if (laneEnds.length >= cap) {
         dropped++;
         continue;
       }
-      placed = laneIntervals.length;
-      laneIntervals.push([]);
+      placed = laneEnds.length;
+      laneEnds.push(s.endMs);
+    } else {
+      laneEnds[placed] = s.endMs;
     }
 
-    laneIntervals[placed].push({ startMs: s.startMs, endMs: s.endMs });
     laneAssignments.set(s.original.sessionId, placed);
   }
 
-  return { laneAssignments, laneCount: laneIntervals.length, dropped };
+  return { laneAssignments, laneCount: laneEnds.length, dropped };
 }
 
 /**
@@ -318,18 +325,24 @@ function buildTimeline(
   totalSessions: number;
   hiddenAutomatedCount: number;
 } {
-  // Determine time bounds. If an explicit window is provided (range selector),
-  // use it. Otherwise fall back to min/max across all sessions ("All" view).
-  // Use the *active* end (start + durationMs), not raw endTime — see comment
-  // on activeEndMs.
+  // Cache parsed start/end times per session — used at least 3 times each
+  // (bounds, window filter, interval map). new Date(...).getTime() isn't free.
+  const timed: Array<{
+    session: ScanResultSession;
+    startMs: number;
+    endMs: number;
+    group: ProjectGroup;
+  }> = [];
   let minMs = Infinity;
   let maxMs = -Infinity;
   for (const g of groups) {
     for (const s of g.sessions) {
       if (!s.startTime) continue;
       const startMs = new Date(s.startTime).getTime();
-      minMs = Math.min(minMs, startMs);
-      maxMs = Math.max(maxMs, activeEndMs(startMs, s));
+      const endMs = activeEndMs(startMs, s);
+      timed.push({ session: s, startMs, endMs, group: g });
+      if (startMs < minMs) minMs = startMs;
+      if (endMs > maxMs) maxMs = endMs;
     }
   }
 
@@ -356,35 +369,30 @@ function buildTimeline(
     rangeEnd = maxMs + paddingMs;
   }
   const rangeMs = rangeEnd - rangeStart;
+  const minMsPerPx = rangeMs / APPROX_TIMELINE_WIDTH_PX;
+
+  // Bucket per-project after window + automated filtering.
+  const perGroup = new Map<ProjectGroup, typeof timed>();
+  let hiddenAutomatedCount = 0;
+  for (const entry of timed) {
+    if (entry.endMs < rangeStart || entry.startMs > rangeEnd) continue;
+    if (!includeAutomated && isAutomated(entry.session)) {
+      hiddenAutomatedCount++;
+      continue;
+    }
+    const bucket = perGroup.get(entry.group);
+    if (bucket) bucket.push(entry);
+    else perGroup.set(entry.group, [entry]);
+  }
 
   const projects: TimelineProject[] = [];
   let totalSessions = 0;
-  let hiddenAutomatedCount = 0;
 
   for (const g of groups) {
-    // Filter to window + automated policy. Use the *active* end so a session
-    // whose JSONL stayed open through 10 days of idle doesn't get pulled into
-    // any window its actual work didn't reach.
-    const filtered = g.sessions.filter((s) => {
-      if (!s.startTime) return false;
-      const startMs = new Date(s.startTime).getTime();
-      const endMs = activeEndMs(startMs, s);
-      if (endMs < rangeStart || startMs > rangeEnd) return false;
-      if (!includeAutomated && isAutomated(s)) {
-        hiddenAutomatedCount++;
-        return false;
-      }
-      return true;
-    });
+    const filtered = perGroup.get(g);
+    if (!filtered || filtered.length === 0) continue;
 
-    if (filtered.length === 0) continue;
-
-    // Build interval list for lane packing. The only visual floor is a small
-    // hit target for very short sessions; width otherwise tracks active time.
-    const minMsPerPx = rangeMs / APPROX_TIMELINE_WIDTH_PX;
-    const intervals = filtered.map((s) => {
-      const startMs = new Date(s.startTime!).getTime();
-      const realEndMs = activeEndMs(startMs, s);
+    const intervals = filtered.map(({ session: s, startMs, endMs: realEndMs }) => {
       const score = sessionScore(s);
       const visualWidthMs = Math.max(realEndMs - startMs, minWidthFor(score) * minMsPerPx);
       return {
@@ -532,21 +540,15 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
     () => buildTimeline(groups, start, end, showAutomated, expandedProjects),
     [groups, start, end, showAutomated, expandedProjects],
   );
-  const timelineSessions = useMemo(
-    () =>
-      projects.flatMap((project) =>
-        project.sessions.map((session) => ({
-          ...session,
-          project: project.project,
-          colorIdx: project.colorIdx,
-        })),
-      ),
-    [projects],
-  );
-  const estimatedTimingCount = useMemo(
-    () => timelineSessions.filter((ts) => sessionHasEstimatedTime(ts.session)).length,
-    [timelineSessions],
-  );
+  const estimatedTimingCount = useMemo(() => {
+    let count = 0;
+    for (const p of projects) {
+      for (const ts of p.sessions) {
+        if (sessionHasEstimatedTime(ts.session)) count++;
+      }
+    }
+    return count;
+  }, [projects]);
 
   const LABEL_WIDTH = 140;
 
@@ -753,19 +755,13 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                             )}
                             {showWick && (
                               <>
-                                {/* K-line wick: bright strip along the bottom marks
-                                      the actual session duration within the (widened)
-                                      bar. Thin enough to coexist with the title above,
-                                      bright enough to register against any project
-                                      color's fill. */}
+                                {/* Bottom strip + end-tick mark the actual session
+                                    duration inside the min-width-padded bar. */}
                                 <span
                                   className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
                                   style={{ width: `${ts.realDurationFraction * 100}%` }}
                                   title="actual duration"
                                 />
-                                {/* End-tick at the wick's right edge so the real
-                                      end-position is visible even when the wick is
-                                      only a few pixels wide. */}
                                 <span
                                   className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
                                   style={{
@@ -1179,9 +1175,6 @@ export default function SessionRelationshipsView({
     () => filteredSessions.filter((session) => sessionHasEstimatedTime(session)).length,
     [filteredSessions],
   );
-  // Totals are derived once per render — same reduce was previously running
-  // twice in the JSX (once for the value, once for plural). For a 300-session
-  // scan that's noticeable and pointless.
   const totals = useMemo(() => {
     let durationMs = 0;
     let cost = 0;

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -720,15 +720,23 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                               )}
                               {showWick && (
                                 <>
+                                  {/* K-line wick: bright strip along the bottom marks
+                                      the actual session duration within the (widened)
+                                      bar. Thin enough to coexist with the title above,
+                                      bright enough to register against any project
+                                      color's fill. */}
                                   <span
-                                    className="pointer-events-none absolute bottom-0 left-0 h-0.5 rounded-r-full bg-terminal-text/70"
+                                    className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
                                     style={{ width: `${ts.realDurationFraction * 100}%` }}
                                     title="actual duration"
                                   />
+                                  {/* End-tick at the wick's right edge so the real
+                                      end-position is visible even when the wick is
+                                      only a few pixels wide. */}
                                   <span
-                                    className="pointer-events-none absolute bottom-0 h-1.5 w-px bg-terminal-text/80"
+                                    className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
                                     style={{
-                                      left: `calc(${ts.realDurationFraction * 100}% - 1px)`,
+                                      left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
                                     }}
                                   />
                                 </>

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -245,11 +245,15 @@ function heightFor(score: number): number {
  */
 function packTimelineLanes(
   sessions: { startMs: number; endMs: number; score: number; original: ScanResultSession }[],
+  /** When true, drop the MAX_LANES_PER_PROJECT cap — used by per-project
+      "show all" toggle so users can opt into seeing every session. */
+  unlimited: boolean = false,
 ): { laneAssignments: Map<string, number>; laneCount: number; dropped: number } {
   const ordered = [...sessions].sort((a, b) => a.startMs - b.startMs || b.score - a.score);
   const laneIntervals: Array<Array<{ startMs: number; endMs: number }>> = [];
   const laneAssignments = new Map<string, number>();
   let dropped = 0;
+  const cap = unlimited ? Infinity : MAX_LANES_PER_PROJECT;
 
   for (const s of ordered) {
     let placed = -1;
@@ -262,7 +266,7 @@ function packTimelineLanes(
     }
 
     if (placed === -1) {
-      if (laneIntervals.length >= MAX_LANES_PER_PROJECT) {
+      if (laneIntervals.length >= cap) {
         dropped++;
         continue;
       }
@@ -305,6 +309,7 @@ function buildTimeline(
   windowStart?: number,
   windowEnd?: number,
   includeAutomated = false,
+  expandedProjects: Set<string> = new Set(),
 ): {
   projects: TimelineProject[];
   ticks: { leftPct: number; label: string }[];
@@ -391,7 +396,10 @@ function buildTimeline(
       };
     });
 
-    const { laneAssignments, laneCount, dropped } = packTimelineLanes(intervals);
+    const { laneAssignments, laneCount, dropped } = packTimelineLanes(
+      intervals,
+      expandedProjects.has(g.project),
+    );
 
     const tSessions: TimelineSession[] = [];
     for (const it of intervals) {
@@ -508,10 +516,21 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
   const [range, setRange] = useState<TimelineRange>("7d");
   const [showAutomated, setShowAutomated] = useState(false);
   const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
+  // Per-project lane-cap override: clicking "+N hidden" on a project's label
+  // adds it here, which lifts MAX_LANES_PER_PROJECT for that project.
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  const toggleExpanded = (project: string) => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(project)) next.delete(project);
+      else next.add(project);
+      return next;
+    });
+  };
   const { start, end } = useMemo(() => rangeWindow(range), [range]);
   const { projects, ticks, totalSessions, hiddenAutomatedCount } = useMemo(
-    () => buildTimeline(groups, start, end, showAutomated),
-    [groups, start, end, showAutomated],
+    () => buildTimeline(groups, start, end, showAutomated, expandedProjects),
+    [groups, start, end, showAutomated, expandedProjects],
   );
   const timelineSessions = useMemo(
     () =>
@@ -637,10 +656,24 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                         <div className="text-[9px] font-mono text-terminal-dimmer truncate">
                           {p.sessions.length} {plural(p.sessions.length, "session")}
                           {p.hiddenInLanesCount > 0 && (
-                            <span className="text-terminal-orange/70">
-                              {" "}
-                              · +{p.hiddenInLanesCount} hidden
-                            </span>
+                            <button
+                              type="button"
+                              onClick={() => toggleExpanded(p.project)}
+                              className="ml-1 text-terminal-orange hover:underline cursor-pointer"
+                              title={`Show the ${p.hiddenInLanesCount} session(s) hidden by the lane cap`}
+                            >
+                              · +{p.hiddenInLanesCount} hidden ▸
+                            </button>
+                          )}
+                          {expandedProjects.has(p.project) && (
+                            <button
+                              type="button"
+                              onClick={() => toggleExpanded(p.project)}
+                              className="ml-1 text-terminal-purple hover:underline cursor-pointer"
+                              title="Restore the lane cap"
+                            >
+                              · collapse
+                            </button>
                           )}
                         </div>
                       </div>

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -543,10 +543,6 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       ),
     [projects],
   );
-  const topSessions = useMemo(
-    () => [...timelineSessions].sort((a, b) => b.score - a.score).slice(0, 6),
-    [timelineSessions],
-  );
   const estimatedTimingCount = useMemo(
     () => timelineSessions.filter((ts) => sessionHasEstimatedTime(ts.session)).length,
     [timelineSessions],
@@ -615,246 +611,178 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           )}
         </div>
       ) : (
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
-          <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
-            <div className="min-w-[760px]">
-              {/* Time axis header */}
-              <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
-                <div className="relative flex-1 h-6">
-                  {ticks.map((t, i) => (
-                    <div
-                      key={i}
-                      className="absolute flex flex-col items-center"
-                      style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
-                    >
-                      <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
-                        {t.label}
-                      </span>
-                      <div className="w-px h-1.5 bg-terminal-border/20 mt-0.5" />
-                    </div>
-                  ))}
-                  <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-terminal-border/25 to-transparent" />
-                </div>
+        <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+          <div className="min-w-[760px]">
+            {/* Time axis header */}
+            <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
+              <div className="relative flex-1 h-6">
+                {ticks.map((t, i) => (
+                  <div
+                    key={i}
+                    className="absolute flex flex-col items-center"
+                    style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+                  >
+                    <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
+                      {t.label}
+                    </span>
+                    <div className="w-px h-1.5 bg-terminal-border/20 mt-0.5" />
+                  </div>
+                ))}
+                <div className="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-terminal-border/25 to-transparent" />
               </div>
+            </div>
 
-              {/* Project rows: time stays on x-axis; project color identifies the lane. */}
-              <div className="space-y-1.5">
-                {projects.map((p) => {
-                  const color = colorFor(p.colorIdx);
-                  const rowHeight = p.totalRowHeightPx;
-                  const accentColor = color.solid;
-                  return (
-                    <div key={p.project} className="flex items-stretch rounded-xl group">
-                      {/* Project label */}
-                      <div
-                        className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
-                        style={{ width: LABEL_WIDTH, height: rowHeight }}
-                      >
-                        <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                          {projectName(p.project)}
-                        </div>
-                        <div className="text-[9px] font-mono text-terminal-dimmer truncate">
-                          {p.sessions.length} {plural(p.sessions.length, "session")}
-                          {p.hiddenInLanesCount > 0 && (
-                            <button
-                              type="button"
-                              onClick={() => toggleExpanded(p.project)}
-                              className="ml-1 text-terminal-orange hover:underline cursor-pointer"
-                              title={`Show the ${p.hiddenInLanesCount} session(s) hidden by the lane cap`}
-                            >
-                              · +{p.hiddenInLanesCount} hidden ▸
-                            </button>
-                          )}
-                          {expandedProjects.has(p.project) && (
-                            <button
-                              type="button"
-                              onClick={() => toggleExpanded(p.project)}
-                              className="ml-1 text-terminal-purple hover:underline cursor-pointer"
-                              title="Restore the lane cap"
-                            >
-                              · collapse
-                            </button>
-                          )}
-                        </div>
+            {/* Project rows: time stays on x-axis; project color identifies the lane. */}
+            <div className="space-y-1.5">
+              {projects.map((p) => {
+                const color = colorFor(p.colorIdx);
+                const rowHeight = p.totalRowHeightPx;
+                const accentColor = color.solid;
+                return (
+                  <div key={p.project} className="flex items-stretch rounded-xl group">
+                    {/* Project label */}
+                    <div
+                      className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
+                      style={{ width: LABEL_WIDTH, height: rowHeight }}
+                    >
+                      <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
+                        {projectName(p.project)}
                       </div>
+                      <div className="text-[9px] font-mono text-terminal-dimmer truncate">
+                        {p.sessions.length} {plural(p.sessions.length, "session")}
+                        {p.hiddenInLanesCount > 0 && (
+                          <button
+                            type="button"
+                            onClick={() => toggleExpanded(p.project)}
+                            className="ml-1 text-terminal-orange hover:underline cursor-pointer"
+                            title={`Show the ${p.hiddenInLanesCount} session(s) hidden by the lane cap`}
+                          >
+                            · +{p.hiddenInLanesCount} hidden ▸
+                          </button>
+                        )}
+                        {expandedProjects.has(p.project) && (
+                          <button
+                            type="button"
+                            onClick={() => toggleExpanded(p.project)}
+                            className="ml-1 text-terminal-purple hover:underline cursor-pointer"
+                            title="Restore the lane cap"
+                          >
+                            · collapse
+                          </button>
+                        )}
+                      </div>
+                    </div>
 
-                      {/* Lane area */}
-                      <div
-                        className="relative flex-1 overflow-hidden rounded-xl bg-terminal-surface/45 shadow-layer-sm transition-colors group-hover:bg-terminal-surface-hover/70"
-                        style={{ height: rowHeight }}
-                      >
-                        {/* Grid lines */}
-                        {ticks.map((t, i) => (
-                          <div
-                            key={i}
-                            className="absolute top-0 bottom-0 w-px bg-terminal-border/[0.06]"
-                            style={{ left: `${t.leftPct}%` }}
-                          />
-                        ))}
+                    {/* Lane area */}
+                    <div
+                      className="relative flex-1 overflow-hidden rounded-xl bg-terminal-surface/45 shadow-layer-sm transition-colors group-hover:bg-terminal-surface-hover/70"
+                      style={{ height: rowHeight }}
+                    >
+                      {/* Grid lines */}
+                      {ticks.map((t, i) => (
+                        <div
+                          key={i}
+                          className="absolute top-0 bottom-0 w-px bg-terminal-border/[0.06]"
+                          style={{ left: `${t.leftPct}%` }}
+                        />
+                      ))}
 
-                        {/* Session blocks */}
-                        {p.sessions.map((ts) => {
-                          const automated = isAutomated(ts.session);
-                          const laneTop = p.laneTopsPx[ts.lane];
-                          const laneH = p.laneHeightsPx[ts.lane];
-                          const top = laneTop + (laneH - ts.heightPx);
-                          const opacity = automated ? 0.4 : ts.opacity;
-                          const lineClamp = Math.max(
-                            1,
-                            Math.floor(
-                              (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
-                            ),
-                          );
-                          const showWick = ts.realDurationFraction < 0.85;
-                          return (
-                            <button
-                              type="button"
-                              key={ts.session.sessionId}
-                              className="absolute overflow-hidden rounded-md text-left shadow-layer-sm transition-all duration-200 ease-material hover:z-10 hover:shadow-layer-md"
-                              style={{
-                                left: `${ts.leftPct}%`,
-                                // Cap min-width to whatever space is left
-                                // between the bar's start and the lane's right
-                                // edge — otherwise bars near "today" overflow
-                                // the overflow-hidden lane container and get
-                                // visually truncated.
-                                width: `max(${ts.widthPct}%, min(${ts.minWidthPx}px, calc(100% - ${ts.leftPct}%)))`,
-                                top,
-                                height: ts.heightPx,
-                                opacity,
-                                zIndex: automated ? 1 : 2,
-                                backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
-                              }}
-                              aria-label={`Open ${sessionTitle(ts.session)}`}
-                              onClick={() => navigateTo({ view: null, session: ts.session.slug })}
-                              onMouseEnter={(e) => {
-                                setTooltip({
-                                  session: ts.session,
-                                  x: e.clientX,
-                                  y: e.clientY,
-                                });
-                              }}
-                              onMouseLeave={() => setTooltip(null)}
-                            >
-                              {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
-                                <span
-                                  className={`pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
-                                    lineClamp === 1
-                                      ? "truncate leading-[18px]"
-                                      : "overflow-hidden pt-1"
-                                  }`}
-                                  style={
-                                    lineClamp === 1
-                                      ? undefined
-                                      : {
-                                          display: "-webkit-box",
-                                          WebkitBoxOrient: "vertical",
-                                          WebkitLineClamp: lineClamp,
-                                        }
-                                  }
-                                >
-                                  {sessionTitle(ts.session)}
-                                </span>
-                              )}
-                              {showWick && (
-                                <>
-                                  {/* K-line wick: bright strip along the bottom marks
+                      {/* Session blocks */}
+                      {p.sessions.map((ts) => {
+                        const automated = isAutomated(ts.session);
+                        const laneTop = p.laneTopsPx[ts.lane];
+                        const laneH = p.laneHeightsPx[ts.lane];
+                        const top = laneTop + (laneH - ts.heightPx);
+                        const opacity = automated ? 0.4 : ts.opacity;
+                        const lineClamp = Math.max(
+                          1,
+                          Math.floor(
+                            (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
+                          ),
+                        );
+                        const showWick = ts.realDurationFraction < 0.85;
+                        return (
+                          <button
+                            type="button"
+                            key={ts.session.sessionId}
+                            className="absolute overflow-hidden rounded-md text-left shadow-layer-sm transition-all duration-200 ease-material hover:z-10 hover:shadow-layer-md"
+                            style={{
+                              left: `${ts.leftPct}%`,
+                              // Cap min-width to whatever space is left
+                              // between the bar's start and the lane's right
+                              // edge — otherwise bars near "today" overflow
+                              // the overflow-hidden lane container and get
+                              // visually truncated.
+                              width: `max(${ts.widthPct}%, min(${ts.minWidthPx}px, calc(100% - ${ts.leftPct}%)))`,
+                              top,
+                              height: ts.heightPx,
+                              opacity,
+                              zIndex: automated ? 1 : 2,
+                              backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
+                            }}
+                            aria-label={`Open ${sessionTitle(ts.session)}`}
+                            onClick={() => navigateTo({ view: null, session: ts.session.slug })}
+                            onMouseEnter={(e) => {
+                              setTooltip({
+                                session: ts.session,
+                                x: e.clientX,
+                                y: e.clientY,
+                              });
+                            }}
+                            onMouseLeave={() => setTooltip(null)}
+                          >
+                            {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
+                              <span
+                                className={`pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
+                                  lineClamp === 1
+                                    ? "truncate leading-[18px]"
+                                    : "overflow-hidden pt-1"
+                                }`}
+                                style={
+                                  lineClamp === 1
+                                    ? undefined
+                                    : {
+                                        display: "-webkit-box",
+                                        WebkitBoxOrient: "vertical",
+                                        WebkitLineClamp: lineClamp,
+                                      }
+                                }
+                              >
+                                {sessionTitle(ts.session)}
+                              </span>
+                            )}
+                            {showWick && (
+                              <>
+                                {/* K-line wick: bright strip along the bottom marks
                                       the actual session duration within the (widened)
                                       bar. Thin enough to coexist with the title above,
                                       bright enough to register against any project
                                       color's fill. */}
-                                  <span
-                                    className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
-                                    style={{ width: `${ts.realDurationFraction * 100}%` }}
-                                    title="actual duration"
-                                  />
-                                  {/* End-tick at the wick's right edge so the real
+                                <span
+                                  className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
+                                  style={{ width: `${ts.realDurationFraction * 100}%` }}
+                                  title="actual duration"
+                                />
+                                {/* End-tick at the wick's right edge so the real
                                       end-position is visible even when the wick is
                                       only a few pixels wide. */}
-                                  <span
-                                    className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
-                                    style={{
-                                      left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
-                                    }}
-                                  />
-                                </>
-                              )}
-                            </button>
-                          );
-                        })}
-                      </div>
+                                <span
+                                  className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
+                                  style={{
+                                    left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
+                                  }}
+                                />
+                              </>
+                            )}
+                          </button>
+                        );
+                      })}
                     </div>
-                  );
-                })}
-              </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
-
-          <aside className="relative overflow-hidden rounded-2xl bg-terminal-surface p-4 shadow-layer-lg">
-            <div className="pointer-events-none absolute -right-16 -top-16 h-36 w-36 rounded-full bg-terminal-blue/5 blur-3xl" />
-            <div className="pointer-events-none absolute -bottom-16 -left-16 h-36 w-36 rounded-full bg-terminal-green/5 blur-3xl" />
-            <div className="relative">
-              <div className="mb-3">
-                <div className="text-sm font-sans font-semibold text-terminal-text">
-                  Top Sessions
-                </div>
-                <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
-                  Ranked by activity signals. Badges show provider and Cursor data source.
-                </div>
-              </div>
-              <div className="space-y-2">
-                {topSessions.map((ts) => {
-                  const color = colorFor(ts.colorIdx);
-                  return (
-                    <button
-                      type="button"
-                      key={ts.session.sessionId}
-                      onClick={() => navigateTo({ view: null, session: ts.session.slug })}
-                      className="w-full rounded-xl bg-terminal-bg/45 p-2.5 text-left shadow-layer-sm transition-all duration-200 ease-material hover:bg-terminal-surface-hover hover:shadow-layer-md"
-                    >
-                      <div className="flex items-start gap-2">
-                        <span
-                          className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full"
-                          style={{ backgroundColor: color.solid }}
-                        />
-                        <div className="min-w-0 flex-1">
-                          <div className="truncate text-xs font-sans font-medium text-terminal-text">
-                            {sessionTitle(ts.session)}
-                          </div>
-                          <div className="mt-0.5 truncate text-[10px] font-mono text-terminal-dimmer">
-                            {projectName(ts.project)}
-                          </div>
-                          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[10px] font-mono">
-                            <span className="rounded-md bg-terminal-green-subtle px-1.5 py-0.5 text-terminal-green">
-                              score {Math.round(ts.score)}
-                            </span>
-                            {sessionBadges(ts.session).map((badge) => (
-                              <span
-                                key={badge}
-                                className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-terminal-dim"
-                              >
-                                {badge}
-                              </span>
-                            ))}
-                            {ts.session.durationMs ? (
-                              <span className="text-terminal-blue">
-                                {fmtDuration(ts.session.durationMs)}
-                              </span>
-                            ) : null}
-                            {ts.session.editCount > 0 ? (
-                              <span className="text-terminal-dimmer">
-                                {ts.session.editCount} {plural(ts.session.editCount, "edit")}
-                              </span>
-                            ) : null}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </aside>
         </div>
       )}
 
@@ -1262,24 +1190,14 @@ export default function SessionRelationshipsView({
             <div className="h-3 w-24 rounded bg-terminal-surface-2 opacity-70" />
             <div className="h-3 w-32 rounded bg-terminal-surface-2 opacity-50" />
           </div>
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
-            <div className="rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
-              <div className="space-y-2">
-                {Array.from({ length: 5 }, (_, i) => (
-                  <div key={i} className="flex items-center gap-3">
-                    <div className="h-8 w-32 rounded bg-terminal-surface-2 opacity-60" />
-                    <div className="h-9 flex-1 rounded-xl bg-terminal-surface/60 shadow-layer-sm" />
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="rounded-2xl bg-terminal-surface p-4 shadow-layer-lg">
-              <div className="mb-3 h-4 w-24 rounded bg-terminal-surface-2" />
-              <div className="space-y-2">
-                {Array.from({ length: 4 }, (_, i) => (
-                  <div key={i} className="h-16 rounded-xl bg-terminal-bg/45 shadow-layer-sm" />
-                ))}
-              </div>
+          <div className="rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+            <div className="space-y-2">
+              {Array.from({ length: 5 }, (_, i) => (
+                <div key={i} className="flex items-center gap-3">
+                  <div className="h-8 w-32 rounded bg-terminal-surface-2 opacity-60" />
+                  <div className="h-9 flex-1 rounded-xl bg-terminal-surface/60 shadow-layer-sm" />
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -125,7 +125,7 @@ function SessionRow({
 }) {
   const duration = session.durationMs ?? 0;
   return (
-    <div className="flex items-center gap-3 px-4 py-2 border-b border-terminal-border/30 hover:bg-terminal-surface-2/50 text-xs font-mono">
+    <div className="flex flex-col gap-2 px-4 py-2 border-b border-terminal-border/30 hover:bg-terminal-surface-2/50 text-xs font-mono sm:flex-row sm:items-center sm:gap-3">
       <div className="flex-1 min-w-0">
         <div className="text-terminal-text truncate">
           {session.title ?? session.firstPrompt ?? session.slug}
@@ -135,7 +135,7 @@ function SessionRow({
           {session.endTime && <span className="ml-2">{timeAgo(session.endTime)} ago</span>}
         </div>
       </div>
-      <div className="flex items-center gap-3 shrink-0">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:shrink-0">
         {duration > 0 && <span className={color.text}>{fmtDuration(duration)}</span>}
         <span className="text-terminal-dimmer">{session.promptCount}p</span>
         {session.editCount > 0 && (
@@ -159,25 +159,27 @@ function ProjectGroupRow({ group }: { group: ProjectGroup }) {
   return (
     <div className={`rounded-xl overflow-hidden border border-terminal-border/40 ${color.bg}`}>
       <button
-        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-terminal-surface-hover/30 transition-colors"
+        className="w-full flex flex-col gap-2 px-4 py-3 text-left hover:bg-terminal-surface-hover/30 transition-colors sm:flex-row sm:items-center sm:gap-3"
         onClick={() => setExpanded((x) => !x)}
       >
-        <span className={`text-xs ${expanded ? "rotate-90" : ""} transition-transform shrink-0`}>
-          ▶
-        </span>
-        <div
-          className={`w-1.5 h-1.5 rounded-full shrink-0`}
-          style={{ backgroundColor: color.solid }}
-        />
-        <div className="flex-1 min-w-0">
-          <span className={`font-sans font-semibold text-sm ${color.text}`}>
-            {shortName(group.project)}
+        <div className="flex min-w-0 items-center gap-3">
+          <span className={`text-xs ${expanded ? "rotate-90" : ""} transition-transform shrink-0`}>
+            ▶
           </span>
-          <span className="text-[10px] font-mono text-terminal-dimmer ml-2 truncate">
-            {group.project}
-          </span>
+          <div
+            className={`w-1.5 h-1.5 rounded-full shrink-0`}
+            style={{ backgroundColor: color.solid }}
+          />
+          <div className="min-w-0">
+            <span className={`font-sans font-semibold text-sm ${color.text}`}>
+              {shortName(group.project)}
+            </span>
+            <span className="block truncate text-[10px] font-mono text-terminal-dimmer sm:ml-2 sm:inline">
+              {group.project}
+            </span>
+          </div>
         </div>
-        <div className="flex items-center gap-4 shrink-0 text-xs font-mono">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 pl-7 text-xs font-mono sm:ml-auto sm:shrink-0 sm:pl-0">
           <span className="text-terminal-text">
             {group.sessions.length} <span className="text-terminal-dimmer">sessions</span>
           </span>
@@ -612,10 +614,10 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
   const LABEL_WIDTH = 140;
 
   return (
-    <div className="p-4 space-y-0 select-none">
+    <div className="p-4 space-y-3 select-none">
       {/* Range selector + automated toggle */}
-      <div className="flex items-center justify-between mb-3 pl-1">
-        <div className="text-[11px] font-mono text-terminal-dimmer flex items-center gap-3">
+      <div className="flex flex-col gap-2 pl-1 lg:flex-row lg:items-center lg:justify-between">
+        <div className="text-[11px] font-mono text-terminal-dimmer flex flex-wrap items-center gap-x-3 gap-y-1">
           <span>
             {totalSessions} <span className="opacity-60">sessions</span>
           </span>
@@ -624,7 +626,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
             row = project · height + width + fill = importance · time → x-axis
           </span>
         </div>
-        <div className="flex items-center gap-3 text-[10px] font-mono">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[10px] font-mono">
           {hiddenAutomatedCount > 0 && !showAutomated && (
             <button
               onClick={() => setShowAutomated(true)}
@@ -674,188 +676,192 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           )}
         </div>
       ) : (
-        <>
-          {/* Time axis header */}
-          <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
-            <div className="relative flex-1 h-6 border-b border-terminal-border/40">
-              {ticks.map((t, i) => (
-                <div
-                  key={i}
-                  className="absolute flex flex-col items-center"
-                  style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
-                >
-                  <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
-                    {t.label}
-                  </span>
-                  <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
-                </div>
-              ))}
+        <div className="overflow-x-auto pb-2">
+          <div className="min-w-[760px]">
+            {/* Time axis header */}
+            <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
+              <div className="relative flex-1 h-6 border-b border-terminal-border/40">
+                {ticks.map((t, i) => (
+                  <div
+                    key={i}
+                    className="absolute flex flex-col items-center"
+                    style={{ left: `${t.leftPct}%`, transform: "translateX(-50%)" }}
+                  >
+                    <span className="text-[9px] font-mono text-terminal-dimmer whitespace-nowrap">
+                      {t.label}
+                    </span>
+                    <div className="w-px h-1.5 bg-terminal-border/40 mt-0.5" />
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
 
-          {/* Project rows — lane-packed, bottom-aligned skyline.
+            {/* Project rows — lane-packed, bottom-aligned skyline.
               Per-bar HEIGHT, WIDTH (min-width by score), FILL alpha, and an
               optional left ACCENT RIM all encode importance — important sessions
               are visibly larger and more saturated, low-importance ones are
               short ghosted ticks but still labeled and clickable. */}
-          {projects.map((p) => {
-            const color = colorFor(p.colorIdx);
-            const rowHeight = p.totalRowHeightPx;
-            const accentColor = color.solid;
-            return (
-              <div
-                key={p.project}
-                className="flex items-stretch border-b border-terminal-border/20 group"
-              >
-                {/* Project label */}
+            {projects.map((p) => {
+              const color = colorFor(p.colorIdx);
+              const rowHeight = p.totalRowHeightPx;
+              const accentColor = color.solid;
+              return (
                 <div
-                  className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
-                  style={{ width: LABEL_WIDTH, height: rowHeight }}
+                  key={p.project}
+                  className="flex items-stretch border-b border-terminal-border/20 group"
                 >
-                  <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                    {shortName(p.project)}
+                  {/* Project label */}
+                  <div
+                    className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
+                    style={{ width: LABEL_WIDTH, height: rowHeight }}
+                  >
+                    <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
+                      {shortName(p.project)}
+                    </div>
+                    <div className="text-[9px] font-mono text-terminal-dimmer truncate">
+                      {p.sessions.length} session{p.sessions.length !== 1 ? "s" : ""}
+                      {p.hiddenInLanesCount > 0 && (
+                        <span className="text-terminal-orange/70">
+                          {" "}
+                          · +{p.hiddenInLanesCount} hidden
+                        </span>
+                      )}
+                    </div>
                   </div>
-                  <div className="text-[9px] font-mono text-terminal-dimmer truncate">
-                    {p.sessions.length} session{p.sessions.length !== 1 ? "s" : ""}
-                    {p.hiddenInLanesCount > 0 && (
-                      <span className="text-terminal-orange/70">
-                        {" "}
-                        · +{p.hiddenInLanesCount} hidden
-                      </span>
-                    )}
-                  </div>
-                </div>
 
-                {/* Lane area */}
-                <div
-                  className="relative flex-1 overflow-hidden bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
-                  style={{ height: rowHeight }}
-                >
-                  {/* Grid lines */}
-                  {ticks.map((t, i) => (
-                    <div
-                      key={i}
-                      className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
-                      style={{ left: `${t.leftPct}%` }}
-                    />
-                  ))}
-
-                  {/* Session blocks — variable height (importance), bottom-aligned within lane */}
-                  {p.sessions.map((ts) => {
-                    const automated = isAutomated(ts.session);
-                    // Adaptive lanes: each lane's row height = its tallest bar.
-                    // Bars are bottom-aligned within their lane.
-                    const laneTop = p.laneTopsPx[ts.lane];
-                    const laneH = p.laneHeightsPx[ts.lane];
-                    const top = laneTop + (laneH - ts.heightPx);
-                    const opacity = automated ? 0.4 : ts.opacity;
-                    // Multi-line label support: clamp to whatever number of
-                    // lines actually fits in the bar's height, so we use the
-                    // full vertical real estate without growing the bar.
-                    const lineClamp = Math.max(
-                      1,
-                      Math.floor((ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX),
-                    );
-                    // K-line "wick": when the bar is widened by min-width, mark
-                    // the actual session duration as a thin strip along the
-                    // bottom so true duration is still readable.
-                    const showWick = ts.realDurationFraction < 0.85;
-                    return (
+                  {/* Lane area */}
+                  <div
+                    className="relative flex-1 overflow-hidden bg-terminal-surface/20 group-hover:bg-terminal-surface/30 transition-colors"
+                    style={{ height: rowHeight }}
+                  >
+                    {/* Grid lines */}
+                    {ticks.map((t, i) => (
                       <div
-                        key={ts.session.sessionId}
-                        className={`absolute overflow-hidden rounded-sm cursor-pointer hover:brightness-125 hover:z-10 transition-all border ${color.border} border-opacity-50`}
-                        style={{
-                          left: `${ts.leftPct}%`,
-                          width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
-                          top,
-                          height: ts.heightPx,
-                          opacity,
-                          zIndex: Math.round(ts.score),
-                          backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
-                          ...(ts.showAccent
-                            ? {
-                                boxShadow: `inset 3px 0 0 ${accentColor}`,
-                              }
-                            : {}),
-                        }}
-                        onMouseEnter={(e) => {
-                          setTooltip({
-                            session: ts.session,
-                            x: e.clientX,
-                            y: e.clientY,
-                          });
-                        }}
-                        onMouseLeave={() => setTooltip(null)}
-                      >
-                        {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
-                          <div
-                            className={`relative h-full flex text-[10px] font-mono leading-tight ${color.text} pointer-events-none ${
-                              lineClamp === 1 ? "items-center" : "items-start pt-1"
-                            }`}
-                            style={{
-                              paddingLeft: ts.showAccent ? 7 : 4,
-                              paddingRight: 4,
-                              minWidth: 0,
-                            }}
-                          >
-                            <span
-                              className={
-                                lineClamp === 1
-                                  ? "block truncate min-w-0 flex-1"
-                                  : "block min-w-0 flex-1 overflow-hidden"
-                              }
-                              style={
-                                lineClamp === 1
-                                  ? undefined
-                                  : {
-                                      display: "-webkit-box",
-                                      WebkitBoxOrient: "vertical",
-                                      WebkitLineClamp: lineClamp,
-                                    }
-                              }
+                        key={i}
+                        className="absolute top-0 bottom-0 w-px bg-terminal-border/10"
+                        style={{ left: `${t.leftPct}%` }}
+                      />
+                    ))}
+
+                    {/* Session blocks — variable height (importance), bottom-aligned within lane */}
+                    {p.sessions.map((ts) => {
+                      const automated = isAutomated(ts.session);
+                      // Adaptive lanes: each lane's row height = its tallest bar.
+                      // Bars are bottom-aligned within their lane.
+                      const laneTop = p.laneTopsPx[ts.lane];
+                      const laneH = p.laneHeightsPx[ts.lane];
+                      const top = laneTop + (laneH - ts.heightPx);
+                      const opacity = automated ? 0.4 : ts.opacity;
+                      // Multi-line label support: clamp to whatever number of
+                      // lines actually fits in the bar's height, so we use the
+                      // full vertical real estate without growing the bar.
+                      const lineClamp = Math.max(
+                        1,
+                        Math.floor(
+                          (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
+                        ),
+                      );
+                      // K-line "wick": when the bar is widened by min-width, mark
+                      // the actual session duration as a thin strip along the
+                      // bottom so true duration is still readable.
+                      const showWick = ts.realDurationFraction < 0.85;
+                      return (
+                        <div
+                          key={ts.session.sessionId}
+                          className={`absolute overflow-hidden rounded-sm cursor-pointer hover:brightness-125 hover:z-10 transition-all border ${color.border} border-opacity-50`}
+                          style={{
+                            left: `${ts.leftPct}%`,
+                            width: `max(${ts.widthPct}%, ${ts.minWidthPx}px)`,
+                            top,
+                            height: ts.heightPx,
+                            opacity,
+                            zIndex: Math.round(ts.score),
+                            backgroundColor: hexToRgba(accentColor, ts.fillAlpha),
+                            ...(ts.showAccent
+                              ? {
+                                  boxShadow: `inset 3px 0 0 ${accentColor}`,
+                                }
+                              : {}),
+                          }}
+                          onMouseEnter={(e) => {
+                            setTooltip({
+                              session: ts.session,
+                              x: e.clientX,
+                              y: e.clientY,
+                            });
+                          }}
+                          onMouseLeave={() => setTooltip(null)}
+                        >
+                          {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
+                            <div
+                              className={`relative h-full flex text-[10px] font-mono leading-tight ${color.text} pointer-events-none ${
+                                lineClamp === 1 ? "items-center" : "items-start pt-1"
+                              }`}
+                              style={{
+                                paddingLeft: ts.showAccent ? 7 : 4,
+                                paddingRight: 4,
+                                minWidth: 0,
+                              }}
                             >
-                              {ts.session.title ?? ts.session.firstPrompt ?? ""}
-                            </span>
-                          </div>
-                        )}
-                        {showWick && (
-                          <>
-                            {/* K-line wick: bright strip along the bottom marks
+                              <span
+                                className={
+                                  lineClamp === 1
+                                    ? "block truncate min-w-0 flex-1"
+                                    : "block min-w-0 flex-1 overflow-hidden"
+                                }
+                                style={
+                                  lineClamp === 1
+                                    ? undefined
+                                    : {
+                                        display: "-webkit-box",
+                                        WebkitBoxOrient: "vertical",
+                                        WebkitLineClamp: lineClamp,
+                                      }
+                                }
+                              >
+                                {ts.session.title ?? ts.session.firstPrompt ?? ""}
+                              </span>
+                            </div>
+                          )}
+                          {showWick && (
+                            <>
+                              {/* K-line wick: bright strip along the bottom marks
                                 the actual session duration within the widened
                                 bar. Uses a near-white color so it contrasts
                                 against the bar's saturated fill. */}
-                            <div
-                              className="absolute bottom-0 left-0 pointer-events-none"
-                              style={{
-                                width: `${ts.realDurationFraction * 100}%`,
-                                height: 3,
-                                backgroundColor: "rgba(255, 255, 255, 0.85)",
-                              }}
-                              title="actual duration"
-                            />
-                            {/* End-of-real-time tick: a 2px-wide × 7px-tall mark
+                              <div
+                                className="absolute bottom-0 left-0 pointer-events-none"
+                                style={{
+                                  width: `${ts.realDurationFraction * 100}%`,
+                                  height: 3,
+                                  backgroundColor: "rgba(255, 255, 255, 0.85)",
+                                }}
+                                title="actual duration"
+                              />
+                              {/* End-of-real-time tick: a 2px-wide × 7px-tall mark
                                 at the wick's right edge so the end-position
                                 stays visible even when the wick itself is just
                                 a few pixels wide. */}
-                            <div
-                              className="absolute bottom-0 pointer-events-none"
-                              style={{
-                                left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
-                                width: 2,
-                                height: 7,
-                                backgroundColor: "rgba(255, 255, 255, 0.95)",
-                              }}
-                            />
-                          </>
-                        )}
-                      </div>
-                    );
-                  })}
+                              <div
+                                className="absolute bottom-0 pointer-events-none"
+                                style={{
+                                  left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
+                                  width: 2,
+                                  height: 7,
+                                  backgroundColor: "rgba(255, 255, 255, 0.95)",
+                                }}
+                              />
+                            </>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            );
-          })}
-        </>
+              );
+            })}
+          </div>
+        </div>
       )}
 
       {/* Tooltip */}
@@ -951,7 +957,7 @@ function buildDispatchTree(sessions: ScanResultSession[]): DispatchNode[] {
     const children: DispatchNode[] = [];
     for (const child of candidates) {
       if (usedIds.has(child.sessionId)) continue;
-      if (child.project !== parent.project) continue;
+      if (rollupProject(child.project) !== rollupProject(parent.project)) continue;
       const childStart = new Date(child.startTime!).getTime();
       const childEnd = child.endTime
         ? new Date(child.endTime).getTime()
@@ -1134,9 +1140,9 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
   const selected = selectedFile ? clusters.find((c) => c.file === selectedFile) : null;
 
   return (
-    <div className="flex gap-4 p-4 h-full">
+    <div className="flex h-full min-w-0 flex-col gap-4 p-4 md:flex-row">
       {/* File list */}
-      <div className="w-64 shrink-0 space-y-1 overflow-y-auto">
+      <div className="max-h-64 w-full shrink-0 space-y-1 overflow-y-auto md:max-h-none md:w-64">
         <div className="text-[10px] font-mono text-terminal-dimmer mb-2 px-2">
           {clusters.length} shared files
         </div>
@@ -1178,14 +1184,16 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
       </div>
 
       {/* Detail panel */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="min-w-0 flex-1 overflow-y-auto">
         {selected ? (
           <div className="space-y-3">
             <div>
-              <div className="text-sm font-mono text-terminal-text font-medium">
+              <div className="text-sm font-mono text-terminal-text font-medium truncate">
                 {selected.displayName.split("/").pop()}
               </div>
-              <div className="text-xs font-mono text-terminal-dimmer mt-0.5">{selected.file}</div>
+              <div className="text-xs font-mono text-terminal-dimmer mt-0.5 break-all">
+                {selected.file}
+              </div>
               <div className="text-xs font-mono text-terminal-dimmer mt-1">
                 {selected.sessions.length} sessions modified this file
               </div>
@@ -1198,10 +1206,10 @@ function FileConnectionsView({ groups }: { groups: ProjectGroup[] }) {
                 return (
                   <div
                     key={s.session.sessionId}
-                    className={`flex items-start gap-3 p-3 rounded-lg border ${color.bg} ${color.border}/40`}
+                    className={`flex flex-col gap-2 p-3 rounded-lg border sm:flex-row sm:items-start sm:gap-3 ${color.bg} ${color.border}/40`}
                   >
                     <div
-                      className="w-2 h-2 rounded-full mt-1.5 shrink-0"
+                      className="hidden w-2 h-2 rounded-full mt-1.5 shrink-0 sm:block"
                       style={{ backgroundColor: color.solid }}
                     />
                     <div className="flex-1 min-w-0">
@@ -1249,13 +1257,9 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
   const { sessions, loading, error } = useRelationshipData();
   const [activeView, setActiveView] = useState<RelView>("timeline");
 
-  const groups = useMemo(() => groupByProject(sessions), [sessions]);
-  // Timeline collapses worktree paths back to their parent repo so the lanes
-  // reflect "real" projects instead of being polluted by every worktree.
-  const timelineGroups = useMemo(
-    () => groupByProject(sessions, { collapseWorktrees: true }),
-    [sessions],
-  );
+  // Collapse agent worktrees back to the project the user recognizes. The
+  // session rows still expose the original path when it matters.
+  const groups = useMemo(() => groupByProject(sessions, { collapseWorktrees: true }), [sessions]);
 
   if (loading) {
     return (
@@ -1282,28 +1286,28 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
   }
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex-1 flex min-w-0 flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center gap-4 px-4 md:px-6 py-3 border-b border-terminal-border/40 shrink-0">
+      <div className="flex shrink-0 flex-col gap-3 border-b border-terminal-border/40 px-4 py-3 md:px-6 lg:flex-row lg:items-center">
         {onBack && (
           <button
             onClick={onBack}
-            className="text-terminal-dimmer hover:text-terminal-text text-xs font-mono transition-colors"
+            className="self-start text-terminal-dimmer hover:text-terminal-text text-xs font-mono transition-colors lg:shrink-0"
           >
             ← Projects
           </button>
         )}
-        <div className="flex-1">
+        <div className="min-w-0 flex-1">
           <h2 className="text-sm font-sans font-semibold text-terminal-text">
             Session Relationships
-            <span className="ml-2 text-terminal-dimmer font-normal text-xs font-mono">
+            <span className="block text-terminal-dimmer font-normal text-xs font-mono sm:ml-2 sm:inline">
               {sessions.length} sessions · {groups.length} projects
             </span>
           </h2>
         </div>
 
         {/* View tabs */}
-        <div className="flex items-center gap-1">
+        <div className="flex max-w-full items-center gap-1 overflow-x-auto pb-1 lg:shrink-0 lg:pb-0">
           {VIEW_TABS.map((tab) => (
             <button
               key={tab.id}
@@ -1323,7 +1327,7 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
       </div>
 
       {/* Stats bar */}
-      <div className="flex items-center gap-4 px-4 md:px-6 py-2 border-b border-terminal-border/20 text-[10px] font-mono text-terminal-dimmer shrink-0">
+      <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-terminal-border/20 px-4 py-2 text-[10px] font-mono text-terminal-dimmer md:px-6">
         <span>
           <span className="text-terminal-text">{sessions.length}</span> sessions
         </span>
@@ -1351,8 +1355,8 @@ export default function SessionRelationshipsView({ onBack }: SessionRelationship
       </div>
 
       {/* View content */}
-      <div className="flex-1 overflow-y-auto">
-        {activeView === "timeline" && <TimelineSwimlaneView groups={timelineGroups} />}
+      <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
+        {activeView === "timeline" && <TimelineSwimlaneView groups={groups} />}
         {activeView === "group" && <ProjectGroupingView groups={groups} />}
         {activeView === "tree" && <DispatchTreeView groups={groups} />}
         {activeView === "files" && <FileConnectionsView groups={groups} />}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -239,8 +239,11 @@ const MAX_LANES_PER_PROJECT = 5;
 const MIN_BAR_HEIGHT_PX = 8; // floor — low-score sessions are short ticks
 const MAX_BAR_HEIGHT_PX = 96; // cap — top-tier sessions tower at this height
 const LABEL_VISIBLE_MIN_HEIGHT_PX = 14; // below this, render bar without label
-const TWO_LINE_LABEL_MIN_HEIGHT_PX = 32;
-const THREE_LINE_LABEL_MIN_HEIGHT_PX = 60;
+// Line metrics for the dynamic line-clamp calculation. text-[10px] with
+// leading-tight resolves to ~12px line-height; we reserve 6px of vertical
+// padding inside the bar so a 14px bar still fits one line.
+const LABEL_LINE_HEIGHT_PX = 12;
+const LABEL_VERTICAL_PADDING_PX = 6;
 
 const MIN_BAR_MIN_WIDTH_PX = 6; // floor for low-importance sessions
 const MAX_BAR_MIN_WIDTH_PX = 160; // cap for the "important short session" widening
@@ -262,6 +265,13 @@ interface TimelineSession {
   fillAlpha: number; // 0-1 background alpha applied to color.solid
   showAccent: boolean;
   opacity: number;
+  /**
+   * Fraction of the rendered bar (0–1) that the *actual* session duration
+   * occupies. When < 1, the bar was widened by the min-width-by-importance
+   * floor; the remainder is visual padding. Drives the K-line "wick" strip
+   * along the bottom that recovers true-duration intuition.
+   */
+  realDurationFraction: number;
 }
 
 interface TimelineProject {
@@ -460,17 +470,24 @@ function buildTimeline(
       const rawRightPct = ((it.realEndMs - rangeStart) / rangeMs) * 100;
       const leftPct = Math.max(0, rawLeftPct);
       const widthPct = Math.max(0, rawRightPct - leftPct);
+      const minWidthPx = minWidthFor(it.score);
+      // Compare real-duration width vs. min-width-padded width to figure out
+      // how much of the rendered bar is actually "real time" vs. visual reach.
+      const realWidthPx = (widthPct / 100) * APPROX_TIMELINE_WIDTH_PX;
+      const visualWidthPx = Math.max(realWidthPx, minWidthPx);
+      const realDurationFraction = visualWidthPx > 0 ? Math.min(1, realWidthPx / visualWidthPx) : 1;
       tSessions.push({
         session: it.original,
         leftPct,
         widthPct,
         lane,
         score: it.score,
-        minWidthPx: minWidthFor(it.score),
+        minWidthPx,
         heightPx: heightFor(it.score),
         fillAlpha: fillAlphaFor(it.score),
         showAccent: it.score >= TOP_ACCENT_SCORE_THRESHOLD,
         opacity: opacityFor(it.score),
+        realDurationFraction,
       });
     }
 
@@ -710,14 +727,17 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                     const laneH = p.laneHeightsPx[ts.lane];
                     const top = laneTop + (laneH - ts.heightPx);
                     const opacity = automated ? 0.4 : ts.opacity;
-                    // Multi-line label support: tall bars allow 2 or 3 lines so
-                    // the extra real estate actually carries information.
-                    const lineClamp =
-                      ts.heightPx >= THREE_LINE_LABEL_MIN_HEIGHT_PX
-                        ? 3
-                        : ts.heightPx >= TWO_LINE_LABEL_MIN_HEIGHT_PX
-                          ? 2
-                          : 1;
+                    // Multi-line label support: clamp to whatever number of
+                    // lines actually fits in the bar's height, so we use the
+                    // full vertical real estate without growing the bar.
+                    const lineClamp = Math.max(
+                      1,
+                      Math.floor((ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX),
+                    );
+                    // K-line "wick": when the bar is widened by min-width, mark
+                    // the actual session duration as a thin strip along the
+                    // bottom so true duration is still readable.
+                    const showWick = ts.realDurationFraction < 0.85;
                     return (
                       <div
                         key={ts.session.sessionId}
@@ -775,6 +795,36 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                               {ts.session.title ?? ts.session.firstPrompt ?? ""}
                             </span>
                           </div>
+                        )}
+                        {showWick && (
+                          <>
+                            {/* K-line wick: bright strip along the bottom marks
+                                the actual session duration within the widened
+                                bar. Uses a near-white color so it contrasts
+                                against the bar's saturated fill. */}
+                            <div
+                              className="absolute bottom-0 left-0 pointer-events-none"
+                              style={{
+                                width: `${ts.realDurationFraction * 100}%`,
+                                height: 3,
+                                backgroundColor: "rgba(255, 255, 255, 0.85)",
+                              }}
+                              title="actual duration"
+                            />
+                            {/* End-of-real-time tick: a 2px-wide × 7px-tall mark
+                                at the wick's right edge so the end-position
+                                stays visible even when the wick itself is just
+                                a few pixels wide. */}
+                            <div
+                              className="absolute bottom-0 pointer-events-none"
+                              style={{
+                                left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
+                                width: 2,
+                                height: 7,
+                                backgroundColor: "rgba(255, 255, 255, 0.95)",
+                              }}
+                            />
+                          </>
                         )}
                       </div>
                     );

--- a/packages/viewer/src/hooks/useRelationshipData.ts
+++ b/packages/viewer/src/hooks/useRelationshipData.ts
@@ -1,30 +1,14 @@
 /**
  * Hook that fetches per-session scan results for relationship visualizations.
- * Uses /api/scan/results to get SessionScanResult[] with startTime, endTime,
- * filesModified, etc. — data not available in the aggregated InsightsPanel context.
+ * Uses /api/scan/results which returns SessionScanResult shape (defined in
+ * packages/cli/src/scanner.ts) — the wire-format subset is canonicalized as
+ * SessionScanWireData in @vibe-replay/types.
  */
 
+import type { SessionScanWireData } from "@vibe-replay/types";
 import { useEffect, useState } from "react";
 
-export interface ScanResultSession {
-  sessionId: string;
-  provider: string;
-  project: string;
-  slug: string;
-  title?: string;
-  firstPrompt?: string;
-  startTime?: string;
-  endTime?: string;
-  durationMs?: number;
-  gitBranch?: string;
-  model?: string;
-  promptCount: number;
-  toolCallCount: number;
-  editCount: number;
-  filesModified: Array<{ file: string; count: number }>;
-  costEstimate?: number;
-  subAgentCount: number;
-}
+export type ScanResultSession = SessionScanWireData;
 
 export interface RelationshipData {
   sessions: ScanResultSession[];

--- a/packages/viewer/src/hooks/useRelationshipData.ts
+++ b/packages/viewer/src/hooks/useRelationshipData.ts
@@ -16,10 +16,13 @@ export interface RelationshipData {
   error: string | null;
 }
 
+let cachedSessions: ScanResultSession[] | null = null;
+let cachedError: string | null = null;
+
 export function useRelationshipData(): RelationshipData {
-  const [sessions, setSessions] = useState<ScanResultSession[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [sessions, setSessions] = useState<ScanResultSession[]>(cachedSessions ?? []);
+  const [loading, setLoading] = useState(cachedSessions === null && cachedError === null);
+  const [error, setError] = useState<string | null>(cachedError);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,13 +32,16 @@ export function useRelationshipData(): RelationshipData {
         const resp = await fetch("/api/scan/results");
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = (await resp.json()) as { results: ScanResultSession[] };
+        cachedSessions = data.results ?? [];
+        cachedError = null;
         if (!cancelled) {
-          setSessions(data.results ?? []);
+          setSessions(cachedSessions);
           setError(null);
         }
       } catch (e) {
+        cachedError = e instanceof Error ? e.message : "Failed to load";
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : "Failed to load");
+          setError(cachedError);
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/packages/viewer/src/hooks/useRelationshipData.ts
+++ b/packages/viewer/src/hooks/useRelationshipData.ts
@@ -1,0 +1,68 @@
+/**
+ * Hook that fetches per-session scan results for relationship visualizations.
+ * Uses /api/scan/results to get SessionScanResult[] with startTime, endTime,
+ * filesModified, etc. — data not available in the aggregated InsightsPanel context.
+ */
+
+import { useEffect, useState } from "react";
+
+export interface ScanResultSession {
+  sessionId: string;
+  provider: string;
+  project: string;
+  slug: string;
+  title?: string;
+  firstPrompt?: string;
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+  gitBranch?: string;
+  model?: string;
+  promptCount: number;
+  toolCallCount: number;
+  editCount: number;
+  filesModified: Array<{ file: string; count: number }>;
+  costEstimate?: number;
+  subAgentCount: number;
+}
+
+export interface RelationshipData {
+  sessions: ScanResultSession[];
+  loading: boolean;
+  error: string | null;
+}
+
+export function useRelationshipData(): RelationshipData {
+  const [sessions, setSessions] = useState<ScanResultSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const resp = await fetch("/api/scan/results");
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data = (await resp.json()) as { results: ScanResultSession[] };
+        if (!cancelled) {
+          setSessions(data.results ?? []);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to load");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { sessions, loading, error };
+}

--- a/packages/viewer/src/hooks/useRelationshipData.ts
+++ b/packages/viewer/src/hooks/useRelationshipData.ts
@@ -30,7 +30,10 @@ const REFRESH_WHILE_SCANNING_MS = 4000;
 export function useRelationshipData(): RelationshipData {
   const [sessions, setSessions] = useState<ScanResultSession[]>(cachedSessions ?? []);
   const [loading, setLoading] = useState(cachedSessions === null && cachedError === null);
-  const [error, setError] = useState<string | null>(cachedError);
+  // Only restore an error state if we have no cached data to fall back on —
+  // otherwise a stale cachedError from a previous transient failure would
+  // render the error screen over still-usable sessions.
+  const [error, setError] = useState<string | null>(cachedSessions === null ? cachedError : null);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,29 +63,30 @@ export function useRelationshipData(): RelationshipData {
     }
 
     async function tick() {
+      let stillRunning = false;
       try {
         const status = await loadStatus();
-        const stillRunning = status?.running === true;
+        stillRunning = status?.running === true;
         const remoteCount = status?.resultCount ?? 0;
-        // Refetch results when we have nothing yet, when the scan reports more
-        // sessions than we last saw, or unconditionally on the first pass.
+        // Refetch results when we have nothing yet or the count diverges.
         if (cachedSessions === null || remoteCount !== cachedResultCount) {
           await loadResults();
-        }
-        if (stillRunning && !cancelled) {
-          pollTimer = setTimeout(tick, REFRESH_WHILE_SCANNING_MS);
         }
       } catch (e) {
         const message = e instanceof Error ? e.message : "Failed to load";
         cachedError = message;
-        if (!cancelled) {
-          // Surface the error only when there's no cached data to fall back
-          // on. Transient network/API failures shouldn't blank a Timeline that
-          // already loaded successfully — leave the prior data visible.
-          if (cachedSessions === null) setError(message);
+        if (!cancelled && cachedSessions === null) {
+          // Only blank the view if there's no cached data. A transient
+          // refresh failure should leave the prior data on screen.
+          setError(message);
         }
       } finally {
         if (!cancelled) setLoading(false);
+        // Keep polling while the scan is running, even if this tick errored —
+        // a single transient 5xx shouldn't stop the live updates permanently.
+        if (!cancelled && stillRunning) {
+          pollTimer = setTimeout(tick, REFRESH_WHILE_SCANNING_MS);
+        }
       }
     }
 

--- a/packages/viewer/src/hooks/useRelationshipData.ts
+++ b/packages/viewer/src/hooks/useRelationshipData.ts
@@ -16,8 +16,16 @@ export interface RelationshipData {
   error: string | null;
 }
 
+interface ScanStatus {
+  running?: boolean;
+  resultCount?: number;
+}
+
 let cachedSessions: ScanResultSession[] | null = null;
 let cachedError: string | null = null;
+let cachedResultCount = 0;
+
+const REFRESH_WHILE_SCANNING_MS = 4000;
 
 export function useRelationshipData(): RelationshipData {
   const [sessions, setSessions] = useState<ScanResultSession[]>(cachedSessions ?? []);
@@ -26,31 +34,62 @@ export function useRelationshipData(): RelationshipData {
 
   useEffect(() => {
     let cancelled = false;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-    async function load() {
+    async function loadResults() {
+      const resp = await fetch("/api/scan/results");
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = (await resp.json()) as { results: ScanResultSession[] };
+      cachedSessions = data.results ?? [];
+      cachedResultCount = cachedSessions.length;
+      cachedError = null;
+      if (!cancelled) {
+        setSessions(cachedSessions);
+        setError(null);
+      }
+    }
+
+    async function loadStatus(): Promise<ScanStatus | null> {
       try {
-        const resp = await fetch("/api/scan/results");
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        const data = (await resp.json()) as { results: ScanResultSession[] };
-        cachedSessions = data.results ?? [];
-        cachedError = null;
-        if (!cancelled) {
-          setSessions(cachedSessions);
-          setError(null);
+        const resp = await fetch("/api/scan/status");
+        if (!resp.ok) return null;
+        return (await resp.json()) as ScanStatus;
+      } catch {
+        return null;
+      }
+    }
+
+    async function tick() {
+      try {
+        const status = await loadStatus();
+        const stillRunning = status?.running === true;
+        const remoteCount = status?.resultCount ?? 0;
+        // Refetch results when we have nothing yet, when the scan reports more
+        // sessions than we last saw, or unconditionally on the first pass.
+        if (cachedSessions === null || remoteCount !== cachedResultCount) {
+          await loadResults();
+        }
+        if (stillRunning && !cancelled) {
+          pollTimer = setTimeout(tick, REFRESH_WHILE_SCANNING_MS);
         }
       } catch (e) {
-        cachedError = e instanceof Error ? e.message : "Failed to load";
+        const message = e instanceof Error ? e.message : "Failed to load";
+        cachedError = message;
         if (!cancelled) {
-          setError(cachedError);
+          // Surface the error only when there's no cached data to fall back
+          // on. Transient network/API failures shouldn't blank a Timeline that
+          // already loaded successfully — leave the prior data visible.
+          if (cachedSessions === null) setError(message);
         }
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
 
-    load();
+    tick();
     return () => {
       cancelled = true;
+      if (pollTimer) clearTimeout(pollTimer);
     };
   }, []);
 

--- a/packages/viewer/src/utils/format.ts
+++ b/packages/viewer/src/utils/format.ts
@@ -1,3 +1,36 @@
+/**
+ * Shared display-formatting helpers used across panels.
+ */
+
+/** Last path segment of a project path (e.g. "/Users/x/Code/foo" → "foo"). */
+export function shortName(project: string): string {
+  return project.split("/").pop() || project;
+}
+
+/**
+ * Compact relative time. Pass `format: "long"` for ProjectsPanel-style suffixes
+ * ("just now", "5m ago"), or omit for SessionRelationshipsView-style ("now", "5m").
+ */
+export function timeAgo(iso?: string, format: "short" | "long" = "short"): string {
+  if (!iso) return "";
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (format === "long") {
+    if (mins < 1) return "just now";
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return `${Math.floor(days / 30)}mo ago`;
+  }
+  if (mins < 1) return "now";
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
 // For the single-session replay view (StatsPanel, SummaryView). The dashboard
 // uses a separate, context-aware formatter in dashboard-utils.ts that takes
 // hasSqlite into account — keep both in sync when adding new source types.

--- a/packages/viewer/src/utils/format.ts
+++ b/packages/viewer/src/utils/format.ts
@@ -7,6 +7,11 @@ export function shortName(project: string): string {
   return project.split("/").pop() || project;
 }
 
+/** Returns `singular` for count === 1, otherwise `pluralForm` (defaults to `${singular}s`). */
+export function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
 /**
  * Compact relative time. Pass `format: "long"` for ProjectsPanel-style suffixes
  * ("just now", "5m ago"), or omit for SessionRelationshipsView-style ("now", "5m").

--- a/packages/viewer/src/utils/sessionSignals.ts
+++ b/packages/viewer/src/utils/sessionSignals.ts
@@ -43,13 +43,3 @@ export function isAutomated(s: SessionScanWireData): boolean {
   }
   return false;
 }
-
-/**
- * Collapse worktree paths back to their parent repo so all worktree sessions
- * land in the same project lane. Anything matching `<repo>/.claude/worktrees/...`
- * folds to `<repo>`. Other paths pass through unchanged.
- */
-export function collapseWorktree(project: string): string {
-  const match = project.match(/^(.+?)\/\.claude\/worktrees\//);
-  return match ? match[1] : project;
-}

--- a/packages/viewer/src/utils/sessionSignals.ts
+++ b/packages/viewer/src/utils/sessionSignals.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for surfacing session importance and provenance in visualizations.
+ * Used by SessionRelationshipsView to make significant work pop and to
+ * separate user-driven sessions from automated/scheduled noise.
+ */
+
+import type { SessionScanWireData } from "@vibe-replay/types";
+
+/**
+ * Importance score in [0, 100]. Combines durable signals (PR links, edits,
+ * sub-agents) with usage signals (turns, tool calls). Penalises automated runs.
+ *
+ * The exact constants are tuned by inspection — bump factors for signals you
+ * want to surface more.
+ */
+export function sessionScore(s: SessionScanWireData): number {
+  const turns = Math.log2(s.promptCount + 1);
+  const tools = Math.log2(s.toolCallCount + 1) * 0.4;
+  const edits = Math.min(8, Math.log2(s.editCount + 1));
+  const files = Math.min(4, Math.log2((s.filesModified?.length ?? 0) + 1));
+  const subAgents = s.subAgentCount > 0 ? 3 : 0;
+  const hasPR = (s.prLinks?.length ?? 0) > 0 ? 8 : 0;
+  const longRun = s.durationMs && s.durationMs > 30 * 60 * 1000 ? 4 : 0;
+  const automatedPenalty = isAutomated(s) ? -10 : 0;
+
+  const raw = turns + tools + edits + files + subAgents + hasPR + longRun + automatedPenalty;
+  // Map roughly into 0-100 range; clamp.
+  return Math.max(0, Math.min(100, raw * 4));
+}
+
+/**
+ * A session is "automated" when it was kicked off by a scheduler / background
+ * job rather than by an interactive prompt. Three signals catch ~all of them:
+ *   - Cowork "scheduled task" preamble in the first prompt
+ *   - Claude Desktop entrypoint (Cowork orchestrator)
+ *   - claude-cowork provider with a scheduled-style preamble
+ */
+export function isAutomated(s: SessionScanWireData): boolean {
+  const first = s.firstPrompt ?? "";
+  if (/^This is an automated run of a scheduled task/i.test(first)) return true;
+  if (s.entrypoint === "claude-desktop" && /scheduled|automated/i.test(first.slice(0, 200))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Collapse worktree paths back to their parent repo so all worktree sessions
+ * land in the same project lane. Anything matching `<repo>/.claude/worktrees/...`
+ * folds to `<repo>`. Other paths pass through unchanged.
+ */
+export function collapseWorktree(project: string): string {
+  const match = project.match(/^(.+?)\/\.claude\/worktrees\//);
+  return match ? match[1] : project;
+}


### PR DESCRIPTION
## Summary

Turns the Projects tab into a first-class Work Map for reviewing and continuing AI work history, with the old visualization hub collapsed into three top-level project views.

- Adds `List`, `Timeline`, and `Hot Files` views directly on the Projects page; removes the separate Visualize / Groups / Dispatch IA.
- Restores the Timeline's useful session encoding: adaptive height, readable min-width for important short sessions, and a true-duration wick/tick marker, while keeping the softer product surface styling.
- Improves Cursor-heavy compatibility with scan result data-source badges, estimated-time indicators, cleaned session titles, cached relationship data, friendlier project labels, and hot files from high-edit single Cursor sessions.
- Keeps project rollups for agent worktrees and aligns the UI with the viewer/site visual language using softer surfaces, gradients, shadows, and lower-contrast chart scaffolding.

## Test plan

- [x] `pnpm typecheck`
- [x] Edited files: `oxlint` + `oxfmt --check`
- [x] `pnpm --filter @vibe-replay/viewer test -- --run`
- [x] `pnpm build`
- [x] `pnpm test:e2e`
- [x] Browser-verified Projects `List`, `Timeline`, and `Hot Files` on a Cursor-heavy local scan
- [x] Browser-verified Timeline adaptive heights, adaptive widths, and true-duration wick/tick markers
- [x] Browser-verified Top Sessions / Hot Files session clicks open `?session=...`