### PR TITLE
feat(viewer): roll up Claude agent worktrees under parent project

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1267,15 +1267,19 @@ function SessionsPanel() {
   const { scanStatus, userInsights, projectInsightsCache, fetchProjectInsights } =
     useScanInsightsContext();
 
+  // Roll worktree paths up to the parent project so URL navigation to a
+  // (possibly cleaned-up) worktree path still hits the parent's data.
+  const selectedProjectKey = rollupProject(selectedProject);
+
   // Fetch project insights when selected project changes
   useEffect(() => {
-    if (selectedProject !== ALL_PROJECTS) {
-      fetchProjectInsights(selectedProject);
+    if (selectedProjectKey !== ALL_PROJECTS) {
+      fetchProjectInsights(selectedProjectKey);
     }
-  }, [selectedProject, fetchProjectInsights]);
+  }, [selectedProjectKey, fetchProjectInsights]);
 
   const projectInsights =
-    selectedProject !== ALL_PROJECTS ? projectInsightsCache.get(selectedProject) : undefined;
+    selectedProjectKey !== ALL_PROJECTS ? projectInsightsCache.get(selectedProjectKey) : undefined;
 
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
   const [generateError, setGenerateError] = useState<string | null>(null);
@@ -1484,14 +1488,21 @@ function SessionsPanel() {
 
   // Group by project, rolling up auto-created Claude agent worktrees under
   // their parent project so the sidebar isn't drowned by sandbox dirs.
+  // Track distinct worktree paths (not session count) per parent so the
+  // `+N wt` badge reads as "N sandboxes" rather than "N sessions".
   const byProject = new Map<string, SourceSession[]>();
-  const worktreeCountByProject = new Map<string, number>();
+  const worktreePathsByProject = new Map<string, Set<string>>();
   for (const s of visibleSources) {
     const key = rollupProject(s.project);
     if (!byProject.has(key)) byProject.set(key, []);
     byProject.get(key)?.push(s);
     if (key !== s.project) {
-      worktreeCountByProject.set(key, (worktreeCountByProject.get(key) || 0) + 1);
+      let paths = worktreePathsByProject.get(key);
+      if (!paths) {
+        paths = new Set();
+        worktreePathsByProject.set(key, paths);
+      }
+      paths.add(s.project);
     }
   }
   const projectEntries = [...byProject.entries()].sort((a, b) => {
@@ -1504,10 +1515,9 @@ function SessionsPanel() {
   const projectLabels = computeProjectLabels(projectEntries.map(([p]) => p));
 
   // Filter sessions within selected project. Tolerate URLs pointing at a
-  // worktree path by rolling that up to its parent before lookup.
-  const selectedProjectKey = rollupProject(selectedProject);
+  // worktree path — `selectedProjectKey` is already rolled up above.
   const projectSessions =
-    selectedProject === ALL_PROJECTS ? visibleSources : byProject.get(selectedProjectKey) || [];
+    selectedProjectKey === ALL_PROJECTS ? visibleSources : byProject.get(selectedProjectKey) || [];
 
   const filtered = filter
     ? projectSessions.filter(
@@ -1626,7 +1636,7 @@ function SessionsPanel() {
           {/* Per-project items */}
           {projectEntries.map(([project, sessions]) => {
             const replayCount = sessions.filter((s) => s.existingReplay).length;
-            const worktreeCount = worktreeCountByProject.get(project) || 0;
+            const worktreeCount = worktreePathsByProject.get(project)?.size ?? 0;
             const isActive = selectedProjectKey === project;
             const label = projectLabels.get(project) || projectName(project);
             // After worktree rollup, sessions[0] may be from a deleted worktree;
@@ -1696,7 +1706,7 @@ function SessionsPanel() {
                   {worktreeCount > 0 && (
                     <span
                       className={`text-xs font-mono ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
-                      title={`${worktreeCount} agent worktree session${worktreeCount === 1 ? "" : "s"} merged in`}
+                      title={`${worktreeCount} agent worktree${worktreeCount === 1 ? "" : "s"} merged in (sandboxes Claude opened against this project)`}
                     >
                       +{worktreeCount} wt
                     </span>
@@ -2154,15 +2164,19 @@ function ReplaysPanel() {
   // Background scan + insights (shared singleton context)
   const { userInsights, projectInsightsCache, fetchProjectInsights } = useScanInsightsContext();
 
+  // Roll worktree paths up to the parent project so URL navigation to a
+  // (possibly cleaned-up) worktree path still hits the parent's data.
+  const selectedProjectKey = rollupProject(selectedProject);
+
   // Fetch project insights when selected project changes
   useEffect(() => {
-    if (selectedProject !== ALL_PROJECTS) {
-      fetchProjectInsights(selectedProject);
+    if (selectedProjectKey !== ALL_PROJECTS) {
+      fetchProjectInsights(selectedProjectKey);
     }
-  }, [selectedProject, fetchProjectInsights]);
+  }, [selectedProjectKey, fetchProjectInsights]);
 
   const projectInsights =
-    selectedProject !== ALL_PROJECTS ? projectInsightsCache.get(selectedProject) : undefined;
+    selectedProjectKey !== ALL_PROJECTS ? projectInsightsCache.get(selectedProjectKey) : undefined;
 
   useEffect(() => {
     let mounted = true;
@@ -2303,14 +2317,20 @@ function ReplaysPanel() {
     : sessions.filter((s) => !archivedSlugs.has(s.slug));
 
   // Group by project, rolling up Claude agent worktrees under their parent.
+  // Count distinct worktree paths so `+N wt` reads as "N sandboxes".
   const byProject = new Map<string, SessionSummary[]>();
-  const worktreeCountByProject = new Map<string, number>();
+  const worktreePathsByProject = new Map<string, Set<string>>();
   for (const s of visibleSessions) {
     const key = rollupProject(s.project);
     if (!byProject.has(key)) byProject.set(key, []);
     byProject.get(key)?.push(s);
     if (key !== s.project) {
-      worktreeCountByProject.set(key, (worktreeCountByProject.get(key) || 0) + 1);
+      let paths = worktreePathsByProject.get(key);
+      if (!paths) {
+        paths = new Set();
+        worktreePathsByProject.set(key, paths);
+      }
+      paths.add(s.project);
     }
   }
   const projectEntries = [...byProject.entries()].sort((a, b) => {
@@ -2321,10 +2341,9 @@ function ReplaysPanel() {
 
   const projectLabels = computeProjectLabels(projectEntries.map(([p]) => p));
 
-  // Filter within selected project (tolerate worktree URLs by rolling up).
-  const selectedProjectKey = rollupProject(selectedProject);
+  // Filter within selected project — `selectedProjectKey` is already rolled up.
   const projectSessions =
-    selectedProject === ALL_PROJECTS ? visibleSessions : byProject.get(selectedProjectKey) || [];
+    selectedProjectKey === ALL_PROJECTS ? visibleSessions : byProject.get(selectedProjectKey) || [];
 
   const filtered = filter
     ? projectSessions.filter(
@@ -2411,7 +2430,7 @@ function ReplaysPanel() {
             const isActive = selectedProjectKey === project;
             const label = projectLabels.get(project) || projectName(project);
             const publishedCount = replays.filter((s) => s.gist?.gistId).length;
-            const worktreeCount = worktreeCountByProject.get(project) || 0;
+            const worktreeCount = worktreePathsByProject.get(project)?.size ?? 0;
             return (
               <button
                 key={project}
@@ -2459,7 +2478,7 @@ function ReplaysPanel() {
                   {worktreeCount > 0 && (
                     <span
                       className={`text-xs font-mono ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
-                      title={`${worktreeCount} agent worktree replay${worktreeCount === 1 ? "" : "s"} merged in`}
+                      title={`${worktreeCount} agent worktree${worktreeCount === 1 ? "" : "s"} merged in (sandboxes Claude opened against this project)`}
                     >
                       +{worktreeCount} wt
                     </span>

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ALL_PROJECTS, usePanelFilters } from "../hooks/usePanelFilters";
 import type { SessionSummary, SourceSession } from "../types";
 import DashboardHome from "./DashboardHome";
 import {
+  agentWorktreeParent,
   cleanPrompt,
   computeProjectLabels,
   formatCacheAge,
@@ -21,6 +22,7 @@ import {
   providerBadgeClass,
   providerBadgeLabel,
   replaySuggestedTitle,
+  rollupProject,
   type SourcesEnrichmentStatus,
   shortModelName,
   sourceDisplayTitle,
@@ -1480,11 +1482,17 @@ function SessionsPanel() {
   const archivedCount = sources.filter((s) => archivedSlugs.has(s.slug)).length;
   const visibleSources = showArchived ? sources : sources.filter((s) => !archivedSlugs.has(s.slug));
 
-  // Group by project, sorted by most recent timestamp
+  // Group by project, rolling up auto-created Claude agent worktrees under
+  // their parent project so the sidebar isn't drowned by sandbox dirs.
   const byProject = new Map<string, SourceSession[]>();
+  const worktreeCountByProject = new Map<string, number>();
   for (const s of visibleSources) {
-    if (!byProject.has(s.project)) byProject.set(s.project, []);
-    byProject.get(s.project)?.push(s);
+    const key = rollupProject(s.project);
+    if (!byProject.has(key)) byProject.set(key, []);
+    byProject.get(key)?.push(s);
+    if (key !== s.project) {
+      worktreeCountByProject.set(key, (worktreeCountByProject.get(key) || 0) + 1);
+    }
   }
   const projectEntries = [...byProject.entries()].sort((a, b) => {
     const aTime = a[1][0]?.timestamp || "";
@@ -1495,9 +1503,11 @@ function SessionsPanel() {
   // Compute disambiguated labels for projects
   const projectLabels = computeProjectLabels(projectEntries.map(([p]) => p));
 
-  // Filter sessions within selected project
+  // Filter sessions within selected project. Tolerate URLs pointing at a
+  // worktree path by rolling that up to its parent before lookup.
+  const selectedProjectKey = rollupProject(selectedProject);
   const projectSessions =
-    selectedProject === ALL_PROJECTS ? visibleSources : byProject.get(selectedProject) || [];
+    selectedProject === ALL_PROJECTS ? visibleSources : byProject.get(selectedProjectKey) || [];
 
   const filtered = filter
     ? projectSessions.filter(
@@ -1616,9 +1626,12 @@ function SessionsPanel() {
           {/* Per-project items */}
           {projectEntries.map(([project, sessions]) => {
             const replayCount = sessions.filter((s) => s.existingReplay).length;
-            const isActive = selectedProject === project;
+            const worktreeCount = worktreeCountByProject.get(project) || 0;
+            const isActive = selectedProjectKey === project;
             const label = projectLabels.get(project) || projectName(project);
-            const exists = sessions[0]?.projectExists !== false;
+            // After worktree rollup, sessions[0] may be from a deleted worktree;
+            // treat the parent as existing if any session reports it exists.
+            const exists = sessions.some((s) => s.projectExists !== false);
             const isGit = sessions.some((s) => s.isGitRepo || s.gitBranch);
             return (
               <button
@@ -1678,6 +1691,14 @@ function SessionsPanel() {
                       className={`text-xs font-mono ${isActive ? "text-terminal-green" : "text-terminal-dimmer"}`}
                     >
                       {replayCount} {replayCount === 1 ? "replay" : "replays"}
+                    </span>
+                  )}
+                  {worktreeCount > 0 && (
+                    <span
+                      className={`text-xs font-mono ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
+                      title={`${worktreeCount} agent worktree session${worktreeCount === 1 ? "" : "s"} merged in`}
+                    >
+                      +{worktreeCount} wt
                     </span>
                   )}
                 </div>
@@ -1887,6 +1908,7 @@ function SessionsPanel() {
                 const sessionTitle = sourceDisplayTitle(s, scanData);
                 const prompts = sessionPromptPreview(s, scanData, sessionTitle);
                 const branch = nonDefaultBranch(scanData?.gitBranch || s.gitBranch);
+                const isWorktree = agentWorktreeParent(s.project) !== null;
                 const displayPromptCount = scanData?.promptCount ?? s.promptCount;
                 const displayToolCount = scanData?.toolCallCount ?? s.toolCallCount;
                 const displayDurationMs = scanData?.durationMs ?? s.durationMsEst;
@@ -1925,6 +1947,14 @@ function SessionsPanel() {
                                 <path d="M5 6v4c0 1.1.9 2 2 2h2" />
                               </svg>
                               {branch}
+                            </span>
+                          )}
+                          {isWorktree && (
+                            <span
+                              className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple shrink-0 uppercase tracking-wider"
+                              title={`Claude agent worktree: ${s.project}`}
+                            >
+                              worktree
                             </span>
                           )}
                         </div>
@@ -2272,11 +2302,16 @@ function ReplaysPanel() {
     ? sessions
     : sessions.filter((s) => !archivedSlugs.has(s.slug));
 
-  // Group by project, sorted by most recent
+  // Group by project, rolling up Claude agent worktrees under their parent.
   const byProject = new Map<string, SessionSummary[]>();
+  const worktreeCountByProject = new Map<string, number>();
   for (const s of visibleSessions) {
-    if (!byProject.has(s.project)) byProject.set(s.project, []);
-    byProject.get(s.project)?.push(s);
+    const key = rollupProject(s.project);
+    if (!byProject.has(key)) byProject.set(key, []);
+    byProject.get(key)?.push(s);
+    if (key !== s.project) {
+      worktreeCountByProject.set(key, (worktreeCountByProject.get(key) || 0) + 1);
+    }
   }
   const projectEntries = [...byProject.entries()].sort((a, b) => {
     const aTime = a[1][0]?.startTime || "";
@@ -2286,9 +2321,10 @@ function ReplaysPanel() {
 
   const projectLabels = computeProjectLabels(projectEntries.map(([p]) => p));
 
-  // Filter within selected project
+  // Filter within selected project (tolerate worktree URLs by rolling up).
+  const selectedProjectKey = rollupProject(selectedProject);
   const projectSessions =
-    selectedProject === ALL_PROJECTS ? visibleSessions : byProject.get(selectedProject) || [];
+    selectedProject === ALL_PROJECTS ? visibleSessions : byProject.get(selectedProjectKey) || [];
 
   const filtered = filter
     ? projectSessions.filter(
@@ -2372,9 +2408,10 @@ function ReplaysPanel() {
 
           {/* Per-project items */}
           {projectEntries.map(([project, replays]) => {
-            const isActive = selectedProject === project;
+            const isActive = selectedProjectKey === project;
             const label = projectLabels.get(project) || projectName(project);
             const publishedCount = replays.filter((s) => s.gist?.gistId).length;
+            const worktreeCount = worktreeCountByProject.get(project) || 0;
             return (
               <button
                 key={project}
@@ -2417,6 +2454,14 @@ function ReplaysPanel() {
                       className={`text-xs font-mono ${isActive ? "text-terminal-purple" : "text-terminal-dimmer"}`}
                     >
                       {publishedCount} published
+                    </span>
+                  )}
+                  {worktreeCount > 0 && (
+                    <span
+                      className={`text-xs font-mono ${isActive ? "text-terminal-dim" : "text-terminal-dimmer"}`}
+                      title={`${worktreeCount} agent worktree replay${worktreeCount === 1 ? "" : "s"} merged in`}
+                    >
+                      +{worktreeCount} wt
                     </span>
                   )}
                 </div>

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { agentWorktreeParent, rollupProject } from "../dashboard-utils";
+
+describe("agentWorktreeParent", () => {
+  it("returns the parent project for a Claude agent worktree path", () => {
+    expect(
+      agentWorktreeParent("~/Code/vibe-replay/.claude/worktrees/affectionate-darwin-968d37"),
+    ).toBe("~/Code/vibe-replay");
+    expect(
+      agentWorktreeParent("/Users/tuo/Code/vibe-replay2/.claude/worktrees/xenodochial-swartz-20"),
+    ).toBe("/Users/tuo/Code/vibe-replay2");
+  });
+
+  it("strips a trailing slash before matching", () => {
+    expect(
+      agentWorktreeParent("~/Code/vibe-replay/.claude/worktrees/affectionate-darwin-968d37/"),
+    ).toBe("~/Code/vibe-replay");
+  });
+
+  it("matches paths nested inside a worktree (resolves to outermost parent)", () => {
+    expect(
+      agentWorktreeParent(
+        "~/Code/vibe-replay/.claude/worktrees/affectionate-darwin-968d37/packages/cli",
+      ),
+    ).toBe("~/Code/vibe-replay");
+  });
+
+  it("returns null for non-worktree project paths", () => {
+    expect(agentWorktreeParent("~/Code/vibe-replay")).toBeNull();
+    expect(agentWorktreeParent("~/.claude")).toBeNull();
+    expect(agentWorktreeParent("Cowork")).toBeNull();
+    expect(agentWorktreeParent("")).toBeNull();
+  });
+
+  it("does not match when the worktree segment is missing a name", () => {
+    expect(agentWorktreeParent("~/Code/vibe-replay/.claude/worktrees/")).toBeNull();
+    expect(agentWorktreeParent("~/Code/vibe-replay/.claude/worktrees")).toBeNull();
+  });
+
+  it("does not match a path that merely contains the substring without the dot prefix", () => {
+    // `claude/worktrees` (no leading dot) is not the convention Claude Code uses
+    expect(agentWorktreeParent("~/Code/repo/claude/worktrees/foo")).toBeNull();
+  });
+});
+
+describe("rollupProject", () => {
+  it("rolls up worktree paths to the parent project", () => {
+    expect(rollupProject("~/Code/vibe-replay/.claude/worktrees/affectionate-darwin-968d37")).toBe(
+      "~/Code/vibe-replay",
+    );
+  });
+
+  it("passes through non-worktree paths unchanged", () => {
+    expect(rollupProject("~/Code/vibe-replay")).toBe("~/Code/vibe-replay");
+    expect(rollupProject("__all__")).toBe("__all__");
+    expect(rollupProject("")).toBe("");
+  });
+});

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -500,6 +500,23 @@ export function formatDataSourceLabel(hasSqlite?: boolean, dataSource?: string):
   return hasSqlite ? "SQLite + JSONL" : "JSONL";
 }
 
+/**
+ * Claude Code's agent isolation creates worktrees under
+ * `<project>/.claude/worktrees/<docker-style-name>/`. These are auto-generated
+ * sandboxes the user has no awareness of and may be cleaned up at any time, so
+ * we roll their sessions up under the parent project for display.
+ */
+const AGENT_WORKTREE_RE = /^(.+?)\/\.claude\/worktrees\/[^/]+(?:\/.*)?$/;
+
+export function agentWorktreeParent(project: string): string | null {
+  const m = project.replace(/\/$/, "").match(AGENT_WORKTREE_RE);
+  return m ? m[1] : null;
+}
+
+export function rollupProject(project: string): string {
+  return agentWorktreeParent(project) ?? project;
+}
+
 function specialProjectLabel(project: string): string | null {
   const normalized = project.replace(/\/$/, "");
   if (!normalized) return null;


### PR DESCRIPTION
## Summary

Claude Code's agent isolation creates worktrees at `<project>/.claude/worktrees/<docker-style-name>/`. These are auto-generated sandboxes the user has no awareness of and may be cleaned up at any time, yet each one previously surfaced as its own entry in the sessions/replays sidebar — drowning out human-created projects (e.g. distinguishing `vibe-replay` vs `vibe-replay2` was lost in a wall of `xenodochial-swartz-…`-style rows).

- Add `agentWorktreeParent` / `rollupProject` helpers in `dashboard-utils.ts` that recognize the worktree path pattern and resolve it back to the parent project.
- In both **Sessions** and **Replays** sidebars, group sessions by the rolled-up key. Show a small `+N wt` indicator when a project has merged-in worktree sessions.
- Mark individual worktree sessions in the right pane with a purple `WORKTREE` pill so users can still tell which sessions ran in a sandbox.
- Resolve `selectedProject` through the rollup before lookup so URLs pointing at a (possibly cleaned-up) worktree path still land on the parent project view.
- Compute the sidebar `exists` flag with `some` instead of `[0]` so a single deleted-worktree session doesn't dim the entire parent row.

Real-world impact on my local dashboard: sidebar went from 296 entries to ~13. `~/Code/vibe-replay` row now reads `128  +9 wt`, `~/Code/vibe-replay2` reads `64  +1 wt`, and human-created project distinctions stay intact.

## Test plan

- [x] `pnpm lint:check` — clean
- [x] `pnpm build` — bundle 765kb (under 800kb limit)
- [x] `pnpm test:e2e` — 28 passed
- [x] Manual: opened `pnpm dev:dashboard`, confirmed:
  - Sidebar drops all `<root>/.claude/worktrees/<name>` rows
  - Parent rows show `+N wt` count
  - Individual worktree session cards show purple `WORKTREE` pill next to the branch label
  - Clicking a parent project shows worktree sessions inline (filter by branch still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)