### PR TITLE
[codex] Roll up worktree projects in replay views

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -901,6 +901,9 @@ function ReplayCard({
   }, []);
   useOutsideClick(menuRef, closeMenu, menuOpen);
 
+  const displayProject = rollupProject(s.project);
+  const isWorktreeReplay = displayProject !== s.project;
+
   return (
     <div
       onClick={onOpen}
@@ -1184,7 +1187,15 @@ function ReplayCard({
       {/* Row 4: identity */}
       <div className="flex items-center gap-2 text-xs font-mono text-terminal-dimmer flex-wrap">
         <ProviderBadge provider={s.provider} />
-        <span>{s.project}</span>
+        <span title={isWorktreeReplay ? s.project : undefined}>{displayProject}</span>
+        {isWorktreeReplay && (
+          <span
+            className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider"
+            title={`Claude agent worktree: ${s.project}`}
+          >
+            worktree
+          </span>
+        )}
         <span className="text-terminal-border">&middot;</span>
         <span>{formatDate(s.startTime)}</span>
         {s.model && (

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { ReplaySession } from "../types";
-import { providerDisplayName } from "./dashboard-utils";
+import { providerDisplayName, rollupProject } from "./dashboard-utils";
 import { formatDuration } from "./StatsPanel";
 
 interface Props {
@@ -59,7 +59,8 @@ export default function LandingHero({ session, onStart, onViewInsights }: Props)
   }, [scenes]);
 
   const duration = formatDuration(meta.stats.durationMs);
-  const title = meta.title || meta.project;
+  const displayProject = rollupProject(meta.project);
+  const title = meta.title || displayProject;
   const providerLabel = formatProviderLabel(meta.provider);
 
   // Build stat cards: pick the best 3–4 from available data

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -5,6 +5,7 @@ import {
   getSessionDataQualityNotes,
   getSessionMetricQuality,
 } from "./DataQualityIndicator";
+import { rollupProject } from "./dashboard-utils";
 
 interface Props {
   session: ReplaySession;
@@ -92,6 +93,8 @@ export default function StatsPanel({ session }: Props) {
   }, [session]);
 
   const { meta } = session;
+  const displayProject = rollupProject(meta.project);
+  const isWorktree = displayProject !== meta.project;
   const dataQualityNotes = useMemo(() => getSessionDataQualityNotes(meta), [meta]);
   const metricQuality = useMemo(() => getSessionMetricQuality(meta), [meta]);
 
@@ -107,12 +110,20 @@ export default function StatsPanel({ session }: Props) {
             {meta.title}
           </div>
         )}
-        <div className="text-terminal-dim truncate" title={meta.cwd}>
-          {meta.project}
+        <div className="text-terminal-dim truncate" title={isWorktree ? meta.project : meta.cwd}>
+          {displayProject}
         </div>
         <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap">
           {meta.model && <span className="text-terminal-dim">{meta.model}</span>}
           {meta.provider && <span>{meta.provider}</span>}
+          {isWorktree && (
+            <span
+              className="px-1 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider text-[10px]"
+              title={`Claude agent worktree: ${meta.project}`}
+            >
+              worktree
+            </span>
+          )}
           {dataQualityNotes.length > 0 && (
             <DataQualityIndicator title={dataQualityNotes.join("\n")} />
           )}


### PR DESCRIPTION
## Summary

- Display generated replay cards under the parent project when the replay was generated from a Claude agent worktree.
- Use the same worktree rollup helper for replay landing fallbacks and the session stats sidebar.
- Keep the original worktree path available via tooltip and a small worktree badge so the sandbox context is still visible without dominating the project identity.

## Validation

- `pnpm exec oxfmt packages/viewer/src/components/Dashboard.tsx packages/viewer/src/components/LandingHero.tsx packages/viewer/src/components/StatsPanel.tsx`
- `pnpm exec oxlint packages/viewer/src/components/Dashboard.tsx packages/viewer/src/components/LandingHero.tsx packages/viewer/src/components/StatsPanel.tsx`
- `pnpm --filter @vibe-replay/viewer test -- packages/viewer/src/components/__tests__/dashboard-utils.test.ts`
- `pnpm exec tsc --noEmit -p packages/viewer/tsconfig.json`

Note: the Codex app shell did not include `pnpm` on PATH initially; validation used the repo owner's nvm Node/Pnpm path.
