### PR TITLE
seo: noindex private pages, enrich SSR content, expand structured data

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -7,10 +7,41 @@ const viewerDevUrl = process.env.DEV_VIEWER_URL;
 // In dev, proxy /api/* to the local Cloudflare Worker so auth + cloud APIs work
 const workerDevUrl = process.env.DEV_WORKER_URL || "http://localhost:8787";
 
+// Pages excluded from sitemap (private / dynamic-only / requires auth).
+// Keep in sync with the noindex meta tags on these routes.
+const SITEMAP_EXCLUDED = new Set(["/profile", "/shared-insights"]);
+
 export default defineConfig({
   site: "https://vibe-replay.com",
   trailingSlash: "always",
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      filter: (page) => {
+        const path = new URL(page).pathname.replace(/\/$/, "");
+        return !SITEMAP_EXCLUDED.has(path);
+      },
+      serialize(item) {
+        const path = new URL(item.url).pathname.replace(/\/$/, "");
+        if (path === "") {
+          item.priority = 1.0;
+          item.changefreq = "weekly";
+        } else if (path === "/blog") {
+          item.priority = 0.9;
+          item.changefreq = "weekly";
+        } else if (path.startsWith("/blog/")) {
+          item.priority = 0.8;
+          item.changefreq = "monthly";
+        } else if (path === "/explore") {
+          item.priority = 0.7;
+          item.changefreq = "daily";
+        } else if (path === "/insights") {
+          item.priority = 0.7;
+          item.changefreq = "weekly";
+        }
+        return item;
+      },
+    }),
+  ],
   vite: {
     server: {
       proxy: {

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,32 @@
+# vibe-replay
+
+> vibe-replay turns your Claude Code and Cursor AI coding sessions into interactive, shareable web replays as single self-contained HTML files. One command, no account, free and open source.
+
+vibe-replay is a CLI (npm package: `vibe-replay`) that reads your local Claude Code (`~/.claude/`) and Cursor (`~/.cursor/`) session data, then renders it as a scrubbable timeline showing every prompt, AI response, tool call, file diff, and thinking block. Output is a single HTML file with all assets inlined — no server, no external requests.
+
+Install: `npx vibe-replay`
+Source: https://github.com/tuo-lei/vibe-replay
+License: MIT
+
+## Core pages
+
+- [Homepage](https://vibe-replay.com/): Product overview, install instructions, feature list.
+- [Explore replays](https://vibe-replay.com/explore/): Public AI coding sessions shared by the community (Claude Code + Cursor).
+- [Insights dashboard](https://vibe-replay.com/insights/): Personal AI coding analytics — sessions, prompts, tool calls, costs, streaks across machines and providers.
+- [Blog](https://vibe-replay.com/blog/): Deep-dives on Claude Code, Cursor, and AI coding workflows.
+
+## Blog posts
+
+- [Capturing Claude's Autonomous Agent Mode: A Deep Dive into Dispatch](https://vibe-replay.com/blog/dispatch-deep-dive/): How vibe-replay captures Claude Desktop Cowork / autonomous sessions, including the technical challenges and the parser changes required.
+- [878 Sessions, 52.9k Tool Calls — What a Year of Vibe Coding Looks Like](https://vibe-replay.com/blog/personal-insights/): Year-long usage breakdown: prompts, tool calls, model distribution (79% Cursor, 21% Claude Code), and what the data reveals about real AI coding habits.
+- [What Actually Happens When Claude Code /simplify Cleans Your Codebase](https://vibe-replay.com/blog/simplify-codebase-with-ai/): Behavioral analysis of Claude Code's `/simplify` slash command and the kinds of refactors it produces.
+- [Claude Code's Source Leaked. We Read It and Shipped 5 Features in a Day](https://vibe-replay.com/blog/claude-code-source-leak/): Findings from the Claude Code source leak, with concrete features built on that knowledge.
+- [What Does Cursor Store on Your Machine? A Deep Dive into ~/.cursor/](https://vibe-replay.com/blog/cursor-local-storage/): Walkthrough of Cursor's local storage layout — SQLite `store.db`, `state.vscdb`, JSONL fallback, and how vibe-replay merges them.
+- [What Does Claude Code Store on Your Machine? A Deep Dive into ~/.claude/](https://vibe-replay.com/blog/claude-code-local-storage/): JSONL transcripts, project mapping, hooks/plugins, and what each file in `~/.claude/` actually contains.
+- [From Prompt to MVP in 53 Minutes — with Full AI Session Replay](https://vibe-replay.com/blog/introducing-vibe-replay/): Project introduction and the 53-minute build session that produced the first working version.
+
+## Optional
+
+- [GitHub repository](https://github.com/tuo-lei/vibe-replay): Source code, issues, releases.
+- [npm package](https://www.npmjs.com/package/vibe-replay): Install via `npm i -g vibe-replay` or one-shot `npx vibe-replay`.
+- [RSS feed](https://vibe-replay.com/rss.xml): Blog updates.

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,12 @@
 User-agent: *
 Allow: /
 
+# API + auth endpoints — never crawl (no HTML, just JSON / OAuth flow)
+Disallow: /api/
+Disallow: /auth/
+
+# /profile/ and /shared-insights/ are intentionally not Disallow'd here —
+# they use <meta name="robots" content="noindex"> instead, which only works
+# if crawlers can still fetch the page to read the tag.
+
 Sitemap: https://vibe-replay.com/sitemap-index.xml

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -12,13 +12,13 @@
     </div>
 
     <nav class="flex items-center gap-6">
-      <a href="/blog" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
+      <a href="/blog/" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
         Blog
       </a>
-      <a href="/explore" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
+      <a href="/explore/" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
         Explore
       </a>
-      <a href="/insights" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
+      <a href="/insights/" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">
         Insights
       </a>
       <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-muted hover:text-text-primary transition-colors flex items-center gap-1.5 text-sm">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -11,7 +11,8 @@ interface Props {
     publishedTime: string;
     author: string;
   };
-  jsonLd?: Record<string, unknown>;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
+  noindex?: boolean;
 }
 
 const {
@@ -22,6 +23,7 @@ const {
   ogType = "website",
   article,
   jsonLd: jsonLdProp,
+  noindex = false,
 } = Astro.props;
 
 const siteBase = import.meta.env.SITE;
@@ -40,6 +42,7 @@ const ogImage = ogImageProp
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
     <meta name="theme-color" content="#00e5a0" />
+    {noindex && <meta name="robots" content="noindex, follow" />}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalURL} />
     <link rel="alternate" type="application/rss+xml" title="vibe-replay blog" href="/rss.xml" />
@@ -66,25 +69,33 @@ const ogImage = ogImageProp
     <meta name="twitter:image:alt" content="vibe-replay — AI coding session replays" />
 
     <!-- Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify(jsonLdProp ?? {
-      "@context": "https://schema.org",
-      "@type": "WebApplication",
-      "name": "vibe-replay",
-      "url": siteBase,
-      "description": description,
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "Any",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD"
-      },
-      "creator": {
-        "@type": "Organization",
+    {(() => {
+      const defaultJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
         "name": "vibe-replay",
-        "url": siteBase
-      }
-    })} />
+        "url": siteBase,
+        "description": description,
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+        },
+        "creator": {
+          "@type": "Organization",
+          "name": "vibe-replay",
+          "url": siteBase,
+        },
+      };
+      const blocks = jsonLdProp
+        ? (Array.isArray(jsonLdProp) ? jsonLdProp : [jsonLdProp])
+        : [defaultJsonLd];
+      return blocks.map((b) => (
+        <script type="application/ld+json" set:html={JSON.stringify(b)} />
+      ));
+    })()}
 
     <!-- Preload hero LCP image (homepage only) -->
     {Astro.url.pathname === "/" && (

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -3,7 +3,11 @@ import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Page not found - vibe-replay" description="The page you're looking for doesn't exist. Head back to vibe-replay to explore AI coding session replays.">
+<Layout
+  title="Page not found - vibe-replay"
+  description="The page you're looking for doesn't exist. Head back to vibe-replay to explore AI coding session replays."
+  noindex
+>
   <div class="flex flex-col min-h-screen">
     <Nav />
     <div class="flex-1 flex items-center justify-center px-6">

--- a/website/src/pages/blog/[slug].astro
+++ b/website/src/pages/blog/[slug].astro
@@ -22,24 +22,42 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 
 const siteBase = import.meta.env.SITE;
-const blogPostJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  headline: post.data.title,
-  description: post.data.excerpt,
-  datePublished: post.data.date.toISOString(),
-  author: {
-    "@type": "Person",
-    name: post.data.author,
-    url: post.data.authorUrl,
+const postUrl = new URL(`/blog/${post.id}/`, siteBase).href;
+const blogPostJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": postUrl },
+    headline: post.data.title,
+    description: post.data.excerpt,
+    datePublished: post.data.date.toISOString(),
+    dateModified: post.data.date.toISOString(),
+    author: {
+      "@type": "Person",
+      name: post.data.author,
+      url: post.data.authorUrl,
+    },
+    ...(post.data.cover ? { image: new URL(post.data.cover, siteBase).href } : {}),
+    publisher: {
+      "@type": "Organization",
+      name: "vibe-replay",
+      url: siteBase,
+      logo: {
+        "@type": "ImageObject",
+        url: new URL("/logo.png", siteBase).href,
+      },
+    },
   },
-  ...(post.data.cover ? { image: new URL(post.data.cover, siteBase).href } : {}),
-  publisher: {
-    "@type": "Organization",
-    name: "vibe-replay",
-    url: siteBase,
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": siteBase },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": new URL("/blog/", siteBase).href },
+      { "@type": "ListItem", "position": 3, "name": post.data.title, "item": postUrl },
+    ],
   },
-};
+];
 ---
 
 <Layout

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -22,7 +22,10 @@ const blogIndexJsonLd = [
       "@type": "Organization",
       "name": "vibe-replay",
       "url": siteBase,
-      "logo": new URL("/logo.png", siteBase).href,
+      "logo": {
+        "@type": "ImageObject",
+        "url": new URL("/logo.png", siteBase).href,
+      },
     },
     "blogPost": posts.map((p) => ({
       "@type": "BlogPosting",

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -8,9 +8,47 @@ import { formatDate } from "../../utils/date";
 const posts = (await getCollection("blog", ({ data }) => data.draft !== true)).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
+
+const siteBase = import.meta.env.SITE;
+const blogIndexJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "name": "vibe-replay blog",
+    "url": new URL("/blog/", siteBase).href,
+    "description":
+      "Updates, guides, and deep-dives on Claude Code, Cursor, AI coding workflows, and the vibe-replay project.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "vibe-replay",
+      "url": siteBase,
+      "logo": new URL("/logo.png", siteBase).href,
+    },
+    "blogPost": posts.map((p) => ({
+      "@type": "BlogPosting",
+      "headline": p.data.title,
+      "description": p.data.excerpt,
+      "datePublished": p.data.date.toISOString(),
+      "url": new URL(`/blog/${p.id}/`, siteBase).href,
+      "author": { "@type": "Person", "name": p.data.author, "url": p.data.authorUrl },
+    })),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": siteBase },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": new URL("/blog/", siteBase).href },
+    ],
+  },
+];
 ---
 
-<Layout title="Blog — vibe-replay" description="Updates, guides, and stories from the vibe-replay project.">
+<Layout
+  title="Blog — Claude Code, Cursor, and AI coding deep-dives | vibe-replay"
+  description="Updates, guides, and deep-dives on Claude Code, Cursor, and AI coding workflows. Learn what AI agents actually store on your machine, how to capture sessions, and more."
+  jsonLd={blogIndexJsonLd}
+>
   <Nav active="blog" />
 
   <main class="min-h-screen pt-16 pb-20 px-6">

--- a/website/src/pages/explore.astro
+++ b/website/src/pages/explore.astro
@@ -22,6 +22,7 @@ const exploreFaq = [
   },
 ];
 
+const siteBase = import.meta.env.SITE;
 const exploreJsonLd = [
   {
     "@context": "https://schema.org",
@@ -29,11 +30,11 @@ const exploreJsonLd = [
     "name": "Public AI coding session replays",
     "description":
       "Browse public AI coding session replays shared by the community. Watch Claude Code and Cursor sessions as interactive web replays.",
-    "url": "https://vibe-replay.com/explore/",
+    "url": new URL("/explore/", siteBase).href,
     "isPartOf": {
       "@type": "WebSite",
       "name": "vibe-replay",
-      "url": "https://vibe-replay.com",
+      "url": siteBase,
     },
   },
   {

--- a/website/src/pages/explore.astro
+++ b/website/src/pages/explore.astro
@@ -2,19 +2,67 @@
 import Footer from "../components/Footer.astro";
 import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
+
+const exploreFaq = [
+  {
+    q: "What are AI coding session replays?",
+    a: "Replays capture every prompt, tool call, file edit, and AI thinking step from a Claude Code or Cursor session, then render them as an interactive timeline you can scrub through. Browse public replays here to see how others build with AI.",
+  },
+  {
+    q: "How do I share my own replay?",
+    a: "Run `npx vibe-replay --gist` (publishes to GitHub Gist) or `npx vibe-replay --cloud` (publishes to vibe-replay cloud). Both produce a public URL you can share. Replays show up here automatically.",
+  },
+  {
+    q: "Can I replay Claude Code and Cursor sessions?",
+    a: "Yes. vibe-replay reads JSONL files for Claude Code and SQLite/JSONL for Cursor — no extra instrumentation. Both providers render with full prompt history, tool calls, diffs, and thinking blocks.",
+  },
+  {
+    q: "Are replays self-contained?",
+    a: "Every replay is a single static HTML file with all assets inlined — no external requests, no tracking. Open it offline, host it on any static server, or attach it to a PR.",
+  },
+];
+
+const exploreJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Public AI coding session replays",
+    "description":
+      "Browse public AI coding session replays shared by the community. Watch Claude Code and Cursor sessions as interactive web replays.",
+    "url": "https://vibe-replay.com/explore/",
+    "isPartOf": {
+      "@type": "WebSite",
+      "name": "vibe-replay",
+      "url": "https://vibe-replay.com",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": exploreFaq.map(({ q, a }) => ({
+      "@type": "Question",
+      "name": q,
+      "acceptedAnswer": { "@type": "Answer", "text": a },
+    })),
+  },
+];
 ---
 
-<Layout title="Explore Replays - vibe-replay" description="Browse public AI coding session replays shared by the community. Watch Claude Code and Cursor sessions as interactive web replays.">
+<Layout
+  title="Explore Public AI Coding Replays — Claude Code & Cursor | vibe-replay"
+  description="Browse public AI coding session replays shared by the community. Watch real Claude Code and Cursor sessions as interactive, scrubbable web replays."
+  jsonLd={exploreJsonLd}
+>
   <div class="min-h-screen flex flex-col">
     <Nav active="explore" />
 
     <!-- Main content -->
     <main class="flex-1 max-w-6xl mx-auto w-full px-6 py-10">
       <!-- Title + sort controls -->
-      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-4">
         <div>
-          <h1 class="text-2xl font-bold text-text-primary mb-1">Public Replays</h1>
-          <p class="text-text-muted text-sm font-mono">AI coding sessions shared by the community</p>
+          <h1 class="text-2xl font-bold text-text-primary mb-1">Public AI coding replays</h1>
+          <p class="text-text-muted text-sm font-mono">Claude Code &amp; Cursor sessions shared by the community</p>
         </div>
         <div class="flex items-center gap-1 rounded-lg border border-border overflow-hidden w-fit shrink-0">
           <button
@@ -33,6 +81,23 @@ import Layout from "../layouts/Layout.astro";
           </button>
         </div>
       </div>
+
+      <!-- Static intro for crawlers + first-paint readers -->
+      <section class="mb-8 text-text-secondary text-sm leading-relaxed max-w-3xl">
+        <p>
+          Watch real <a href="/blog/" class="text-accent hover:underline">AI coding sessions</a> from
+          Claude Code and Cursor &mdash; full prompts, tool calls, file diffs, and thinking blocks
+          rendered as an interactive timeline. Each replay is a self-contained HTML file you can open
+          offline, embed in a PR, or share as a link.
+        </p>
+        <p class="mt-3">
+          Want to share your own? Run
+          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay --gist</code>
+          or
+          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay --cloud</code>
+          and your replay will appear here.
+        </p>
+      </section>
 
       <!-- Loading state -->
       <div id="loading" class="text-center py-20">
@@ -54,6 +119,19 @@ import Layout from "../layouts/Layout.astro";
       <!-- Replay grid -->
       <div id="replay-grid" class="hidden grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       </div>
+
+      <!-- Static FAQ for crawlers (matches FAQPage JSON-LD above) -->
+      <section class="mt-16 pt-10 border-t border-border max-w-3xl">
+        <h2 class="text-lg font-bold text-text-primary mb-6">Frequently asked questions</h2>
+        <div class="flex flex-col gap-6">
+          {exploreFaq.map(({ q, a }) => (
+            <div>
+              <h3 class="text-sm font-semibold text-text-primary mb-1.5">{q}</h3>
+              <p class="text-text-secondary text-sm leading-relaxed" set:html={a.replace(/`([^`]+)`/g, '<code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">$1</code>')} />
+            </div>
+          ))}
+        </div>
+      </section>
     </main>
 
     <Footer />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,26 +8,30 @@ import HowItWorks from "../components/HowItWorks.astro";
 import Plugin from "../components/Plugin.astro";
 import Layout from "../layouts/Layout.astro";
 
+const siteBase = import.meta.env.SITE;
 const homeJsonLd = [
   {
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "vibe-replay",
-    "url": "https://vibe-replay.com",
+    "url": siteBase,
     "description":
       "Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays.",
     "publisher": {
       "@type": "Organization",
       "name": "vibe-replay",
-      "url": "https://vibe-replay.com",
-      "logo": "https://vibe-replay.com/logo.png",
+      "url": siteBase,
+      "logo": {
+        "@type": "ImageObject",
+        "url": new URL("/logo.png", siteBase).href,
+      },
     },
   },
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "vibe-replay",
-    "url": "https://vibe-replay.com",
+    "url": siteBase,
     "description":
       "Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays. One command, one self-contained HTML file. Free and open source.",
     "applicationCategory": "DeveloperApplication",
@@ -41,7 +45,7 @@ const homeJsonLd = [
     "creator": {
       "@type": "Organization",
       "name": "vibe-replay",
-      "url": "https://vibe-replay.com",
+      "url": siteBase,
     },
     "license": "https://github.com/tuo-lei/vibe-replay/blob/main/LICENSE",
   },

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -7,9 +7,52 @@ import Hero from "../components/Hero.astro";
 import HowItWorks from "../components/HowItWorks.astro";
 import Plugin from "../components/Plugin.astro";
 import Layout from "../layouts/Layout.astro";
+
+const homeJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "vibe-replay",
+    "url": "https://vibe-replay.com",
+    "description":
+      "Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "vibe-replay",
+      "url": "https://vibe-replay.com",
+      "logo": "https://vibe-replay.com/logo.png",
+    },
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "vibe-replay",
+    "url": "https://vibe-replay.com",
+    "description":
+      "Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays. One command, one self-contained HTML file. Free and open source.",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "downloadUrl": "https://www.npmjs.com/package/vibe-replay",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD",
+    },
+    "creator": {
+      "@type": "Organization",
+      "name": "vibe-replay",
+      "url": "https://vibe-replay.com",
+    },
+    "license": "https://github.com/tuo-lei/vibe-replay/blob/main/LICENSE",
+  },
+];
 ---
 
-<Layout title="vibe-replay - Turn AI coding sessions into shareable replays" description="Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays. One command, one self-contained HTML file. Free and open source.">
+<Layout
+  title="vibe-replay - Turn AI coding sessions into shareable replays"
+  description="Replay, analyze, and share your Claude Code and Cursor AI coding sessions as interactive web replays. One command, one self-contained HTML file. Free and open source."
+  jsonLd={homeJsonLd}
+>
   <main>
     <Hero />
     <HowItWorks />

--- a/website/src/pages/profile.astro
+++ b/website/src/pages/profile.astro
@@ -4,7 +4,11 @@ import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Profile - vibe-replay" description="Manage your shared AI coding session replays. View storage usage, cloud replays, and GitHub Gists.">
+<Layout
+  title="Profile - vibe-replay"
+  description="Manage your shared AI coding session replays. View storage usage, cloud replays, and GitHub Gists."
+  noindex
+>
   <div class="min-h-screen flex flex-col">
     <Nav active="profile" />
 

--- a/website/src/pages/shared-insights.astro
+++ b/website/src/pages/shared-insights.astro
@@ -4,7 +4,11 @@ import Nav from "../components/Nav.astro";
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Insights - vibe-replay" description="Vibe coding insights shared via vibe-replay">
+<Layout
+  title="Shared Insights - vibe-replay"
+  description="A public vibe-coding insights profile shared via vibe-replay."
+  noindex
+>
   <div class="min-h-screen flex flex-col">
     <Nav active="insights" />
 


### PR DESCRIPTION
## Why

GSC says only `/` and `/insights/` are indexed; **8 blog URLs + `/explore/` are stuck at "URL is unknown to Google"**, even though the sitemap is submitted (Discovered pages: 12, Last read: Apr 17).

URL Inspection on a 1-month-old blog post shows the real picture:
- ✅ LIVE TEST: "URL is available to Google" + "Page can be indexed"
- ❌ Sitemaps: "No referring sitemaps detected"
- ❌ Referring page: None detected
- ❌ Last crawl: N/A

Technical setup is fine — Google just hasn't allocated crawl budget. This PR addresses two contributing factors so when Google does crawl, the signals are clean.

(I separately requested indexing for all 9 unindexed URLs in GSC; expect ~1-2 weeks for Google to act.)

## What changed

**Quality signals — stop thin/private pages from dragging the site down:**
- `/profile/`, `/shared-insights/`, `/404` emit `<meta robots="noindex">`
- `/shared-insights/` `<title>` no longer duplicates `/insights/` (both said "Insights - vibe-replay")
- Sitemap excludes the noindex routes; remaining 11 URLs gain `priority` + `changefreq`
- `robots.txt` disallows `/api/` and `/auth/` only; **noindex pages stay crawlable** so Google can read the meta tag
- Footer internal links use trailing slash → match canonical, avoid 301 hops

**Crawler-visible content + rich results:**
- `/explore/` SSR was just `"Loading replays..."` — now ships a static intro + 4-question FAQ with matching `FAQPage` JSON-LD
- `Layout.astro` supports `jsonLd` as an array
- Multiple schemas per page:
  - Home: `WebSite` + `SoftwareApplication`
  - Blog index: `Blog` + `BreadcrumbList`
  - Blog posts: `BlogPosting` (with `mainEntityOfPage`, `dateModified`, publisher logo) + `BreadcrumbList`
  - `/explore/`: `CollectionPage` + `FAQPage`
- New `/llms.txt` for AI-crawler discovery (Perplexity, ChatGPT, etc.)

## Test plan

- [x] `pnpm build` → 14 pages built
- [x] `pnpm test:e2e` → 28 passed
- [x] `pnpm lint:check` → 0 errors
- [x] Inspected generated `dist/`:
  - `sitemap-0.xml` has 11 URLs with priority/changefreq, **no** `/profile/` or `/shared-insights/`
  - `dist/profile/index.html`, `dist/shared-insights/index.html`, `dist/404.html` all have `<meta robots="noindex, follow">`
  - `dist/index.html`, `dist/blog/*/index.html`, `dist/explore/index.html`, `dist/insights/index.html` have **no** noindex
  - Blog post HTML contains `BlogPosting`, `BreadcrumbList`, `Organization`, `Person`, `WebPage`, `ImageObject`, `ListItem` schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)