### PR TITLE
feat(skill): redesign /replay with redaction audit + ask-then-do PR-share flow

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,6 +41,7 @@ interface GitHubExportResult {
   svgPath: string;
   gifPath?: string;
   mdPath: string;
+  redactionsPath: string;
 }
 
 async function runGitHubExport(
@@ -86,12 +87,37 @@ async function runGitHubExport(
   await writeFile(mdFilePath, markdown, "utf-8");
   mdSpinner.succeed(`Markdown: ${mdFilePath}`);
 
+  // Redaction report: lets agents/users audit what was filtered before sharing.
+  // - alreadyRedactedCount: counts [REDACTED] markers from transform.ts (layer 1)
+  // - leftoverFindings: layer-2 scan of the final markdown for anything that slipped past
+  const redactionsSpinner = ora("Generating redaction report...").start();
+  const alreadyRedactedCount = (markdown.match(/\[REDACTED\]/g) || []).length;
+  const leftoverFindings = scanForSecrets(markdown);
+  const redactionsReport = {
+    version: 1,
+    source: "github-summary.md",
+    alreadyRedactedCount,
+    leftoverFindings,
+    notes: [
+      "alreadyRedactedCount: substrings replaced by transform.ts before this export.",
+      "leftoverFindings: regex matches in the final markdown — review these before sharing.",
+    ],
+  };
+  const redactionsPath = join(outputDir, "redactions.json");
+  await writeFile(redactionsPath, `${JSON.stringify(redactionsReport, null, 2)}\n`, "utf-8");
+  const leftoverNote =
+    leftoverFindings.length > 0
+      ? chalk.yellow(`(${leftoverFindings.length} leftover finding(s) — review)`)
+      : chalk.dim("(no leftover findings)");
+  redactionsSpinner.succeed(`Redactions: ${redactionsPath} ${leftoverNote}`);
+
   return {
     markdown,
     outputDir,
     svgPath: svgFilePath,
     gifPath: gifGenerated ? join(outputDir, "session-preview.gif") : undefined,
     mdPath: mdFilePath,
+    redactionsPath,
   };
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -683,6 +683,7 @@ program
       console.log();
       console.log(chalk.bold.green("  Done!"));
       console.log(chalk.dim("  Files: ") + chalk.white(outputDir));
+      console.log(chalk.dim("  Redactions: ") + chalk.white(result.redactionsPath));
       console.log(
         chalk.dim("  Tip: ") +
           chalk.white(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -575,7 +575,10 @@ program
       console.log(result.markdown);
       // Status messages go to stderr so they don't pollute piped output
       process.stderr.write(`\n${chalk.bold.green("  Done!")}\n`);
-      process.stderr.write(`${chalk.dim("  Files: ")}${chalk.white(outputDir)}\n\n`);
+      process.stderr.write(`${chalk.dim("  Files: ")}${chalk.white(outputDir)}\n`);
+      process.stderr.write(
+        `${chalk.dim("  Redactions: ")}${chalk.white(result.redactionsPath)}\n\n`,
+      );
       return;
     }
 

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -2,9 +2,10 @@
  * Post-generation secret scanner.
  *
  * Layer 2 defense: after transform.ts redacts inline, this module
- * scans the final serialized JSON for anything that slipped through.
- * Results are presented interactively — the user decides what's a
- * false alarm and what should block publishing.
+ * scans the final serialized output (JSON or markdown — anything
+ * stringy) for anything that slipped through. Results are presented
+ * interactively — the user decides what's a false alarm and what
+ * should block publishing.
  */
 
 export interface Finding {
@@ -87,11 +88,11 @@ const SCAN_RULES: { id: string; label: string; pattern: RegExp }[] = [
 ];
 
 /**
- * Scan a JSON string for potential secrets.
+ * Scan any string (JSON, markdown, plain text) for potential secrets.
  * Returns deduplicated findings with context.
  */
-export function scanForSecrets(json: string): Finding[] {
-  const lines = json.split("\n");
+export function scanForSecrets(content: string): Finding[] {
+  const lines = content.split("\n");
   const findings: Finding[] = [];
   const seen = new Set<string>();
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -2,7 +2,7 @@
 
 Top-level home for AI prompts that are shared across the project. Kept at the repo root (not under any one package) because multiple consumers reference the same text:
 
-- **AI Studio** (`packages/cli/src/server.ts` + viewer panel, see `plan/features/003-ai-studio.md`) — server-side code reads these files when invoking a headless CLI tool to translate or adjust tone.
-- **Replay skill** (`skills/replay/SKILL.md`) — the same prompt text is inlined into the skill so an agent applies the same instructions when assisting with PR sharing.
+- **Replay skill** (`skills/replay/SKILL.md`) — *current consumer*. The prompt text is inlined verbatim into SKILL.md so an agent applies the same instructions when assisting with PR sharing.
+- **AI Studio** (*planned* — see `plan/features/003-ai-studio.md`) — *not yet wired*. When implemented, server-side code in `packages/cli/src/server.ts` will read these files before invoking a headless CLI tool to translate or adjust tone.
 
 If you change a prompt here, also update the inline copy in `skills/replay/SKILL.md` so the two stay in sync. Frequency is low — a build-time sync script is overkill for now.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,8 @@
+# Prompts
+
+Top-level home for AI prompts that are shared across the project. Kept at the repo root (not under any one package) because multiple consumers reference the same text:
+
+- **AI Studio** (`packages/cli/src/server.ts` + viewer panel, see `plan/features/003-ai-studio.md`) — server-side code reads these files when invoking a headless CLI tool to translate or adjust tone.
+- **Replay skill** (`skills/replay/SKILL.md`) — the same prompt text is inlined into the skill so an agent applies the same instructions when assisting with PR sharing.
+
+If you change a prompt here, also update the inline copy in `skills/replay/SKILL.md` so the two stay in sync. Frequency is low — a build-time sync script is overkill for now.

--- a/prompts/soften-tone.md
+++ b/prompts/soften-tone.md
@@ -1,0 +1,14 @@
+You are a tone adjustment assistant for AI coding sessions.
+Rewrite the following user prompts to be more {style}.
+
+Rules:
+- Preserve the EXACT technical meaning and intent
+- Remove frustration, harsh language, profanity, or passive-aggressive tone
+- Keep code references, file paths, and technical terms unchanged
+- If a prompt is already appropriate, return it unchanged
+- Do NOT add excessive politeness or corporate-speak — keep it natural
+
+Style guide:
+- Professional: direct but respectful, suitable for work sharing
+- Neutral: factual and unemotional, like documentation
+- Friendly: warm and collaborative, like messaging a teammate

--- a/prompts/translate.md
+++ b/prompts/translate.md
@@ -1,0 +1,10 @@
+You are a translation assistant for AI coding sessions.
+Translate the following user prompts from {source} to {target}.
+
+Rules:
+- Only translate natural language text
+- Preserve code blocks, file paths, variable names, CLI commands verbatim
+- Preserve markdown formatting
+- Keep technical jargon in English (API, endpoint, middleware, etc.)
+- Maintain the original intent and tone
+- If a prompt is already in {target}, return it unchanged

--- a/skills/replay/SKILL.md
+++ b/skills/replay/SKILL.md
@@ -1,90 +1,127 @@
 ---
 name: replay
-description: Generate interactive HTML replays and GitHub PR artifacts (markdown summary + animated GIF) from AI coding sessions. Use when creating PRs with session context, documenting development workflow, sharing coding sessions, or when the user mentions replay/session recording.
-allowed-tools: Bash(npx *) Bash(grep *) Bash(ls *) Bash(cat *) Bash(cp *)
+description: Generate a shareable replay summary of an AI coding session and help paste it into a PR. Walks the user through reviewing redactions, optionally translating prompts, and optionally softening tone before sharing. Use when the user asks for a "replay", wants to share a session, or wants to attach session context to a PR.
+allowed-tools: Bash(npx *) Bash(grep *) Bash(ls *) Bash(cat *) Bash(cp *) Bash(gh *)
 argument-hint: [session-path]
 ---
 
-# Session Replay Generator
+# Session Replay → PR
 
-Generate replay artifacts from AI coding sessions using [vibe-replay](https://github.com/tuo-lei/vibe-replay).
+This skill turns the current (or a specified) AI coding session into a polished markdown summary that is safe to paste into a PR. It uses [vibe-replay](https://github.com/tuo-lei/vibe-replay) to produce the raw artifacts, then walks the user through three opt-in cleanup steps before sharing.
 
-## Current Session
+## What this skill is for
 
-- Session ID: `${CLAUDE_SESSION_ID}`
+Plain text summaries of an AI session — stats, tool breakdown, per-prompt details — are hard for an agent to write from scratch. This skill delegates that to `vibe-replay`, then uses agent reasoning to handle the things a CLI cannot do well:
 
-## Capabilities
+- **Reviewing flagged credentials** — deciding whether a regex hit is a real secret or a false positive
+- **Translating** session prompts that aren't in the audience's language
+- **Softening tone** in prompts written when the user was frustrated
 
-### 1. GitHub PR Artifacts (markdown + animated GIF)
+Each step is **opt-in** — ask the user before doing it. Never silently rewrite their content.
 
-Best for: embedding in PR descriptions, issue comments, documentation.
+## Step 1 — Generate the artifacts
 
-```bash
-npx vibe-replay --session <PATH> --github
-```
-
-This generates three files in `~/.vibe-replay/<slug>/`:
-- `github-summary.md` — markdown with stats, tool breakdown, and session details
-- `session-preview.gif` — animated GIF showing the session flow
-- `session-preview.svg` — animated SVG (CSS keyframes)
-
-The markdown is also printed to stdout.
-
-**To use in a PR**: read `github-summary.md` and include its content in the PR body. By default, **skip the first line** (image reference `![AI Session: ...](...)`), since committing a binary GIF to the repo bloats repository size. The text summary alone provides full value for reviewers.
-
-**If the user explicitly asks for the GIF** in the PR, include it by:
-1. Copying the GIF into the repo (e.g., `.github/session-preview.gif`)
-2. Updating the image path in the markdown to match
-3. Committing both the GIF and the markdown
-
-Let the user know the GIF is typically 30-300 KB and will be part of git history permanently.
-
-### 2. Interactive HTML Replay
-
-Best for: sharing a full interactive replay via file, Slack, or email.
-
-```bash
-npx vibe-replay --session <PATH> --open
-```
-
-Generates a self-contained HTML file (`~/.vibe-replay/<slug>/index.html`) and opens it in the browser. The HTML makes zero external requests — it can be shared directly.
-
-### 3. Interactive Mode (all features)
-
-For full control (editor, gist publishing, dashboard):
-
-```bash
-npx vibe-replay
-```
-
-## How to Find the Session File
-
-Find the JSONL file for the current session ID `${CLAUDE_SESSION_ID}`:
+Find the session file (use `${CLAUDE_SESSION_ID}` if running inside a live session, otherwise ask the user for a path):
 
 ```bash
 grep -l '"sessionId":"${CLAUDE_SESSION_ID}"' ~/.claude/projects/*/*.jsonl 2>/dev/null
 ```
 
-If no results, try with a space after the colon:
+If multiple files match (normal after `/resume`), pick the oldest — `vibe-replay` auto-discovers related files.
+
+Then run:
 
 ```bash
-grep -l '"sessionId": "${CLAUDE_SESSION_ID}"' ~/.claude/projects/*/*.jsonl 2>/dev/null
+npx vibe-replay --session <PATH> --github
 ```
 
-If multiple files are found (normal with `/resume`), use the first (oldest) path — vibe-replay auto-discovers related files.
+This writes to `~/.vibe-replay/<slug>/`:
 
-## PR Workflow Integration
+- `github-summary.md` — the markdown summary (this is what gets pasted into the PR)
+- `redactions.json` — credential audit report (read this in step 2)
+- `session-preview.gif` / `.svg` — preview animations (skip unless the user explicitly asks)
 
-When creating a PR and the user wants session replay context:
+## Step 2 — Review credential redactions
 
-1. Find the session file (see above)
-2. Run `npx vibe-replay --session <PATH> --github` to generate artifacts
-3. Read the generated `github-summary.md`
-4. By default, strip the first line (image reference) and include the text in the PR description under a `## Session Replay` heading
-5. If the user asked for the GIF, copy `session-preview.gif` into the repo and keep the image reference in the markdown
+Read `redactions.json`. It has two fields:
 
-## Optional Flags
+- `alreadyRedactedCount` — how many secrets `vibe-replay` already replaced with `[REDACTED]` automatically. Just report this number to the user.
+- `leftoverFindings` — regex hits in the final markdown that `vibe-replay` was not confident enough to auto-redact.
 
-- `--title "..."` — override auto-detected title
-- `--open` — generate HTML and open in browser
-- `--github` — generate GitHub artifacts (markdown + GIF + SVG)
+**If `leftoverFindings` is empty**, say so and move on.
+
+**If `leftoverFindings` is non-empty**, present the findings to the user with `AskUserQuestion`. For each one:
+
+- Show: rule (e.g. "GitHub Token"), context snippet (one line of surrounding text), and your judgment of whether it looks real
+- Note that some matches are false positives — commit hashes, UUIDs, version strings, package names can look like tokens. Use the surrounding context to judge.
+- Offer choices: "Redact all", "Review one-by-one", "Keep as-is" (if you believe they're false positives), or "Cancel"
+
+For anything the user wants redacted, replace the matched substring in `github-summary.md` with `[REDACTED]`.
+
+## Step 3 — Offer translation
+
+Detect the language of the user-prompt sections in `github-summary.md`. If the dominant language is not English (or doesn't match the repo's primary language — check `README.md` if unsure), ask:
+
+> "The prompts are in {detected language}. Translate to {target language} before sharing? [Yes / No]"
+
+If yes, apply this prompt to the user-prompt sections of the markdown:
+
+```
+You are a translation assistant for AI coding sessions.
+Translate the following user prompts from {source} to {target}.
+
+Rules:
+- Only translate natural language text
+- Preserve code blocks, file paths, variable names, CLI commands verbatim
+- Preserve markdown formatting
+- Keep technical jargon in English (API, endpoint, middleware, etc.)
+- Maintain the original intent and tone
+- If a prompt is already in {target}, return it unchanged
+```
+
+Only rewrite the prompt text — do not touch tool-call output, file diffs, or stats.
+
+## Step 4 — Offer tone softening
+
+Scan the user-prompt sections for harsh language, profanity, frustration, or passive-aggressive tone toward the AI. If you find any, ask:
+
+> "Some prompts contain {brief example, e.g. 'frustrated language'}. Soften the tone before sharing? [Professional / Neutral / Friendly / Skip]"
+
+If the user picks a style, apply this prompt to the affected user prompts:
+
+```
+You are a tone adjustment assistant for AI coding sessions.
+Rewrite the following user prompts to be more {style}.
+
+Rules:
+- Preserve the EXACT technical meaning and intent
+- Remove frustration, harsh language, profanity, or passive-aggressive tone
+- Keep code references, file paths, and technical terms unchanged
+- If a prompt is already appropriate, return it unchanged
+- Do NOT add excessive politeness or corporate-speak — keep it natural
+
+Style guide:
+- Professional: direct but respectful, suitable for work sharing
+- Neutral: factual and unemotional, like documentation
+- Friendly: warm and collaborative, like messaging a teammate
+```
+
+## Step 5 — Preview and paste
+
+Show the user the final markdown (or a diff against the original if changes were made). Ask:
+
+> "Paste into a PR now? [Current branch's PR / Open new PR / Just save the file / Cancel]"
+
+If pasting into the current branch's PR:
+
+```bash
+gh pr edit --body-file <updated-markdown>
+```
+
+If saving locally only, write the cleaned version to `~/.vibe-replay/<slug>/github-summary.clean.md` and report the path.
+
+## Notes
+
+- **The skip-the-image rule still applies**: by default, do NOT include the GIF reference (first line of the original markdown) when pasting into a PR — committing a binary GIF bloats git history. Only include it if the user explicitly asks for the GIF.
+- **Never modify the original `github-summary.md`** unless the user is doing a destructive edit and confirms. Write changes to `github-summary.clean.md` so the original is recoverable.
+- **Session ID detection**: the literal `${CLAUDE_SESSION_ID}` is interpolated by the harness when this skill runs. If it's empty, ask the user which session they want.

--- a/skills/replay/SKILL.md
+++ b/skills/replay/SKILL.md
@@ -56,15 +56,27 @@ Read `redactions.json`. It has two fields:
 - Note that some matches are false positives — commit hashes, UUIDs, version strings, package names can look like tokens. Use the surrounding context to judge.
 - Offer choices: "Redact all", "Review one-by-one", "Keep as-is" (if you believe they're false positives), or "Cancel"
 
-For anything the user wants redacted, replace the matched substring in `github-summary.md` with `[REDACTED]`.
+If the user chooses to redact any finding, **first copy the original to a working file** (do not overwrite `github-summary.md`):
+
+```bash
+cp ~/.vibe-replay/<slug>/github-summary.md ~/.vibe-replay/<slug>/github-summary.clean.md
+```
+
+Then apply replacements to `github-summary.clean.md`. The original stays intact so the user can recover the unedited version. All later steps (translation, tone) also operate on the `.clean.md` copy — create it on the first edit, then keep using it.
 
 ## Step 3 — Offer translation
 
-Detect the language of the user-prompt sections in `github-summary.md`. If the dominant language is not English (or doesn't match the repo's primary language — check `README.md` if unsure), ask:
+Read the working file (`github-summary.clean.md` if it exists from step 2, otherwise `github-summary.md`):
+
+```bash
+cat ~/.vibe-replay/<slug>/github-summary.clean.md 2>/dev/null || cat ~/.vibe-replay/<slug>/github-summary.md
+```
+
+Detect the language of the user-prompt sections. If the dominant language is not English (or doesn't match the repo's primary language — check `README.md` if unsure), ask:
 
 > "The prompts are in {detected language}. Translate to {target language} before sharing? [Yes / No]"
 
-If yes, apply this prompt to the user-prompt sections of the markdown:
+If yes, apply this prompt to the user-prompt sections of the markdown (always write the result to `github-summary.clean.md`, creating it from a copy of the original if it doesn't exist yet):
 
 ```
 You are a translation assistant for AI coding sessions.
@@ -87,7 +99,7 @@ Scan the user-prompt sections for harsh language, profanity, frustration, or pas
 
 > "Some prompts contain {brief example, e.g. 'frustrated language'}. Soften the tone before sharing? [Professional / Neutral / Friendly / Skip]"
 
-If the user picks a style, apply this prompt to the affected user prompts:
+If the user picks a style, apply this prompt to the affected user prompts (write the result to `github-summary.clean.md`, same rule as step 3):
 
 ```
 You are a tone adjustment assistant for AI coding sessions.
@@ -110,18 +122,34 @@ Style guide:
 
 Show the user the final markdown (or a diff against the original if changes were made). Ask:
 
-> "Paste into a PR now? [Current branch's PR / Open new PR / Just save the file / Cancel]"
+> "Paste into a PR now? [Append to current PR's body / Replace current PR's body / Open new PR / Just save the file / Cancel]"
 
-If pasting into the current branch's PR:
+**Important**: `gh pr edit --body-file <file>` **replaces** the entire PR body. If the user already has a hand-written summary, checklist, or screenshots in the PR body, replacing wipes them silently. Default to **appending** under a `## Session Replay` heading instead.
+
+To append (recommended default):
 
 ```bash
-gh pr edit --body-file <updated-markdown>
+# Read existing body, then write existing + separator + cleaned summary
+gh pr view --json body --jq .body > /tmp/pr-body.md
+echo "" >> /tmp/pr-body.md
+echo "---" >> /tmp/pr-body.md
+echo "" >> /tmp/pr-body.md
+echo "## Session Replay" >> /tmp/pr-body.md
+echo "" >> /tmp/pr-body.md
+cat ~/.vibe-replay/<slug>/github-summary.clean.md >> /tmp/pr-body.md
+gh pr edit --body-file /tmp/pr-body.md
 ```
 
-If saving locally only, write the cleaned version to `~/.vibe-replay/<slug>/github-summary.clean.md` and report the path.
+To replace (only if the user explicitly chooses this — confirm out loud what's about to be lost first):
+
+```bash
+gh pr edit --body-file ~/.vibe-replay/<slug>/github-summary.clean.md
+```
+
+If saving locally only, the cleaned version is already at `~/.vibe-replay/<slug>/github-summary.clean.md` from earlier steps — just report the path. If no cleanup steps ran, copy the original first so the user has a `.clean.md` to share without touching the source.
 
 ## Notes
 
 - **The skip-the-image rule still applies**: by default, do NOT include the GIF reference (first line of the original markdown) when pasting into a PR — committing a binary GIF bloats git history. Only include it if the user explicitly asks for the GIF.
-- **Never modify the original `github-summary.md`** unless the user is doing a destructive edit and confirms. Write changes to `github-summary.clean.md` so the original is recoverable.
+- **`github-summary.clean.md` is the only file the skill writes to**. The original `github-summary.md` is treated as read-only so the user can always recover the raw output.
 - **Session ID detection**: the literal `${CLAUDE_SESSION_ID}` is interpolated by the harness when this skill runs. If it's empty, ask the user which session they want.


### PR DESCRIPTION
## Summary

Redesigns the `/replay` skill to address why even the author wasn't using it: pasting a raw session summary into a PR feels risky — language mismatch, possible credentials in the transcript, harsh tone toward the AI. The skill now walks through three opt-in cleanups before sharing.

## Changes

- **`prompts/` (new, repo root)** — canonical home for AI prompts shared between the AI Studio panel (plan/features/003) and this skill. `translate.md` + `soften-tone.md` + a README explaining the duplication policy.
- **`packages/cli/src/index.ts`** — `--github` now emits `redactions.json` next to `github-summary.md`. Reports `alreadyRedactedCount` (transform.ts layer 1) and `leftoverFindings` (`scanForSecrets()` layer 2). Makes the existing redaction work auditable.
- **`skills/replay/SKILL.md`** — rewritten as a five-step ask-then-do flow: generate → review redactions → offer translation → offer tone softening → preview → paste into PR. Translation and tone prompts inlined verbatim from `prompts/*.md`.

## Test plan

- [x] `pnpm --filter vibe-replay build`
- [x] `pnpm test:e2e` (28 passed, 40 skipped)
- [x] `pnpm lint:check`
- [x] Real run: `--github` on a real session produces `redactions.json` with the expected shape
- [x] Eat-our-own-dog-food: this PR body itself was produced by the new skill flow on the session that built it (see below)

---

## Session that built this PR

> Generated via the new `/replay` skill flow:
> 1. `npx vibe-replay --github` → 0 redaction findings (clean)
> 2. Translation: Chinese prompts → English (audience-appropriate)
> 3. Tone: one mildly harsh phrase softened to "going off on tangents"
> 4. Pasted below

### AI Coding Session

11 min · 5 files changed · claude-opus-4-7
23 responses · 82 tools — Read 15 · Write 6 · Edit 2 · Bash (ls, cat, find, rg, ...) 46 · Glob 1 · Grep 1 · ToolSearch 1 · TaskCreate 3 · TaskUpdate 7

<details>
<summary>View session details (12 prompts, 82 tool calls)</summary>

> **What's the current state of the skill? Let's revisit it.**
> 1 responses · 11 tools — Read 3 · Bash (ls, cat, find) 8
>
> *Inventory of current skill state: skill files at `skills/replay/SKILL.md` + plugin/marketplace configs published to Anthropic's official marketplace; Phase 2 distribution channels (awesome lists, registries) not started…*

> **Setting marketing aside — is there anything worth improving in the skill itself? I notice I don't really use it myself.**
> 1 responses · 1 tools — Read 1
>
> *Read the SKILL.md and was direct about why even the author doesn't use it: the skill mostly wraps `npx vibe-replay --github`, which doesn't need an LLM. Three "capabilities" (PR artifacts, HTML, interactive mode) are three different products, none of which is a daily-use core scenario…*

> **You haven't grasped the situation. The places where skills work *are* agents like Claude Code — the point is integrating vibe-replay into them, so the GitHub markdown paste is actually the most useful piece (any agent can summarize without a skill). The real issue is that my default session can't be shared directly, and once it goes to GitHub there's a permanent record: (1) I write in Chinese but my audience is English; (2) I'm worried about credentials in the transcript; (3) I'm worried about coworkers seeing how harsh I was with the AI. Focus on solving these so I'll actually use it, instead of going off on tangents.**
> 1 responses
>
> *Acknowledged misreading the goal. The skill's job is to splice vibe-replay into the agent workflow — and `--github` is the CLI-unique artifact that an agent can't reproduce. Real blockers are pre-share cleanup: language, redaction, tone — three LLM-friendly tasks the CLI can't do…*

> **How do you plan to do it — in the CLI, or as prompts in the md file?**
> 1 responses
>
> *Hybrid approach: CLI handles the mechanical part (regex-based redaction baseline, audit-able by anyone — preserves the self-contained design principle), the skill handles the semantic part (false-positive judgment, translation, tone softening — pure LLM tasks)…*

> **Important note: our AI Studio feature requires users to install specific software so we can reuse another AI's dependency. But skills are viable because the prerequisite for a skill to work is that the user has an LLM. Translation actually kind of works in the skill — and maybe you can reuse the prompt?…**
> 1 responses · 2 tools — Read 1 · Bash (ls) 1
>
> *Plan 003 already designed translation/tone prompts. New design: extract them to shared `prompts/*.md` files. Both AI Studio (server-side) and the skill (inline in SKILL.md) read the same source, so changes don't drift…*

> **Re: "2. CLI adds `--print-prompt <name>` subcommand" — what's the purpose of this?**
> 1 responses
>
> *Acknowledged the over-design. Simpler approach: SKILL.md is markdown the agent reads anyway, so just inline the prompt text directly. No new CLI surface…*

> **OK.**
> 2 responses · 14 tools — Read 6 · Bash (rg) 2 · Grep 1 · ToolSearch 1 · TaskCreate 3 · TaskUpdate 1
>
> *Confirmed plan: 1) extract `prompts/translate.md` + `soften-tone.md`, 2) `--github` emits `redactions.json`, 3) rewrite SKILL.md as ask-then-do flow. Discovered transform.ts already does inline redaction — adjusted scope from "add `--redact` flag" to "expose redaction audit"…*

> **Go ahead and do the work.**
> 4 responses · 24 tools — Read 2 · Write 4 · Edit 2 · Bash (ls, rg, pnpm, node) 10 · TaskUpdate 6
>
> *All three tasks complete: prompts extracted, `--github` now emits `redactions.json` (alreadyRedactedCount + leftoverFindings via existing scanForSecrets), SKILL.md rewritten as five-step ask-then-do flow with prompts inlined. Build / e2e / lint all green; verified on a real session…*

> **Earlier you ran out of tokens, so I had another agent continue. Latest changes are on #191 — pull and read the comments. The other agent may have regressed some of your features…**
> 4 tools — Bash (git, gh) 4

> **My mistake — you should keep working on the skill. Probably hadn't done it yet, right? Let's go back to the skill work, sorry for the confusion.**
> 2 responses · 7 tools — Read 1 · Write 2 · Bash (mkdir, rg, git, pnpm) 4
>
> *Confirmed skill work was done but uncommitted. Per the user's earlier feedback that "moving prompts to project root is reasonable", relocated `packages/cli/prompts/` → `prompts/` (top-level). No code references the old path; updated README to explain the cross-package rationale. Re-ran build / e2e / lint — all green…*

> **How's the skill work going? Why am I not on the skill branch?**
> 4 responses · 8 tools — Bash (git, cat, grep, /usr/bin/grep, ...) 8
>
> *I'd been working on `codex/replay-worktree-rollup` (a merged branch). Stashed the skill work, opened `feat/replay-skill-pr-share` from `origin/main`, popped the stash, re-verified — all green…*

> **Open a PR, then wait 3 minutes to see the review. And since you've got the skill now, include the vibe-replay of the current session in this PR.**
> 5 responses · 11 tools — Read 1 · Bash (git, echo, ls, node, ...) 9 · Glob 1
>
> *Committed and pushed `feat/replay-skill-pr-share`. Ran the new skill flow on this very session: redactions.json clean (0 leftover), then asked the user about translation (Chinese prompts → English audience) and tone (one mild "going off on tangents" line). Both confirmed. This is the cleaned summary…*

**Signals:**
- 1 test failure(s) (resolved)

</details>

<sub>Generated by [vibe-replay](https://vibe-replay.com) — translated and tone-adjusted via the `/replay` skill</sub>
