### PR TITLE
chore(skill): bump plugin version to 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "vibe-replay",
       "description": "Generate interactive HTML replays and GitHub PR artifacts from AI coding sessions",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Tuo Lei"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate interactive HTML replays of AI coding sessions. Record, share, and replay your Claude Code, Cursor, and Codex sessions.",
   "author": {
     "name": "vibe-replay",


### PR DESCRIPTION
## Summary

Bumps the plugin manifest version so users running \`/plugin update\` actually receive the SKILL.md rewrite from #199. Without a version bump, Claude Code's plugin update check reports \"already at the latest version\" even when the upstream repo changed.

## Changes

- \`.claude-plugin/plugin.json\`: \`1.0.0\` → \`1.0.1\`
- \`.claude-plugin/marketplace.json\`: \`1.0.0\` → \`1.0.1\` (kept in sync)

## Test plan

- [x] \`pnpm lint:check\`
- [x] Both manifest files now read \`1.0.1\`
- [ ] After merge: existing installers see an update available on next \`/plugin update\` (verify out-of-band)