### PR TITLE
Refactor file diff logic and consolidate data source formatting

### DIFF
--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -197,6 +197,34 @@ export function transformToReplay(
   };
 }
 
+function buildFileDiff(
+  toolName: string,
+  input: Record<string, any>,
+): ToolCallScene["diff"] | undefined {
+  if (toolName === "Edit" && input.file_path) {
+    return {
+      filePath: redactPath(input.file_path),
+      oldContent: input.old_string ?? "",
+      newContent: input.new_string ?? "",
+    };
+  }
+  if (toolName === "Write" && input.file_path) {
+    return {
+      filePath: redactPath(input.file_path),
+      oldContent: "",
+      newContent: truncate(input.content || "", 3000),
+    };
+  }
+  if (toolName === "Delete" && input.file_path) {
+    return {
+      filePath: redactPath(input.file_path),
+      oldContent: input.old_string ?? "(file deleted)",
+      newContent: "",
+    };
+  }
+  return undefined;
+}
+
 function buildToolScene(
   toolName: string,
   input: Record<string, any>,
@@ -211,24 +239,9 @@ function buildToolScene(
     ...(images && images.length > 0 ? { images } : {}),
   };
 
-  if (toolName === "Edit" && input.file_path) {
-    scene.diff = {
-      filePath: redactPath(input.file_path),
-      oldContent: input.old_string ?? "",
-      newContent: input.new_string ?? "",
-    };
-  } else if (toolName === "Write" && input.file_path) {
-    scene.diff = {
-      filePath: redactPath(input.file_path),
-      oldContent: "",
-      newContent: truncate(input.content || "", 3000),
-    };
-  } else if (toolName === "Delete" && input.file_path) {
-    scene.diff = {
-      filePath: redactPath(input.file_path),
-      oldContent: input.old_string ?? "(file deleted)",
-      newContent: "",
-    };
+  const diff = buildFileDiff(toolName, input);
+  if (diff) {
+    scene.diff = diff;
   } else if (toolName === "Bash" && input.command) {
     scene.bashOutput = {
       command: redactSecrets(redactPath(input.command)),
@@ -391,25 +404,9 @@ function redactSubAgentScene(s: Scene): Scene {
       isError: s.isError || false,
     };
 
-    // Preserve diff for file-modifying tools (same logic as buildToolScene)
-    if (toolName === "Edit" && input.file_path) {
-      scene.diff = {
-        filePath: redactPath(input.file_path),
-        oldContent: input.old_string ?? "",
-        newContent: input.new_string ?? "",
-      };
-    } else if (toolName === "Write" && input.file_path) {
-      scene.diff = {
-        filePath: redactPath(input.file_path),
-        oldContent: "",
-        newContent: truncate(input.content || "", 3000),
-      };
-    } else if (toolName === "Delete" && input.file_path) {
-      scene.diff = {
-        filePath: redactPath(input.file_path),
-        oldContent: input.old_string ?? "(file deleted)",
-        newContent: "",
-      };
+    const diff = buildFileDiff(toolName, input);
+    if (diff) {
+      scene.diff = diff;
     }
 
     return scene;

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { ReplaySession } from "../types";
+import { formatReplaySourceLabel } from "../utils/format";
 import {
   DataQualityIndicator,
   getSessionDataQualityNotes,
@@ -405,7 +406,7 @@ export default function StatsPanel({ session }: Props) {
           </div>
           <div className="text-terminal-dim">
             <span className="text-terminal-blue">
-              {formatDataSourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
+              {formatReplaySourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
             </span>
           </div>
           {meta.dataSourceInfo?.sources && meta.dataSourceInfo.sources.length > 0 && (
@@ -480,17 +481,6 @@ export function formatDuration(ms?: number): string {
   if (mins < 60) return `${mins}m ${secs % 60}s`;
   const hrs = Math.floor(mins / 60);
   return `${hrs}h ${mins % 60}m`;
-}
-
-function formatDataSourceLabel(source?: string): string {
-  if (!source) return "unknown";
-  const labels: Record<string, string> = {
-    sqlite: "SQLite (store.db)",
-    "global-state": "SQLite (global state.vscdb)",
-    jsonl: "JSONL transcript",
-    "jsonl+tools": "JSONL + agent-tools",
-  };
-  return labels[source] || source;
 }
 
 function formatGeneratedAt(iso?: string): string {

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { computeCacheHitRate, computeContextLayers, turnCacheHitRate } from "../engine";
 import type { ReplaySession, TurnStat } from "../types";
+import { formatReplaySourceLabel } from "../utils/format";
 import {
   DataQualityIndicator,
   getSessionDataQualityNotes,
@@ -40,17 +41,6 @@ function classifyBash(command: string): string {
   if (cmd.trimStart().startsWith("git ")) return "git";
   if (/\b(lint|biome|eslint|prettier|format)\b/.test(cmd)) return "lint";
   return "other";
-}
-
-function formatDataSourceLabel(source?: string): string {
-  if (!source) return "unknown";
-  const labels: Record<string, string> = {
-    sqlite: "SQLite (store.db)",
-    "global-state": "SQLite (global state.vscdb)",
-    jsonl: "JSONL transcript",
-    "jsonl+tools": "JSONL + agent-tools",
-  };
-  return labels[source] || source;
 }
 
 function getOrderedBranchChain(gitBranch?: string, gitBranches?: string[]): string[] | undefined {
@@ -369,7 +359,7 @@ export default function SummaryView({ session }: Props) {
               Data Source
             </div>
             <div className="text-xs font-mono text-terminal-text">
-              {formatDataSourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
+              {formatReplaySourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
             </div>
             {meta.dataSourceInfo?.sources && meta.dataSourceInfo.sources.length > 0 && (
               <div className="mt-1 space-y-0.5">

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -497,6 +497,8 @@ export function formatDataSourceLabel(hasSqlite?: boolean, dataSource?: string):
   if (dataSource === "sqlite") return hasSqlite ? "SQLite + JSONL supplement" : "SQLite";
   if (dataSource === "global-state") return "Cursor global state";
   if (dataSource === "jsonl") return hasSqlite ? "JSONL fallback" : "JSONL transcript";
+  if (dataSource === "jsonl+tools")
+    return hasSqlite ? "JSONL + agent-tools fallback" : "JSONL + agent-tools";
   return hasSqlite ? "SQLite + JSONL" : "JSONL";
 }
 

--- a/packages/viewer/src/utils/format.ts
+++ b/packages/viewer/src/utils/format.ts
@@ -1,0 +1,11 @@
+const DATA_SOURCE_LABELS: Record<string, string> = {
+  sqlite: "SQLite (store.db)",
+  "global-state": "SQLite (global state.vscdb)",
+  jsonl: "JSONL transcript",
+  "jsonl+tools": "JSONL + agent-tools",
+};
+
+export function formatReplaySourceLabel(source?: string): string {
+  if (!source) return "unknown";
+  return DATA_SOURCE_LABELS[source] || source;
+}

--- a/packages/viewer/src/utils/format.ts
+++ b/packages/viewer/src/utils/format.ts
@@ -1,3 +1,6 @@
+// For the single-session replay view (StatsPanel, SummaryView). The dashboard
+// uses a separate, context-aware formatter in dashboard-utils.ts that takes
+// hasSqlite into account — keep both in sync when adding new source types.
 const DATA_SOURCE_LABELS: Record<string, string> = {
   sqlite: "SQLite (store.db)",
   "global-state": "SQLite (global state.vscdb)",


### PR DESCRIPTION
## Summary
This PR refactors the codebase to improve code reusability and maintainability by extracting common logic into shared utilities.

## Key Changes

- **Extract `buildFileDiff` function**: Created a new `buildFileDiff` function in `transform.ts` that encapsulates the logic for building file diff objects for Edit, Write, and Delete tool calls. This eliminates duplicate code that was previously in both `buildToolScene` and `redactSubAgentScene`.

- **Consolidate data source label formatting**: Moved the `formatDataSourceLabel` function from `StatsPanel.tsx` and `SummaryView.tsx` into a new shared utility file `packages/viewer/src/utils/format.ts` as `formatReplaySourceLabel`. Both components now import and use this centralized function.

- **Update dashboard utils**: Added support for the "jsonl+tools" data source type in `dashboard-utils.ts` to handle the new agent-tools format consistently.

## Implementation Details

- The `buildFileDiff` function returns `ToolCallScene["diff"] | undefined`, allowing callers to conditionally set the diff property only when applicable.
- Changed nested `else if` statements to sequential `if` statements in `buildFileDiff` for clearer control flow and early returns.
- The data source label mapping is now defined as a constant `DATA_SOURCE_LABELS` in the shared utility, making it easier to maintain a single source of truth.

https://claude.ai/code/session_01Vno5mzzC2T6vFwSogo24nB