### PR TITLE
fix(cursor): close JSONL parity gaps

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,8 @@
     "**/.astro/**",
     "**/build/**",
     "packages/cli/assets/**",
+    "packages/cli/vibe-replay/**",
+    "packages/viewer/public/**",
     "website/public/**",
     "cloudflare/drizzle/**",
     "cloudflare/worker-configuration.d.ts",

--- a/packages/cli/src/cleanup-warning.ts
+++ b/packages/cli/src/cleanup-warning.ts
@@ -44,11 +44,12 @@ export async function getClaudeCodeCleanupPeriod(): Promise<number> {
 export function computeDaysUntilCleanup(
   timestamp: string,
   cleanupPeriodDays: number,
+  nowMs = Date.now(),
 ): number | undefined {
   if (cleanupPeriodDays <= 0) return undefined;
   const sessionTime = new Date(timestamp).getTime();
   if (Number.isNaN(sessionTime)) return undefined;
-  const ageDays = (Date.now() - sessionTime) / (1000 * 60 * 60 * 24);
+  const ageDays = (nowMs - sessionTime) / (1000 * 60 * 60 * 24);
   return Math.max(0, Math.floor(cleanupPeriodDays - ageDays));
 }
 

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -7,6 +7,9 @@ vi.mock("./sqlite-reader.js", () => ({
   CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
   isSystemContextText: (text: string) =>
     /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/.test(text.trim()),
+  mapCursorToolName: (name: string) => name,
+  mapToolArgs: (_toolName: string, args: unknown) =>
+    args && typeof args === "object" && !Array.isArray(args) ? args : {},
   parseCursorSqlite: vi.fn(),
 }));
 

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -3,8 +3,13 @@ import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
 import type { DataSourceInfo, ProviderParseResult } from "../types.js";
-import { sanitizeCursorAssistantText } from "./sanitize.js";
-import { isSystemContextText, parseCursorSqlite } from "./sqlite-reader.js";
+import { sanitizeCursorAssistantText, sanitizeCursorReasoningText } from "./sanitize.js";
+import {
+  isSystemContextText,
+  mapCursorToolName,
+  mapToolArgs,
+  parseCursorSqlite,
+} from "./sqlite-reader.js";
 
 function toErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
@@ -198,14 +203,18 @@ async function parseCursorJsonl(
           blocks.push({ type: "_user_images", images: dedupedImages });
         }
         if (blocks.length > 0) {
-          allTurns.push({ role, blocks });
+          allTurns.push({
+            role,
+            ...(typeof obj.timestamp === "string" ? { timestamp: obj.timestamp } : {}),
+            blocks,
+          });
         }
         continue;
       }
 
       const hasInlineToolUse = contentBlocks.some((block) => block?.type === "tool_use");
       const blocks: ContentBlock[] = [];
-      for (const block of contentBlocks as ContentBlock[]) {
+      for (const block of contentBlocks) {
         if (block.type === "text" && block.text) {
           const cleanedText = sanitizeAssistantTextForReplay(block.text, hasInlineToolUse);
           if (!cleanedText) continue;
@@ -222,15 +231,27 @@ async function parseCursorJsonl(
           } else {
             blocks.push({ type: "text", text: cleanedText });
           }
+        } else if (block.type === "thinking" || block.type === "reasoning") {
+          const rawThinking =
+            typeof block.thinking === "string"
+              ? block.thinking
+              : typeof block.text === "string"
+                ? block.text
+                : "";
+          const thinking = sanitizeCursorReasoningText(rawThinking);
+          if (thinking) blocks.push({ type: "thinking", thinking });
         } else if (block.type === "tool_use") {
+          const rawName =
+            typeof block.name === "string" && block.name.trim() ? block.name.trim() : "Tool";
+          const name = mapCursorToolName(rawName);
           blocks.push({
             type: "tool_use",
             id:
               typeof block.id === "string" && block.id.trim()
                 ? block.id
                 : `cursor-inline-${syntheticToolId++}`,
-            name: typeof block.name === "string" && block.name.trim() ? block.name : "Tool",
-            input: block.input && typeof block.input === "object" ? block.input : {},
+            name,
+            input: mapToolArgs(rawName, block.input),
           });
         }
       }
@@ -413,7 +434,10 @@ function attachToolResults(
     for (const block of turn.blocks) {
       if (block.type !== "tool_use" || typeof block.id !== "string") continue;
       const result = toolResults.get(block.id);
-      if (result !== undefined) block._result = result;
+      if (result !== undefined) {
+        block._result = result;
+        block.input = mapToolArgs(block.name, block.input, result);
+      }
       const images = toolImages.get(block.id);
       if (images?.length) block._images = images;
       if (toolErrors.get(block.id)) block._isError = true;

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -251,6 +251,8 @@ async function parseCursorJsonl(
                 ? block.id
                 : `cursor-inline-${syntheticToolId++}`,
             name,
+            // Keep the raw name here because Cursor raw tools carry different arg
+            // schemas even when they map to the same canonical replay tool.
             input: mapToolArgs(rawName, block.input),
           });
         }

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2198,7 +2198,7 @@ function buildStoreTurnStats(turns: ParsedTurn[]): TurnStat[] {
   return turnStats;
 }
 
-function mapCursorToolName(name: string): string {
+export function mapCursorToolName(name: string): string {
   const mapping: Record<string, string> = {
     Shell: "Bash",
     run_terminal_command_v2: "Bash",
@@ -2227,6 +2227,8 @@ function mapCursorToolName(name: string): string {
     search_replace: "Edit",
     ApplyPatch: "Edit",
     apply_patch: "Edit",
+    MultiEdit: "MultiEdit",
+    multi_edit: "MultiEdit",
     Write: "Write",
     WriteFile: "Write",
     write: "Write",
@@ -2353,7 +2355,7 @@ function mapEditLikeArgs(argsObj: Record<string, any>, resultText: string): Reco
   return mapped;
 }
 
-function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<string, any> {
+export function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<string, any> {
   const argsObj =
     args && typeof args === "object" && !Array.isArray(args) ? (args as Record<string, any>) : null;
   if (toolName === "ApplyPatch" || toolName === "apply_patch") {
@@ -2399,6 +2401,15 @@ function mapToolArgs(toolName: string, args: unknown, resultText = ""): Record<s
   }
   if (toolName === "Edit" && (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)) {
     return mapEditLikeArgs(argsObj, resultText);
+  }
+  if (
+    (toolName === "MultiEdit" || toolName === "multi_edit") &&
+    (argsObj.path || argsObj.file_path || argsObj.relativeWorkspacePath)
+  ) {
+    return {
+      file_path: argsObj.file_path ?? argsObj.path ?? argsObj.relativeWorkspacePath,
+      edits: Array.isArray(argsObj.edits) ? argsObj.edits : [],
+    };
   }
   if (
     (toolName === "Write" || toolName === "WriteFile") &&

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -684,6 +684,7 @@ function buildScanResultFromParsed(
   const costEstimate = estimateParsedCost(parsed);
   const fallbackStart = parsed.startTime || input.timestamp;
   const durationMs = parsed.totalDurationMs;
+  const firstPrompt = firstUserPrompt(parsed.turns) || input.firstPrompt || parsed.title;
 
   return {
     sessionId: input.sessionId,
@@ -691,7 +692,7 @@ function buildScanResultFromParsed(
     project: input.project,
     slug: input.slug,
     title: parsed.title || input.title,
-    firstPrompt: parsed.title || input.firstPrompt,
+    firstPrompt,
     startTime: fallbackStart,
     endTime: parsed.endTime,
     durationMs,
@@ -722,6 +723,18 @@ function buildScanResultFromParsed(
       ?.map((t) => t.durationMs)
       .filter((d): d is number => d != null && d > 0),
   };
+}
+
+function firstUserPrompt(turns: ProviderParseResult["turns"]): string | undefined {
+  for (const turn of turns) {
+    if (turn.role !== "user" || turn.subtype === "compaction-summary") continue;
+    for (const block of turn.blocks) {
+      if (block.type !== "text") continue;
+      const text = block.text.replace(/\s+/g, " ").trim();
+      if (text.length >= 10) return text.slice(0, 200);
+    }
+  }
+  return undefined;
 }
 
 function estimateParsedCost(parsed: ProviderParseResult): number | undefined {

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -216,6 +216,8 @@ function buildFileDiff(
       return edit != null && typeof edit === "object";
     });
     if (edits.length > 0) {
+      // MultiEdit records independent replacements, not full before/after file
+      // states. Show a synthetic chunk list so the replay still surfaces what changed.
       return {
         filePath: redactPath(input.file_path),
         oldContent: edits.map((edit) => edit.old_string ?? "").join("\n\n"),

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -211,6 +211,18 @@ function buildFileDiff(
       newContent: input.new_string ?? "",
     };
   }
+  if (toolName === "MultiEdit" && input.file_path && Array.isArray(input.edits)) {
+    const edits = input.edits.filter((edit: unknown): edit is Record<string, any> => {
+      return edit != null && typeof edit === "object";
+    });
+    if (edits.length > 0) {
+      return {
+        filePath: redactPath(input.file_path),
+        oldContent: edits.map((edit) => edit.old_string ?? "").join("\n\n"),
+        newContent: edits.map((edit) => edit.new_string ?? "").join("\n\n"),
+      };
+    }
+  }
   if (toolName === "Write" && input.file_path) {
     return {
       filePath: redactPath(input.file_path),

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -18,6 +18,7 @@ export function normalizeTitle(value?: string): string | undefined {
 /** Tool names that modify files on disk. Used to count edits and track modified files. */
 export const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
   "Edit",
+  "MultiEdit",
   "Write",
   "NotebookEdit",
   "Delete",

--- a/packages/cli/test/cleanup-warning.test.ts
+++ b/packages/cli/test/cleanup-warning.test.ts
@@ -21,6 +21,8 @@ function makeSession(overrides: Partial<SessionInfo>): SessionInfo {
 }
 
 describe("computeDaysUntilCleanup", () => {
+  const NOW = Date.parse("2026-04-25T12:00:00.000Z");
+
   it("returns undefined when cleanupPeriodDays is 0 (disabled)", () => {
     expect(computeDaysUntilCleanup(new Date().toISOString(), 0)).toBeUndefined();
   });
@@ -31,28 +33,28 @@ describe("computeDaysUntilCleanup", () => {
 
   it("returns correct days for a recent session", () => {
     // Session created 5 days ago with 30-day cleanup → 25 days left (floor)
-    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
-    const daysLeft = computeDaysUntilCleanup(fiveDaysAgo, 30);
+    const fiveDaysAgo = new Date(NOW - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const daysLeft = computeDaysUntilCleanup(fiveDaysAgo, 30, NOW);
     expect(daysLeft).toBe(25);
   });
 
   it("returns 0 for sessions past cleanup deadline", () => {
-    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString();
-    const daysLeft = computeDaysUntilCleanup(fortyDaysAgo, 30);
+    const fortyDaysAgo = new Date(NOW - 40 * 24 * 60 * 60 * 1000).toISOString();
+    const daysLeft = computeDaysUntilCleanup(fortyDaysAgo, 30, NOW);
     expect(daysLeft).toBe(0);
   });
 
   it("returns correct days for session near expiry", () => {
     // Session created 27 days ago with 30-day cleanup → 3 days left
-    const twentySevenDaysAgo = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
-    const daysLeft = computeDaysUntilCleanup(twentySevenDaysAgo, 30);
+    const twentySevenDaysAgo = new Date(NOW - 27 * 24 * 60 * 60 * 1000).toISOString();
+    const daysLeft = computeDaysUntilCleanup(twentySevenDaysAgo, 30, NOW);
     expect(daysLeft).toBe(3);
   });
 
   it("uses Math.floor for conservative estimate", () => {
     // Session 25.9 days old → 30 - 25.9 = 4.1 → floor = 4 (not ceil = 5)
-    const almostTwentySixDays = new Date(Date.now() - 25.9 * 24 * 60 * 60 * 1000).toISOString();
-    const daysLeft = computeDaysUntilCleanup(almostTwentySixDays, 30);
+    const almostTwentySixDays = new Date(NOW - 25.9 * 24 * 60 * 60 * 1000).toISOString();
+    const daysLeft = computeDaysUntilCleanup(almostTwentySixDays, 30, NOW);
     expect(daysLeft).toBe(4);
   });
 });

--- a/packages/cli/test/cursor-parser-comprehensive.test.ts
+++ b/packages/cli/test/cursor-parser-comprehensive.test.ts
@@ -231,6 +231,124 @@ describe("Cursor parser — inline JSONL fixtures", () => {
     expect(result.dataSourceInfo?.sources?.length).toBeGreaterThan(0);
   });
 
+  it("normalizes inline Cursor JSONL tool calls for diff parity", async () => {
+    const path = await writeJsonl(tempDir, "inline-tool-call.jsonl", [
+      {
+        role: "user",
+        timestamp: "2026-04-01T00:00:00.000Z",
+        message: { content: [{ type: "text", text: "Patch the app" }] },
+      },
+      {
+        role: "assistant",
+        timestamp: "2026-04-01T00:00:01.000Z",
+        message: {
+          content: [
+            { type: "reasoning", text: "Need to update the literal." },
+            {
+              type: "tool_use",
+              id: "edit-1",
+              name: "search_replace",
+              input: {
+                relativeWorkspacePath: "src/app.ts",
+                oldStr: "const value = 1;",
+                newStr: "const value = 2;",
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const parsed = await parseCursorSession(path);
+    expect(parsed.turns[0].timestamp).toBe("2026-04-01T00:00:00.000Z");
+
+    const assistant = parsed.turns.find((turn) => turn.role === "assistant")!;
+    expect(assistant.blocks[0]).toMatchObject({
+      type: "thinking",
+      thinking: "Need to update the literal.",
+    });
+    expect(assistant.blocks[1]).toMatchObject({
+      type: "tool_use",
+      name: "Edit",
+      input: {
+        file_path: "src/app.ts",
+        old_string: "const value = 1;",
+        new_string: "const value = 2;",
+      },
+    });
+
+    const replay = transformToReplay(parsed, "cursor", "~/test");
+    const toolScene = replay.scenes.find((scene) => scene.type === "tool-call");
+    expect(toolScene?.type).toBe("tool-call");
+    if (toolScene?.type === "tool-call") {
+      expect(toolScene.toolName).toBe("Edit");
+      expect(toolScene.diff).toMatchObject({
+        filePath: "src/app.ts",
+        oldContent: "const value = 1;",
+        newContent: "const value = 2;",
+      });
+    }
+  });
+
+  it("infers Cursor edit diffs from JSONL tool results", async () => {
+    const path = await writeJsonl(tempDir, "inline-edit-result.jsonl", [
+      {
+        role: "user",
+        message: { content: [{ type: "text", text: "Update config" }] },
+      },
+      {
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "edit-1",
+              name: "edit_file_v2",
+              input: {
+                relativeWorkspacePath: "src/config.ts",
+                streamingContent: "",
+              },
+            },
+          ],
+        },
+      },
+      {
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "edit-1",
+              content: JSON.stringify({
+                contentsAfterEdit: "export const enabled = true;",
+                diff: {
+                  chunks: [
+                    {
+                      diffString:
+                        "@@\n-export const enabled = false;\n+export const enabled = true;",
+                    },
+                  ],
+                },
+              }),
+            },
+          ],
+        },
+      },
+    ]);
+
+    const parsed = await parseCursorSession(path);
+    const replay = transformToReplay(parsed, "cursor", "~/test");
+    const toolScene = replay.scenes.find((scene) => scene.type === "tool-call");
+    expect(toolScene?.type).toBe("tool-call");
+    if (toolScene?.type === "tool-call") {
+      expect(toolScene.diff).toMatchObject({
+        filePath: "src/config.ts",
+        oldContent: "export const enabled = false;",
+        newContent: "export const enabled = true;",
+      });
+    }
+  });
+
   it("maps tool output to marker and converts extras to thinking", async () => {
     const jsonl = await writeJsonl(tempDir, "marker-pairing.jsonl", [
       {

--- a/packages/cli/test/cursor-thinking-merge.test.ts
+++ b/packages/cli/test/cursor-thinking-merge.test.ts
@@ -12,6 +12,9 @@ vi.mock("../src/providers/cursor/sqlite-reader.js", () => ({
   CURSOR_SYSTEM_CONTEXT_RE: /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/,
   isSystemContextText: (text: string) =>
     /^<(?:user_info|system_reminder|agent_transcripts|rules|git_status)>/.test(text.trim()),
+  mapCursorToolName: (name: string) => name,
+  mapToolArgs: (_toolName: string, args: unknown) =>
+    args && typeof args === "object" && !Array.isArray(args) ? args : {},
   parseCursorSqlite: mockParseCursorSqlite,
 }));
 

--- a/packages/cli/test/scanner-cursor-duration.test.ts
+++ b/packages/cli/test/scanner-cursor-duration.test.ts
@@ -82,4 +82,35 @@ describe("scanSession cursor duration", () => {
 
     expect(result.subAgentCount).toBe(1);
   });
+
+  it("uses the first user prompt instead of the parsed title for Cursor scan previews", async () => {
+    mockedParseCursorSession.mockResolvedValueOnce({
+      sessionId: "cursor-session",
+      slug: "cursor-slug",
+      title: "Hand-written session title",
+      cwd: "/repo",
+      turns: [
+        {
+          role: "user",
+          blocks: [{ type: "text", text: "Please audit Cursor parity gaps in this project" }],
+        },
+        { role: "assistant", blocks: [{ type: "text", text: "I will inspect the codebase." }] },
+      ],
+      dataSource: "jsonl",
+    });
+
+    const result = await scanSession({
+      sessionId: "cursor-session",
+      provider: "cursor",
+      project: "~/Code/project",
+      slug: "cursor-slug",
+      filePaths: ["/tmp/session.jsonl"],
+      timestamp: "2025-01-01T00:00:00.000Z",
+      title: "Source title",
+      firstPrompt: "Fallback prompt",
+    });
+
+    expect(result.title).toBe("Hand-written session title");
+    expect(result.firstPrompt).toBe("Please audit Cursor parity gaps in this project");
+  });
 });

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -833,14 +833,29 @@ function CompactAssistantGroup({
 
   // Ordered tool names for display (common ones first)
   const sortedToolEntries = useMemo(() => {
-    const order = ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Agent"];
+    const order = [
+      "Read",
+      "Write",
+      "Edit",
+      "MultiEdit",
+      "Delete",
+      "Bash",
+      "Glob",
+      "Grep",
+      "SemanticSearch",
+      "Browser",
+      "Agent",
+    ];
+    const priority = (name: string) => {
+      const index = order.indexOf(name);
+      return index >= 0 ? index : 100;
+    };
     const entries = Object.entries(stats.toolBreakdown);
     entries.sort((a, b) => {
-      const ai = order.indexOf(a[0]);
-      const bi = order.indexOf(b[0]);
-      const ao = ai >= 0 ? ai : 100;
-      const bo = bi >= 0 ? bi : 100;
-      return ao - bo;
+      const byPriority = priority(a[0]) - priority(b[0]);
+      if (byPriority !== 0) return byPriority;
+      const byCount = b[1] - a[1];
+      return byCount !== 0 ? byCount : a[0].localeCompare(b[0]);
     });
     return entries;
   }, [stats.toolBreakdown]);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4,7 +4,6 @@ import { ALL_PROJECTS, usePanelFilters } from "../hooks/usePanelFilters";
 import type { SessionSummary, SourceSession } from "../types";
 import DashboardHome from "./DashboardHome";
 import {
-  agentWorktreeParent,
   cleanPrompt,
   computeProjectLabels,
   formatCacheAge,
@@ -1191,7 +1190,7 @@ function ReplayCard({
         {isWorktreeReplay && (
           <span
             className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider"
-            title={`Claude agent worktree: ${s.project}`}
+            title={`Agent worktree: ${s.project}`}
           >
             worktree
           </span>
@@ -1944,7 +1943,8 @@ function SessionsPanel() {
                 const sessionTitle = sourceDisplayTitle(s, scanData);
                 const prompts = sessionPromptPreview(s, scanData, sessionTitle);
                 const branch = nonDefaultBranch(scanData?.gitBranch || s.gitBranch);
-                const isWorktree = agentWorktreeParent(s.project) !== null;
+                const rolledProject = rollupProject(s.project);
+                const isWorktree = rolledProject !== s.project;
                 const displayPromptCount = scanData?.promptCount ?? s.promptCount;
                 const displayToolCount = scanData?.toolCallCount ?? s.toolCallCount;
                 const displayDurationMs = scanData?.durationMs ?? s.durationMsEst;
@@ -1988,7 +1988,7 @@ function SessionsPanel() {
                           {isWorktree && (
                             <span
                               className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple shrink-0 uppercase tracking-wider"
-                              title={`Claude agent worktree: ${s.project}`}
+                              title={`Agent worktree: ${s.project}`}
                             >
                               worktree
                             </span>
@@ -2110,7 +2110,9 @@ function SessionsPanel() {
                           className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim"
                           title={s.project}
                         >
-                          {projectLabels.get(s.project) || projectName(s.project)}
+                          {projectLabels.get(rolledProject) ||
+                            projectLabels.get(s.project) ||
+                            projectName(rolledProject)}
                         </span>
                       )}
                       {displayModel && (

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1944,6 +1944,7 @@ function SessionsPanel() {
                 const prompts = sessionPromptPreview(s, scanData, sessionTitle);
                 const branch = nonDefaultBranch(scanData?.gitBranch || s.gitBranch);
                 const rolledProject = rollupProject(s.project);
+                // True when the display project is a rolled-up agent worktree path.
                 const isWorktree = rolledProject !== s.project;
                 const displayPromptCount = scanData?.promptCount ?? s.promptCount;
                 const displayToolCount = scanData?.toolCallCount ?? s.toolCallCount;

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -446,7 +446,7 @@ export function ProjectInsightsPanel({ insights }: { insights: ProjectInsights }
     const entries = Object.entries(insights.models);
     if (entries.length === 0) return null;
     entries.sort((a, b) => b[1] - a[1]);
-    return entries[0][0].replace(/^claude-/, "").split("-202")[0];
+    return shortModelName(entries[0][0]);
   }, [insights.models]);
 
   const multiBranchSessions = useMemo(() => {
@@ -592,7 +592,7 @@ export function ProjectInsightsPanel({ insights }: { insights: ProjectInsights }
                 Models:{" "}
                 {Object.entries(insights.models)
                   .sort((a, b) => b[1] - a[1])
-                  .map(([m, c]) => `${m.replace(/^claude-/, "").split("-202")[0]} (${c})`)
+                  .map(([m, c]) => `${shortModelName(m)} (${c})`)
                   .join(", ")}
               </span>
             )}

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -247,8 +247,7 @@ function ProjectOverview({
         )}
         {insight.memoryFileCount > 0 && (
           <span>
-            {insight.memoryFileCount}{" "}
-            {insight.memoryFileCount === 1 ? "Claude memory" : "Claude memories"}
+            {insight.memoryFileCount} {plural(insight.memoryFileCount, "memory file")}
           </span>
         )}
       </div>

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -120,7 +120,7 @@ export default function StatsPanel({ session }: Props) {
           {isWorktree && (
             <span
               className="px-1 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider text-[10px]"
-              title={`Claude agent worktree: ${meta.project}`}
+              title={`Agent worktree: ${meta.project}`}
             >
               worktree
             </span>

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -590,8 +590,12 @@ export default function SummaryView({ session }: Props) {
                     </div>
                     <div className="text-terminal-dimmer">
                       {maxRetry > 0
-                        ? "Cursor automatically retried some of these errors."
-                        : "These errors were observed in local Cursor metadata."}
+                        ? meta.provider === "cursor"
+                          ? "Cursor automatically retried some of these errors."
+                          : "The provider retried some of these errors before continuing."
+                        : meta.provider === "cursor"
+                          ? "These errors were observed in local Cursor metadata."
+                          : "These errors were observed in session telemetry."}
                     </div>
                   </>
                 );


### PR DESCRIPTION
## Summary
- Normalize Cursor JSONL inline tool calls through the same mapper used by SQLite-backed sessions, restoring edit diffs, edit counts, and file-modified analytics for JSONL-only sessions.
- Preserve Cursor JSONL user timestamps and reasoning/thinking blocks, and fix scan previews to use the first user prompt instead of the parsed title.
- Clean up Cursor/Claude parity rough edges in viewer model labels, project chips, API error copy, worktree labels, memory copy, and tool ordering.

## Local Cursor validation
- Discovered and validated 731 local Cursor sessions on this machine.
- Full batch parse/transform result: 731 parsed, 0 failures.
- Data source coverage: 552 global-state, 167 sqlite, 11 jsonl, 1 jsonl+tools.
- Aggregate replay coverage: 64,625 scenes, 3,863 prompts, 32,660 tool scenes, 15,525 thinking scenes, 3,012 diff scenes.
- HTML generation smoke: generated 18 replay HTML files from local Cursor sessions across global-state/sqlite/jsonl/jsonl+tools, 0 failures.
- Single CLI smoke: generated GitHub replay artifacts from a real local Cursor JSONL session, no secret findings.

## AI review follow-up
- Confirmed the reported `claude-code/discover.ts` timestamp concern is not in this PR diff.
- Added clarifying comments for raw Cursor arg normalization, synthetic MultiEdit diffs, and rolled-up worktree detection.

## Test plan
- [x] pnpm test
- [x] pnpm typecheck
- [x] pnpm lint:check
- [x] pnpm build && pnpm test:e2e
- [x] Batch-validate many local Cursor sessions and update this PR with results
- [x] Address AI review comments