### PR TITLE
Add Codex session provider

### DIFF
--- a/packages/cli/src/providers/codex/constants.ts
+++ b/packages/cli/src/providers/codex/constants.ts
@@ -1,0 +1,1 @@
+export const USER_MESSAGE_BEGIN = "## My request for Codex:";

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -1,0 +1,294 @@
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+import { cleanPromptText } from "../../clean-prompt.js";
+import type { SessionInfo } from "../../types.js";
+import { shortenPath } from "../../utils.js";
+import { USER_MESSAGE_BEGIN } from "./constants.js";
+
+const STATE_DB_FILENAME = "state_5.sqlite";
+
+interface CodexThreadRow {
+  id: string;
+  rollout_path: string;
+  created_at: number;
+  updated_at: number;
+  source: string;
+  cwd: string;
+  title: string;
+  tokens_used: number;
+  git_branch?: string;
+  cli_version?: string;
+  first_user_message?: string;
+  model?: string;
+  reasoning_effort?: string;
+  created_at_ms?: number;
+  updated_at_ms?: number;
+}
+
+export async function discoverCodexSessions(): Promise<SessionInfo[]> {
+  const byId = new Map<string, SessionInfo>();
+  const codexHome = getCodexHome();
+
+  for (const row of await readThreadRowsFromStateDb()) {
+    const info = await sessionInfoFromThreadRow(row);
+    if (info) byId.set(info.sessionId, info);
+  }
+
+  for (const filePath of await findRolloutFiles(join(codexHome, "sessions"))) {
+    const fileStat = await stat(filePath).catch(() => null);
+    if (!fileStat?.isFile()) continue;
+    const info = await extractCodexSessionInfo(filePath, fileStat.size);
+    if (info && !byId.has(info.sessionId)) byId.set(info.sessionId, info);
+  }
+
+  return [...byId.values()].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}
+
+async function sessionInfoFromThreadRow(row: CodexThreadRow): Promise<SessionInfo | null> {
+  if (!row.id || !row.rollout_path) return null;
+  const fileStat = await stat(row.rollout_path).catch(() => null);
+  if (!fileStat?.isFile()) return null;
+
+  const extracted = await extractCodexSessionInfo(row.rollout_path, fileStat.size);
+  const firstPrompt = cleanCodexUserMessage(row.first_user_message || extracted?.firstPrompt || "");
+  if (!firstPrompt) return extracted;
+
+  return {
+    provider: "codex",
+    sessionId: row.id,
+    slug: row.id.slice(0, 8),
+    title: row.title || extracted?.title,
+    project: shortenPath(row.cwd || extracted?.cwd || ""),
+    cwd: row.cwd || extracted?.cwd || "",
+    version: row.cli_version || extracted?.version || "",
+    gitBranch: row.git_branch || extracted?.gitBranch,
+    timestamp:
+      toIsoFlexible(row.updated_at_ms || row.updated_at) ||
+      extracted?.timestamp ||
+      fileStat.mtime.toISOString(),
+    lineCount: extracted?.lineCount || 0,
+    fileSize: fileStat.size,
+    filePath: row.rollout_path,
+    filePaths: [row.rollout_path],
+    firstPrompt,
+    prompts: extracted?.prompts?.length ? extracted.prompts : [firstPrompt],
+    promptCount: extracted?.promptCount,
+    toolCallCount: extracted?.toolCallCount,
+    model: row.model || extracted?.model,
+    durationMsEst: extracted?.durationMsEst,
+    editCountEst: extracted?.editCountEst,
+    hasPR: extracted?.hasPR,
+  };
+}
+
+export async function extractCodexSessionInfo(
+  filePath: string,
+  fileSize: number,
+): Promise<SessionInfo | null> {
+  let sessionId = "";
+  let cwd = "";
+  let version = "";
+  let timestamp = "";
+  let title: string | undefined;
+  let model: string | undefined;
+  let gitBranch: string | undefined;
+  let lineCount = 0;
+  let promptCount = 0;
+  let toolCallCount = 0;
+  let editCountEst = 0;
+  let durationMsEst = 0;
+  const prompts: string[] = [];
+
+  let rl: ReturnType<typeof createInterface> | undefined;
+  try {
+    const input = createReadStream(filePath, { encoding: "utf-8" });
+    rl = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
+    for await (const raw of rl) {
+      const line = raw.trim();
+      if (!line) continue;
+      lineCount++;
+      let obj: any;
+      try {
+        obj = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (obj.timestamp) timestamp = obj.timestamp;
+
+      if (obj.type === "session_meta") {
+        const p = obj.payload || {};
+        sessionId = sessionId || p.id || "";
+        cwd = cwd || p.cwd || "";
+        version = version || p.cli_version || "";
+        if (p.timestamp && !timestamp) timestamp = p.timestamp;
+        gitBranch = gitBranch || p.git?.branch || p.git_branch;
+        continue;
+      }
+
+      if (obj.type === "turn_context") {
+        const p = obj.payload || {};
+        model = model || p.model;
+        continue;
+      }
+
+      if (obj.type === "event_msg") {
+        const p = obj.payload || {};
+        if (p.type === "thread_name_updated" && p.thread_name) title = p.thread_name;
+        if (p.type === "user_message") {
+          const cleaned = typeof p.message === "string" ? cleanCodexUserMessage(p.message) : "";
+          const hasImages = hasUserImages(p);
+          if (cleaned.length >= 10 || hasImages) {
+            promptCount++;
+            if (prompts.length < 2) {
+              prompts.push((cleaned || "[Image]").slice(0, 200));
+            }
+          }
+        }
+        if (p.type === "exec_command_end" && typeof p.duration?.secs === "number") {
+          durationMsEst += p.duration.secs * 1000 + Math.round((p.duration.nanos || 0) / 1_000_000);
+        }
+        continue;
+      }
+
+      if (obj.type === "response_item") {
+        const p = obj.payload || {};
+        if (p.type === "function_call") {
+          toolCallCount++;
+          if (isEditTool(p.name)) editCountEst++;
+        }
+      }
+    }
+  } catch {
+    return null;
+  } finally {
+    rl?.close();
+  }
+
+  if (!sessionId) {
+    const m = basename(filePath).match(/rollout-.+-(.+)\.jsonl$/);
+    sessionId = m?.[1] || "";
+  }
+  if (!sessionId || prompts.length === 0) return null;
+
+  return {
+    provider: "codex",
+    sessionId,
+    slug: sessionId.slice(0, 8),
+    title,
+    project: shortenPath(cwd),
+    cwd,
+    version,
+    gitBranch,
+    timestamp: timestamp || (await stat(filePath).then((s) => s.mtime.toISOString())),
+    lineCount,
+    fileSize,
+    filePath,
+    filePaths: [filePath],
+    firstPrompt: prompts[0],
+    prompts,
+    promptCount,
+    toolCallCount,
+    model,
+    durationMsEst: durationMsEst || undefined,
+    editCountEst: editCountEst || undefined,
+  };
+}
+
+async function readThreadRowsFromStateDb(): Promise<CodexThreadRow[]> {
+  const stateDbPath = getStateDbPath();
+  const dbStat = await stat(stateDbPath).catch(() => null);
+  if (!dbStat?.isFile() || dbStat.size < 1024) return [];
+
+  try {
+    const mod = await import("sql.js");
+    const SQL = await mod.default();
+    const dbBuffer = await import("node:fs/promises").then((fs) => fs.readFile(stateDbPath));
+    const db = new SQL.Database(dbBuffer);
+    try {
+      const result = db.exec(`
+        SELECT id, rollout_path, created_at, updated_at, source, cwd, title,
+               tokens_used, git_branch, cli_version, first_user_message, model, reasoning_effort,
+               created_at_ms, updated_at_ms
+        FROM threads
+        WHERE archived = 0
+        ORDER BY updated_at_ms DESC, updated_at DESC
+      `);
+      const table = result[0];
+      if (!table) return [];
+      return table.values.map((values: any[]) => {
+        const row: Record<string, any> = {};
+        table.columns.forEach((col: string, i: number) => {
+          row[col] = values[i];
+        });
+        return row as CodexThreadRow;
+      });
+    } finally {
+      db.close();
+    }
+  } catch {
+    return [];
+  }
+}
+
+async function findRolloutFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(current: string): Promise<void> {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fp = join(current, entry.name);
+      if (entry.isDirectory()) await walk(fp);
+      else if (
+        entry.isFile() &&
+        entry.name.startsWith("rollout-") &&
+        entry.name.endsWith(".jsonl")
+      ) {
+        out.push(fp);
+      }
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+function getCodexHome(): string {
+  return process.env.CODEX_HOME || join(homedir(), ".codex");
+}
+
+function getStateDbPath(): string {
+  const sqliteHome = process.env.CODEX_SQLITE_HOME || getCodexHome();
+  return join(sqliteHome, STATE_DB_FILENAME);
+}
+
+function toIsoFlexible(value?: number): string | undefined {
+  if (!value) return undefined;
+  const millis = value < 1_577_836_800_000 ? value * 1000 : value;
+  const d = new Date(millis);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+function isEditTool(name?: string): boolean {
+  return !!name && ["apply_patch", "edit", "write_file"].includes(name);
+}
+
+function cleanCodexUserMessage(text: string): string {
+  const withoutPrefix = text.includes(USER_MESSAGE_BEGIN)
+    ? text.slice(text.indexOf(USER_MESSAGE_BEGIN) + USER_MESSAGE_BEGIN.length)
+    : text;
+  return cleanPromptText(withoutPrefix);
+}
+
+function hasUserImages(payload: any): boolean {
+  return (
+    (Array.isArray(payload.images) && payload.images.length > 0) ||
+    (Array.isArray(payload.local_images) && payload.local_images.length > 0)
+  );
+}

--- a/packages/cli/src/providers/codex/index.ts
+++ b/packages/cli/src/providers/codex/index.ts
@@ -1,0 +1,10 @@
+import type { Provider } from "../types.js";
+import { discoverCodexSessions } from "./discover.js";
+import { parseCodexSession } from "./parser.js";
+
+export const codexProvider: Provider = {
+  name: "codex",
+  displayName: "Codex",
+  discover: discoverCodexSessions,
+  parse: parseCodexSession,
+};

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -1,0 +1,516 @@
+import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+import { estimateActiveDuration } from "../../duration.js";
+import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
+import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
+import { USER_MESSAGE_BEGIN } from "./constants.js";
+
+interface PendingTool {
+  id: string;
+  name: string;
+  input: Record<string, any>;
+  timestamp?: string;
+}
+
+interface ToolResult {
+  result: string;
+  isError?: boolean;
+  timestamp?: string;
+  durationMs?: number;
+}
+
+export async function parseCodexSession(
+  filePaths: string | string[],
+  sessionInfo?: SessionInfo,
+): Promise<ProviderParseResult> {
+  const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
+  const lines: string[] = [];
+  for (const fp of paths) {
+    const content = await readFile(fp, "utf-8");
+    lines.push(...content.split("\n").filter((l) => l.trim()));
+  }
+  return parseCodexLines(lines, sessionInfo, paths);
+}
+
+export function parseCodexLines(
+  lines: string[],
+  sessionInfo?: SessionInfo,
+  sourcePaths: string[] = [],
+): ProviderParseResult {
+  let sessionId = sessionInfo?.sessionId || "";
+  let slug = sessionInfo?.slug || "";
+  let title = sessionInfo?.title;
+  let cwd = sessionInfo?.cwd || "";
+  let model = sessionInfo?.model;
+  let startTime: string | undefined;
+  let endTime: string | undefined;
+  let gitBranch = sessionInfo?.gitBranch;
+  let entrypoint: string | undefined;
+  let permissionMode: string | undefined;
+  let approvalPolicy: string | undefined;
+
+  const turns: ParsedTurn[] = [];
+  const allTimestamps: string[] = [];
+  const compactions: Compaction[] = [];
+  const tools = new Map<string, PendingTool>();
+  const toolResults = new Map<string, ToolResult>();
+  const tokenSnapshots: Array<{ timestamp?: string; total?: any; last?: any }> = [];
+  const mcpServersUsed = new Set<string>();
+  const skillsUsed = new Set<string>();
+  const gitBranches: string[] = [];
+
+  for (const line of lines) {
+    let obj: any;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (obj.timestamp) {
+      allTimestamps.push(obj.timestamp);
+      endTime = obj.timestamp;
+      if (!startTime) startTime = obj.timestamp;
+    }
+
+    if (obj.type === "session_meta") {
+      const p = obj.payload || {};
+      sessionId = sessionId || p.id || "";
+      slug = slug || (sessionId ? sessionId.slice(0, 8) : "");
+      cwd = cwd || p.cwd || "";
+      if (p.timestamp) startTime = startTime || p.timestamp;
+      gitBranch = gitBranch || p.git?.branch || p.git_branch;
+      if (gitBranch) pushUnique(gitBranches, gitBranch);
+      entrypoint = entrypoint || p.originator || p.source;
+      continue;
+    }
+
+    if (obj.type === "turn_context") {
+      const p = obj.payload || {};
+      model = model || p.model;
+      permissionMode = permissionMode || p.permission_profile?.type || p.sandbox_policy?.type;
+      approvalPolicy = approvalPolicy || p.approval_policy;
+      continue;
+    }
+
+    if (obj.type === "event_msg") {
+      const p = obj.payload || {};
+      if (p.type === "thread_name_updated" && p.thread_name) {
+        title = p.thread_name;
+        continue;
+      }
+      if (p.type === "user_message") {
+        const blocks = userMessageBlocks(p);
+        if (blocks.length > 0) {
+          turns.push({ role: "user", timestamp: obj.timestamp, blocks });
+        }
+        continue;
+      }
+      if (p.type === "agent_reasoning" && typeof p.text === "string" && p.text.trim()) {
+        turns.push({
+          role: "assistant",
+          timestamp: obj.timestamp,
+          blocks: [{ type: "thinking", thinking: p.text }],
+        });
+        continue;
+      }
+      if (p.type === "exec_command_end" && p.call_id) {
+        toolResults.set(p.call_id, {
+          result: formatExecResult(p),
+          isError: typeof p.exit_code === "number" ? p.exit_code !== 0 : undefined,
+          timestamp: obj.timestamp,
+          durationMs: durationToMs(p.duration),
+        });
+        continue;
+      }
+      if (p.type === "token_count") {
+        tokenSnapshots.push({
+          timestamp: obj.timestamp,
+          total: p.info?.total_token_usage,
+          last: p.info?.last_token_usage,
+        });
+        continue;
+      }
+      if (p.type === "web_search_end" && p.query) {
+        const callId = p.call_id || `web_search:${obj.timestamp}`;
+        if (!tools.has(callId)) {
+          tools.set(callId, {
+            id: callId,
+            name: "web_search",
+            input: p.action || { query: p.query },
+            timestamp: obj.timestamp,
+          });
+        }
+        toolResults.set(callId, {
+          result: `[Search: ${typeof p.query === "string" ? p.query : JSON.stringify(p.query)}]`,
+          timestamp: obj.timestamp,
+        });
+      }
+      continue;
+    }
+
+    if (obj.type !== "response_item") continue;
+    const p = obj.payload || {};
+
+    if (p.type === "message" && p.role === "assistant") {
+      const text = contentText(p.content);
+      if (text.trim()) {
+        turns.push({
+          role: "assistant",
+          timestamp: obj.timestamp,
+          blocks: [{ type: "text", text }],
+        });
+      }
+      continue;
+    }
+
+    if (p.type === "compaction") {
+      compactions.push({
+        timestamp: obj.timestamp || "",
+        trigger: "codex",
+      });
+      continue;
+    }
+
+    if (p.type === "reasoning") {
+      const thinking = reasoningText(p);
+      if (thinking.trim()) {
+        turns.push({
+          role: "assistant",
+          timestamp: obj.timestamp,
+          blocks: [{ type: "thinking", thinking }],
+        });
+      }
+      continue;
+    }
+
+    if (
+      p.type === "function_call" ||
+      p.type === "local_shell_call" ||
+      p.type === "custom_tool_call" ||
+      p.type === "tool_search_call" ||
+      p.type === "web_search_call" ||
+      p.type === "image_generation_call"
+    ) {
+      const callId = p.call_id || p.id || `${p.type}:${obj.timestamp}:${tools.size}`;
+      const name = p.name || normalizeCodexToolName(p.type);
+      const input = inputForResponseItem(p);
+      tools.set(callId, { id: callId, name, input, timestamp: obj.timestamp });
+      if (name.startsWith("mcp__")) {
+        const server = name.split("__")[1];
+        if (server) mcpServersUsed.add(server);
+      }
+      if (name === "tool_search") skillsUsed.add("tool_search");
+      continue;
+    }
+
+    if (
+      p.type === "function_call_output" ||
+      p.type === "custom_tool_call_output" ||
+      p.type === "tool_search_output"
+    ) {
+      if (p.call_id) {
+        toolResults.set(p.call_id, {
+          result: formatOutputPayload(p),
+          timestamp: obj.timestamp,
+        });
+      }
+      continue;
+    }
+  }
+
+  for (const tool of tools.values()) {
+    const tr = toolResults.get(tool.id);
+    turns.push({
+      role: "assistant",
+      timestamp: tool.timestamp,
+      blocks: [
+        {
+          type: "tool_use",
+          id: tool.id,
+          name: normalizeToolName(tool.name),
+          input: normalizeToolInput(tool.name, tool.input),
+          _result: tr?.result || "",
+          ...(tr?.isError ? { _isError: true } : {}),
+          ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
+        },
+      ],
+    });
+  }
+
+  turns.sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+
+  const tokenUsage = tokenUsageFromSnapshots(tokenSnapshots);
+  const tokenUsageByModel =
+    tokenUsage && model
+      ? {
+          [model]: tokenUsage,
+        }
+      : undefined;
+  const turnStats = buildCodexTurnStats(turns, tokenSnapshots, model);
+
+  return {
+    sessionId,
+    slug: slug || sessionId.slice(0, 8),
+    title,
+    cwd,
+    model,
+    startTime,
+    endTime,
+    totalDurationMs: estimateActiveDuration(allTimestamps),
+    turns,
+    tokenUsage,
+    tokenUsageByModel,
+    compactions: compactions.length > 0 ? compactions : undefined,
+    turnStats: turnStats.length > 0 ? turnStats : undefined,
+    gitBranch,
+    gitBranches: gitBranches.length > 1 ? gitBranches : undefined,
+    entrypoint,
+    permissionMode: approvalPolicy || permissionMode,
+    skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
+    mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
+    dataSource: "jsonl",
+    dataSourceInfo: {
+      primary: "jsonl",
+      sources: ["~/.codex/state_5.sqlite", "~/.codex/sessions"],
+      supplements: sourcePaths,
+      notes: ["Discovered from Codex state and parsed from rollout JSONL (local beta)."],
+    },
+  };
+}
+
+function userMessageBlocks(payload: any): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  const text =
+    typeof payload.message === "string" ? stripUserMessagePrefix(payload.message).trim() : "";
+  if (text) blocks.push({ type: "text", text });
+
+  const imageUrls = [...(Array.isArray(payload.images) ? payload.images : [])].filter(
+    (v) => typeof v === "string" && v.trim(),
+  );
+  const localImages = (Array.isArray(payload.local_images) ? payload.local_images : [])
+    .filter((v: unknown): v is string => typeof v === "string" && !!v.trim())
+    .map((v: string) => localImageToDataUrl(v))
+    .filter((v: string | undefined): v is string => !!v);
+  imageUrls.push(...localImages);
+  if (imageUrls.length > 0) blocks.push({ type: "_user_images", images: imageUrls });
+  return blocks;
+}
+
+function contentText(content: any): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part?.type === "output_text" || part?.type === "input_text" || part?.type === "text") {
+        return part.text || "";
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function reasoningText(payload: any): string {
+  if (typeof payload.content === "string") return payload.content;
+  if (Array.isArray(payload.content)) return contentText(payload.content);
+  if (Array.isArray(payload.summary)) return contentText(payload.summary);
+  return "";
+}
+
+function parseArguments(value: any): Record<string, any> {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  if (typeof value !== "string") return { value };
+  if (!value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed : { value: parsed };
+  } catch {
+    return { value };
+  }
+}
+
+function inputForResponseItem(payload: any): Record<string, any> {
+  if (payload.type === "local_shell_call") {
+    return localShellActionInput(payload.action);
+  }
+  if (payload.type === "custom_tool_call") {
+    return parseArguments(payload.input);
+  }
+  if (payload.type === "image_generation_call") {
+    return {
+      status: payload.status,
+      revised_prompt: payload.revised_prompt,
+      result: payload.result,
+    };
+  }
+  return parseArguments(payload.arguments ?? payload.action ?? {});
+}
+
+function localShellActionInput(action: any): Record<string, any> {
+  const command = Array.isArray(action?.command)
+    ? action.command.map(String).join(" ")
+    : typeof action?.command === "string"
+      ? action.command
+      : "";
+  return {
+    command,
+    cmd: command,
+    workdir: action?.working_directory || undefined,
+    timeout_ms: action?.timeout_ms ?? undefined,
+    env: action?.env ?? undefined,
+    user: action?.user ?? undefined,
+  };
+}
+
+function normalizeCodexToolName(type: string): string {
+  if (type === "local_shell_call") return "Bash";
+  if (type === "custom_tool_call") return "custom_tool";
+  if (type === "tool_search_call") return "tool_search";
+  if (type === "web_search_call") return "web_search";
+  if (type === "image_generation_call") return "image_generation";
+  return type;
+}
+
+function normalizeToolName(name: string): string {
+  if (name === "exec_command") return "Bash";
+  if (name === "apply_patch" || name === "edit") return "Edit";
+  if (name === "write_file") return "Write";
+  return name;
+}
+
+function normalizeToolInput(name: string, input: Record<string, any>): Record<string, any> {
+  if (name === "exec_command" && typeof input.cmd === "string" && !input.command) {
+    return { ...input, command: input.cmd };
+  }
+  return input;
+}
+
+function formatExecResult(payload: any): string {
+  const output = payload.aggregated_output || payload.stdout || payload.stderr || "";
+  const status = payload.status ? `Status: ${payload.status}` : "";
+  const exit = typeof payload.exit_code === "number" ? `Exit code: ${payload.exit_code}` : "";
+  return [output, status, exit].filter(Boolean).join("\n");
+}
+
+function formatOutputPayload(payload: any): string {
+  if (typeof payload.output === "string") return payload.output;
+  if (Array.isArray(payload.output)) return formatContentItems(payload.output);
+  if (payload.tools) return JSON.stringify(payload.tools, null, 2);
+  if (payload.action) return JSON.stringify(payload.action, null, 2);
+  return JSON.stringify(payload);
+}
+
+function formatContentItems(items: any[]): string {
+  return items
+    .map((item) => {
+      if (item?.type === "input_text" || item?.type === "output_text" || item?.type === "text") {
+        return item.text || "";
+      }
+      if (item?.type === "input_image") return item.image_url || "[image]";
+      return JSON.stringify(item);
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function durationToMs(duration: any): number | undefined {
+  if (!duration || typeof duration !== "object") return undefined;
+  const secs = typeof duration.secs === "number" ? duration.secs : 0;
+  const nanos = typeof duration.nanos === "number" ? duration.nanos : 0;
+  const ms = secs * 1000 + Math.round(nanos / 1_000_000);
+  return ms > 0 ? ms : undefined;
+}
+
+function tokenUsageFromSnapshots(
+  snapshots: Array<{ total?: any; last?: any }>,
+): TokenUsage | undefined {
+  const latest = [...snapshots].toReversed().find((s) => s.total)?.total;
+  if (!latest) return undefined;
+  const input = latest.input_tokens || 0;
+  const cached = latest.cached_input_tokens || 0;
+  return {
+    inputTokens: Math.max(0, input - cached),
+    outputTokens: latest.output_tokens || 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: cached,
+  };
+}
+
+function buildCodexTurnStats(
+  turns: ParsedTurn[],
+  snapshots: Array<{ timestamp?: string; last?: any }>,
+  model?: string,
+) {
+  const userTurns = turns.filter((t) => t.role === "user");
+  const usable = snapshots.filter((s) => s.last);
+  return userTurns.map((turn, i) => {
+    const usage = usable[i]?.last;
+    const stat: {
+      turnIndex: number;
+      model?: string;
+      tokenUsage?: TokenUsage;
+      contextTokens?: number;
+      durationMs?: number;
+    } = { turnIndex: i };
+    if (model) stat.model = model;
+    if (usage) {
+      const input = usage.input_tokens || 0;
+      const cached = usage.cached_input_tokens || 0;
+      stat.tokenUsage = {
+        inputTokens: Math.max(0, input - cached),
+        outputTokens: usage.output_tokens || 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: cached,
+      };
+      stat.contextTokens = input;
+    }
+    const nextUser = userTurns[i + 1]?.timestamp;
+    if (turn.timestamp) {
+      const end = nextUser || usable[i]?.timestamp;
+      if (end) {
+        const diff = Date.parse(end) - Date.parse(turn.timestamp);
+        if (diff > 0 && diff < 12 * 60 * 60 * 1000) stat.durationMs = diff;
+      }
+    }
+    return stat;
+  });
+}
+
+function pushUnique(items: string[], value: string): void {
+  if (items.length === 0 || items[items.length - 1] !== value) items.push(value);
+}
+
+function stripUserMessagePrefix(text: string): string {
+  const idx = text.indexOf(USER_MESSAGE_BEGIN);
+  return idx === -1 ? text : text.slice(idx + USER_MESSAGE_BEGIN.length);
+}
+
+function localImageToDataUrl(path: string): string | undefined {
+  try {
+    const data = readFileSync(path);
+    return `data:${mimeTypeForPath(path)};base64,${data.toString("base64")}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function mimeTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".webp":
+      return "image/webp";
+    case ".gif":
+      return "image/gif";
+    case ".svg":
+      return "image/svg+xml";
+    case ".png":
+    default:
+      return "image/png";
+  }
+}

--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -1,6 +1,7 @@
 import { claudeCodeProvider } from "./claude-code/index.js";
 import { claudeCoworkProvider } from "./claude-cowork/index.js";
 import { claudeDesktopProvider } from "./claude-desktop/index.js";
+import { codexProvider } from "./codex/index.js";
 import { cursorProvider } from "./cursor/index.js";
 import type { Provider } from "./types.js";
 import type { SessionInfo } from "../types.js";
@@ -9,13 +10,15 @@ const providers: Provider[] = [
   claudeCoworkProvider,
   claudeDesktopProvider,
   claudeCodeProvider,
+  codexProvider,
   cursorProvider,
 ];
 
 // Priority order for deduplication — lower index = higher priority.
 // Cowork ranks first because its audit.jsonl is self-contained and the only
 // source of truth for agent-mode sessions (no other provider can discover them).
-const PROVIDER_PRIORITY = ["claude-cowork", "claude-desktop", "claude-code", "cursor"];
+// Codex uses distinct rollout UUIDs, so it does not collide with the Claude family.
+const PROVIDER_PRIORITY = ["claude-cowork", "claude-desktop", "claude-code", "codex", "cursor"];
 
 export function getAllProviders(): Provider[] {
   return providers;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { estimateActiveDuration } from "./duration.js";
 import { estimateCost, estimateCostSimple } from "./pricing.js";
+import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { getCursorSessionCachePaths } from "./providers/cursor/sqlite-reader.js";
 import type { ProviderParseResult } from "./providers/types.js";
@@ -23,7 +24,7 @@ import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 import { FILE_EDIT_TOOLS, extractToolFilePath, localDayKey, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
-const SCANNER_VERSION = 7;
+const SCANNER_VERSION = 8;
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -277,6 +278,14 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     } catch {
       // Fall back to the legacy lightweight scanner below so Cursor sessions
       // still show up even if richer parsing fails for one host/schema.
+    }
+  }
+  if (input.provider === "codex") {
+    try {
+      return await scanCodexSession(input);
+    } catch {
+      // Fall through to the lightweight scanner so a partial Codex rollout
+      // still appears in insights if the richer parser hits an unknown event.
     }
   }
 
@@ -592,6 +601,27 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
     turnDurations: turnDurations.length > 0 ? turnDurations : undefined,
   };
+}
+
+async function scanCodexSession(input: ScanInput): Promise<SessionScanResult> {
+  const sessionInfo: SessionInfo = {
+    provider: "codex",
+    sessionId: input.sessionId,
+    slug: input.slug,
+    title: input.title,
+    project: input.project,
+    cwd: input.workspacePath || input.project,
+    version: "",
+    timestamp: input.timestamp || new Date().toISOString(),
+    lineCount: 0,
+    fileSize: 0,
+    filePath: input.filePaths[0] || "",
+    filePaths: input.filePaths,
+    firstPrompt: input.firstPrompt || input.title || "",
+  };
+
+  const parsed = await parseCodexSession(input.filePaths, sessionInfo);
+  return buildScanResultFromParsed(input, parsed);
 }
 
 async function scanCursorSession(input: ScanInput): Promise<SessionScanResult> {

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -1,0 +1,344 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { extractCodexSessionInfo } from "../src/providers/codex/discover.js";
+import { parseCodexLines } from "../src/providers/codex/parser.js";
+import { transformToReplay } from "../src/transform.js";
+
+const lines = [
+  {
+    timestamp: "2026-04-26T05:00:00.000Z",
+    type: "session_meta",
+    payload: {
+      id: "codex-session-1",
+      timestamp: "2026-04-26T05:00:00.000Z",
+      cwd: "/Users/test/project",
+      originator: "Codex CLI",
+      cli_version: "0.125.0",
+      source: "cli",
+      git: { branch: "main" },
+    },
+  },
+  {
+    timestamp: "2026-04-26T05:00:00.100Z",
+    type: "turn_context",
+    payload: { model: "gpt-5.4", effort: "high", approval_policy: "never" },
+  },
+  {
+    timestamp: "2026-04-26T05:00:01.000Z",
+    type: "event_msg",
+    payload: { type: "user_message", message: "Please update the auth flow\n" },
+  },
+  {
+    timestamp: "2026-04-26T05:00:02.000Z",
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "I'll inspect the code first." }],
+    },
+  },
+  {
+    timestamp: "2026-04-26T05:00:03.000Z",
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      name: "exec_command",
+      call_id: "call_1",
+      arguments: JSON.stringify({ cmd: "pnpm test", workdir: "/Users/test/project" }),
+    },
+  },
+  {
+    timestamp: "2026-04-26T05:00:05.000Z",
+    type: "event_msg",
+    payload: {
+      type: "exec_command_end",
+      call_id: "call_1",
+      aggregated_output: "tests passed",
+      exit_code: 0,
+      status: "completed",
+      duration: { secs: 2, nanos: 0 },
+    },
+  },
+  {
+    timestamp: "2026-04-26T05:00:05.100Z",
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: {
+          input_tokens: 1000,
+          cached_input_tokens: 300,
+          output_tokens: 50,
+          total_tokens: 1050,
+        },
+        last_token_usage: {
+          input_tokens: 1000,
+          cached_input_tokens: 300,
+          output_tokens: 50,
+          total_tokens: 1050,
+        },
+      },
+    },
+  },
+].map((line) => JSON.stringify(line));
+
+describe("Codex parser", () => {
+  it("parses Codex rollout JSONL into replay turns", () => {
+    const result = parseCodexLines(lines);
+
+    expect(result.sessionId).toBe("codex-session-1");
+    expect(result.cwd).toBe("/Users/test/project");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.gitBranch).toBe("main");
+    expect(result.tokenUsage).toMatchObject({
+      inputTokens: 700,
+      cacheReadTokens: 300,
+      outputTokens: 50,
+    });
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "Bash",
+      _result: expect.stringContaining("tests passed"),
+      _durationMs: 2000,
+    });
+  });
+
+  it("transforms Codex tool calls into replay scenes", () => {
+    const parsed = parseCodexLines(lines);
+    const replay = transformToReplay(parsed, "codex", "~/project");
+
+    expect(replay.meta.provider).toBe("codex");
+    expect(replay.scenes.some((scene) => scene.type === "user-prompt")).toBe(true);
+    const bash = replay.scenes.find(
+      (scene) => scene.type === "tool-call" && scene.toolName === "Bash",
+    );
+    expect(bash?.type === "tool-call" && bash.bashOutput?.command).toBe("pnpm test");
+  });
+
+  it("strips Codex user prompt prefixes and parses local shell calls", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T06:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-2", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T06:00:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "user_message",
+            message: "## My request for Codex: run the tests",
+          },
+        },
+        {
+          timestamp: "2026-04-26T06:00:02.000Z",
+          type: "response_item",
+          payload: {
+            type: "local_shell_call",
+            call_id: "shell_1",
+            status: "completed",
+            action: {
+              type: "exec",
+              command: ["pnpm", "test"],
+              working_directory: "/Users/test/project",
+            },
+          },
+        },
+        {
+          timestamp: "2026-04-26T06:00:04.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call_output",
+            call_id: "shell_1",
+            output: "ok",
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.turns[0].blocks[0]).toMatchObject({
+      type: "text",
+      text: "run the tests",
+    });
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "Bash",
+      input: { command: "pnpm test", workdir: "/Users/test/project" },
+      _result: "ok",
+    });
+  });
+
+  it("converts Codex local image paths to data URLs", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-replay-codex-"));
+    const imagePath = join(dir, "tiny.png");
+    await writeFile(imagePath, Buffer.from("89504e470d0a1a0a", "hex"));
+
+    try {
+      const result = parseCodexLines(
+        [
+          {
+            timestamp: "2026-04-26T07:00:00.000Z",
+            type: "session_meta",
+            payload: { id: "codex-session-3", cwd: "/Users/test/project", source: "cli" },
+          },
+          {
+            timestamp: "2026-04-26T07:00:01.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "",
+              local_images: [imagePath],
+            },
+          },
+        ].map((line) => JSON.stringify(line)),
+      );
+
+      const imageBlock = result.turns[0].blocks.find((block) => block.type === "_user_images");
+      expect(imageBlock).toMatchObject({
+        type: "_user_images",
+        images: [expect.stringMatching(/^data:image\/png;base64,/)],
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes Codex edit tool names for scan counters", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T08:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-4", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T08:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "edit",
+            call_id: "edit_1",
+            arguments: JSON.stringify({ file_path: "src/app.ts" }),
+          },
+        },
+        {
+          timestamp: "2026-04-26T08:00:02.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "write_file",
+            call_id: "write_1",
+            arguments: JSON.stringify({ path: "src/new.ts" }),
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(
+      result.turns.flatMap((turn) =>
+        turn.blocks.flatMap((block) => (block.type === "tool_use" ? [block.name] : [])),
+      ),
+    ).toEqual(["Edit", "Write"]);
+  });
+
+  it("discovers image-only Codex prompts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-replay-codex-discover-"));
+    const rolloutPath = join(dir, "rollout-2026-04-26T09-00-00-codex-session-5.jsonl");
+    const content = [
+      {
+        timestamp: "2026-04-26T09:00:00.000Z",
+        type: "session_meta",
+        payload: { id: "codex-session-5", cwd: "/Users/test/project", source: "cli" },
+      },
+      {
+        timestamp: "2026-04-26T09:00:01.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          local_images: ["/Users/test/screenshot.png"],
+        },
+      },
+    ]
+      .map((line) => JSON.stringify(line))
+      .join("\n");
+    await writeFile(rolloutPath, content);
+
+    try {
+      const info = await extractCodexSessionInfo(rolloutPath, Buffer.byteLength(content));
+
+      expect(info).toMatchObject({
+        sessionId: "codex-session-5",
+        firstPrompt: "[Image]",
+        promptCount: 1,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses Codex reasoning, compaction, title, and web search events", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-6", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:00:01.000Z",
+          type: "event_msg",
+          payload: { type: "thread_name_updated", thread_name: "Ship Codex support" },
+        },
+        {
+          timestamp: "2026-04-26T10:00:02.000Z",
+          type: "event_msg",
+          payload: { type: "agent_reasoning", text: "Need to inspect the schema." },
+        },
+        {
+          timestamp: "2026-04-26T10:00:03.000Z",
+          type: "response_item",
+          payload: {
+            type: "reasoning",
+            summary: [{ type: "text", text: "Schema confirmed." }],
+          },
+        },
+        {
+          timestamp: "2026-04-26T10:00:04.000Z",
+          type: "response_item",
+          payload: { type: "compaction" },
+        },
+        {
+          timestamp: "2026-04-26T10:00:05.000Z",
+          type: "event_msg",
+          payload: {
+            type: "web_search_end",
+            call_id: "web_1",
+            query: "Codex rollout schema",
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.title).toBe("Ship Codex support");
+    expect(result.compactions).toMatchObject([{ trigger: "codex" }]);
+
+    const blocks = result.turns.flatMap((turn) => turn.blocks);
+    expect(blocks.filter((block) => block.type === "thinking")).toHaveLength(2);
+    expect(blocks.find((block) => block.type === "tool_use")).toMatchObject({
+      type: "tool_use",
+      name: "web_search",
+      _result: "[Search: Codex rollout schema]",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Codex provider that discovers local sessions from ~/.codex/state_5.sqlite and rollout JSONL files
- parse Codex rollout items into replay turns, including user prompts, assistant text, shell/custom/tool search calls, compactions, token usage, and metadata
- route Codex scan results through the richer parser and cover Codex rollout shapes with tests

## Validation
- PATH=/Users/tuo/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /tmp/pnpm-macos/package/pnpm --filter vibe-replay test -- test/codex-parser.test.ts
- PATH=/Users/tuo/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /tmp/pnpm-macos/package/pnpm --filter vibe-replay build
- PATH=/Users/tuo/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json
- smoke-tested against local ~/.codex sessions: discovered 13 sessions and parsed the latest rollout successfully