### PR TITLE
feat(cli): parse extra Claude Code session metadata

### DIFF
--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -54,7 +54,7 @@ export async function parseClaudeCodeLines(
   // Counts of queue-operation events — written by Claude Code's MessageQueueManager
   // when the user enqueues/cancels a queued message while Claude is busy.
   let queueEnqueueCount = 0;
-  let queueRemoveCount = 0;
+  let queueCancelledCount = 0;
 
   // Token usage: track last usage + model per message ID to avoid double-counting
   // (each message.id appears in multiple JSONL lines with the same cumulative usage)
@@ -176,12 +176,15 @@ export async function parseClaudeCodeLines(
 
     // Worktree session state. Last-wins per Claude Code: an enter writes the
     // session, an exit writes null (worktreeSession === null).
+    // Use ?? not || — Claude Code always writes name+path+branch together for
+    // a given worktree, so the previous-value fallback is just defensive; ??
+    // keeps "" from being treated as absent if that contract ever changes.
     if (obj.type === "worktree-state") {
       const ws = obj.worktreeSession;
       if (ws && typeof ws === "object") {
-        worktreeName = ws.worktreeName || worktreeName;
-        worktreePath = ws.worktreePath || worktreePath;
-        worktreeBranch = ws.worktreeBranch || worktreeBranch;
+        worktreeName = ws.worktreeName ?? worktreeName;
+        worktreePath = ws.worktreePath ?? worktreePath;
+        worktreeBranch = ws.worktreeBranch ?? worktreeBranch;
       } else if (ws === null) {
         // Explicit exit — clear so we don't misreport an old worktree.
         worktreeName = undefined;
@@ -193,10 +196,12 @@ export async function parseClaudeCodeLines(
 
     // Queue-operation events: track how often the user enqueued or cancelled
     // a queued message. Useful as a "user changed their mind" signal.
+    // "dequeue" = message was dispatched normally (not cancelled), so we
+    // intentionally skip it — only "remove" indicates a user cancellation.
     if (obj.type === "queue-operation") {
       const op = obj.operation;
       if (op === "enqueue") queueEnqueueCount++;
-      else if (op === "remove") queueRemoveCount++;
+      else if (op === "remove") queueCancelledCount++;
       continue;
     }
 
@@ -558,8 +563,8 @@ export async function parseClaudeCodeLines(
   // Cancelled queue events are the interesting signal — surface even when zero
   // enqueues so callers can use it consistently. Omit entirely if no events.
   const queueOperationStats =
-    queueEnqueueCount > 0 || queueRemoveCount > 0
-      ? { enqueued: queueEnqueueCount, cancelled: queueRemoveCount }
+    queueEnqueueCount > 0 || queueCancelledCount > 0
+      ? { enqueued: queueEnqueueCount, cancelled: queueCancelledCount }
       : undefined;
 
   const worktree =

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -40,12 +40,21 @@ export async function parseClaudeCodeLines(
   let cwd = "";
   let model: string | undefined;
   let title: string | undefined;
+  let aiTitle: string | undefined;
+  let agentName: string | undefined;
+  let worktreeName: string | undefined;
+  let worktreePath: string | undefined;
+  let worktreeBranch: string | undefined;
   let startTime: string | undefined;
   let endTime: string | undefined;
   let totalDurationMs = 0;
   const gitBranches: string[] = []; // all branches in order of appearance
   let entrypoint: string | undefined;
   let permissionMode: string | undefined;
+  // Counts of queue-operation events — written by Claude Code's MessageQueueManager
+  // when the user enqueues/cancels a queued message while Claude is busy.
+  let queueEnqueueCount = 0;
+  let queueRemoveCount = 0;
 
   // Token usage: track last usage + model per message ID to avoid double-counting
   // (each message.id appears in multiple JSONL lines with the same cumulative usage)
@@ -142,6 +151,53 @@ export async function parseClaudeCodeLines(
 
     if (obj.type === "custom-title") {
       title = obj.customTitle || obj.title || title;
+      continue;
+    }
+
+    // AI-generated session title — used as fallback after custom-title.
+    // Distinct entry type so user renames always win (logs.ts AiTitleMessage).
+    if (obj.type === "ai-title") {
+      if (obj.aiTitle) aiTitle = obj.aiTitle;
+      continue;
+    }
+
+    // Agent's custom name (from /rename or swarm). Latest wins.
+    if (obj.type === "agent-name") {
+      if (obj.agentName) agentName = obj.agentName;
+      continue;
+    }
+
+    // Standalone permission-mode entries are more authoritative than
+    // message-level obj.permissionMode (which is often stale). Latest wins.
+    if (obj.type === "permission-mode") {
+      if (obj.permissionMode) permissionMode = obj.permissionMode;
+      continue;
+    }
+
+    // Worktree session state. Last-wins per Claude Code: an enter writes the
+    // session, an exit writes null (worktreeSession === null).
+    if (obj.type === "worktree-state") {
+      const ws = obj.worktreeSession;
+      if (ws && typeof ws === "object") {
+        worktreeName = ws.worktreeName || worktreeName;
+        worktreePath = ws.worktreePath || worktreePath;
+        worktreeBranch = ws.worktreeBranch || worktreeBranch;
+      } else if (ws === null) {
+        // Explicit exit — clear so we don't misreport an old worktree.
+        worktreeName = undefined;
+        worktreePath = undefined;
+        worktreeBranch = undefined;
+      }
+      continue;
+    }
+
+    // Queue-operation events: track how often the user enqueued or cancelled
+    // a queued message. Useful as a "user changed their mind" signal.
+    if (obj.type === "queue-operation") {
+      const op = obj.operation;
+      if (op === "enqueue") queueEnqueueCount++;
+      else if (op === "remove") queueRemoveCount++;
+      continue;
     }
 
     if (obj.type === "file-history-snapshot") {
@@ -495,10 +551,30 @@ export async function parseClaudeCodeLines(
   // Count truncated assistant responses (stop_reason: "max_tokens")
   const truncatedCount = [...stopReasons.values()].filter((r) => r === "max_tokens").length;
 
+  // Title resolution: customTitle (user) > aiTitle (Claude generated) > undefined
+  // (transform falls back to firstPrompt). Keeps user renames sacred.
+  const resolvedTitle = title || aiTitle;
+
+  // Cancelled queue events are the interesting signal — surface even when zero
+  // enqueues so callers can use it consistently. Omit entirely if no events.
+  const queueOperationStats =
+    queueEnqueueCount > 0 || queueRemoveCount > 0
+      ? { enqueued: queueEnqueueCount, cancelled: queueRemoveCount }
+      : undefined;
+
+  const worktree =
+    worktreeName || worktreePath
+      ? {
+          ...(worktreeName ? { name: worktreeName } : {}),
+          ...(worktreePath ? { path: worktreePath } : {}),
+          ...(worktreeBranch ? { branch: worktreeBranch } : {}),
+        }
+      : undefined;
+
   return {
     sessionId,
     slug,
-    title,
+    title: resolvedTitle,
     cwd,
     model,
     startTime,
@@ -521,6 +597,9 @@ export async function parseClaudeCodeLines(
     truncatedResponses: truncatedCount > 0 ? truncatedCount : undefined,
     skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
+    agentName,
+    worktree,
+    queueOperationStats,
   };
 }
 

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -66,4 +66,17 @@ export interface ProviderParseResult {
   mcpServersUsed?: string[];
   /** Count of assistant responses truncated by max_tokens */
   truncatedResponses?: number;
+  /** Agent's custom name (from `/rename` or swarm) */
+  agentName?: string;
+  /** Worktree state at session end (Claude Code EnterWorktree / --worktree) */
+  worktree?: {
+    name?: string;
+    path?: string;
+    branch?: string;
+  };
+  /** Queue-operation event counts — proxy for "user changed their mind" frequency */
+  queueOperationStats?: {
+    enqueued: number;
+    cancelled: number;
+  };
 }

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -192,6 +192,9 @@ export function transformToReplay(
       ...(parsed.skillsUsed ? { skillsUsed: parsed.skillsUsed } : {}),
       ...(parsed.mcpServersUsed ? { mcpServersUsed: parsed.mcpServersUsed } : {}),
       ...(parsed.truncatedResponses ? { truncatedResponses: parsed.truncatedResponses } : {}),
+      ...(parsed.agentName ? { agentName: parsed.agentName } : {}),
+      ...(parsed.worktree ? { worktree: parsed.worktree } : {}),
+      ...(parsed.queueOperationStats ? { queueOperationStats: parsed.queueOperationStats } : {}),
     },
     scenes,
   };

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -96,10 +96,12 @@ export interface RawMessage {
     | "ai-title"
     | "tag"
     | "mode"
+    | "permission-mode"
     | "worktree-state"
     | "speculation-accept"
     | "attribution-snapshot"
-    | "content-replacement";
+    | "content-replacement"
+    | "attachment";
   subtype?: string;
   timestamp?: string;
   message?: {
@@ -122,6 +124,17 @@ export interface RawMessage {
   entrypoint?: string;
   permissionMode?: string;
   customTitle?: string;
+  aiTitle?: string;
+  agentName?: string;
+  /** worktree-state entries: null means user exited the worktree */
+  worktreeSession?: {
+    worktreeName?: string;
+    worktreePath?: string;
+    worktreeBranch?: string;
+  } | null;
+  /** queue-operation entry payload */
+  operation?: string;
+  content?: string;
   snapshot?: {
     timestamp?: string;
     trackedFileBackups?: Record<string, unknown>;

--- a/packages/cli/test/claude-code-extra-metadata.test.ts
+++ b/packages/cli/test/claude-code-extra-metadata.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { parseClaudeCodeLines } from "../src/providers/claude-code/parser.js";
+import { transformToReplay } from "../src/transform.js";
+
+const baseUserMessage = (content: string, ts: string) =>
+  JSON.stringify({
+    type: "user",
+    message: { role: "user", content },
+    timestamp: ts,
+    sessionId: "extras-session",
+    slug: "extras-slug",
+    cwd: "/Users/test/project",
+    gitBranch: "main",
+  });
+
+describe("Extra Claude Code metadata extraction", () => {
+  it("falls back to ai-title when no custom-title is present", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "ai-title",
+        aiTitle: "Refactor auth middleware",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.title).toBe("Refactor auth middleware");
+  });
+
+  it("prefers custom-title over ai-title", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "ai-title",
+        aiTitle: "AI generated title",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "custom-title",
+        customTitle: "User chosen title",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.title).toBe("User chosen title");
+  });
+
+  it("captures agent-name", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "agent-name",
+        agentName: "auth-refactor-bot",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.agentName).toBe("auth-refactor-bot");
+  });
+
+  it("standalone permission-mode entry overrides message-level value", async () => {
+    const lines = [
+      // Message-level permissionMode = "default"
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "hi" },
+        timestamp: "2026-04-01T00:00:00Z",
+        sessionId: "extras-session",
+        slug: "extras-slug",
+        cwd: "/Users/test/project",
+        permissionMode: "default",
+      }),
+      // Standalone entry switches to bypass
+      JSON.stringify({
+        type: "permission-mode",
+        permissionMode: "bypassPermissions",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.permissionMode).toBe("bypassPermissions");
+  });
+
+  it("captures worktree state and clears it on null", async () => {
+    const enter = await parseClaudeCodeLines([
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "worktree-state",
+        worktreeSession: {
+          worktreeName: "feat-x",
+          worktreePath: "/Users/test/project/.worktrees/feat-x",
+          worktreeBranch: "claude/feat-x",
+          sessionId: "extras-session",
+        },
+        sessionId: "extras-session",
+      }),
+    ]);
+    expect(enter.worktree).toEqual({
+      name: "feat-x",
+      path: "/Users/test/project/.worktrees/feat-x",
+      branch: "claude/feat-x",
+    });
+
+    const exited = await parseClaudeCodeLines([
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "worktree-state",
+        worktreeSession: {
+          worktreeName: "feat-x",
+          worktreePath: "/Users/test/project/.worktrees/feat-x",
+          sessionId: "extras-session",
+        },
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "worktree-state",
+        worktreeSession: null,
+        sessionId: "extras-session",
+      }),
+    ]);
+    expect(exited.worktree).toBeUndefined();
+  });
+
+  it("counts queue-operation enqueue and remove events", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2026-04-01T00:00:01Z",
+        sessionId: "extras-session",
+        content: "queued message 1",
+      }),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2026-04-01T00:00:02Z",
+        sessionId: "extras-session",
+        content: "queued message 2",
+      }),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "dequeue",
+        timestamp: "2026-04-01T00:00:03Z",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "remove",
+        timestamp: "2026-04-01T00:00:04Z",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.queueOperationStats).toEqual({ enqueued: 2, cancelled: 1 });
+  });
+
+  it("plumbs new metadata through transformToReplay", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "ai-title",
+        aiTitle: "Refactor",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "agent-name",
+        agentName: "refactor-bot",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "worktree-state",
+        worktreeSession: {
+          worktreeName: "feat-x",
+          worktreePath: "/Users/test/project/.worktrees/feat-x",
+          sessionId: "extras-session",
+        },
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "enqueue",
+        timestamp: "2026-04-01T00:00:01Z",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "queue-operation",
+        operation: "remove",
+        timestamp: "2026-04-01T00:00:02Z",
+        sessionId: "extras-session",
+      }),
+    ];
+    const parsed = await parseClaudeCodeLines(lines);
+    const replay = transformToReplay(parsed, "claude-code", "~/test");
+
+    expect(replay.meta.title).toBe("Refactor");
+    expect(replay.meta.agentName).toBe("refactor-bot");
+    expect(replay.meta.worktree?.name).toBe("feat-x");
+    expect(replay.meta.queueOperationStats).toEqual({ enqueued: 1, cancelled: 1 });
+  });
+
+  it("omits new fields when no relevant entries are present (backward compat)", async () => {
+    const lines = [baseUserMessage("hi", "2026-04-01T00:00:00Z")];
+    const parsed = await parseClaudeCodeLines(lines);
+    const replay = transformToReplay(parsed, "claude-code", "~/test");
+
+    expect(parsed.agentName).toBeUndefined();
+    expect(parsed.worktree).toBeUndefined();
+    expect(parsed.queueOperationStats).toBeUndefined();
+    expect(replay.meta).not.toHaveProperty("agentName");
+    expect(replay.meta).not.toHaveProperty("worktree");
+    expect(replay.meta).not.toHaveProperty("queueOperationStats");
+  });
+});

--- a/packages/cli/test/claude-code-extra-metadata.test.ts
+++ b/packages/cli/test/claude-code-extra-metadata.test.ts
@@ -45,6 +45,24 @@ describe("Extra Claude Code metadata extraction", () => {
     expect(result.title).toBe("User chosen title");
   });
 
+  it("prefers custom-title even when ai-title appears after it", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "custom-title",
+        customTitle: "User chosen title",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "ai-title",
+        aiTitle: "AI generated title",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.title).toBe("User chosen title");
+  });
+
   it("captures agent-name", async () => {
     const lines = [
       baseUserMessage("hi", "2026-04-01T00:00:00Z"),
@@ -56,6 +74,24 @@ describe("Extra Claude Code metadata extraction", () => {
     ];
     const result = await parseClaudeCodeLines(lines);
     expect(result.agentName).toBe("auth-refactor-bot");
+  });
+
+  it("agent-name is latest-wins when multiple entries appear", async () => {
+    const lines = [
+      baseUserMessage("hi", "2026-04-01T00:00:00Z"),
+      JSON.stringify({
+        type: "agent-name",
+        agentName: "first-name",
+        sessionId: "extras-session",
+      }),
+      JSON.stringify({
+        type: "agent-name",
+        agentName: "renamed-bot",
+        sessionId: "extras-session",
+      }),
+    ];
+    const result = await parseClaudeCodeLines(lines);
+    expect(result.agentName).toBe("renamed-bot");
   });
 
   it("standalone permission-mode entry overrides message-level value", async () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -295,6 +295,19 @@ export interface ReplaySession {
     mcpServersUsed?: string[];
     /** Number of assistant responses truncated by max_tokens */
     truncatedResponses?: number;
+    /** Agent's custom name (from `/rename` or swarm) — Claude Code only */
+    agentName?: string;
+    /** Worktree state at session end (Claude Code EnterWorktree / --worktree) */
+    worktree?: {
+      name?: string;
+      path?: string;
+      branch?: string;
+    };
+    /** Queue-operation event counts — proxy for "user changed their mind" frequency */
+    queueOperationStats?: {
+      enqueued: number;
+      cancelled: number;
+    };
   };
   scenes: Scene[];
   annotations?: Annotation[];


### PR DESCRIPTION
## Summary

Audited the Claude Code source (`~/code/claude-code/src/types/logs.ts`) against vibe-replay's parser and surveyed 170 local sessions. Adds parsing for the high-frequency entry types we were dropping; deliberately skipped types in the schema with zero local occurrences (attribution-snapshot, marble-origami-*, task-summary, etc. — likely feature-flagged or removed).

New metadata captured:

- **`ai-title`** → title fallback after `custom-title` (user rename always wins, matching Claude Code's own `AiTitleMessage` precedence).
- **`agent-name`** → `ReplaySession.meta.agentName` for swarm / `/rename` sessions.
- **`permission-mode`** standalone entry → latest-wins, overrides stale message-level value.
- **`worktree-state`** → `{ name, path, branch }`; null entry (worktree exit) clears the value.
- **`queue-operation`** → aggregated `{ enqueued, cancelled }` counts — proxy for "user changed their mind" frequency.

Plumbed through `ProviderParseResult` → `ReplaySession.meta` using the existing optional-spread pattern. `RawMessage` type extended with the new entry types and payload fields.

## Test plan

- [x] New unit tests in `claude-code-extra-metadata.test.ts` cover each extraction path
- [x] Backward-compat test asserts new fields are omitted when no relevant entries exist
- [x] `pnpm test` — 669 passed
- [x] `pnpm test:e2e` — 68 passed
- [x] `pnpm lint:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)