### PR TITLE
fix: address tool result display edge cases

### DIFF
--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -638,16 +638,42 @@ function extractToolResultText(block: ContentBlock): string {
   if (block.type !== "tool_result") return "";
 
   const { content } = block;
-  if (typeof content === "string") return content;
+  if (typeof content === "string") return unwrapPersistedOutput(content);
   if (Array.isArray(content)) {
-    return content
+    const text = content
       .map((c) => {
         if (c.type === "text") return c.text;
+        // Image blocks are extracted separately by extractImages(); skip them
+        // here so a base64 payload doesn't get JSON-stringified into the
+        // result text (would dump kilobytes of garbage in the UI).
+        if (c.type === "image") return "";
         return JSON.stringify(c);
       })
+      .filter((s) => s.length > 0)
       .join("\n");
+    return unwrapPersistedOutput(text);
   }
   return JSON.stringify(content);
+}
+
+/**
+ * Claude Code wraps oversized tool results as:
+ *   <persisted-output>
+ *   Output too large (XKB). Full output saved to: <path>
+ *
+ *   Preview (first 2KB):
+ *   <preview content>
+ *   </persisted-output>
+ *
+ * Strip the wrapper and metadata so the UI sees clean preview content.
+ * Returns the input unchanged if the wrapper isn't present.
+ */
+function unwrapPersistedOutput(text: string): string {
+  if (!text.includes("<persisted-output>")) return text;
+  return text.replace(
+    /<persisted-output>\s*(?:Output too large [^\n]*\n+)?(?:Full output saved to:[^\n]*\n+)?(?:Preview \([^)]*\):\s*\n)?([\s\S]*?)\n?<\/persisted-output>/g,
+    (_, preview) => preview.trimEnd(),
+  );
 }
 
 /**
@@ -892,12 +918,7 @@ async function readSubagents(
             prompt = (block.text || "").slice(0, 500);
           }
           if (block.type === "tool_result") {
-            const resultText =
-              typeof block.content === "string"
-                ? block.content
-                : Array.isArray(block.content)
-                  ? block.content.map((c: any) => c.text || "").join("\n")
-                  : "";
+            const resultText = extractToolResultText(block as ContentBlock);
             saToolResults.set(block.tool_use_id, resultText.slice(0, 1000));
             if (block.is_error) saToolErrors.set(block.tool_use_id, true);
           }

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -642,7 +642,9 @@ function extractToolResultText(block: ContentBlock): string {
   if (Array.isArray(content)) {
     const text = content
       .map((c) => {
-        if (c.type === "text") return c.text;
+        // External JSONL is untyped; tolerate text blocks with missing/null
+        // `text` rather than crashing the whole session parse on a TypeError.
+        if (c.type === "text") return typeof c.text === "string" ? c.text : "";
         // Image blocks are extracted separately by extractImages(); skip them
         // here so a base64 payload doesn't get JSON-stringified into the
         // result text (would dump kilobytes of garbage in the UI).

--- a/packages/cli/test/claude-code-parser-comprehensive.test.ts
+++ b/packages/cli/test/claude-code-parser-comprehensive.test.ts
@@ -407,6 +407,79 @@ describe("Claude Code parser — tool result content types", () => {
     // Should extract text from the array content
     expect((toolBlock as any)._result).toContain("Screenshot captured");
   });
+
+  it("does not pollute result text with image block JSON", async () => {
+    // Mixed text+image tool_result should not embed the base64 payload as
+    // JSON.stringify garbage in the textual result — images are surfaced via
+    // _images instead.
+    const result = await parseClaudeCodeSession(fixture("claude-code-images.jsonl"));
+    const toolBlock = result.turns
+      .filter((t) => t.role === "assistant")
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_use");
+    const resultText = (toolBlock as any)._result as string;
+    expect(resultText).toBe("Screenshot captured");
+    expect(resultText).not.toContain("base64");
+    expect(resultText).not.toContain('"type":"image"');
+  });
+
+  it("unwraps Claude Code <persisted-output> wrapper", async () => {
+    // Build a tiny JSONL fixture in-memory and run it through the
+    // line-level parser to verify the wrapper gets stripped.
+    const { parseClaudeCodeLines } = await import("../src/providers/claude-code/parser.js");
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:00Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:01Z",
+        message: {
+          id: "m1",
+          role: "assistant",
+          model: "claude-opus-4",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_1",
+              name: "Bash",
+              input: { command: "cat big.txt" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:02Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool_1",
+              content:
+                "<persisted-output>\nOutput too large (12.3KB). Full output saved to: /tmp/x.txt\n\nPreview (first 2KB):\nactual preview line 1\nactual preview line 2\n</persisted-output>",
+            },
+          ],
+        },
+      }),
+    ];
+    const parsed = await parseClaudeCodeLines(lines);
+    const tool = parsed.turns
+      .filter((t) => t.role === "assistant")
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_use");
+    const resultText = (tool as any)._result as string;
+    expect(resultText).toBe("actual preview line 1\nactual preview line 2");
+    expect(resultText).not.toContain("<persisted-output>");
+    expect(resultText).not.toContain("Output too large");
+    expect(resultText).not.toContain("Preview (first");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/claude-code-parser-comprehensive.test.ts
+++ b/packages/cli/test/claude-code-parser-comprehensive.test.ts
@@ -480,6 +480,142 @@ describe("Claude Code parser — tool result content types", () => {
     expect(resultText).not.toContain("Output too large");
     expect(resultText).not.toContain("Preview (first");
   });
+
+  it("unwraps <persisted-output> wrapper from array-content tool result", async () => {
+    // Same wrapper, but inside a content-block array (mixed pattern Claude Code
+    // uses when a tool returns text + image, or just a single text block).
+    const { parseClaudeCodeLines } = await import("../src/providers/claude-code/parser.js");
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:01Z",
+        message: {
+          id: "m1",
+          role: "assistant",
+          model: "claude-opus-4",
+          content: [{ type: "tool_use", id: "t1", name: "WebFetch", input: { url: "https://x" } }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:02Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: [
+                {
+                  type: "text",
+                  text: "<persisted-output>\nOutput too large (5KB). Full output saved to: /tmp/y.txt\n\nPreview (first 2KB):\narray-path preview\n</persisted-output>",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ];
+    const parsed = await parseClaudeCodeLines(lines);
+    const tool = parsed.turns
+      .filter((t) => t.role === "assistant")
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_use");
+    expect((tool as any)._result).toBe("array-path preview");
+  });
+
+  it("unwraps multiple <persisted-output> blocks in a single result", async () => {
+    // Defensive: the regex uses /g, so multiple wrappers in one string should
+    // all unwrap. Hypothetical (Claude Code typically emits one per result),
+    // but cheap to guarantee.
+    const { parseClaudeCodeLines } = await import("../src/providers/claude-code/parser.js");
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:01Z",
+        message: {
+          id: "m1",
+          role: "assistant",
+          model: "claude-opus-4",
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "x" } }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:02Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content:
+                "<persisted-output>\nOutput too large (1KB). Full output saved to: /tmp/a.txt\n\nPreview (first 2KB):\nfirst\n</persisted-output>\n\n<persisted-output>\nOutput too large (2KB). Full output saved to: /tmp/b.txt\n\nPreview (first 2KB):\nsecond\n</persisted-output>",
+            },
+          ],
+        },
+      }),
+    ];
+    const parsed = await parseClaudeCodeLines(lines);
+    const tool = parsed.turns
+      .filter((t) => t.role === "assistant")
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_use");
+    const resultText = (tool as any)._result as string;
+    expect(resultText).toContain("first");
+    expect(resultText).toContain("second");
+    expect(resultText).not.toContain("<persisted-output>");
+  });
+
+  it("tolerates text blocks with missing/null text field without crashing", async () => {
+    // Defensive: external JSONL is untyped. A `type:"text"` block with no
+    // `text` field used to be silently coerced to ""; the post-fix code must
+    // continue to do so instead of throwing TypeError on `.length`.
+    const { parseClaudeCodeLines } = await import("../src/providers/claude-code/parser.js");
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:01Z",
+        message: {
+          id: "m1",
+          role: "assistant",
+          model: "claude-opus-4",
+          content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "x" } }],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        sessionId: "s",
+        timestamp: "2025-01-01T00:00:02Z",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t1",
+              content: [
+                { type: "text" }, // missing text field
+                { type: "text", text: null }, // null text field
+                { type: "text", text: "real content" },
+              ],
+            },
+          ],
+        },
+      }),
+    ];
+    // Should not throw
+    const parsed = await parseClaudeCodeLines(lines);
+    const tool = parsed.turns
+      .filter((t) => t.role === "assistant")
+      .flatMap((t) => t.blocks)
+      .find((b) => b.type === "tool_use");
+    expect((tool as any)._result).toBe("real content");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -463,7 +463,11 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
   );
 });
 
-function summarizeInput(name: string, input: Record<string, any>): string {
+// Multi-line / very long Bash pipelines would overflow the one-line summary.
+// 200 chars is enough to identify a command without breaking layout.
+const BASH_SUMMARY_MAX = 200;
+
+export function summarizeInput(name: string, input: Record<string, any>): string {
   switch (name) {
     case "Read":
     case "Write":
@@ -476,10 +480,13 @@ function summarizeInput(name: string, input: Record<string, any>): string {
       return input.pattern || "";
     case "Grep":
       return `/${input.pattern || ""}/ ${input.path || ""}`.trim();
-    case "Bash":
+    case "Bash": {
       // Prefer command (more identifying); fall back to description.
-      // The Agent-rendered AgentTypeBadge handles subagent_type already.
-      return input.command || input.description || "";
+      // Collapse newlines so multi-line commands stay one-line in the summary.
+      const raw = (input.command || input.description || "") as string;
+      const oneLine = raw.replace(/\s+/g, " ").trim();
+      return oneLine.length > BASH_SUMMARY_MAX ? `${oneLine.slice(0, BASH_SUMMARY_MAX)}…` : oneLine;
+    }
     case "BashOutput":
       return input.bash_id || "";
     case "Agent":
@@ -511,7 +518,7 @@ function summarizeInput(name: string, input: Record<string, any>): string {
   }
 }
 
-function shortenScalarSummary(input: Record<string, any>): string {
+export function shortenScalarSummary(input: Record<string, any>): string {
   // Prefer commonly meaningful keys before falling back to all string values.
   const preferred = ["url", "path", "file_path", "query", "name", "id"];
   for (const k of preferred) {

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -466,25 +466,60 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
 function summarizeInput(name: string, input: Record<string, any>): string {
   switch (name) {
     case "Read":
+    case "Write":
+    case "Edit":
+    case "MultiEdit":
       return input.file_path || "";
+    case "NotebookEdit":
+      return input.notebook_path || "";
     case "Glob":
       return input.pattern || "";
     case "Grep":
-      return `/${input.pattern || ""}/ ${input.path || ""}`;
+      return `/${input.pattern || ""}/ ${input.path || ""}`.trim();
+    case "Bash":
+      // Prefer command (more identifying); fall back to description.
+      // The Agent-rendered AgentTypeBadge handles subagent_type already.
+      return input.command || input.description || "";
+    case "BashOutput":
+      return input.bash_id || "";
     case "Agent":
-      return input.description || "";
-    case "Write":
-      return input.file_path || "";
-    case "Edit":
-      return input.file_path || "";
+    case "Task": {
+      const desc = input.description || "";
+      const subtype = input.subagent_type;
+      return subtype ? `${subtype} — ${desc}` : desc;
+    }
+    case "TodoWrite": {
+      const todos = Array.isArray(input.todos) ? input.todos : [];
+      if (todos.length === 0) return "";
+      const inProgress = todos.find((t: any) => t?.status === "in_progress");
+      return inProgress?.content
+        ? `${todos.length} todos · ${inProgress.content}`
+        : `${todos.length} todos`;
+    }
     case "WebSearch":
       return input.query || "";
     case "WebFetch":
       return input.url || "";
+    case "SlashCommand":
+      return input.command || "";
+    case "ExitPlanMode":
+      return (input.plan || "").slice(0, 80);
     default:
-      return Object.values(input)
-        .filter((v) => typeof v === "string")
-        .join(" ")
-        .slice(0, 80);
+      // mcp__server__tool — surface the most likely identifying value, or
+      // fall back to a short joined string of scalar args.
+      return shortenScalarSummary(input);
   }
+}
+
+function shortenScalarSummary(input: Record<string, any>): string {
+  // Prefer commonly meaningful keys before falling back to all string values.
+  const preferred = ["url", "path", "file_path", "query", "name", "id"];
+  for (const k of preferred) {
+    const v = input[k];
+    if (typeof v === "string" && v) return v.slice(0, 80);
+  }
+  return Object.values(input)
+    .filter((v) => typeof v === "string")
+    .join(" ")
+    .slice(0, 80);
 }

--- a/packages/viewer/src/components/__tests__/tool-summary.test.ts
+++ b/packages/viewer/src/components/__tests__/tool-summary.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { shortenScalarSummary, summarizeInput } from "../ToolCallBlock";
+
+describe("summarizeInput", () => {
+  it("uses file_path for file tools", () => {
+    expect(summarizeInput("Read", { file_path: "/a/b.ts" })).toBe("/a/b.ts");
+    expect(summarizeInput("Write", { file_path: "/a/b.ts" })).toBe("/a/b.ts");
+    expect(summarizeInput("Edit", { file_path: "/a/b.ts" })).toBe("/a/b.ts");
+    expect(summarizeInput("MultiEdit", { file_path: "/a/b.ts" })).toBe("/a/b.ts");
+  });
+
+  it("uses notebook_path for NotebookEdit", () => {
+    expect(summarizeInput("NotebookEdit", { notebook_path: "/n.ipynb" })).toBe("/n.ipynb");
+  });
+
+  it("Grep formats pattern + path and trims trailing space when path is empty", () => {
+    expect(summarizeInput("Grep", { pattern: "foo", path: "src" })).toBe("/foo/ src");
+    expect(summarizeInput("Grep", { pattern: "foo" })).toBe("/foo/");
+  });
+
+  describe("Bash", () => {
+    it("prefers command over description", () => {
+      expect(summarizeInput("Bash", { command: "ls", description: "list files" })).toBe("ls");
+    });
+
+    it("falls back to description when command is missing", () => {
+      expect(summarizeInput("Bash", { description: "list files" })).toBe("list files");
+    });
+
+    it("collapses multi-line commands to one line", () => {
+      const input = { command: "for i in 1 2 3; do\n  echo $i\ndone" };
+      expect(summarizeInput("Bash", input)).toBe("for i in 1 2 3; do echo $i done");
+    });
+
+    it("truncates very long commands with ellipsis", () => {
+      const longCmd = `echo ${"x".repeat(300)}`;
+      const result = summarizeInput("Bash", { command: longCmd });
+      expect(result.length).toBeLessThanOrEqual(201); // 200 + ellipsis
+      expect(result.endsWith("…")).toBe(true);
+    });
+  });
+
+  describe("Agent / Task", () => {
+    it("joins subagent_type and description", () => {
+      expect(summarizeInput("Agent", { subagent_type: "Explore", description: "find X" })).toBe(
+        "Explore — find X",
+      );
+    });
+
+    it("falls back to description alone when subagent_type is missing", () => {
+      expect(summarizeInput("Task", { description: "do thing" })).toBe("do thing");
+    });
+  });
+
+  describe("TodoWrite", () => {
+    it("returns empty string when no todos", () => {
+      expect(summarizeInput("TodoWrite", { todos: [] })).toBe("");
+      expect(summarizeInput("TodoWrite", {})).toBe("");
+    });
+
+    it("shows count alone when nothing in progress", () => {
+      const todos = [
+        { status: "completed", content: "a" },
+        { status: "pending", content: "b" },
+      ];
+      expect(summarizeInput("TodoWrite", { todos })).toBe("2 todos");
+    });
+
+    it("shows count + in_progress content when one is active", () => {
+      const todos = [
+        { status: "completed", content: "a" },
+        { status: "in_progress", content: "b" },
+        { status: "pending", content: "c" },
+      ];
+      expect(summarizeInput("TodoWrite", { todos })).toBe("3 todos · b");
+    });
+  });
+
+  it("uses shortenScalarSummary fallback for unknown tools (e.g. mcp__*)", () => {
+    expect(summarizeInput("mcp__server__tool", { url: "https://x.com" })).toBe("https://x.com");
+  });
+});
+
+describe("shortenScalarSummary", () => {
+  it("prefers url over other keys", () => {
+    expect(shortenScalarSummary({ url: "https://a.com", path: "/x", name: "n" })).toBe(
+      "https://a.com",
+    );
+  });
+
+  it("falls back through preferred keys: path, file_path, query, name, id", () => {
+    expect(shortenScalarSummary({ path: "/x", name: "n" })).toBe("/x");
+    expect(shortenScalarSummary({ file_path: "/x", name: "n" })).toBe("/x");
+    expect(shortenScalarSummary({ query: "q", name: "n" })).toBe("q");
+    expect(shortenScalarSummary({ name: "n", id: "i" })).toBe("n");
+    expect(shortenScalarSummary({ id: "i" })).toBe("i");
+  });
+
+  it("ignores empty strings when picking a preferred key", () => {
+    expect(shortenScalarSummary({ url: "", path: "/x" })).toBe("/x");
+  });
+
+  it("ignores non-string preferred values", () => {
+    expect(shortenScalarSummary({ url: 42, path: "/x" })).toBe("/x");
+  });
+
+  it("falls back to joined string values when no preferred key matches", () => {
+    expect(shortenScalarSummary({ foo: "a", bar: "b", baz: 99 })).toBe("a b");
+  });
+
+  it("truncates the preferred value at 80 chars", () => {
+    const long = "x".repeat(200);
+    expect(shortenScalarSummary({ url: long }).length).toBe(80);
+  });
+
+  it("returns empty string when input has no usable values", () => {
+    expect(shortenScalarSummary({ count: 5, active: true })).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Three independent fixes for how Claude Code session tool results render. Each was verified against real local sessions before fixing.

### 1. Unwrap `<persisted-output>` wrappers
Claude Code stores oversized tool results to `tool-results/<id>.txt` and inlines a wrapped preview:

```
<persisted-output>
Output too large (46.4KB). Full output saved to: /Users/.../tool-results/xxx.txt

Preview (first 2KB):
<actual content>
</persisted-output>
```

Previously we displayed the wrapper tags + metadata verbatim. Now we strip them and show only the preview content.

**Prevalence:** 21 of the 100 most recent main-session JSONL files contain this wrapper (104 occurrences total). Common on WebFetch and any Bash command with large output.

### 2. Skip image blocks in `extractToolResultText`
When `tool_result.content` is an array containing both `text` and `image` blocks, the previous code did `JSON.stringify(c)` on the image block — dumping the base64 payload as a JSON-encoded string into the rendered result text. Images are already pulled out separately via `extractImages()` into `_images`.

### 3. Improve `summarizeInput` one-liner
Previously missing or incomplete: `Bash` command, `MultiEdit`, `NotebookEdit`, `TodoWrite` (now shows count + in-progress item), `Task` subagent_type, `SlashCommand`, `ExitPlanMode`, `BashOutput`. The default fallback now prefers identifying keys (`url` / `path` / `query` / `name` / `id`) before falling back to a joined-strings summary, which gives `mcp__*` tools a sensible one-liner too.

## Test plan

- [x] `pnpm --filter vibe-replay test` — 676 unit tests pass (added 2 new ones for persisted-output unwrap + image-block exclusion)
- [x] `pnpm build && pnpm test:e2e` — all 30 E2E tests pass
- [x] `pnpm lint:check` — clean
- [x] Generated HTML from a real local session containing `<persisted-output>` and verified in Playwright: 0 console errors, no `persisted-output` / `Preview (first` / `data:image/png;base64` strings reach the DOM