### PR TITLE
refactor(cli): dedupe cursor first-text-snippet, drop two `as any` casts

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -619,6 +619,14 @@ export function countComposerConversationHeaders(composer: Record<string, any>):
     : 0;
 }
 
+function firstUserTextSnippet(turns: ParsedTurn[]): string | undefined {
+  const firstUser = turns.find((t) => t.role === "user");
+  const firstText = firstUser?.blocks.find(
+    (b): b is Extract<ContentBlock, { type: "text" }> => b.type === "text",
+  );
+  return firstText?.text.slice(0, 80);
+}
+
 function finalizeGlobalStateDiscovery(
   discoveredSessions: SessionInfo[],
   knownSessionIds: Set<string>,
@@ -902,9 +910,7 @@ async function parseCursorStoreDb(sessionId: string): Promise<ProviderParseResul
     const { turns, turnStats, totalDurationMs } = messagesToTurns(messages);
     const slug = sessionId.slice(0, 8);
 
-    const firstUser = turns.find((t) => t.role === "user");
-    const firstText = firstUser?.blocks.find((b) => b.type === "text");
-    const title = metaJson.name || (firstText as any)?.text?.slice(0, 80);
+    const title = metaJson.name || firstUserTextSnippet(turns);
     const hasDurationStats = turnStats.some((stat) => (stat.durationMs || 0) > 0);
 
     const notes: string[] = [];
@@ -1939,8 +1945,6 @@ async function parseCursorGlobalStateDb(
     const turns = entries.map((entry) => entry.turn);
     if (turns.length === 0) return null;
 
-    const firstUser = turns.find((t) => t.role === "user");
-    const firstText = firstUser?.blocks.find((b) => b.type === "text") as any;
     const inferredProject = await inferProjectFromComposerData(rawComposer, []);
     const modelName = normalizeCursorModelName(
       composer.modelConfig &&
@@ -2010,8 +2014,7 @@ async function parseCursorGlobalStateDb(
       sessionId,
       slug: sessionId.slice(0, 8),
       title:
-        (typeof composer.name === "string" && composer.name.trim()) ||
-        (firstText?.text as string | undefined)?.slice(0, 80),
+        (typeof composer.name === "string" && composer.name.trim()) || firstUserTextSnippet(turns),
       cwd: inferredProject || "",
       model: modelName,
       startTime,


### PR DESCRIPTION
## Summary

- Extract `firstUserTextSnippet(turns)` helper in `packages/cli/src/providers/cursor/sqlite-reader.ts` to consolidate the duplicated "find first user turn → first text block → slice(0, 80)" pattern used in both `parseCursorStoreDb` and `parseCursorGlobalStateDb`.
- Replaces two `as any` casts on `ContentBlock` with a `b is Extract<ContentBlock, { type: "text" }>` type predicate inside `Array.prototype.find`.
- Net diff: `+10 / -7`, single file.

## Motivation

Type-safety improvement that also removes a small duplication. Pure type-level change — the runtime predicate is still `b.type === "text"`, the string slice length stays at 80, and the `?.` chain falls back to `undefined` identically when there's no user turn or no text block.

## Test plan

- [x] `pnpm test` — all 678 CLI unit tests + 130 viewer unit tests pass
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — clean
- [x] `pnpm build` — viewer 806.23 kB (unchanged from baseline; pre-existing), CLI builds clean
- [x] `pnpm test:e2e` — 30 passed / 40 skipped (auth-worker etc.) — generated-html, editor-server, cli-smoke all green

> 🤖 Daily auto-quality routine. Self-merged after AI review per routine policy.