### PR TITLE
chore(cli): drop dead isSidechain field from RawMessage

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -66,7 +66,6 @@ export interface ParsedTurn {
 export interface RawMessage {
   parentUuid: string | null;
   uuid?: string;
-  isSidechain: boolean;
   /** True for system-injected messages (skill injection, context injection, etc.) */
   isMeta?: boolean;
   /** True for compaction summary messages */


### PR DESCRIPTION
## Summary
- Removes `isSidechain: boolean` from `RawMessage` in `packages/cli/src/types.ts`.
- The field was declared as **required `boolean`** but had **zero readers** anywhere in the codebase (only ever appeared in test fixtures, always as `false`).
- Recent Claude Code JSONL no longer emits `isSidechain` at all, so the type was lying — claiming a required `boolean` that is `undefined` at runtime. This would mislead future contributors into thinking we already handle sidechain (edited-history) messages when we don't.

## Why now
Spotted while surveying adjacent tools' parsing layers. Two options were on the table:
1. Actually use the field — filter sidechain messages out of the main thread.
2. Delete it as dead code.

Option 2 won because vibe-replay's value prop is sharable replays, where the user wouldn't be showing edited-history branches anyway. If we ever want sidechain handling later, we can reintroduce the field with intent.

## Test plan
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm test` — 679 + 130 unit tests pass
- [x] `pnpm build` — viewer 806KB, CLI 392KB
- [x] `pnpm test:e2e` — 30 passed (skipped tests are unrelated cloud/auth fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)