### PR TITLE
feat(cli): add cloud share to picker + standalone `share` command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import { deduplicateSessionsByProvider, getAllProviders, getProvider } from "./p
 import {
   getAuthFilePath,
   loadAuthToken,
+  publishCloud,
   removeAuthTokenSync,
   saveAuthTokenSync,
 } from "./publishers/cloud.js";
@@ -587,12 +588,16 @@ program
     const gistLabel = publishStatus.available
       ? `${chalk.blue("↑")} Publish to Gist now ${chalk.dim("(skip editor, publish directly)")}`
       : `${chalk.dim("↑ Publish to Gist now")} ${chalk.red("(login required)")}`;
+    const isLoggedIn = !!loadAuthToken();
+    const cloudLabel = isLoggedIn
+      ? `${chalk.cyan("☁")} Share via Cloud ${chalk.dim("(7-day link, up to 10MB)")}`
+      : `${chalk.dim("☁ Share via Cloud")} ${chalk.red("(login required)")}`;
 
     // Publish target
     console.log();
     const choices: {
       name: string;
-      value: "local" | "editor" | "gist" | "github" | "exit";
+      value: "local" | "editor" | "cloud" | "gist" | "github" | "exit";
     }[] = [
       {
         name: `${chalk.magenta("✎")} Open in Editor ${chalk.dim("(annotate, publish, export)")}`,
@@ -602,6 +607,7 @@ program
         name: `${chalk.green("●")} Quick preview ${chalk.dim("(open HTML in browser, no editing)")}`,
         value: "local" as const,
       },
+      { name: cloudLabel, value: "cloud" as const },
       { name: gistLabel, value: "gist" as const },
       {
         name: `${chalk.yellow("★")} Export for GitHub ${chalk.dim("(markdown + animated SVG for PRs)")}`,
@@ -625,6 +631,34 @@ program
           : undefined,
       });
       return; // startServer blocks until Ctrl+C
+    } else if (target === "cloud") {
+      if (!isLoggedIn) {
+        console.log();
+        console.log(chalk.yellow("  Login required for cloud sharing."));
+        console.log(chalk.dim("  Run → ") + chalk.white("vibe-replay auth login"));
+      } else {
+        const { confirm } = await import("@inquirer/prompts");
+        const ok = await confirm({
+          message: "Upload to vibe-replay cloud? (unlisted link, expires in 7 days)",
+          default: true,
+        });
+        if (!ok) {
+          console.log(chalk.dim("\n  Cloud share cancelled."));
+        } else {
+          const cloudSpinner = ora("Uploading to cloud...").start();
+          try {
+            const result = await publishCloud(outputDir);
+            cloudSpinner.succeed("Uploaded!");
+            console.log(chalk.dim("  Share URL: ") + chalk.cyan(result.url));
+            console.log(
+              chalk.dim("  Expires:   ") +
+                chalk.white(new Date(result.expiresAt).toLocaleDateString()),
+            );
+          } catch (err: unknown) {
+            cloudSpinner.fail(err instanceof Error ? err.message : String(err));
+          }
+        }
+      }
     } else if (target === "gist") {
       if (!publishStatus.available) {
         console.log();
@@ -864,6 +898,109 @@ authCmd
     console.log(chalk.dim("  API:       ") + chalk.white(apiUrl));
     console.log(chalk.dim("  Auth file: ") + chalk.white(getAuthFilePath()));
     console.log();
+  });
+
+// ---------------------------------------------------------------------------
+// share — upload an existing replay to the cloud
+// ---------------------------------------------------------------------------
+
+program
+  .command("share")
+  .description("Share an existing replay via cloud (7-day link)")
+  .argument("[path]", "Path to replay directory or replay.json")
+  .option("--visibility <type>", "Visibility: public, unlisted, private", "unlisted")
+  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .action(async (pathArg: string | undefined, opts: { visibility: string; apiUrl: string }) => {
+    const { existsSync, statSync } = await import("node:fs");
+    const { readFile, readdir } = await import("node:fs/promises");
+    const { join, dirname, resolve } = await import("node:path");
+    const { homedir } = await import("node:os");
+
+    // Honor --api-url by setting env var, since publishCloud reads from getApiUrl()
+    const apiUrl = opts.apiUrl.replace(/\/$/, "");
+    process.env.VIBE_REPLAY_API_URL = apiUrl;
+
+    const visibility = opts.visibility as "public" | "unlisted" | "private";
+    if (!["public", "unlisted", "private"].includes(visibility)) {
+      console.error(chalk.red(`\n  ✗ Invalid --visibility: ${opts.visibility}`));
+      console.error(chalk.dim("  Must be one of: public, unlisted, private\n"));
+      process.exit(1);
+    }
+
+    let outputDir: string;
+
+    if (pathArg) {
+      const abs = resolve(pathArg);
+      if (!existsSync(abs)) {
+        console.error(chalk.red(`\n  ✗ Path not found: ${abs}\n`));
+        process.exit(1);
+      }
+      const s = statSync(abs);
+      outputDir = s.isDirectory() ? abs : dirname(abs);
+    } else {
+      const replayBaseDir = join(homedir(), ".vibe-replay");
+      const entries = await readdir(replayBaseDir).catch(() => [] as string[]);
+      const replays: { name: string; value: string; time: string }[] = [];
+
+      for (const slug of entries) {
+        if (slug.startsWith(".") || slug === "cache") continue;
+        const jsonPath = join(replayBaseDir, slug, "replay.json");
+        try {
+          const raw = await readFile(jsonPath, "utf-8");
+          const replay = JSON.parse(raw) as ReplaySession;
+          const title = replay.meta?.title || slug;
+          const startTime = replay.meta?.startTime || "";
+          const time = startTime
+            ? new Date(startTime).toLocaleString("en-US", {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+              })
+            : "";
+          replays.push({
+            name: time ? `${chalk.dim(`[${time}]`)} ${chalk.white(title)}` : chalk.white(title),
+            value: join(replayBaseDir, slug),
+            time: startTime,
+          });
+        } catch {
+          // skip slugs without a valid replay.json
+        }
+      }
+
+      if (replays.length === 0) {
+        console.log(chalk.yellow("\n  No replays found. Generate one first!\n"));
+        process.exit(1);
+      }
+
+      replays.sort((a, b) => b.time.localeCompare(a.time));
+      outputDir = await select({
+        message: "Pick a replay to share:",
+        choices: replays,
+      });
+    }
+
+    const jsonPath = join(outputDir, "replay.json");
+    if (!existsSync(jsonPath)) {
+      console.error(chalk.red(`\n  ✗ No replay.json found in ${outputDir}\n`));
+      process.exit(1);
+    }
+
+    const spinner = ora("Uploading to cloud...").start();
+    try {
+      const result = await publishCloud(outputDir, { visibility });
+      spinner.succeed("Uploaded!");
+      console.log();
+      console.log(chalk.dim("  Share URL: ") + chalk.cyan(result.url));
+      console.log(
+        chalk.dim("  Expires:   ") + chalk.white(new Date(result.expiresAt).toLocaleDateString()),
+      );
+      console.log();
+    } catch (err: unknown) {
+      spinner.fail(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
   });
 
 // Keep backwards-compatible hidden alias

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,7 +19,7 @@ import {
   DEFAULT_API_URL,
   getAuthFilePath,
   loadAuthToken,
-  publishCloud,
+  publishCloudWithOverlays,
   removeAuthTokenSync,
   saveAuthTokenSync,
 } from "./publishers/cloud.js";
@@ -648,7 +648,7 @@ program
         } else {
           const cloudSpinner = ora("Uploading to cloud...").start();
           try {
-            const result = await publishCloud(outputDir);
+            const result = await publishCloudWithOverlays(outputDir);
             cloudSpinner.succeed("Uploaded!");
             console.log(chalk.dim("  Share URL: ") + chalk.cyan(result.url));
             console.log(
@@ -913,18 +913,18 @@ program
   .description("Share an existing replay via cloud (unlisted link, expires in 7 days)")
   .argument("[path]", "Path to replay directory or replay.json")
   .option("--visibility <type>", `Visibility: ${VISIBILITIES.join(", ")}`, "unlisted")
-  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
-  .action(async (pathArg: string | undefined, opts: { visibility: string; apiUrl: string }) => {
+  .option("--api-url <url>", `API base URL (default: ${DEFAULT_API_URL})`)
+  .action(async (pathArg: string | undefined, opts: { visibility: string; apiUrl?: string }) => {
     const { existsSync, statSync } = await import("node:fs");
     const { readFile, readdir } = await import("node:fs/promises");
     const { join, dirname, resolve } = await import("node:path");
     const { homedir } = await import("node:os");
 
-    // Honor --api-url by setting env var, since publishCloud reads from getApiUrl().
-    // Only mutate when the user actually overrode the default.
-    const apiUrl = opts.apiUrl.replace(/\/$/, "");
-    if (apiUrl !== DEFAULT_API_URL) {
-      process.env.VIBE_REPLAY_API_URL = apiUrl;
+    // Honor --api-url whenever the user supplies it, even when the value
+    // matches DEFAULT_API_URL (overriding a preset shell env var).
+    // Without the flag, fall through to existing precedence: env > DEFAULT_API_URL.
+    if (opts.apiUrl) {
+      process.env.VIBE_REPLAY_API_URL = opts.apiUrl.replace(/\/$/, "");
     }
 
     // Validate raw string before narrowing the type.
@@ -1004,7 +1004,7 @@ program
 
     const spinner = ora("Uploading to cloud...").start();
     try {
-      const result = await publishCloud(outputDir, { visibility });
+      const result = await publishCloudWithOverlays(outputDir, { visibility });
       spinner.succeed("Uploaded!");
       console.log();
       console.log(chalk.dim("  Share URL: ") + chalk.cyan(result.url));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.j
 import { generateOutput } from "./generator.js";
 import { deduplicateSessionsByProvider, getAllProviders, getProvider } from "./providers/index.js";
 import {
+  DEFAULT_API_URL,
   getAuthFilePath,
   loadAuthToken,
   publishCloud,
@@ -904,26 +905,40 @@ authCmd
 // share — upload an existing replay to the cloud
 // ---------------------------------------------------------------------------
 
+const VISIBILITIES = ["public", "unlisted", "private"] as const;
+type Visibility = (typeof VISIBILITIES)[number];
+
 program
   .command("share")
-  .description("Share an existing replay via cloud (7-day link)")
+  .description("Share an existing replay via cloud (unlisted link, expires in 7 days)")
   .argument("[path]", "Path to replay directory or replay.json")
-  .option("--visibility <type>", "Visibility: public, unlisted, private", "unlisted")
-  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .option("--visibility <type>", `Visibility: ${VISIBILITIES.join(", ")}`, "unlisted")
+  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
   .action(async (pathArg: string | undefined, opts: { visibility: string; apiUrl: string }) => {
     const { existsSync, statSync } = await import("node:fs");
     const { readFile, readdir } = await import("node:fs/promises");
     const { join, dirname, resolve } = await import("node:path");
     const { homedir } = await import("node:os");
 
-    // Honor --api-url by setting env var, since publishCloud reads from getApiUrl()
+    // Honor --api-url by setting env var, since publishCloud reads from getApiUrl().
+    // Only mutate when the user actually overrode the default.
     const apiUrl = opts.apiUrl.replace(/\/$/, "");
-    process.env.VIBE_REPLAY_API_URL = apiUrl;
+    if (apiUrl !== DEFAULT_API_URL) {
+      process.env.VIBE_REPLAY_API_URL = apiUrl;
+    }
 
-    const visibility = opts.visibility as "public" | "unlisted" | "private";
-    if (!["public", "unlisted", "private"].includes(visibility)) {
+    // Validate raw string before narrowing the type.
+    if (!(VISIBILITIES as readonly string[]).includes(opts.visibility)) {
       console.error(chalk.red(`\n  ✗ Invalid --visibility: ${opts.visibility}`));
-      console.error(chalk.dim("  Must be one of: public, unlisted, private\n"));
+      console.error(chalk.dim(`  Must be one of: ${VISIBILITIES.join(", ")}\n`));
+      process.exit(1);
+    }
+    const visibility = opts.visibility as Visibility;
+
+    // Pre-flight auth check — fail fast before any picker / I/O / spinner.
+    if (!loadAuthToken()) {
+      console.error(chalk.red("\n  ✗ Not logged in."));
+      console.error(chalk.dim("  Run → ") + chalk.white("vibe-replay auth login\n"));
       process.exit(1);
     }
 

--- a/packages/cli/src/overlays.ts
+++ b/packages/cli/src/overlays.ts
@@ -1,0 +1,56 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type { ReplaySession, SessionOverlays } from "./types.js";
+
+export const EMPTY_OVERLAYS: SessionOverlays = { version: 1, overlays: [] };
+
+/**
+ * Load overlays.json for a session, falling back to ./vibe-replay/<slug> for
+ * legacy layouts. Returns EMPTY_OVERLAYS when no file is found.
+ */
+export async function loadOverlays(baseDir: string, slug: string): Promise<SessionOverlays> {
+  const dirs = [join(baseDir, slug), resolve("./vibe-replay", slug)];
+  for (const dir of dirs) {
+    try {
+      const raw = await readFile(join(dir, "overlays.json"), "utf-8");
+      const parsed = JSON.parse(raw) as SessionOverlays;
+      if (parsed && typeof parsed === "object" && Array.isArray(parsed.overlays)) {
+        return parsed;
+      }
+    } catch {
+      /* not found */
+    }
+  }
+  return EMPTY_OVERLAYS;
+}
+
+/**
+ * Apply the latest overlay (by updatedAt) for each scene index to the session.
+ * Used so publish/export/AI-chain operations work against the user's edited
+ * content, not the raw original.
+ */
+export function sessionWithEffectiveContent(
+  session: ReplaySession,
+  existing: SessionOverlays,
+): ReplaySession {
+  if (existing.overlays.length === 0) return session;
+  const latestByScene = new Map<number, { value: string; time: string }>();
+  for (const o of existing.overlays) {
+    const current = latestByScene.get(o.sceneIndex);
+    if (!current || o.updatedAt > current.time) {
+      latestByScene.set(o.sceneIndex, { value: o.modifiedValue, time: o.updatedAt });
+    }
+  }
+  if (latestByScene.size === 0) return session;
+  return {
+    ...session,
+    scenes: session.scenes.map((scene, i) => {
+      const entry = latestByScene.get(i);
+      if (!entry) return scene;
+      if (scene.type === "user-prompt" || scene.type === "text-response") {
+        return { ...scene, content: entry.value };
+      }
+      return scene;
+    }),
+  };
+}

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 const CLOUD_META_FILE = ".vibe-replay-cloud.json";
-const DEFAULT_API_URL = "https://vibe-replay.com";
+export const DEFAULT_API_URL = "https://vibe-replay.com";
 const AUTH_DIR = join(homedir(), ".config", "vibe-replay");
 const AUTH_FILE = join(AUTH_DIR, "auth.json");
 

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
+import { loadOverlays, sessionWithEffectiveContent } from "../overlays.js";
+import type { ReplaySession } from "../types.js";
 
 const CLOUD_META_FILE = ".vibe-replay-cloud.json";
 export const DEFAULT_API_URL = "https://vibe-replay.com";
@@ -212,6 +214,35 @@ export async function publishCloud(
   });
 
   return data;
+}
+
+/**
+ * Like publishCloud, but first merges any editor overlays (overlays.json next
+ * to replay.json) into the session so cloud links reflect the user's edits.
+ * Writes the merged content to replay.json for the duration of the upload,
+ * then restores the original on the way out.
+ */
+export async function publishCloudWithOverlays(
+  outputDir: string,
+  opts?: { visibility?: "public" | "unlisted" | "private" },
+): Promise<CloudResult> {
+  const slug = basename(outputDir);
+  const baseDir = dirname(outputDir);
+  const overlays = await loadOverlays(baseDir, slug);
+  if (overlays.overlays.length === 0) {
+    return publishCloud(outputDir, opts);
+  }
+
+  const replayPath = join(outputDir, "replay.json");
+  const originalContent = await readFile(replayPath, "utf-8");
+  const session = JSON.parse(originalContent) as ReplaySession;
+  const merged = sessionWithEffectiveContent(session, overlays);
+  await writeFile(replayPath, JSON.stringify(merged), "utf-8");
+  try {
+    return await publishCloud(outputDir, opts);
+  } finally {
+    await writeFile(replayPath, originalContent, "utf-8");
+  }
 }
 
 export async function loadSavedCloudInfo(outputDir: string): Promise<SavedCloudInfo | undefined> {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -23,6 +23,7 @@ import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js";
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
+import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
@@ -31,7 +32,7 @@ import {
   loadAnyAuthToken,
   loadAuthToken,
   loadSavedCloudInfo,
-  publishCloud,
+  publishCloudWithOverlays,
   removeAuthToken,
   saveAuthToken,
 } from "./publishers/cloud.js";
@@ -734,24 +735,6 @@ async function saveAnnotations(
 }
 
 // ─── Overlay persistence ────────────────────────────────────────────────────
-
-const EMPTY_OVERLAYS: SessionOverlays = { version: 1, overlays: [] };
-
-async function loadOverlays(baseDir: string, slug: string): Promise<SessionOverlays> {
-  const dirs = [join(baseDir, slug), resolve("./vibe-replay", slug)];
-  for (const dir of dirs) {
-    try {
-      const raw = await readFile(join(dir, "overlays.json"), "utf-8");
-      const parsed = JSON.parse(raw) as SessionOverlays;
-      if (parsed && typeof parsed === "object" && Array.isArray(parsed.overlays)) {
-        return parsed;
-      }
-    } catch {
-      /* not found */
-    }
-  }
-  return EMPTY_OVERLAYS;
-}
 
 async function saveOverlays(
   baseDir: string,
@@ -2356,31 +2339,18 @@ export async function startServer(
     }
   });
 
-  // Publish to cloud (R2)
+  // Publish to cloud (R2) — overlay merging is handled by publishCloudWithOverlays
   app.post("/api/publish/cloud", async (c) => {
     const result = requireSlug(c.req.query("slug"));
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetDir = join(baseDir, result.slug);
 
     try {
-      const rawSession = await loadSessionFromDisk(baseDir, result.slug);
-      const overlaysData = await loadOverlays(baseDir, result.slug);
-      const targetSession = sessionWithEffectiveContent(rawSession, overlaysData);
-
-      // Write effective content for upload, then restore the original replay.json
-      const replayPath = join(targetDir, "replay.json");
-      const originalContent = await readFile(replayPath, "utf-8");
-      await writeFile(replayPath, JSON.stringify(targetSession), "utf-8");
-
-      try {
-        const body = await c.req.json().catch(() => ({}));
-        const cloudResult = await publishCloud(targetDir, {
-          visibility: body.visibility || "unlisted",
-        });
-        return c.json(cloudResult);
-      } finally {
-        await writeFile(replayPath, originalContent, "utf-8");
-      }
+      const body = await c.req.json().catch(() => ({}));
+      const cloudResult = await publishCloudWithOverlays(targetDir, {
+        visibility: body.visibility || "unlisted",
+      });
+      return c.json(cloudResult);
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
     }
@@ -2626,36 +2596,6 @@ export async function startServer(
     }
     return c.json({ ok: true });
   });
-
-  // --- Overlay chaining helper ---
-  // When running a new operation (translate/tone), use effective content from existing
-  // overlays so operations chain correctly (e.g. soften AFTER translate works on translated text)
-  function sessionWithEffectiveContent(
-    session: ReplaySession,
-    existing: SessionOverlays,
-  ): ReplaySession {
-    if (existing.overlays.length === 0) return session;
-    // For each scene, find the latest overlay by updatedAt
-    const latestByScene = new Map<number, { value: string; time: string }>();
-    for (const o of existing.overlays) {
-      const current = latestByScene.get(o.sceneIndex);
-      if (!current || o.updatedAt > current.time) {
-        latestByScene.set(o.sceneIndex, { value: o.modifiedValue, time: o.updatedAt });
-      }
-    }
-    if (latestByScene.size === 0) return session;
-    return {
-      ...session,
-      scenes: session.scenes.map((scene, i) => {
-        const entry = latestByScene.get(i);
-        if (!entry) return scene;
-        if (scene.type === "user-prompt" || scene.type === "text-response") {
-          return { ...scene, content: entry.value };
-        }
-        return scene;
-      }),
-    };
-  }
 
   // After generation, fix originalValue to be the TRUE original from the unmodified session
   function fixOriginalValues(


### PR DESCRIPTION
## Summary

Wires the existing cloud publisher (`publishers/cloud.ts`) into the CLI surface users actually see.

- Post-generation picker now offers `☁ Share via Cloud` between **Quick preview** and **Gist** — auth-gated label, confirm prompt, 7-day unlisted link.
- New top-level `vibe-replay share [path]` subcommand. Without `[path]`, it lists `~/.vibe-replay/<slug>` entries with a valid `replay.json`, sorted by start time. Supports `--visibility public|unlisted|private` (validated) and `--api-url` (forwarded via `VIBE_REPLAY_API_URL` so `publishCloud` picks it up).
- Closes the in_progress portion of `plan/features/007-cli-share-command.md`.

## Test plan

- [x] `pnpm build` — CLI bundle 420 KB
- [x] `pnpm test` — 686 unit tests pass
- [x] `pnpm test:e2e` — 70 e2e tests pass (cli-smoke / editor-server / generated-html / auth-worker / cloud-auth / file-storage)
- [x] `node dist/index.js share --help` registers; top-level help lists the new command
- [x] `share /nonexistent` exits 1 with clear "Path not found"
- [x] `share <valid-dir>` without auth exits 1 with "Not logged in. Run \`vibe-replay auth login\` first."
- [ ] Manual: log in, run `vibe-replay share` interactively → pick a replay → verify URL + 7-day expiry print

## Notes

- Picker option ordering matches the plan doc: Editor → Quick preview → Cloud Share → Gist → GitHub Export → Exit.
- `--api-url` validation is intentionally light here (string passed through to `getApiUrl()` via env). The phishing-prevention check lives in `auth login`, since that's the command that persists tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Session Replay

### AI Coding Session

4 min · 1 files changed · claude-opus-4-7
16 responses · 56 tools — Read 12 · Edit 4 · Bash (ls, wc, pnpm, node, ...) 22 · Grep 5 · ToolSearch 1 · TaskCreate 4 · TaskUpdate 7 · Skill 1

<details>
<summary>View session details (3 prompts, 56 tool calls)</summary>

> **Let's go through the plan and see what we can pick up**
> 2 responses · 8 tools — Read 4 · Bash (ls) 3 · Grep 1
>
> *我把 plan 过了一遍，下面是当前可执行的清单（按"小→大"和优先级排）。 ## 进行中 / 近期可推进 \*\*1. CLI Share — \`features/0…*

> **Let's do #1**
> 13 responses · 40 tools — Read 8 · Edit 4 · Bash (wc, ls, pnpm, node, ...) 12 · Grep 4 · ToolSearch 1 · TaskCreate 4 · TaskUpdate 7
>
> *Implementation works, all tests pass. Before I touch git, want to confirm the next step with you — based on your overni…*

> **Are you done? Open a PR and include a vibe-replay**
> 1 responses · 8 tools — Bash (git, gh, grep, npx) 7 · Skill 1
>
> *PR #210 opened. Now generate a vibe-replay of this session and attach it.*

**Signals:**
- `src/index.ts` modified 4x
- 1 test failure(s) (resolved)

</details>

<sub>Generated by [vibe-replay](https://vibe-replay.com)</sub>
