### PR TITLE
chore(cli): bump version to 0.1.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- Bump CLI version 0.1.7 → 0.1.8 so the skill's `npx vibe-replay` invocation picks up a fresh release.

## Test plan
- [x] `pnpm --filter vibe-replay build` succeeds
- [x] `node packages/cli/dist/index.js --version` prints `0.1.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)