### PR TITLE
feat(website): promote GitHub star to primary hero CTA

### DIFF
--- a/website/src/components/GitHubStar.astro
+++ b/website/src/components/GitHubStar.astro
@@ -1,5 +1,5 @@
 <!-- GitHub Star link — count hidden until repo has meaningful momentum -->
-<a id="github-star" href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener"
+<a id="github-star" href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener noreferrer"
   class="inline-flex items-center h-7 px-2 gap-1 rounded-md border border-border text-xs font-medium text-text-secondary hover:text-text-primary hover:border-text-secondary/30 transition-colors">
   <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>
   Star

--- a/website/src/components/GitHubStar.astro
+++ b/website/src/components/GitHubStar.astro
@@ -1,21 +1,6 @@
-<!-- Self-contained GitHub Star button — no external iframe, height fully controllable -->
+<!-- GitHub Star link — count hidden until repo has meaningful momentum -->
 <a id="github-star" href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener"
-  class="inline-flex items-center h-7 rounded-md border border-border text-xs font-medium text-text-secondary hover:text-text-primary hover:border-text-secondary/30 transition-colors">
-  <span class="inline-flex items-center gap-1 px-2">
-    <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>
-    Star
-  </span>
-  <span id="star-count" class="inline-flex items-center px-2 h-full border-l border-border" style="display:none"></span>
+  class="inline-flex items-center h-7 px-2 gap-1 rounded-md border border-border text-xs font-medium text-text-secondary hover:text-text-primary hover:border-text-secondary/30 transition-colors">
+  <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"/></svg>
+  Star
 </a>
-
-<script>
-  fetch("https://api.github.com/repos/tuo-lei/vibe-replay")
-    .then((r) => r.json())
-    .then((d) => {
-      if (d.stargazers_count != null) {
-        const el = document.getElementById("star-count");
-        if (el) { el.textContent = String(d.stargazers_count); el.style.display = ""; }
-      }
-    })
-    .catch(() => {});
-</script>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -115,7 +115,7 @@ const slides = [
 
       <!-- Bottom status bar: slide label + dots -->
       <div class="flex items-center justify-between px-4 py-2 bg-[#161b22] border-t border-[#30363d]">
-        <span id="hero-slide-label" class="text-xs text-[#8b949e] font-mono transition-opacity duration-300">$ npx vibe-replay</span>
+        <span id="hero-slide-label" class="text-xs text-[#8b949e] font-mono transition-opacity duration-300">&nbsp;</span>
         <div class="flex items-center gap-1.5">
           {slides.map((_, i) => (
             <button
@@ -137,7 +137,7 @@ const slides = [
         id="hero-github-star"
         href="https://github.com/tuo-lei/vibe-replay"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         class="relative flex items-center gap-2 px-6 py-3 rounded-lg bg-surface-1 border border-border hover:border-accent/40 font-semibold transition-colors"
       >
         <svg class="w-4 h-4 text-text-primary" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
@@ -180,7 +180,6 @@ const slides = [
 
   let currentSlide = -1; // -1 = terminal phase
   let autoTimer: ReturnType<typeof setTimeout> | null = null;
-  const aborted = false;
 
   // Reduced motion check
   const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -235,7 +234,6 @@ const slides = [
   async function typeText(text: string) {
     if (!typed) return;
     for (let i = 0; i < text.length; i++) {
-      if (aborted) return;
       typed.textContent = text.slice(0, i + 1);
       await new Promise((r) => setTimeout(r, 45 + Math.random() * 30));
     }
@@ -253,13 +251,11 @@ const slides = [
     // Phase 1: type command
     await typeText("npx vibe-replay");
     await new Promise((r) => setTimeout(r, 300));
-    if (aborted) return;
 
     // Show output
     if (cursor) cursor.style.display = "none";
     if (output) output.classList.remove("hidden");
     await new Promise((r) => setTimeout(r, 1200));
-    if (aborted) return;
 
     // Phase 2: transition to screenshots
     showSlide(0);
@@ -299,15 +295,7 @@ const slides = [
     }
   }
   document.getElementById("hero-url-bar")?.addEventListener("click", () => {
-    navigator.clipboard.writeText("npx vibe-replay").then(showCopySuccess).catch(() => {
-      const input = document.createElement("input");
-      input.value = "npx vibe-replay";
-      document.body.appendChild(input);
-      input.select();
-      document.execCommand("copy");
-      document.body.removeChild(input);
-      showCopySuccess();
-    });
+    navigator.clipboard.writeText("npx vibe-replay").then(showCopySuccess).catch(() => {});
   });
 
 </script>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -59,7 +59,22 @@ const slides = [
           <div class="w-3 h-3 rounded-full bg-[#28c840]/80"></div>
         </div>
         <div class="flex-1 flex justify-center">
-          <div id="hero-url-bar" class="px-4 py-1 rounded-md bg-[#0d1117]/60 text-xs text-[#8b949e] font-mono transition-all duration-500">Terminal</div>
+          <button
+            id="hero-url-bar"
+            type="button"
+            class="group inline-flex items-center gap-2 px-3 py-1 rounded-md bg-[#0d1117]/60 hover:bg-[#0d1117] border border-transparent hover:border-[#30363d] text-xs text-[#8b949e] hover:text-[#e6edf3] font-mono transition-all duration-300 cursor-pointer"
+            aria-label="Copy npx vibe-replay"
+          >
+            <span class="text-[#3fb950]">$</span>
+            <span>npx vibe-replay</span>
+            <svg id="hero-url-copy-icon" class="w-3 h-3 opacity-60 group-hover:opacity-100 transition-opacity" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" stroke-width="2"/>
+              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" stroke-width="2"/>
+            </svg>
+            <svg id="hero-url-check-icon" class="w-3 h-3 text-[#3fb950] hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <polyline points="20 6 9 17 4 12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
         </div>
         <div class="w-[54px]"></div>
       </div>
@@ -116,6 +131,19 @@ const slides = [
 
   <!-- CTAs -->
   <div class="relative mt-6 sm:mt-10 flex flex-col sm:flex-row items-center gap-3 sm:gap-4">
+    <div class="group relative">
+      <div class="absolute -inset-0.5 bg-gradient-to-r from-accent/40 to-cyan-400/40 rounded-lg blur opacity-40 group-hover:opacity-60 transition"></div>
+      <a
+        id="hero-github-star"
+        href="https://github.com/tuo-lei/vibe-replay"
+        target="_blank"
+        rel="noopener"
+        class="relative flex items-center gap-2 px-6 py-3 rounded-lg bg-surface-1 border border-border hover:border-accent/40 font-semibold transition-colors"
+      >
+        <svg class="w-4 h-4 text-text-primary" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        <span class="text-text-primary">Star on GitHub</span>
+      </a>
+    </div>
     <a
       href={DEMO_URL}
       class="flex items-center gap-2 px-6 py-3 rounded-lg bg-accent/10 text-accent font-semibold hover:bg-accent/20 transition-colors"
@@ -123,23 +151,6 @@ const slides = [
       <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
       Watch a real session
     </a>
-    <div class="group relative">
-      <div class="absolute -inset-0.5 bg-gradient-to-r from-accent/40 to-cyan-400/40 rounded-lg blur opacity-30 group-hover:opacity-50 transition"></div>
-      <button
-        id="hero-copy-btn"
-        class="relative flex items-center gap-3 px-6 py-3 bg-surface-1 border border-border rounded-lg font-mono text-base hover:border-accent/40 transition-all cursor-pointer"
-      >
-        <span class="text-text-muted select-none">$</span>
-        <span class="text-text-primary">npx vibe-replay</span>
-        <svg id="hero-copy-icon" class="w-4 h-4 text-text-muted group-hover:text-accent transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" stroke-width="2"/>
-          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" stroke-width="2"/>
-        </svg>
-        <svg id="hero-check-icon" class="w-4 h-4 text-accent hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <polyline points="20 6 9 17 4 12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-    </div>
   </div>
 </section>
 
@@ -163,7 +174,6 @@ const slides = [
   const typed = document.getElementById("hero-typed");
   const cursor = document.getElementById("hero-cursor");
   const output = document.getElementById("hero-output");
-  const urlBar = document.getElementById("hero-url-bar");
   const label = document.getElementById("hero-slide-label");
   const slides = document.querySelectorAll<HTMLImageElement>(".hero-slide");
   const dots = document.querySelectorAll<HTMLButtonElement>(".hero-dot");
@@ -192,7 +202,7 @@ const slides = [
       d.classList.toggle("bg-[#30363d]", i !== index);
     });
 
-    // Update label and URL bar
+    // Update label
     if (label) {
       label.style.opacity = "0";
       setTimeout(() => {
@@ -200,7 +210,6 @@ const slides = [
         label.style.opacity = "1";
       }, 200);
     }
-    if (urlBar) urlBar.textContent = "localhost:13456";
   }
 
   function nextSlide() {
@@ -276,10 +285,10 @@ const slides = [
     }, 2500);
   }
 
-  // Copy button
+  // URL-bar copy button
   function showCopySuccess() {
-    const copyIcon = document.getElementById("hero-copy-icon");
-    const checkIcon = document.getElementById("hero-check-icon");
+    const copyIcon = document.getElementById("hero-url-copy-icon");
+    const checkIcon = document.getElementById("hero-url-check-icon");
     if (copyIcon && checkIcon) {
       copyIcon.classList.add("hidden");
       checkIcon.classList.remove("hidden");
@@ -289,7 +298,7 @@ const slides = [
       }, 2000);
     }
   }
-  document.getElementById("hero-copy-btn")?.addEventListener("click", () => {
+  document.getElementById("hero-url-bar")?.addEventListener("click", () => {
     navigator.clipboard.writeText("npx vibe-replay").then(showCopySuccess).catch(() => {
       const input = document.createElement("input");
       input.value = "npx vibe-replay";
@@ -300,4 +309,5 @@ const slides = [
       showCopySuccess();
     });
   });
+
 </script>


### PR DESCRIPTION
## Summary

- Moved `npx vibe-replay` install hint into the demo's browser-chrome URL bar as a compact click-to-copy button — it's always visible regardless of carousel phase
- Promoted **Star on GitHub** to a primary hero CTA next to *Watch a real session* (it's a trust signal we want to surface, especially on mobile where the GitHub link was previously hidden in the hamburger)
- Hid the star count in both the nav and hero buttons — early-stage star numbers are noise, easy to re-enable later

## Test plan

- [x] `pnpm lint:check` passes
- [x] Verified with Playwright at 390px (mobile) and 1280px (desktop), in both terminal and carousel phases of the hero animation
- [x] URL-bar copy button works (click copies `npx vibe-replay`, swaps to check icon)
- [x] GitHub Star CTA links to repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)