### PR TITLE
fix(cursor): show tool badge parity for JSONL sessions

### DIFF
--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -104,6 +104,11 @@ interface ParseJsonlOptions {
   inferToolPaths: boolean;
 }
 
+interface CursorToolResult {
+  result: string;
+  timestamp?: string;
+}
+
 function defaultDataSourceInfo(
   dataSource?: ProviderParseResult["dataSource"],
 ): DataSourceInfo | undefined {
@@ -426,11 +431,6 @@ function extractToolResultImages(block: Extract<ContentBlock, { type: "tool_resu
       return `data:${mediaType};base64,${source.data}`;
     })
     .filter((value): value is string => typeof value === "string");
-}
-
-interface CursorToolResult {
-  result: string;
-  timestamp?: string;
 }
 
 function attachToolResults(

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -138,7 +138,7 @@ async function parseCursorJsonl(
 ): Promise<ProviderParseResult> {
   const allTurns: ParsedTurn[] = [];
   let syntheticToolId = 0;
-  const toolResults = new Map<string, string>();
+  const toolResults = new Map<string, CursorToolResult>();
   const toolErrors = new Map<string, boolean>();
   const toolImages = new Map<string, string[]>();
   const sortedTranscriptPaths = await sortByMtime(transcriptPaths);
@@ -167,7 +167,10 @@ async function parseCursorJsonl(
         if (block.type === "tool_result") {
           const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
           if (toolUseId) {
-            toolResults.set(toolUseId, extractToolResultText(block));
+            toolResults.set(toolUseId, {
+              result: extractToolResultText(block),
+              timestamp: typeof obj.timestamp === "string" ? obj.timestamp : undefined,
+            });
             if ((block as any).is_error) toolErrors.set(toolUseId, true);
             const images = extractToolResultImages(block);
             if (images.length > 0) toolImages.set(toolUseId, images);
@@ -425,9 +428,14 @@ function extractToolResultImages(block: Extract<ContentBlock, { type: "tool_resu
     .filter((value): value is string => typeof value === "string");
 }
 
+interface CursorToolResult {
+  result: string;
+  timestamp?: string;
+}
+
 function attachToolResults(
   turns: ParsedTurn[],
-  toolResults: Map<string, string>,
+  toolResults: Map<string, CursorToolResult>,
   toolErrors: Map<string, boolean>,
   toolImages: Map<string, string[]>,
 ): void {
@@ -437,8 +445,10 @@ function attachToolResults(
       if (block.type !== "tool_use" || typeof block.id !== "string") continue;
       const result = toolResults.get(block.id);
       if (result !== undefined) {
-        block._result = result;
-        block.input = mapToolArgs(block.name, block.input, result);
+        block._result = result.result;
+        block.input = mapToolArgs(block.name, block.input, result.result);
+        const durationMs = durationBetween(turn.timestamp, result.timestamp);
+        if (durationMs !== undefined) block._durationMs = durationMs;
       }
       const images = toolImages.get(block.id);
       if (images?.length) block._images = images;
@@ -704,6 +714,8 @@ function attachToolEvents(turns: ParsedTurn[], tools: ToolEvent[]): void {
       ...tool.input,
     };
     marker.block._result = tool.result;
+    const durationMs = durationBetween(marker.turn.timestamp, tool.timestamp);
+    if (durationMs !== undefined) marker.block._durationMs = durationMs;
     marker.block._isPendingMarker = undefined;
     if (!marker.turn.timestamp && tool.timestamp) {
       marker.turn.timestamp = tool.timestamp;
@@ -740,6 +752,14 @@ function toToolUseBlock(tool: ToolEvent): ContentBlock {
     input: tool.input,
     _result: tool.result,
   };
+}
+
+function durationBetween(start?: string, end?: string): number | undefined {
+  if (!start || !end) return undefined;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
+  return Math.round(endMs - startMs);
 }
 
 function splitToolMarker(text: string): { markerName: string; textBody?: string } | undefined {

--- a/packages/cli/test/cursor-parser.test.ts
+++ b/packages/cli/test/cursor-parser.test.ts
@@ -151,6 +151,50 @@ describe("Cursor parser — tool outputs", () => {
     expect(toolScenes[1].result).toContain("https://example.com/docs");
   });
 
+  it("uses JSONL tool_result timestamps for tool-call durations", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-tool-duration-"));
+    const jsonlPath = join(tempDir, "tool-duration.jsonl");
+    await writeFile(
+      jsonlPath,
+      [
+        JSON.stringify({
+          role: "assistant",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_1",
+                name: "run_terminal_cmd",
+                input: { command: "pnpm test" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "user",
+          timestamp: "2026-01-01T00:00:02.500Z",
+          message: {
+            content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "tests passed" }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      const parsed = await parseCursorSession(jsonlPath);
+      const replay = transformToReplay(parsed, "cursor", "~/test/project");
+      const toolScenes = replay.scenes.filter((s) => s.type === "tool-call");
+
+      expect(toolScenes).toHaveLength(1);
+      expect(toolScenes[0].durationMs).toBe(2500);
+      expect(toolScenes[0].resultTokens).toBeGreaterThan(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("converts unpaired marker to thinking when no tool output matches", async () => {
     const parsed = await parseCursorSession(FIXTURE);
     const replay = transformToReplay(parsed, "cursor", "~/test/project");

--- a/packages/viewer/src/components/Badges.tsx
+++ b/packages/viewer/src/components/Badges.tsx
@@ -3,6 +3,8 @@
  * styling stays consistent — change the pill once, all variants update.
  */
 
+import { formatToolDuration, formatTokens } from "./StatsPanel";
+
 export function ErrorBadge() {
   return (
     <span
@@ -10,6 +12,32 @@ export function ErrorBadge() {
       title="This tool call returned an error"
     >
       ERROR
+    </span>
+  );
+}
+
+export function ToolDuration({ ms }: { ms?: number }) {
+  const label = formatToolDuration(ms);
+  if (!label) return null;
+  return (
+    <span
+      className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+      title={`Tool execution: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function ToolTokens({ tokens }: { tokens?: number }) {
+  const label = formatTokens(tokens);
+  if (!label) return null;
+  return (
+    <span
+      className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+      title={`~${label} tokens added to context (heuristic estimate)`}
+    >
+      ~{label} tok
     </span>
   );
 }

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -2,6 +2,7 @@ import { diffLines as computeLineDiff } from "diff";
 import { Highlight, themes } from "prism-react-renderer";
 import { memo, useMemo, useSyncExternalStore } from "react";
 import { ErrorBadge } from "./Badges";
+import { formatToolDuration, formatTokens } from "./StatsPanel";
 
 // Subscribe to dark/light class changes on <html> for prism theme switching
 const subscribe = (cb: () => void) => {
@@ -18,6 +19,8 @@ interface Props {
   newContent: string;
   isActive: boolean;
   isError?: boolean;
+  durationMs?: number;
+  resultTokens?: number;
 }
 
 interface DiffLine {
@@ -77,12 +80,16 @@ export default memo(function CodeDiffBlock({
   newContent,
   isActive: _isActive,
   isError,
+  durationMs,
+  resultTokens,
 }: Props) {
   const diffLines = useMemo(() => computeDiff(oldContent, newContent), [oldContent, newContent]);
   const language = guessLanguage(filePath);
   const isDark = useSyncExternalStore(subscribe, getIsDark);
   const isNewFile = !oldContent;
   const isDeletedFile = toolName === "Delete" && !newContent;
+  const tokenLabel = formatTokens(resultTokens);
+  const durationLabel = formatToolDuration(durationMs);
 
   return (
     <div
@@ -98,6 +105,22 @@ export default memo(function CodeDiffBlock({
         </span>
         <span className="text-xs font-mono text-terminal-blue truncate flex-1">{filePath}</span>
         {isError && <ErrorBadge />}
+        {tokenLabel && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title={`~${tokenLabel} tokens added to context`}
+          >
+            ~{tokenLabel} tok
+          </span>
+        )}
+        {durationLabel && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title={`Execution: ${durationLabel}`}
+          >
+            {durationLabel}
+          </span>
+        )}
         {isNewFile && (
           <span className="text-xs px-1.5 py-0.5 rounded bg-terminal-green/20 text-terminal-green">
             new

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -1,8 +1,7 @@
 import { diffLines as computeLineDiff } from "diff";
 import { Highlight, themes } from "prism-react-renderer";
 import { memo, useMemo, useSyncExternalStore } from "react";
-import { ErrorBadge } from "./Badges";
-import { formatToolDuration, formatTokens } from "./StatsPanel";
+import { ErrorBadge, ToolDuration, ToolTokens } from "./Badges";
 
 // Subscribe to dark/light class changes on <html> for prism theme switching
 const subscribe = (cb: () => void) => {
@@ -88,8 +87,6 @@ export default memo(function CodeDiffBlock({
   const isDark = useSyncExternalStore(subscribe, getIsDark);
   const isNewFile = !oldContent;
   const isDeletedFile = toolName === "Delete" && !newContent;
-  const tokenLabel = formatTokens(resultTokens);
-  const durationLabel = formatToolDuration(durationMs);
 
   return (
     <div
@@ -105,22 +102,8 @@ export default memo(function CodeDiffBlock({
         </span>
         <span className="text-xs font-mono text-terminal-blue truncate flex-1">{filePath}</span>
         {isError && <ErrorBadge />}
-        {tokenLabel && (
-          <span
-            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
-            title={`~${tokenLabel} tokens added to context`}
-          >
-            ~{tokenLabel} tok
-          </span>
-        )}
-        {durationLabel && (
-          <span
-            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
-            title={`Execution: ${durationLabel}`}
-          >
-            {durationLabel}
-          </span>
-        )}
+        <ToolTokens tokens={resultTokens} />
+        <ToolDuration ms={durationMs} />
         {isNewFile && (
           <span className="text-xs px-1.5 py-0.5 rounded bg-terminal-green/20 text-terminal-green">
             new

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -336,6 +336,8 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
         newContent={scene.diff.newContent}
         isActive={isActive}
         isError={scene.isError}
+        durationMs={scene.durationMs}
+        resultTokens={scene.resultTokens}
       />
     );
   }

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -1,38 +1,12 @@
 import { memo, useState } from "react";
 import type { Scene, SubAgent } from "../types";
 import { displayToolName } from "../utils/toolName";
-import { ErrorBadge } from "./Badges";
+import { ErrorBadge, ToolDuration, ToolTokens } from "./Badges";
 import BashBlock from "./BashBlock";
 import CodeDiffBlock from "./CodeDiffBlock";
-import { formatToolDuration, formatTokens } from "./StatsPanel";
+import { formatTokens } from "./StatsPanel";
 
 const CHEVRON = "▶";
-
-function ToolDuration({ ms }: { ms?: number }) {
-  const label = formatToolDuration(ms);
-  if (!label) return null;
-  return (
-    <span
-      className="text-[10px] text-terminal-dimmer font-mono shrink-0"
-      title={`Tool execution: ${label}`}
-    >
-      {label}
-    </span>
-  );
-}
-
-function ToolTokens({ tokens }: { tokens?: number }) {
-  const label = formatTokens(tokens);
-  if (!label) return null;
-  return (
-    <span
-      className="text-[10px] text-terminal-dimmer font-mono shrink-0"
-      title={`~${label} tokens added to context (heuristic estimate)`}
-    >
-      ~{label} tok
-    </span>
-  );
-}
 
 function subAgentTotalTokens(sa: SubAgent): number {
   if (!sa.tokenUsage) return 0;


### PR DESCRIPTION
## Summary
- Infer Cursor JSONL tool-call durations from matching tool result timestamps.
- Pass per-tool context and duration badges through diff tool rendering.
- Add parser coverage for Cursor JSONL duration/result token parity.

## Test plan
- pnpm --filter vibe-replay test -- cursor-parser.test.ts
- pnpm --filter @vibe-replay/viewer build
- pnpm lint:check
- pnpm typecheck


Made with [Cursor](https://cursor.com)