### PR TITLE
feat(live): stream a running AI coding session into the viewer

### DIFF
--- a/e2e/live-mode.test.ts
+++ b/e2e/live-mode.test.ts
@@ -1,0 +1,280 @@
+// E2E for live mode (`/api/live` SSE endpoint)
+// — boots the *real* CLI server with a temp $HOME containing a fake
+//   Claude Code JSONL session, opens an SSE connection, then appends new
+//   turns to the JSONL and asserts the stream delivers updated payloads.
+//
+// HOME is overridden BEFORE the dynamic import so the Claude Code provider's
+// module-level `CLAUDE_DIR = join(homedir(), ...)` resolves to the temp dir.
+
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type Browser, chromium } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+interface ParsedSseEvent {
+  data: any;
+}
+
+/**
+ * Subscribe to an SSE endpoint and yield each parsed event as it arrives.
+ * Caller is responsible for cancelling via the AbortController when done.
+ */
+async function* readSse(
+  url: string,
+  signal: AbortSignal,
+): AsyncGenerator<ParsedSseEvent, void, void> {
+  const resp = await fetch(url, { signal, headers: { Accept: "text/event-stream" } });
+  if (!resp.body) throw new Error("no body");
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buffer += decoder.decode(value, { stream: true });
+
+    // Events are separated by a blank line (\n\n)
+    let sepIdx: number;
+    while ((sepIdx = buffer.indexOf("\n\n")) !== -1) {
+      const rawEvent = buffer.slice(0, sepIdx);
+      buffer = buffer.slice(sepIdx + 2);
+      const dataLine = rawEvent.split("\n").find((l) => l.startsWith("data:"));
+      if (!dataLine) continue;
+      const json = dataLine.slice(5).trim();
+      try {
+        yield { data: JSON.parse(json) };
+      } catch {
+        // Ignore malformed lines (e.g., keep-alive comments)
+      }
+    }
+  }
+}
+
+describe("Live mode SSE", () => {
+  const sessionId = "live-test-session-001";
+  const projectPath = "/Users/test/live-project";
+  const projectDirEncoded = "-Users-test-live-project";
+  let tmpHome: string;
+  let jsonlPath: string;
+  let serverProcess: ReturnType<typeof spawn> | null = null;
+  let serverPort: number | null = null;
+  let browser: Browser | null = null;
+
+  beforeAll(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "vibe-live-test-"));
+    const projectsDir = join(tmpHome, ".claude", "projects", projectDirEncoded);
+    await mkdir(projectsDir, { recursive: true });
+    jsonlPath = join(projectsDir, `${sessionId}.jsonl`);
+
+    // Initial JSONL — system init + first user prompt + first assistant text
+    const initialLines = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        sessionId,
+        slug: "live-slug",
+        cwd: projectPath,
+        version: "1.0.0",
+        timestamp: "2026-04-26T10:00:00Z",
+      }),
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Hello, please help me." },
+        timestamp: "2026-04-26T10:00:01Z",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "Sure, what do you need?" }],
+        },
+        timestamp: "2026-04-26T10:00:02Z",
+      }),
+    ];
+    await writeFile(jsonlPath, `${initialLines.join("\n")}\n`, "utf-8");
+
+    // Spawn the real CLI server with our temp HOME so Claude Code's discover()
+    // points at the fixture. We use a bootstrap script that calls startServer
+    // directly — the `vibe-replay` entry doesn't expose a way to skip auto-open
+    // without going through `live` (which would auto-pick the wrong session).
+    const bootstrap = `
+      import { startServer } from "${join(import.meta.dirname, "..", "packages/cli/src/server.ts").replace(/\\\\/g, "/")}";
+      const port = await new Promise(async (resolve) => {
+        const baseDir = "${join(tmpHome, ".vibe-replay").replace(/\\\\/g, "/")}";
+        // startServer auto-opens unless VIBE_REPLAY_NO_AUTO_OPEN=1; that's set in env
+        startServer(baseDir, { openDashboard: true });
+      });
+    `;
+    const bootstrapPath = join(tmpHome, "boot.mjs");
+    await writeFile(bootstrapPath, bootstrap, "utf-8");
+
+    serverProcess = spawn("pnpm", ["exec", "tsx", bootstrapPath], {
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        USERPROFILE: tmpHome, // win compat (test still skipped on win)
+        VIBE_REPLAY_NO_AUTO_OPEN: "1",
+      },
+      cwd: join(import.meta.dirname, ".."),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Parse the port from server stdout: "Dashboard running at http://localhost:PORT/..."
+    serverPort = await new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("server start timeout")), 20_000);
+      const onData = (buf: Buffer) => {
+        const text = buf.toString();
+        const m = text.match(/http:\/\/localhost:(\d+)/);
+        if (m) {
+          clearTimeout(timeout);
+          serverProcess!.stdout!.off("data", onData);
+          resolve(Number(m[1]));
+        }
+      };
+      serverProcess!.stdout!.on("data", onData);
+      serverProcess!.stderr!.on("data", (b) => {
+        // Surface server errors during boot for easier debugging
+        process.stderr.write(b);
+      });
+      serverProcess!.on("exit", (code) => {
+        if (serverPort === null) {
+          clearTimeout(timeout);
+          reject(new Error(`server exited early with code ${code}`));
+        }
+      });
+    });
+
+    browser = await chromium.launch({ headless: true });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (browser) await browser.close();
+    if (serverProcess && !serverProcess.killed) {
+      serverProcess.kill("SIGTERM");
+      // Give it a beat to clean up watchers
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    if (tmpHome) {
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("streams an initial session and a delta after the JSONL grows", async () => {
+    expect(serverPort).not.toBeNull();
+    const ac = new AbortController();
+    const url = `http://127.0.0.1:${serverPort}/api/live?provider=claude-code&sessionId=${encodeURIComponent(sessionId)}`;
+
+    const events: any[] = [];
+    const collect = (async () => {
+      for await (const ev of readSse(url, ac.signal)) {
+        if (ev.data.type === "ping") continue;
+        events.push(ev.data);
+        if (events.length >= 2) {
+          ac.abort();
+          break;
+        }
+      }
+    })().catch((err) => {
+      // Aborting causes an AbortError — that's expected once we have 2 events
+      if (err?.name !== "AbortError") throw err;
+    });
+
+    // Wait for initial event
+    const waitForCount = async (n: number, timeoutMs: number) => {
+      const start = Date.now();
+      while (events.length < n && Date.now() - start < timeoutMs) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    };
+    await waitForCount(1, 5_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0].type).toBe("session");
+    const initialScenes = events[0].session.scenes.length;
+    expect(initialScenes).toBeGreaterThan(0);
+
+    // Append a new user+assistant turn — this should trip fs.watch
+    const newLines = [
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Tell me a joke." },
+        timestamp: "2026-04-26T10:01:00Z",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "Why did the dev cross the road?" }],
+        },
+        timestamp: "2026-04-26T10:01:01Z",
+      }),
+    ];
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(jsonlPath, `${newLines.join("\n")}\n`, "utf-8");
+
+    // Wait for delta event (debounce is 250ms so allow generous timeout)
+    await waitForCount(2, 5_000);
+    await collect;
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[1].type).toBe("session");
+    expect(events[1].session.scenes.length).toBeGreaterThan(initialScenes);
+  }, 30_000);
+
+  it("renders the LIVE badge in the viewer and follows tail when JSONL grows", async () => {
+    expect(browser).not.toBeNull();
+    expect(serverPort).not.toBeNull();
+    const page = await browser!.newPage();
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") return;
+      const text = msg.text();
+      // Auth probe + favicon 404s are unrelated network noise; live mode does
+      // not care about them.
+      if (text.includes("Failed to load resource")) return;
+      consoleErrors.push(text);
+    });
+
+    const url = `http://127.0.0.1:${serverPort}/?live=1&provider=claude-code&sessionId=${encodeURIComponent(sessionId)}`;
+    // domcontentloaded — networkidle would never settle while the SSE stream
+    // is held open
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+
+    // LIVE badge — green dot + "Live" label once SSE is open
+    const liveBadge = page.locator("text=Live").first();
+    await liveBadge.waitFor({ timeout: 10_000 });
+
+    // Initial conversation should be visible — first user prompt content
+    await page.waitForSelector("text=Hello, please help me.", { timeout: 10_000 });
+
+    // Append a NEW user prompt; the viewer should auto-follow tail and surface
+    // the new prompt without a manual refresh.
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(
+      jsonlPath,
+      `${JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Tell me a fresh joke please." },
+        timestamp: "2026-04-26T10:02:00Z",
+      })}\n${JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "A different punchline." }],
+        },
+        timestamp: "2026-04-26T10:02:01Z",
+      })}\n`,
+      "utf-8",
+    );
+
+    await page.waitForSelector("text=Tell me a fresh joke please.", { timeout: 10_000 });
+
+    expect(consoleErrors, `unexpected console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+    await page.close();
+  }, 40_000);
+});

--- a/e2e/live-mode.test.ts
+++ b/e2e/live-mode.test.ts
@@ -101,13 +101,11 @@ describe("Live mode SSE", () => {
     // points at the fixture. We use a bootstrap script that calls startServer
     // directly — the `vibe-replay` entry doesn't expose a way to skip auto-open
     // without going through `live` (which would auto-pick the wrong session).
+    // startServer keeps the process alive on its own; we read the port from
+    // stdout once it logs the listening URL.
     const bootstrap = `
       import { startServer } from "${join(import.meta.dirname, "..", "packages/cli/src/server.ts").replace(/\\\\/g, "/")}";
-      const port = await new Promise(async (resolve) => {
-        const baseDir = "${join(tmpHome, ".vibe-replay").replace(/\\\\/g, "/")}";
-        // startServer auto-opens unless VIBE_REPLAY_NO_AUTO_OPEN=1; that's set in env
-        startServer(baseDir, { openDashboard: true });
-      });
+      await startServer("${join(tmpHome, ".vibe-replay").replace(/\\\\/g, "/")}", {});
     `;
     const bootstrapPath = join(tmpHome, "boot.mjs");
     await writeFile(bootstrapPath, bootstrap, "utf-8");

--- a/e2e/live-mode.test.ts
+++ b/e2e/live-mode.test.ts
@@ -214,7 +214,7 @@ describe("Live mode SSE", () => {
     const { appendFile } = await import("node:fs/promises");
     await appendFile(jsonlPath, `${newLines.join("\n")}\n`, "utf-8");
 
-    // Wait for delta event (debounce is 250ms so allow generous timeout)
+    // Wait for delta event (debounce is 100ms so allow generous timeout)
     await waitForCount(2, 5_000);
     await collect;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1022,6 +1022,11 @@ program
 // live — open the dashboard streaming a currently-active session
 // ---------------------------------------------------------------------------
 
+// If the most-recent session was last touched more than this long ago, warn
+// the user — the source process is probably no longer running, so the live
+// stream will sit idle until they kick off a new turn.
+const LIVE_STALENESS_WARNING_MS = 5 * 60_000;
+
 program
   .command("live")
   .description("Watch a running AI coding session live in the browser")
@@ -1095,7 +1100,7 @@ program
             ? `${Math.round(ageMs / 60_000)}m ago`
             : `${Math.round(ageMs / 3_600_000)}h ago`;
       spinner.succeed(`${top.title || top.sessionId.slice(0, 8)} (${top.provider}, ${ageLabel})`);
-      if (ageMs > 5 * 60_000) {
+      if (ageMs > LIVE_STALENESS_WARNING_MS) {
         console.log(
           chalk.yellow(
             `  ⚠ Last activity was ${ageLabel} — the session may not be running anymore.`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1018,6 +1018,98 @@ program
     }
   });
 
+// ---------------------------------------------------------------------------
+// live — open the dashboard streaming a currently-active session
+// ---------------------------------------------------------------------------
+
+program
+  .command("live")
+  .description("Watch a running AI coding session live in the browser")
+  .option("-p, --provider <name>", "Provider name (default: auto-detect)")
+  .option("-s, --session <sessionId>", "Specific session ID to watch")
+  .action(async (opts: { provider?: string; session?: string }) => {
+    if (process.platform === "win32") {
+      console.log(chalk.yellow("\n  ⚠ Windows is not supported yet.\n"));
+      process.exit(1);
+    }
+
+    const { join: pathJoin } = await import("node:path");
+    const { homedir } = await import("node:os");
+    const replayBaseDir = pathJoin(homedir(), ".vibe-replay");
+
+    console.log(chalk.bold.cyan("\n  vibe-replay live") + chalk.dim(` v${CLI_VERSION}\n`));
+
+    let target: { provider: string; sessionId: string; title?: string } | null = null;
+
+    if (opts.session) {
+      // Explicit session id — find which provider owns it
+      const providerHint = opts.provider;
+      const providers = providerHint
+        ? [getProvider(providerHint)].filter((p): p is NonNullable<typeof p> => !!p)
+        : getAllProviders();
+      for (const provider of providers) {
+        try {
+          const sessions = await provider.discover();
+          const match = sessions.find((s) => s.sessionId === opts.session);
+          if (match) {
+            target = { provider: match.provider, sessionId: match.sessionId, title: match.title };
+            break;
+          }
+        } catch {
+          // best-effort across providers
+        }
+      }
+      if (!target) {
+        console.log(chalk.red(`  ✗ Session not found: ${opts.session}\n`));
+        process.exit(1);
+      }
+    } else {
+      // Auto-pick most-recently-active session across providers
+      const ora = (await import("ora")).default;
+      const spinner = ora("Finding the most recent session...").start();
+      const all: SessionInfo[] = [];
+      const providers = opts.provider
+        ? [getProvider(opts.provider)].filter((p): p is NonNullable<typeof p> => !!p)
+        : getAllProviders();
+      for (const provider of providers) {
+        try {
+          const sessions = await provider.discover();
+          all.push(...sessions);
+        } catch {
+          // best-effort
+        }
+      }
+      if (all.length === 0) {
+        spinner.fail("No AI coding sessions found");
+        console.log(chalk.dim("  Start a Claude Code or Cursor session, then run again.\n"));
+        process.exit(1);
+      }
+      all.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+      const top = all[0]!;
+      target = { provider: top.provider, sessionId: top.sessionId, title: top.title };
+      const ageMs = Date.now() - new Date(top.timestamp).getTime();
+      const ageLabel =
+        ageMs < 60_000
+          ? `${Math.max(1, Math.round(ageMs / 1000))}s ago`
+          : ageMs < 3_600_000
+            ? `${Math.round(ageMs / 60_000)}m ago`
+            : `${Math.round(ageMs / 3_600_000)}h ago`;
+      spinner.succeed(`${top.title || top.sessionId.slice(0, 8)} (${top.provider}, ${ageLabel})`);
+      if (ageMs > 5 * 60_000) {
+        console.log(
+          chalk.yellow(
+            `  ⚠ Last activity was ${ageLabel} — the session may not be running anymore.`,
+          ),
+        );
+        console.log(chalk.dim("    The viewer will still update if Claude writes new turns.\n"));
+      }
+    }
+
+    await startServer(replayBaseDir, {
+      openLive: { provider: target.provider, sessionId: target.sessionId },
+    });
+  });
+
 // Keep backwards-compatible hidden alias
 program
   .command("login", { hidden: true })

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1309,10 +1309,14 @@ export async function startServer(
         return;
       }
 
-      // Discover the source session by sessionId. We re-discover on each connect
-      // so we always pick up new file paths (e.g. /resume creates new JSONL files).
+      // Discover the source session by sessionId. We re-discover on each
+      // connect (and on every rebuild) so we always pick up new file paths —
+      // Claude `/resume` creates new JSONL shards under the same logical
+      // session, and `mergeSameSessions` collapses them into one record so
+      // `parse()` sees the full conversation history instead of a single
+      // shard mid-stream.
       const resolveSessionInfo = async () => {
-        const all = await provider.discover();
+        const all = mergeSameSessions(await provider.discover());
         return all.find((s) => s.sessionId === sessionId);
       };
 
@@ -1374,12 +1378,16 @@ export async function startServer(
               generatedAt: new Date().toISOString(),
             },
           });
-          // Dedup on content — generatedAt would otherwise change every parse
-          // and force every fs.watch event (including atime-only) to emit a
-          // redundant 100KB payload. Scene count + last scene timestamp +
-          // turn count is enough to identify "anything changed".
-          const lastScene = replay.scenes[replay.scenes.length - 1];
-          const signature = `${replay.scenes.length}|${replay.meta.stats.userPrompts}|${replay.meta.stats.toolCalls}|${lastScene?.timestamp || ""}`;
+          // Dedup on the serialized scene array. Hashing only coarse counters
+          // (scene count, prompt count, last timestamp) misses content-only
+          // mutations — e.g. Claude tool_result lines populate `_result` on an
+          // existing tool_use scene without changing scene count or the latest
+          // turn timestamp, so the user would never see tool output appear.
+          // Stringify excludes meta.generator.generatedAt (which would
+          // otherwise force every fs.watch tick to emit a redundant payload),
+          // and is fast enough at typical session sizes (~500 scenes,
+          // ~tens of KB).
+          const signature = JSON.stringify(replay.scenes);
           if (signature !== lastSignature) {
             lastSignature = signature;
             await stream.writeSSE({
@@ -1420,6 +1428,20 @@ export async function startServer(
       // every reported file path on this first call.
       await buildAndSend();
 
+      // Polling fallback for sources we can't directly fs.watch. Cursor
+      // SQLite-backed sessions report `filePaths: []` (the SQLite file is
+      // discovered separately and isn't in `paths`); without a poll, the
+      // initial payload is the only update the client ever sees. The 3s
+      // cadence still feels live enough for human reading, and the dedup
+      // signature suppresses redundant emits when nothing actually changed.
+      const pollInterval =
+        watchedPaths.size === 0
+          ? setInterval(() => {
+              if (aborted) return;
+              scheduleRebuild(0);
+            }, 3_000)
+          : null;
+
       // SSE keepalive — proxies (and some browsers) drop idle connections.
       const pingInterval = setInterval(() => {
         if (aborted) return;
@@ -1432,6 +1454,7 @@ export async function startServer(
           aborted = true;
           if (pendingTimer) clearTimeout(pendingTimer);
           clearInterval(pingInterval);
+          if (pollInterval) clearInterval(pollInterval);
           for (const w of watchers) {
             try {
               w.close();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -678,6 +678,60 @@ async function buildSourcesResult(
   });
 }
 
+/**
+ * Live-session state derived from Claude Code's per-process metadata file
+ * (`~/.claude/sessions/<pid>.json`).
+ *
+ * - `busy`    — Claude is actively processing (streaming a response, running a
+ *               tool, etc.). The metadata file's `status` field is "busy" and
+ *               its PID is alive.
+ * - `idle`    — Claude is alive but waiting on the user (prompt input is
+ *               focused, no in-flight request). `status` is anything other
+ *               than "busy" and PID is alive.
+ * - `stopped` — No metadata file matches `sessionId`, the file lacks a
+ *               `status` field (Claude exited cleanly), or the PID is dead.
+ *               Cursor / Codex / Cowork sessions also fall through to this
+ *               since they don't write the Claude metadata file — for those
+ *               providers `state` is reported as `unknown` instead so the
+ *               viewer doesn't claim "Session ended" when we genuinely
+ *               can't tell.
+ */
+type LiveSessionState = "busy" | "idle" | "stopped" | "unknown";
+
+async function readClaudeSessionState(sessionId: string): Promise<LiveSessionState> {
+  const sessionsDir = join(homedir(), ".claude", "sessions");
+  let files: string[];
+  try {
+    files = await readdir(sessionsDir);
+  } catch {
+    return "stopped";
+  }
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    let data: { sessionId?: string; pid?: number; status?: string };
+    try {
+      const content = await readFile(join(sessionsDir, file), "utf-8");
+      data = JSON.parse(content);
+    } catch {
+      continue;
+    }
+    if (data.sessionId !== sessionId) continue;
+    // Match found. Both pid and status must be present, and the process
+    // must still be running. PID-only liveness is the simple-and-correct
+    // heuristic — Claude Code overwrites `status` between busy/idle as
+    // state changes, but the PID file is the authoritative "alive" signal.
+    if (typeof data.pid !== "number" || !data.status) return "stopped";
+    try {
+      // Signal 0 doesn't kill — it just probes existence + permission.
+      process.kill(data.pid, 0);
+    } catch {
+      return "stopped";
+    }
+    return data.status === "busy" ? "busy" : "idle";
+  }
+  return "stopped";
+}
+
 function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
   const groups = new Map<string, SessionInfo[]>();
   for (const s of sessions) {
@@ -1356,6 +1410,12 @@ export async function startServer(
       let inFlight = false;
       let dirty = false;
       let lastSignature: string | null = null;
+      // Live session state (busy / idle / stopped / unknown) — populated
+      // from `~/.claude/sessions/<pid>.json` for Claude. Other providers
+      // don't write that file, so they get "unknown" and the viewer keeps
+      // the existing always-live UI rather than misreporting "stopped".
+      const isClaudeProvider = providerName === "claude-code";
+      let lastLiveState: LiveSessionState = isClaudeProvider ? "busy" : "unknown";
 
       const ensureWatchersFor = (paths: Iterable<string>): void => {
         for (const fp of paths) {
@@ -1453,10 +1513,11 @@ export async function startServer(
         return cached.lines;
       };
 
-      // Cache the last `provider.parse` result for fallback (non-Claude)
-      // providers; we still need to call provider.parse for Cursor/Codex etc.
-      // because those formats aren't pure JSONL.
-      const isClaudeJsonl = providerName === "claude-code";
+      // Claude is the only provider with a pure-JSONL transcript that's
+      // safe to incrementally tail. Cursor / Codex / Cowork stay on full
+      // provider.parse() each tick — their formats aren't append-only or
+      // need provider-specific decoding (SQLite, encoded blobs, etc.).
+      const isClaudeJsonl = isClaudeProvider;
 
       const buildAndSend = async () => {
         if (aborted) return;
@@ -1513,11 +1574,22 @@ export async function startServer(
           // otherwise force every fs.watch tick to emit a redundant payload),
           // and is fast enough at typical session sizes (~500 scenes,
           // ~tens of KB).
+          // Refresh live state before emit so the payload's `state` matches
+          // the latest session metadata. This is the only state read tied to
+          // file changes — the standalone 5s poller below catches busy↔idle
+          // and idle→stopped transitions that don't touch the JSONL.
+          if (isClaudeProvider) {
+            lastLiveState = await readClaudeSessionState(sessionId);
+          }
           const signature = JSON.stringify(replay.scenes);
           if (signature !== lastSignature) {
             lastSignature = signature;
             await stream.writeSSE({
-              data: JSON.stringify({ type: "session", session: replay }),
+              data: JSON.stringify({
+                type: "session",
+                session: replay,
+                state: lastLiveState,
+              }),
             });
           }
         } catch (err) {
@@ -1581,6 +1653,23 @@ export async function startServer(
         stream.writeSSE({ data: JSON.stringify({ type: "ping" }) }).catch(() => {});
       }, 25_000);
 
+      // Standalone state poller — Claude can transition busy↔idle (and
+      // idle→stopped on exit) without touching the JSONL, so file-watch
+      // alone misses those edges. We poll the metadata file at 2s; on a
+      // change, push a state-only event so the viewer can swap the bottom
+      // BUSY / IDLE / ENDED card without re-rendering scenes.
+      const stateInterval = isClaudeProvider
+        ? setInterval(async () => {
+            if (aborted) return;
+            const next = await readClaudeSessionState(sessionId);
+            if (next === lastLiveState) return;
+            lastLiveState = next;
+            await stream
+              .writeSSE({ data: JSON.stringify({ type: "state", state: next }) })
+              .catch(() => {});
+          }, 2_000)
+        : null;
+
       // Block until the client disconnects, then tear down.
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
@@ -1588,6 +1677,7 @@ export async function startServer(
           if (pendingTimer) clearTimeout(pendingTimer);
           clearInterval(pingInterval);
           if (pollInterval) clearInterval(pollInterval);
+          if (stateInterval) clearInterval(stateInterval);
           for (const w of watchers) {
             try {
               w.close();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1315,9 +1315,18 @@ export async function startServer(
       // session, and `mergeSameSessions` collapses them into one record so
       // `parse()` sees the full conversation history instead of a single
       // shard mid-stream.
+      //
+      // Note: `mergeSameSessions` keeps the latest shard's sessionId on the
+      // merged record, so we look the user-supplied sessionId up against the
+      // unmerged list first (any shard matches), then return the merged
+      // record for that shard's project+slug — that way the viewer can pass
+      // whichever sessionId it knows about and still get the full history.
       const resolveSessionInfo = async () => {
-        const all = mergeSameSessions(await provider.discover());
-        return all.find((s) => s.sessionId === sessionId);
+        const all = await provider.discover();
+        const seed = all.find((s) => s.sessionId === sessionId);
+        if (!seed) return undefined;
+        const merged = mergeSameSessions(all);
+        return merged.find((s) => s.project === seed.project && s.slug === seed.slug);
       };
 
       let sessionInfo = await resolveSessionInfo();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1295,9 +1295,12 @@ export async function startServer(
   });
 
   // --- Live: stream a session as it's being written to disk ---
-  // Watches the source JSONL file(s), re-parses + transforms on every change,
-  // and pushes the full ReplaySession over SSE. The viewer hot-swaps and (when
-  // the user is at the tail) auto-follows the newest scene.
+  // For Claude (JSONL) we tail each shard at the byte level — fs.read() at
+  // the cached offset, accumulate complete lines, hold an incomplete trailing
+  // fragment until the next newline arrives. Other providers fall back to
+  // full provider.parse() on every change (their formats aren't pure JSONL).
+  // The transformed ReplaySession is pushed as a full snapshot over SSE; the
+  // viewer hot-swaps and auto-follows the tail when the user is there.
   app.get("/api/live", (c) => {
     const providerName = c.req.query("provider") || "";
     const sessionId = c.req.query("sessionId") || "";
@@ -1318,18 +1321,16 @@ export async function startServer(
         return;
       }
 
-      // Discover the source session by sessionId. We re-discover on each
-      // connect (and on every rebuild) so we always pick up new file paths —
-      // Claude `/resume` creates new JSONL shards under the same logical
-      // session, and `mergeSameSessions` collapses them into one record so
-      // `parse()` sees the full conversation history instead of a single
-      // shard mid-stream.
+      // Resolve sessionId → SessionInfo. Discovery is expensive (full
+      // ~/.claude/projects walk for Claude), so we only run it on the
+      // initial connect and on a 15s cadence inside buildAndSend — that's
+      // the safety net that picks up `/resume` shards mid-stream.
       //
-      // Note: `mergeSameSessions` keeps the latest shard's sessionId on the
-      // merged record, so we look the user-supplied sessionId up against the
+      // `mergeSameSessions` keeps the latest shard's sessionId on the merged
+      // record, so we look the user-supplied sessionId up against the
       // unmerged list first (any shard matches), then return the merged
-      // record for that shard's project+slug — that way the viewer can pass
-      // whichever sessionId it knows about and still get the full history.
+      // record for that shard's project+slug — the viewer can pass whichever
+      // sessionId it happens to know about and still get the full history.
       const resolveSessionInfo = async () => {
         const all = await provider.discover();
         const seed = all.find((s) => s.sessionId === sessionId);
@@ -1383,8 +1384,24 @@ export async function startServer(
       // flush mid-line). Each fs.watch tick reads only the new bytes via
       // pread() instead of re-reading the whole file — a multi-thousand-line
       // session goes from O(file_size) per tick to O(new_bytes).
-      type TailCache = { offset: number; partial: string; lines: string[] };
+      //
+      // `partial` is a Buffer (not a string) on purpose: a write may flush
+      // mid-multi-byte-character (UTF-8 user prompts contain Chinese / emoji
+      // routinely), and Buffer.toString("utf8") on a half-character silently
+      // emits U+FFFD and discards the broken bytes. Holding raw bytes lets
+      // us defer decoding until a `\n` arrives, by which point the next
+      // read has supplied the rest of the multi-byte sequence.
+      const NEWLINE = 0x0a;
+      type TailCache = { offset: number; partial: Buffer; lines: string[] };
       const jsonlTail = new Map<string, TailCache>();
+
+      const splitDecodedLines = (combined: Buffer): { lines: string[]; partial: Buffer } => {
+        const lastNl = combined.lastIndexOf(NEWLINE);
+        if (lastNl < 0) return { lines: [], partial: combined };
+        const decoded = combined.subarray(0, lastNl).toString("utf8");
+        const lines = decoded.split("\n").filter((l) => l.length > 0);
+        return { lines, partial: combined.subarray(lastNl + 1) };
+      };
 
       const tailReadJsonl = async (filePath: string): Promise<string[]> => {
         const cached = jsonlTail.get(filePath);
@@ -1399,14 +1416,12 @@ export async function startServer(
 
         // First read or file shrank (truncate / rotate) — read whole file.
         // Invariants: `offset` = absolute byte position to read NEXT (= end of
-        // last read). `partial` = trailing fragment held back from `lines`
-        // until a newline arrives. Next call reads `[offset, size)`, prepends
-        // `partial` in memory, and re-splits.
+        // last read). `partial` = bytes after the last newline (may be a
+        // half-written line, possibly mid-UTF8). Next call reads `[offset,
+        // size)`, prepends `partial`, and re-splits at the last newline.
         if (!cached || size < cached.offset) {
-          const content = await readFile(filePath, "utf-8");
-          const parts = content.split("\n");
-          const partial = parts.pop() ?? "";
-          const lines = parts.filter((l) => l.length > 0);
+          const content = await readFile(filePath);
+          const { lines, partial } = splitDecodedLines(content);
           jsonlTail.set(filePath, { offset: size, partial, lines });
           return lines;
         }
@@ -1422,13 +1437,10 @@ export async function startServer(
         try {
           const buf = Buffer.alloc(len);
           await fh.read(buf, 0, len, cached.offset);
-          const text = cached.partial + buf.toString("utf8");
-          const parts = text.split("\n");
-          const newPartial = parts.pop() ?? "";
-          for (const line of parts) {
-            if (line.length > 0) cached.lines.push(line);
-          }
-          cached.partial = newPartial;
+          const combined = cached.partial.length === 0 ? buf : Buffer.concat([cached.partial, buf]);
+          const { lines, partial } = splitDecodedLines(combined);
+          for (const line of lines) cached.lines.push(line);
+          cached.partial = partial;
           cached.offset = size;
         } finally {
           await fh.close();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -698,6 +698,21 @@ async function buildSourcesResult(
  */
 type LiveSessionState = "busy" | "idle" | "stopped" | "unknown";
 
+/**
+ * Walk `~/.claude/sessions/*.json` looking for an alive process whose
+ * sessionId matches. After a `/resume` (or any abnormal exit), the dir
+ * can hold multiple files for the same logical session — the dead
+ * pre-resume one and the live post-resume one — and `readdir` order is
+ * not guaranteed. We must inspect every match and only conclude
+ * "stopped" once all of them are dead/missing-status.
+ *
+ * Known limitation: PID recycling. If a Claude process exits without
+ * cleaning up its metadata file and a new process happens to claim the
+ * same PID, this function will report busy/idle for one tick. The 2s
+ * poller corrects on the next iteration once the recycled process
+ * touches the state file (or doesn't, surfacing "stopped"). Probability
+ * is low and the false reading self-heals.
+ */
 async function readClaudeSessionState(sessionId: string): Promise<LiveSessionState> {
   const sessionsDir = join(homedir(), ".claude", "sessions");
   let files: string[];
@@ -716,18 +731,24 @@ async function readClaudeSessionState(sessionId: string): Promise<LiveSessionSta
       continue;
     }
     if (data.sessionId !== sessionId) continue;
-    // Match found. Both pid and status must be present, and the process
-    // must still be running. PID-only liveness is the simple-and-correct
-    // heuristic — Claude Code overwrites `status` between busy/idle as
-    // state changes, but the PID file is the authoritative "alive" signal.
-    if (typeof data.pid !== "number" || !data.status) return "stopped";
+    // Partial / racing-write file (pid not flushed yet, status absent on
+    // first init) — keep iterating; another file may carry the live state.
+    if (typeof data.pid !== "number" || !data.status) continue;
+
+    // Liveness probe via signal 0. Two errors to disambiguate:
+    //   ESRCH — process truly gone → keep looking, prefer a live match
+    //           if any other file matches; only "stopped" if none do.
+    //   EPERM — process exists but we can't signal it (different uid,
+    //           e.g. Claude was started under sudo). Treat as alive.
+    let alive = false;
     try {
-      // Signal 0 doesn't kill — it just probes existence + permission.
       process.kill(data.pid, 0);
-    } catch {
-      return "stopped";
+      alive = true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EPERM") alive = true;
     }
-    return data.status === "busy" ? "busy" : "idle";
+    if (alive) return data.status === "busy" ? "busy" : "idle";
+    // Dead PID — don't return yet; another file may be the live one.
   }
   return "stopped";
 }
@@ -1576,7 +1597,7 @@ export async function startServer(
           // ~tens of KB).
           // Refresh live state before emit so the payload's `state` matches
           // the latest session metadata. This is the only state read tied to
-          // file changes — the standalone 5s poller below catches busy↔idle
+          // file changes — the standalone 2s poller below catches busy↔idle
           // and idle→stopped transitions that don't touch the JSONL.
           if (isClaudeProvider) {
             lastLiveState = await readClaudeSessionState(sessionId);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1670,6 +1670,21 @@ export async function startServer(
           }, 2_000)
         : null;
 
+      // Rediscovery heartbeat. The 15s `RESOLVE_REFRESH_INTERVAL_MS`
+      // sessionInfo refresh lives INSIDE buildAndSend(), so it only runs
+      // when something else has already woken us up. Without an
+      // independent tick: a Claude session that does `/resume` will write
+      // the new turn to a *new* JSONL shard while the old shard goes
+      // silent — no fs.watch event fires on the old file, polling is
+      // disabled (watchedPaths is non-empty, hasSqlite is false), and
+      // the live stream silently stalls until the user reconnects.
+      // Fire scheduleRebuild() every 15s as the safety net; the existing
+      // dedup signature absorbs the no-op when nothing changed.
+      const rediscoverInterval = setInterval(() => {
+        if (aborted) return;
+        scheduleRebuild(0);
+      }, RESOLVE_REFRESH_INTERVAL_MS);
+
       // Block until the client disconnects, then tear down.
       await new Promise<void>((resolve) => {
         stream.onAbort(() => {
@@ -1678,6 +1693,7 @@ export async function startServer(
           clearInterval(pingInterval);
           if (pollInterval) clearInterval(pollInterval);
           if (stateInterval) clearInterval(stateInterval);
+          clearInterval(rediscoverInterval);
           for (const w of watchers) {
             try {
               w.close();

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1419,10 +1419,15 @@ export async function startServer(
         // last read). `partial` = bytes after the last newline (may be a
         // half-written line, possibly mid-UTF8). Next call reads `[offset,
         // size)`, prepends `partial`, and re-splits at the last newline.
+        //
+        // offset comes from `content.length`, not the earlier stat `size`:
+        // the file may grow between stat() and readFile() if Claude is
+        // writing concurrently, and stamping `size` here would let the next
+        // tick re-read bytes in [size, content.length) and emit them twice.
         if (!cached || size < cached.offset) {
           const content = await readFile(filePath);
           const { lines, partial } = splitDecodedLines(content);
-          jsonlTail.set(filePath, { offset: size, partial, lines });
+          jsonlTail.set(filePath, { offset: content.length, partial, lines });
           return lines;
         }
 
@@ -1527,9 +1532,9 @@ export async function startServer(
           inFlight = false;
           if (dirty && !aborted) {
             dirty = false;
-            // Tail-call equivalent: schedule the next build that piled up while we
-            // were busy. Use a microtask delay so other awaiters (e.g. abort
-            // handler) get a chance to run first.
+            // Drain the dirty flag: a rebuild was queued while we were
+            // in-flight. Use a 0ms timer so the abort handler (and any other
+            // awaiters) gets a chance to run before the next build starts.
             scheduleRebuild(0);
           }
         }
@@ -1552,19 +1557,23 @@ export async function startServer(
       // every reported file path on this first call.
       await buildAndSend();
 
-      // Polling fallback for sources we can't directly fs.watch. Cursor
-      // SQLite-backed sessions report `filePaths: []` (the SQLite file is
-      // discovered separately and isn't in `paths`); without a poll, the
-      // initial payload is the only update the client ever sees. The 3s
-      // cadence still feels live enough for human reading, and the dedup
-      // signature suppresses redundant emits when nothing actually changed.
-      const pollInterval =
-        watchedPaths.size === 0
-          ? setInterval(() => {
-              if (aborted) return;
-              scheduleRebuild(0);
-            }, 3_000)
-          : null;
+      // Polling fallback for sources we can't directly fs.watch. Two cases:
+      //   1. `watchedPaths.size === 0` — Cursor SQLite-only sessions report
+      //      `filePaths: []` (SQLite file is discovered separately and isn't
+      //      in `paths`).
+      //   2. `sessionInfo?.hasSqlite` — Cursor sessions where SQLite is
+      //      authoritative but transcript / tool sidecars are *also* watched.
+      //      Updates landing only in SQLite (no sidecar write) wouldn't
+      //      trigger any fs.watch event, so the stream would silently stall.
+      // The 3s cadence still feels live enough for human reading, and the
+      // dedup signature suppresses redundant emits when nothing changed.
+      const needsPolling = watchedPaths.size === 0 || !!sessionInfo?.hasSqlite;
+      const pollInterval = needsPolling
+        ? setInterval(() => {
+            if (aborted) return;
+            scheduleRebuild(0);
+          }, 3_000)
+        : null;
 
       // SSE keepalive — proxies (and some browsers) drop idle connections.
       const pingInterval = setInterval(() => {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,7 +1,15 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import { type FSWatcher, watch as fsWatch } from "node:fs";
-import { mkdir, readdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  open as fsOpen,
+  readdir,
+  readFile,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -25,6 +33,7 @@ import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.j
 import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js";
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
+import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
@@ -1361,6 +1370,77 @@ export async function startServer(
         }
       };
 
+      // Re-resolving (full provider.discover()) is expensive — for Claude it
+      // walks the whole ~/.claude/projects tree and takes seconds. We only do
+      // it on a slow periodic cadence (and lazily, the next time we need to
+      // build) so that fast-path rebuilds — driven by fs.watch events on the
+      // already-known JSONL — pay only parse + transform cost.
+      const RESOLVE_REFRESH_INTERVAL_MS = 15_000;
+      let lastResolvedAt = Date.now();
+
+      // Per-file JSONL tail cache. Tracks the last byte offset we read for
+      // each path plus an unterminated trailing fragment (a JSONL append may
+      // flush mid-line). Each fs.watch tick reads only the new bytes via
+      // pread() instead of re-reading the whole file — a multi-thousand-line
+      // session goes from O(file_size) per tick to O(new_bytes).
+      type TailCache = { offset: number; partial: string; lines: string[] };
+      const jsonlTail = new Map<string, TailCache>();
+
+      const tailReadJsonl = async (filePath: string): Promise<string[]> => {
+        const cached = jsonlTail.get(filePath);
+        let size: number;
+        try {
+          size = (await stat(filePath)).size;
+        } catch {
+          // File disappeared — drop cache so a fresh read sets up clean state.
+          jsonlTail.delete(filePath);
+          return cached?.lines ?? [];
+        }
+
+        // First read or file shrank (truncate / rotate) — read whole file.
+        // Invariants: `offset` = absolute byte position to read NEXT (= end of
+        // last read). `partial` = trailing fragment held back from `lines`
+        // until a newline arrives. Next call reads `[offset, size)`, prepends
+        // `partial` in memory, and re-splits.
+        if (!cached || size < cached.offset) {
+          const content = await readFile(filePath, "utf-8");
+          const parts = content.split("\n");
+          const partial = parts.pop() ?? "";
+          const lines = parts.filter((l) => l.length > 0);
+          jsonlTail.set(filePath, { offset: size, partial, lines });
+          return lines;
+        }
+
+        if (size === cached.offset) {
+          return cached.lines;
+        }
+
+        // Read just the new tail. Use a file handle + read() at offset so we
+        // don't slurp the whole file for a tiny append.
+        const len = size - cached.offset;
+        const fh = await fsOpen(filePath, "r");
+        try {
+          const buf = Buffer.alloc(len);
+          await fh.read(buf, 0, len, cached.offset);
+          const text = cached.partial + buf.toString("utf8");
+          const parts = text.split("\n");
+          const newPartial = parts.pop() ?? "";
+          for (const line of parts) {
+            if (line.length > 0) cached.lines.push(line);
+          }
+          cached.partial = newPartial;
+          cached.offset = size;
+        } finally {
+          await fh.close();
+        }
+        return cached.lines;
+      };
+
+      // Cache the last `provider.parse` result for fallback (non-Claude)
+      // providers; we still need to call provider.parse for Cursor/Codex etc.
+      // because those formats aren't pure JSONL.
+      const isClaudeJsonl = providerName === "claude-code";
+
       const buildAndSend = async () => {
         if (aborted) return;
         if (inFlight) {
@@ -1369,9 +1449,14 @@ export async function startServer(
         }
         inFlight = true;
         try {
-          // Re-resolve so we pick up new filePaths from /resume mid-stream
-          const fresh = await resolveSessionInfo();
-          if (fresh) sessionInfo = fresh;
+          // Refresh sessionInfo only if it's been a while since the last
+          // resolve. This lets /resume mid-stream eventually pick up new
+          // JSONL shards without paying a full discovery cost on every save.
+          if (Date.now() - lastResolvedAt >= RESOLVE_REFRESH_INTERVAL_MS) {
+            const fresh = await resolveSessionInfo();
+            if (fresh) sessionInfo = fresh;
+            lastResolvedAt = Date.now();
+          }
           const info = sessionInfo!;
           const paths = [...info.filePaths, ...(info.toolPaths || [])];
           // Register watchers for any new paths (e.g. /resume created a new
@@ -1379,7 +1464,22 @@ export async function startServer(
           // would never trigger another scheduleRebuild and the stream would
           // silently go stale.
           ensureWatchersFor(paths);
-          const parsed = await provider.parse(paths, info);
+          let parsed;
+          if (isClaudeJsonl) {
+            // Tail-based fast path. Concat already-cached lines from every
+            // shard (filePaths is sorted chronologically by mergeSameSessions)
+            // and parse them as one stream — the parser handles cross-shard
+            // continuity. Subagent agents/ files are still re-read in full
+            // inside the parser, but they're typically small.
+            const allLines: string[] = [];
+            for (const fp of paths) {
+              const lines = await tailReadJsonl(fp);
+              allLines.push(...lines);
+            }
+            parsed = await parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] });
+          } else {
+            parsed = await provider.parse(paths, info);
+          }
           const replay = transformToReplay(parsed, providerName, projectFor(info), {
             generator: {
               name: "vibe-replay",
@@ -1423,7 +1523,10 @@ export async function startServer(
         }
       };
 
-      const scheduleRebuild = (delay = 250) => {
+      // 100ms debounce — claude-devtools uses the same value. Long enough to
+      // coalesce a burst of fs.watch events from a single JSONL flush, short
+      // enough that a streamed assistant response feels live.
+      const scheduleRebuild = (delay = 100) => {
         if (aborted) return;
         if (pendingTimer) clearTimeout(pendingTimer);
         pendingTimer = setTimeout(() => {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import { type FSWatcher, watch as fsWatch } from "node:fs";
 import { mkdir, readdir, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -750,6 +751,7 @@ export async function startServer(
   opts?: {
     openDashboard?: boolean;
     openSlug?: string;
+    openLive?: { provider: string; sessionId: string };
     externalViewerUrl?: string;
   },
 ): Promise<void> {
@@ -1280,6 +1282,194 @@ export async function startServer(
       return c.json(session);
     } catch {
       return c.json({ error: `Session not found: ${result.slug}` }, 404);
+    }
+  });
+
+  // --- Live: stream a session as it's being written to disk ---
+  // Watches the source JSONL file(s), re-parses + transforms on every change,
+  // and pushes the full ReplaySession over SSE. The viewer hot-swaps and (when
+  // the user is at the tail) auto-follows the newest scene.
+  app.get("/api/live", (c) => {
+    const providerName = c.req.query("provider") || "";
+    const sessionId = c.req.query("sessionId") || "";
+
+    return streamSSE(c, async (stream) => {
+      const sendError = async (message: string) => {
+        await stream.writeSSE({ data: JSON.stringify({ type: "error", message }) });
+      };
+
+      if (!providerName || !sessionId) {
+        await sendError("provider and sessionId query parameters are required");
+        return;
+      }
+
+      const provider = getProvider(providerName);
+      if (!provider) {
+        await sendError(`Unknown provider: ${providerName}`);
+        return;
+      }
+
+      // Discover the source session by sessionId. We re-discover on each connect
+      // so we always pick up new file paths (e.g. /resume creates new JSONL files).
+      const resolveSessionInfo = async () => {
+        const all = await provider.discover();
+        return all.find((s) => s.sessionId === sessionId);
+      };
+
+      let sessionInfo = await resolveSessionInfo();
+      if (!sessionInfo) {
+        await sendError(`Session not found: ${sessionId}`);
+        return;
+      }
+
+      const home = homedir();
+      const projectFor = (info: SessionInfo): string =>
+        info.project.startsWith(home) ? `~${info.project.slice(home.length)}` : info.project;
+
+      const watchers: FSWatcher[] = [];
+      let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+      let aborted = false;
+      let inFlight = false;
+      let dirty = false;
+      let lastSignature: string | null = null;
+
+      const buildAndSend = async () => {
+        if (aborted) return;
+        if (inFlight) {
+          dirty = true;
+          return;
+        }
+        inFlight = true;
+        try {
+          // Re-resolve so we pick up new filePaths from /resume mid-stream
+          const fresh = await resolveSessionInfo();
+          if (fresh) sessionInfo = fresh;
+          const info = sessionInfo!;
+          const paths = [...info.filePaths, ...(info.toolPaths || [])];
+          const parsed = await provider.parse(paths, info);
+          const replay = transformToReplay(parsed, providerName, projectFor(info), {
+            generator: {
+              name: "vibe-replay",
+              version: CLI_VERSION,
+              generatedAt: new Date().toISOString(),
+            },
+          });
+          // Dedup on content — generatedAt would otherwise change every parse
+          // and force every fs.watch event (including atime-only) to emit a
+          // redundant 100KB payload. Scene count + last scene timestamp +
+          // turn count is enough to identify "anything changed".
+          const lastScene = replay.scenes[replay.scenes.length - 1];
+          const signature = `${replay.scenes.length}|${replay.meta.stats.userPrompts}|${lastScene?.timestamp || ""}|${lastScene?.id || ""}`;
+          if (signature !== lastSignature) {
+            lastSignature = signature;
+            await stream.writeSSE({
+              data: JSON.stringify({ type: "session", session: replay }),
+            });
+          }
+        } catch (err) {
+          if (!aborted) {
+            await stream
+              .writeSSE({
+                data: JSON.stringify({ type: "error", message: getErrorMessage(err) }),
+              })
+              .catch(() => {});
+          }
+        } finally {
+          inFlight = false;
+          if (dirty && !aborted) {
+            dirty = false;
+            // Tail-call equivalent: schedule the next build that piled up while we
+            // were busy. Use a microtask delay so other awaiters (e.g. abort
+            // handler) get a chance to run first.
+            scheduleRebuild(0);
+          }
+        }
+      };
+
+      const scheduleRebuild = (delay = 250) => {
+        if (aborted) return;
+        if (pendingTimer) clearTimeout(pendingTimer);
+        pendingTimer = setTimeout(() => {
+          pendingTimer = null;
+          void buildAndSend();
+        }, delay);
+      };
+
+      // Initial payload — establishes the baseline session before any deltas.
+      await buildAndSend();
+
+      // Watch every file path the provider reported. fs.watch fires on append
+      // for JSONL-style writes and is debounced via scheduleRebuild.
+      const watchPaths = new Set<string>([
+        ...sessionInfo.filePaths,
+        ...(sessionInfo.toolPaths || []),
+      ]);
+      for (const fp of watchPaths) {
+        try {
+          const w = fsWatch(fp, { persistent: false }, () => scheduleRebuild());
+          w.on("error", () => {});
+          watchers.push(w);
+        } catch {
+          // best-effort — if a path can't be watched, the others may still work
+        }
+      }
+
+      // SSE keepalive — proxies (and some browsers) drop idle connections.
+      const pingInterval = setInterval(() => {
+        if (aborted) return;
+        stream.writeSSE({ data: JSON.stringify({ type: "ping" }) }).catch(() => {});
+      }, 25_000);
+
+      // Block until the client disconnects, then tear down.
+      await new Promise<void>((resolve) => {
+        stream.onAbort(() => {
+          aborted = true;
+          if (pendingTimer) clearTimeout(pendingTimer);
+          clearInterval(pingInterval);
+          for (const w of watchers) {
+            try {
+              w.close();
+            } catch {
+              // ignore close errors during teardown
+            }
+          }
+          resolve();
+        });
+      });
+    });
+  });
+
+  // --- Live source lookup: helper for the viewer to resolve provider/sessionId
+  // from the most-recently-active source so the user can land on /?live=1
+  // without picking. ---
+  app.get("/api/live/most-recent", async (c) => {
+    try {
+      const providers = getAllProviders();
+      const collected: SessionInfo[] = [];
+      for (const provider of providers) {
+        try {
+          const sessions = await provider.discover();
+          collected.push(...sessions);
+        } catch {
+          // best-effort across providers
+        }
+      }
+      if (collected.length === 0) {
+        return c.json({ session: null });
+      }
+      collected.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+      const top = collected[0]!;
+      return c.json({
+        session: {
+          provider: top.provider,
+          sessionId: top.sessionId,
+          title: top.title,
+          project: top.project,
+          timestamp: top.timestamp,
+        },
+      });
+    } catch (err) {
+      return c.json({ error: getErrorMessage(err) }, 500);
     }
   });
 
@@ -2739,7 +2929,14 @@ export async function startServer(
       // Build the URL to open in the browser
       let browseUrl: string;
       const viewerBase = opts?.externalViewerUrl || url;
-      if (opts?.openDashboard) {
+      if (opts?.openLive) {
+        const qp = new URLSearchParams({
+          live: "1",
+          provider: opts.openLive.provider,
+          sessionId: opts.openLive.sessionId,
+        });
+        browseUrl = `${viewerBase}/?${qp.toString()}`;
+      } else if (opts?.openDashboard) {
         browseUrl = `${viewerBase}/?view=dashboard`;
       } else if (opts?.openSlug) {
         browseUrl = `${viewerBase}/?session=${encodeURIComponent(opts.openSlug)}`;
@@ -2747,7 +2944,11 @@ export async function startServer(
         browseUrl = `${viewerBase}/?view=dashboard`;
       }
 
-      const label = opts?.openDashboard || !opts?.openSlug ? "Dashboard" : "Editor";
+      const label = opts?.openLive
+        ? "Live"
+        : opts?.openDashboard || !opts?.openSlug
+          ? "Dashboard"
+          : "Editor";
       if (opts?.externalViewerUrl) {
         console.log(
           chalk.bold.cyan(`\n  ${label} API running on port ${port}`) +

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1327,11 +1327,26 @@ export async function startServer(
         info.project.startsWith(home) ? `~${info.project.slice(home.length)}` : info.project;
 
       const watchers: FSWatcher[] = [];
+      const watchedPaths = new Set<string>();
       let pendingTimer: ReturnType<typeof setTimeout> | null = null;
       let aborted = false;
       let inFlight = false;
       let dirty = false;
       let lastSignature: string | null = null;
+
+      const ensureWatchersFor = (paths: Iterable<string>): void => {
+        for (const fp of paths) {
+          if (aborted || watchedPaths.has(fp)) continue;
+          try {
+            const w = fsWatch(fp, { persistent: false }, () => scheduleRebuild());
+            w.on("error", () => {});
+            watchers.push(w);
+            watchedPaths.add(fp);
+          } catch {
+            // best-effort — if a path can't be watched, the others may still work
+          }
+        }
+      };
 
       const buildAndSend = async () => {
         if (aborted) return;
@@ -1346,6 +1361,11 @@ export async function startServer(
           if (fresh) sessionInfo = fresh;
           const info = sessionInfo!;
           const paths = [...info.filePaths, ...(info.toolPaths || [])];
+          // Register watchers for any new paths (e.g. /resume created a new
+          // JSONL between rebuilds). Without this, appends to those new files
+          // would never trigger another scheduleRebuild and the stream would
+          // silently go stale.
+          ensureWatchersFor(paths);
           const parsed = await provider.parse(paths, info);
           const replay = transformToReplay(parsed, providerName, projectFor(info), {
             generator: {
@@ -1359,7 +1379,7 @@ export async function startServer(
           // redundant 100KB payload. Scene count + last scene timestamp +
           // turn count is enough to identify "anything changed".
           const lastScene = replay.scenes[replay.scenes.length - 1];
-          const signature = `${replay.scenes.length}|${replay.meta.stats.userPrompts}|${lastScene?.timestamp || ""}|${lastScene?.id || ""}`;
+          const signature = `${replay.scenes.length}|${replay.meta.stats.userPrompts}|${replay.meta.stats.toolCalls}|${lastScene?.timestamp || ""}`;
           if (signature !== lastSignature) {
             lastSignature = signature;
             await stream.writeSSE({
@@ -1396,23 +1416,9 @@ export async function startServer(
       };
 
       // Initial payload — establishes the baseline session before any deltas.
+      // ensureWatchersFor() inside buildAndSend() also registers fs.watch for
+      // every reported file path on this first call.
       await buildAndSend();
-
-      // Watch every file path the provider reported. fs.watch fires on append
-      // for JSONL-style writes and is debounced via scheduleRebuild.
-      const watchPaths = new Set<string>([
-        ...sessionInfo.filePaths,
-        ...(sessionInfo.toolPaths || []),
-      ]);
-      for (const fp of watchPaths) {
-        try {
-          const w = fsWatch(fp, { persistent: false }, () => scheduleRebuild());
-          w.on("error", () => {});
-          watchers.push(w);
-        } catch {
-          // best-effort — if a path can't be watched, the others may still work
-        }
-      }
 
       // SSE keepalive — proxies (and some browsers) drop idle connections.
       const pingInterval = setInterval(() => {
@@ -1437,40 +1443,6 @@ export async function startServer(
         });
       });
     });
-  });
-
-  // --- Live source lookup: helper for the viewer to resolve provider/sessionId
-  // from the most-recently-active source so the user can land on /?live=1
-  // without picking. ---
-  app.get("/api/live/most-recent", async (c) => {
-    try {
-      const providers = getAllProviders();
-      const collected: SessionInfo[] = [];
-      for (const provider of providers) {
-        try {
-          const sessions = await provider.discover();
-          collected.push(...sessions);
-        } catch {
-          // best-effort across providers
-        }
-      }
-      if (collected.length === 0) {
-        return c.json({ session: null });
-      }
-      collected.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-      const top = collected[0]!;
-      return c.json({
-        session: {
-          provider: top.provider,
-          sessionId: top.sessionId,
-          title: top.title,
-          project: top.project,
-          timestamp: top.timestamp,
-        },
-      });
-    } catch (err) {
-      return c.json({ error: getErrorMessage(err) }, 500);
-    }
   });
 
   // --- Dashboard: list all sessions ---

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -245,6 +245,7 @@ export default function App() {
   const session = loadState.status === "ready" ? loadState.session : null;
   const viewerMode = loadState.status === "ready" ? loadState.mode : "embedded";
   const gistOwner = loadState.status === "ready" ? loadState.gistOwner : undefined;
+  const live = loadState.status === "ready" ? loadState.live : undefined;
   const isEditor = viewerMode === "editor";
 
   const [activeView, setActiveView] = useState<ActiveView>(getActiveViewFromUrl());
@@ -377,6 +378,31 @@ export default function App() {
               Local
               <span className="instant-tooltip-text">
                 {`v${__CLI_VERSION__}\nViewer ${window.location.host}${import.meta.env.VITE_API_PORT ? `\nCLI :${import.meta.env.VITE_API_PORT}` : ""}${__CLOUD_API_URL__ ? `\nCloud ${__CLOUD_API_URL__}` : ""}`}
+              </span>
+            </span>
+          )}
+          {live && (
+            <span
+              className={`instant-tooltip inline-flex items-center gap-1 text-[9px] font-sans font-bold px-2 py-0.5 rounded-full uppercase tracking-wider border ${
+                live.state === "open"
+                  ? "bg-terminal-red/10 text-terminal-red border-terminal-red/20"
+                  : "bg-terminal-dim/10 text-terminal-dim border-terminal-dim/20"
+              }`}
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${
+                  live.state === "open" ? "bg-terminal-red animate-pulse" : "bg-terminal-dim"
+                }`}
+              />
+              {live.state === "open"
+                ? "Live"
+                : live.state === "connecting"
+                  ? "Connecting"
+                  : "Offline"}
+              <span className="instant-tooltip-text">
+                {live.state === "open"
+                  ? `Streaming ${live.scenes} scene${live.scenes === 1 ? "" : "s"}${live.lastUpdate ? `\nLast update ${new Date(live.lastUpdate).toLocaleTimeString()}` : ""}`
+                  : live.error || "Reconnecting..."}
               </span>
             </span>
           )}
@@ -666,6 +692,7 @@ export default function App() {
         activeView={activeView}
         setActiveView={handleViewChange}
         returnToLandingRef={returnToLandingRef}
+        live={live}
       />
     </div>
   );

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -23,8 +23,15 @@ interface Props {
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
   /** When set, the session is being streamed live and the trailing "the end"
-   *  card is replaced with a "waiting for next turn" indicator. */
+   *  card is replaced with a state-aware indicator. */
   isLive?: boolean;
+  /** Current Claude session state, surfaced from `~/.claude/sessions/<pid>.json`.
+   *  - busy:    Claude is actively processing → red pulsing indicator.
+   *  - idle:    Claude is alive, waiting for the next user prompt → green dim.
+   *  - stopped: Claude exited / process is dead → muted "session ended".
+   *  - unknown: non-Claude provider, no metadata file → fall back to BUSY UX.
+   *  Only consulted when `isLive` is true. */
+  liveSessionState?: "busy" | "idle" | "stopped" | "unknown";
 }
 
 interface TurnGroup {
@@ -63,6 +70,7 @@ export default function ConversationView({
   overlayActions,
   turnStats,
   isLive,
+  liveSessionState,
 }: Props & { onSeek?: (index: number) => void }) {
   // Pre-compute ALL groups once — stable across playback ticks
   const allGroups = useMemo(() => {
@@ -266,23 +274,83 @@ export default function ConversationView({
         </div>
       )}
 
-      {visibleCount >= scenes.length && isLive && (
-        <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
-          <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
-          <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-red-subtle/50 border border-terminal-red/20">
-            <span className="relative flex w-2 h-2">
-              <span className="absolute inline-flex h-full w-full rounded-full bg-terminal-red opacity-75 animate-ping" />
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-red" />
-            </span>
-            <span className="text-[10px] font-mono font-bold text-terminal-red uppercase tracking-[0.25em]">
-              Busy
-            </span>
-          </div>
-          <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
-            waiting for the next turn to land on disk
-          </div>
+      {visibleCount >= scenes.length && isLive && <LiveStateCard sessionState={liveSessionState} />}
+    </div>
+  );
+}
+
+/**
+ * Trailing card for live mode. Branches on the Claude session state so the
+ * user gets honest feedback about whether anything is going to happen:
+ *
+ * - `busy`              — red pulsing dot, "BUSY" + the waiting message.
+ *                         Claude is mid-turn (streaming, running a tool).
+ * - `idle`              — green dot (no animation), "IDLE" + "Claude is
+ *                         waiting for your next prompt". File watcher will
+ *                         not show progress until you submit something.
+ * - `stopped`           — muted gray, "ENDED" + "the Claude process exited".
+ *                         Tells the user that further updates won't arrive
+ *                         and they should just read this as a static replay.
+ * - `unknown` / undef.  — fall back to the busy UI for non-Claude providers
+ *                         (Cursor / Codex etc.) where we can't tell.
+ */
+function LiveStateCard({
+  sessionState,
+}: {
+  sessionState?: "busy" | "idle" | "stopped" | "unknown";
+}) {
+  const effective = sessionState ?? "busy";
+
+  if (effective === "stopped") {
+    return (
+      <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
+        <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
+        <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-surface/40 border border-terminal-border-subtle">
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-dimmer" />
+          <span className="text-[10px] font-mono font-bold text-terminal-dim uppercase tracking-[0.25em]">
+            Ended
+          </span>
         </div>
-      )}
+        <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
+          the claude process exited — no further updates will arrive
+        </div>
+      </div>
+    );
+  }
+
+  if (effective === "idle") {
+    return (
+      <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
+        <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
+        <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-green-subtle/40 border border-terminal-green/20">
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-green" />
+          <span className="text-[10px] font-mono font-bold text-terminal-green uppercase tracking-[0.25em]">
+            Idle
+          </span>
+        </div>
+        <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
+          claude is waiting for your next prompt
+        </div>
+      </div>
+    );
+  }
+
+  // busy + unknown: same red pulsing UI
+  return (
+    <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
+      <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
+      <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-red-subtle/50 border border-terminal-red/20">
+        <span className="relative flex w-2 h-2">
+          <span className="absolute inline-flex h-full w-full rounded-full bg-terminal-red opacity-75 animate-ping" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-red" />
+        </span>
+        <span className="text-[10px] font-mono font-bold text-terminal-red uppercase tracking-[0.25em]">
+          Busy
+        </span>
+      </div>
+      <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
+        waiting for the next turn to land on disk
+      </div>
     </div>
   );
 }

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -166,7 +166,6 @@ export default function ConversationView({
           <GroupCard
             group={group}
             currentIndex={currentIndex}
-            visibleCount={visibleCount}
             effectivePrefs={effectivePrefs}
             focusIndex={focusIndex}
             annotatedScenes={annotatedScenes}
@@ -358,7 +357,6 @@ const LazyGroup = memo(function LazyGroup({
 const GroupCard = memo(function GroupCard({
   group,
   currentIndex,
-  visibleCount,
   effectivePrefs,
   focusIndex,
   annotatedScenes: _annotatedScenes,
@@ -369,7 +367,6 @@ const GroupCard = memo(function GroupCard({
 }: {
   group: TurnGroup;
   currentIndex: number;
-  visibleCount: number;
   effectivePrefs: EffectivePrefs;
   focusIndex?: number;
   annotatedScenes?: Set<number>;

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -22,6 +22,9 @@ interface Props {
   state?: string;
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
+  /** When set, the session is being streamed live and the trailing "the end"
+   *  card is replaced with a "waiting for next turn" indicator. */
+  isLive?: boolean;
 }
 
 interface TurnGroup {
@@ -59,6 +62,7 @@ export default function ConversationView({
   state,
   overlayActions,
   turnStats,
+  isLive,
 }: Props & { onSeek?: (index: number) => void }) {
   // Pre-compute ALL groups once — stable across playback ticks
   const allGroups = useMemo(() => {
@@ -212,7 +216,7 @@ export default function ConversationView({
         </div>
       )}
 
-      {visibleCount >= scenes.length && (
+      {visibleCount >= scenes.length && !isLive && (
         <div className="pt-12 pb-24 flex flex-col items-center justify-center animate-in fade-in zoom-in-95 duration-1000 ease-out select-none">
           <div className="h-px w-8 bg-terminal-border-subtle mb-6" />
           <div className="flex flex-col items-center gap-1">
@@ -257,6 +261,24 @@ export default function ConversationView({
               <div className="w-1 h-1 rounded-full bg-terminal-blue" />
               <div className="w-1 h-1 rounded-full bg-terminal-orange" />
             </div>
+          </div>
+        </div>
+      )}
+
+      {visibleCount >= scenes.length && isLive && (
+        <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
+          <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
+          <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-red-subtle/50 border border-terminal-red/20">
+            <span className="relative flex w-2 h-2">
+              <span className="absolute inline-flex h-full w-full rounded-full bg-terminal-red opacity-75 animate-ping" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-red" />
+            </span>
+            <span className="text-[10px] font-mono font-bold text-terminal-red uppercase tracking-[0.25em]">
+              Busy
+            </span>
+          </div>
+          <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
+            waiting for the next turn to land on disk
           </div>
         </div>
       )}

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -109,15 +109,17 @@ export default function ConversationView({
     return result;
   }, [scenes]);
 
-  // Only show groups that have visible scenes, filtered by effectivePrefs
+  // Show ALL turns by default — never hide content the user already has on
+  // disk. Playback (the play button + currentIndex / visibleCount) now
+  // controls only the camera (scroll-to-current) and the focus indicator.
+  // Hiding follow-up turns made it look like content was missing — see
+  // https://github.com/tuo-lei/vibe-replay/pull/215 review feedback.
   const displayGroups = useMemo(() => {
     if (effectivePrefs.promptsOnly) {
-      return allGroups.filter(
-        (g) => (g.type === "user" || g.type === "compaction") && g.scenes[0].index < visibleCount,
-      );
+      return allGroups.filter((g) => g.type === "user" || g.type === "compaction");
     }
-    return allGroups.filter((g) => g.scenes[0].index < visibleCount);
-  }, [allGroups, visibleCount, effectivePrefs.promptsOnly]);
+    return allGroups;
+  }, [allGroups, effectivePrefs.promptsOnly]);
 
   // Find which group contains the currentIndex
   const currentGroupIdx = useMemo(() => {
@@ -401,18 +403,17 @@ const GroupCard = memo(function GroupCard({
     return peak > 200_000 ? 1_000_000 : 200_000;
   }, [turnStats]);
 
-  // Only include scenes that are visible so far
-  const visibleScenes = useMemo(
-    () => group.scenes.filter((s) => s.index < visibleCount),
-    [group.scenes, visibleCount],
-  );
+  // Render every scene in the group — no longer gated by visibleCount.
+  // Playback advance still updates currentIndex (used for the focus
+  // indicator + scroll-follow), but never hides content.
+  const groupScenes = group.scenes;
 
-  const groupHasCurrent = visibleScenes.some(({ index }) => index === currentIndex);
+  const groupHasCurrent = groupScenes.some(({ index }) => index === currentIndex);
   const groupHasFocusedTarget =
-    typeof focusIndex === "number" && visibleScenes.some(({ index }) => index === focusIndex);
-  const firstIndex = visibleScenes[0]?.index;
+    typeof focusIndex === "number" && groupScenes.some(({ index }) => index === focusIndex);
+  const firstIndex = groupScenes[0]?.index;
 
-  if (visibleScenes.length === 0) return null;
+  if (groupScenes.length === 0) return null;
 
   // User groups get a group-level comment button (single scene)
   const userCommentCount = group.type === "user" ? annotationCounts?.get(firstIndex) || 0 : 0;
@@ -520,7 +521,7 @@ const GroupCard = memo(function GroupCard({
             );
           })()}
         <div className="text-left">
-          {visibleScenes.map(({ scene, index }) => {
+          {groupScenes.map(({ scene, index }) => {
             const sceneOverlays = overlayActions?.getOverlays(index) ?? [];
             const effectiveContent = overlayActions?.getEffectiveContent(index);
             const isShowingOriginal = overlayActions?.showOriginal.has(index);
@@ -569,7 +570,7 @@ const GroupCard = memo(function GroupCard({
   }
 
   if (group.type === "compaction") {
-    const scene = visibleScenes[0]?.scene;
+    const scene = groupScenes[0]?.scene;
     if (!scene || scene.type !== "compaction-summary") return null;
 
     // Find compaction token impact from turnStats (context drop > 50%) near this group's position
@@ -624,7 +625,7 @@ const GroupCard = memo(function GroupCard({
   }
 
   if (group.type === "context-injection") {
-    const scene = visibleScenes[0]?.scene;
+    const scene = groupScenes[0]?.scene;
     if (!scene || scene.type !== "context-injection") return null;
     const it = scene.injectionType || "system";
     const label = it.startsWith("skill:")
@@ -665,8 +666,8 @@ const GroupCard = memo(function GroupCard({
 
   // Assistant group — filter by effectivePrefs
   const filteredScenes = effectivePrefs.hideThinking
-    ? visibleScenes.filter((s) => s.scene.type !== "thinking")
-    : visibleScenes;
+    ? groupScenes.filter((s) => s.scene.type !== "thinking")
+    : groupScenes;
 
   if (filteredScenes.length === 0) return null;
 

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
   getErrorMessage,
   isCacheFresh,
   navigateTo,
+  navigateToLive,
   normalizeTitleText,
   parseCachedList,
   projectName,
@@ -772,6 +773,19 @@ export function SessionDetailPopup({
             )}
           </div>
           <div className="flex items-center gap-2">
+            {s.sessionId && (
+              <button
+                onClick={() => navigateToLive(s.provider, s.sessionId!)}
+                title="Stream this source session as the provider writes new turns"
+                className="h-11 px-5 text-sm font-sans font-semibold rounded-xl bg-terminal-red-subtle text-terminal-red hover:bg-terminal-red-emphasis transition-all duration-200 flex items-center gap-2"
+              >
+                <span className="relative flex w-2 h-2">
+                  <span className="absolute inline-flex h-full w-full rounded-full bg-terminal-red opacity-75 animate-ping" />
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-red" />
+                </span>
+                Watch live
+              </button>
+            )}
             {s.replay && (
               <>
                 <button

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useAnnotations } from "../hooks/useAnnotations";
 import { useOverlays } from "../hooks/useOverlays";
 import { usePlayback } from "../hooks/usePlayback";
@@ -85,7 +85,13 @@ export default function Player({
   const { effectiveSession } = overlayActions;
   const { annotations } = annotationActions;
 
-  const effectivePrefs = getEffectivePrefs(viewPrefs);
+  // Force "all" display mode in live — compact hides thinking and collapses
+  // tools, which makes a streaming session look like nothing is happening
+  // (the user's complaint: "we never see progress"). Don't mutate the
+  // persisted pref; just override the derived flags for this render.
+  const effectivePrefs = isLive
+    ? getEffectivePrefs({ ...viewPrefs, displayMode: "all" })
+    : getEffectivePrefs(viewPrefs);
 
   const {
     state,
@@ -258,6 +264,17 @@ export default function Player({
     }
     const el = scrollRef.current;
     programScrollRef.current = true;
+    // Live mode: snap to the bottom instantly. Smooth animations from
+    // back-to-back SSE ticks stack on each other and produce visible jitter
+    // ("屏幕抖动"); the user experience the user actually wants here is
+    // "always at the latest", not "smoothly follow each new scene".
+    if (isLive) {
+      el.scrollTop = el.scrollHeight;
+      setTimeout(() => {
+        programScrollRef.current = false;
+      }, 50);
+      return;
+    }
     const getGroupFirstIndex = (idx: number): number => {
       const scenes = session.scenes;
       if (idx < 0 || idx >= scenes.length) return idx;
@@ -299,7 +316,7 @@ export default function Player({
         programScrollRef.current = false;
       }, 400);
     });
-  }, [currentIndex, state, session.scenes]);
+  }, [currentIndex, state, session.scenes, isLive]);
 
   // User scroll/touch → auto-pause + enter infinite scroll mode
   useEffect(() => {
@@ -469,24 +486,20 @@ export default function Player({
     };
   }, [currentIndex, state, landed, isLive]);
 
-  // Live mode tail-follow — when the streaming session grows, jump to the new
-  // last scene as long as the user was already pinned to (or past) the previous
-  // tail. If they've scrolled back to read something earlier, leave them alone.
+  // Live mode tail-follow — always pin to the latest scene. Claude Code's
+  // own CLI does this and the user expects parity: they want continuous
+  // progress signal, not a stale view they'd have to manually scroll
+  // forward. useLayoutEffect (not useEffect) so currentIndex updates
+  // before paint — otherwise we'd render a frame with new scenes but
+  // stale currentIndex, and the user sees a flicker every SSE tick.
   const prevLiveCountRef = useRef(0);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isLive) return;
-    const prev = prevLiveCountRef.current;
     const curr = session.scenes.length;
+    if (curr === 0 || curr === prevLiveCountRef.current) return;
     prevLiveCountRef.current = curr;
-    if (curr === 0 || curr <= prev) return;
-    // currentIndex < 0 covers the initial load (no scene picked yet). The
-    // >= prev - 1 check covers steady-state tail-follow: prev was the previous
-    // total scene count, so the previous tail index is prev - 1; if the user
-    // is sitting on (or past) it, they're "at the tail" and we can advance.
-    if (currentIndex < 0 || currentIndex >= prev - 1) {
-      seekTo(curr - 1);
-    }
-  }, [isLive, session.scenes.length, currentIndex, seekTo]);
+    seekTo(curr - 1);
+  }, [isLive, session.scenes.length, seekTo]);
 
   const hasAiStudio = viewerMode === "editor";
   const hasAiFeedback = useMemo(
@@ -779,7 +792,7 @@ export default function Player({
                 >
                   <ConversationView
                     scenes={session.scenes}
-                    visibleCount={visibleCount}
+                    visibleCount={isLive ? session.scenes.length : visibleCount}
                     currentIndex={currentIndex}
                     effectivePrefs={effectivePrefs}
                     focusIndex={navFocusIndex}
@@ -789,6 +802,7 @@ export default function Player({
                     state={state}
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
+                    isLive={isLive}
                     onComment={
                       isReadOnly
                         ? undefined

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -479,8 +479,10 @@ export default function Player({
     const curr = session.scenes.length;
     prevLiveCountRef.current = curr;
     if (curr === 0 || curr <= prev) return;
-    // currentIndex < 0 covers the initial load (no scene picked yet); the
-    // >= prev - 1 check covers the steady-state "user is at the tail" case.
+    // currentIndex < 0 covers the initial load (no scene picked yet). The
+    // >= prev - 1 check covers steady-state tail-follow: prev was the previous
+    // total scene count, so the previous tail index is prev - 1; if the user
+    // is sitting on (or past) it, they're "at the tail" and we can advance.
     if (currentIndex < 0 || currentIndex >= prev - 1) {
       seekTo(curr - 1);
     }

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -803,6 +803,7 @@ export default function Player({
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
                     isLive={isLive}
+                    liveSessionState={live?.sessionState}
                     onComment={
                       isReadOnly
                         ? undefined

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAnnotations } from "../hooks/useAnnotations";
 import { useOverlays } from "../hooks/useOverlays";
 import { usePlayback } from "../hooks/usePlayback";
-import type { ViewerMode } from "../hooks/useSessionLoader";
+import type { LiveStatus, ViewerMode } from "../hooks/useSessionLoader";
 import { getEffectivePrefs, type ViewPrefs } from "../hooks/useViewPrefs";
 import type { ReplaySession } from "../types";
 import AiStudioDrawer from "./AiStudioDrawer";
@@ -28,6 +28,8 @@ interface Props {
   setActiveView: (view: ActiveView) => void;
   /** Ref that Player populates with a function to return to the landing page */
   returnToLandingRef?: React.MutableRefObject<(() => void) | null>;
+  /** When set, the session is being streamed from a running CLI process */
+  live?: LiveStatus;
 }
 
 function flashJumpTarget(el: HTMLElement) {
@@ -47,9 +49,13 @@ export default function Player({
   activeView,
   setActiveView,
   returnToLandingRef,
+  live,
 }: Props) {
   const isReadOnly = viewerMode === "readonly";
-  const [landed, setLanded] = useState(false);
+  const isLive = !!live;
+  // In live mode, skip the landing hero — the user explicitly asked to tail
+  // a running session, so we should drop them straight into the conversation.
+  const [landed, setLanded] = useState(isLive);
 
   // Expose a callback so the parent header can return to the landing page
   useEffect(() => {
@@ -446,9 +452,11 @@ export default function Player({
   }, []);
 
   // Sync currentIndex → URL ?s= param (debounced to avoid noise during playback)
+  // Skip in live mode — the URL identifies the running session by provider/sessionId
+  // and a moving ?s= param fights with auto-follow.
   const urlSyncTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (currentIndex < 0 || !landed) return;
+    if (currentIndex < 0 || !landed || isLive) return;
     if (urlSyncTimer.current) clearTimeout(urlSyncTimer.current);
     const delay = state === "playing" ? 500 : 0;
     urlSyncTimer.current = setTimeout(() => {
@@ -459,7 +467,24 @@ export default function Player({
     return () => {
       if (urlSyncTimer.current) clearTimeout(urlSyncTimer.current);
     };
-  }, [currentIndex, state, landed]);
+  }, [currentIndex, state, landed, isLive]);
+
+  // Live mode tail-follow — when the streaming session grows, jump to the new
+  // last scene as long as the user was already pinned to (or past) the previous
+  // tail. If they've scrolled back to read something earlier, leave them alone.
+  const prevLiveCountRef = useRef(0);
+  useEffect(() => {
+    if (!isLive) return;
+    const prev = prevLiveCountRef.current;
+    const curr = session.scenes.length;
+    prevLiveCountRef.current = curr;
+    if (curr === 0 || curr <= prev) return;
+    // currentIndex < 0 covers the initial load (no scene picked yet); the
+    // >= prev - 1 check covers the steady-state "user is at the tail" case.
+    if (currentIndex < 0 || currentIndex >= prev - 1) {
+      seekTo(curr - 1);
+    }
+  }, [isLive, session.scenes.length, currentIndex, seekTo]);
 
   const hasAiStudio = viewerMode === "editor";
   const hasAiFeedback = useMemo(

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -360,6 +360,38 @@ export function navigateTo(
   }
 }
 
+/**
+ * Navigate to live mode for a running source session.
+ *
+ * Live mode is a separate viewer state, not a dashboard tab — so we strip
+ * every dashboard- and viewer-scoped query param before applying the live
+ * triplet. Otherwise leftovers like `view=dashboard` or `tab=sessions` (which
+ * useSessionLoader prioritizes) would block the SSE stream from opening.
+ */
+export function navigateToLive(provider: string, sessionId: string) {
+  const url = new URL(window.location.href);
+  for (const k of [
+    "view",
+    "tab",
+    "session",
+    "gist",
+    "cloud",
+    "url",
+    "project",
+    "q",
+    "archived",
+    "v",
+    "s",
+  ]) {
+    url.searchParams.delete(k);
+  }
+  url.searchParams.set("live", "1");
+  url.searchParams.set("provider", provider);
+  url.searchParams.set("sessionId", sessionId);
+  window.history.pushState({}, "", url.toString());
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
 // ─── Shared UI components ────────────────────────────────────────────
 
 // ─── Shared UI helpers ────────────────────────────────────────────────

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -110,6 +110,11 @@ function readLiveParams(): LiveParams | null {
   // view=dashboard but leaves the live params intact in popstate) would
   // re-open the SSE stream instead of showing the dashboard.
   if (params.get("view") === "dashboard") return null;
+  // ?session=<slug> also wins over ?live=1. The reverse navigation from
+  // live → a specific replay can leave stale `live=1` in the URL; an
+  // explicit session request should always resolve to that replay rather
+  // than re-opening the SSE stream.
+  if (params.get("session")) return null;
   const provider = params.get("provider");
   const sessionId = params.get("sessionId");
   if (!provider || !sessionId) return null;

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -137,7 +137,15 @@ function startLiveStream(
   let lastSession: ReplaySession | null = null;
   let liveStatus: LiveStatus = { state: "connecting", scenes: 0 };
 
+  // Guard against stale handlers from a closed-but-not-yet-cleaned-up
+  // EventSource overwriting state owned by a fresher stream. closeLive()
+  // calls .close() and clears ref.current, but events queued on the JS
+  // event loop before the close may still fire afterwards. Without this
+  // guard, those late events would call setState with stale `lastSession`
+  // / `liveStatus` from this closed-over scope, clobbering the new view
+  // (or surfacing an "error" toast that no longer applies).
   const emit = () => {
+    if (ref.current !== source) return;
     if (lastSession) {
       setState({
         status: "ready",

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -24,6 +24,13 @@ export interface LiveStatus {
   lastUpdate?: number;
   /** Last reported error, if any */
   error?: string;
+  /**
+   * Live session state surfaced by the server from
+   * `~/.claude/sessions/<pid>.json`. `unknown` for non-Claude providers
+   * (Cursor / Codex / Cowork) — they don't write that file, so we keep
+   * the existing always-live UI rather than misreporting "stopped".
+   */
+  sessionState?: "busy" | "idle" | "stopped" | "unknown";
 }
 
 interface LoadResult {
@@ -164,7 +171,12 @@ function startLiveStream(
   };
 
   source.onmessage = (ev) => {
-    let payload: { type?: string; session?: ReplaySession; message?: string };
+    let payload: {
+      type?: string;
+      session?: ReplaySession;
+      message?: string;
+      state?: LiveStatus["sessionState"];
+    };
     try {
       payload = JSON.parse(ev.data);
     } catch {
@@ -177,7 +189,14 @@ function startLiveStream(
         scenes: payload.session.scenes.length,
         lastUpdate: Date.now(),
         error: undefined,
+        sessionState: payload.state ?? liveStatus.sessionState,
       };
+      emit();
+    } else if (payload.type === "state" && payload.state) {
+      // Standalone state-only event: server detected busy↔idle or
+      // idle→stopped without a JSONL change. Update sessionState in place
+      // so the viewer can swap the bottom card without re-rendering scenes.
+      liveStatus = { ...liveStatus, sessionState: payload.state };
       emit();
     } else if (payload.type === "error") {
       liveStatus = {

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -105,6 +105,11 @@ interface LiveParams {
 function readLiveParams(): LiveParams | null {
   const params = new URLSearchParams(window.location.search);
   if (params.get("live") !== "1") return null;
+  // ?view=dashboard wins over ?live=1 — without this, navigating from the
+  // live viewer back to the dashboard via the in-app link (which sets
+  // view=dashboard but leaves the live params intact in popstate) would
+  // re-open the SSE stream instead of showing the dashboard.
+  if (params.get("view") === "dashboard") return null;
   const provider = params.get("provider");
   const sessionId = params.get("sessionId");
   if (!provider || !sessionId) return null;

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -1,32 +1,68 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ReplaySession } from "../types";
 
 export type ViewerMode = "embedded" | "editor" | "readonly";
 
 type LoadState =
   | { status: "loading" }
-  | { status: "ready"; session: ReplaySession; mode: ViewerMode; gistOwner?: string }
+  | {
+      status: "ready";
+      session: ReplaySession;
+      mode: ViewerMode;
+      gistOwner?: string;
+      live?: LiveStatus;
+    }
   | { status: "dashboard" }
   | { status: "error"; message: string };
+
+export interface LiveStatus {
+  /** Connection state of the SSE stream */
+  state: "connecting" | "open" | "error" | "closed";
+  /** Total scenes in the latest payload */
+  scenes: number;
+  /** Time of the last received session payload */
+  lastUpdate?: number;
+  /** Last reported error, if any */
+  error?: string;
+}
 
 interface LoadResult {
   session: ReplaySession;
   mode: ViewerMode;
   gistOwner?: string;
+  live?: LiveStatus;
 }
 
 /**
  * Load session data from one of:
  * 1. window.__VIBE_REPLAY_DATA__ (embedded by CLI)
- * 2. Editor mode — with ?view=dashboard shows dashboard, with ?session=slug loads another session
+ * 2. Editor mode — with ?view=dashboard shows dashboard, with ?session=slug loads another session,
+ *    or ?live=1&provider=<>&sessionId=<> streams a running session via SSE
  * 3. ?url=<jsonl-or-json-url> (fetch from URL, e.g., raw gist)
  * 4. ?file=<local-path> (dev mode, fetch from Vite public/)
  */
 export function useSessionLoader(): LoadState {
   const [state, setState] = useState<LoadState>({ status: "loading" });
+  const liveSourceRef = useRef<EventSource | null>(null);
+
+  const closeLive = useCallback(() => {
+    if (liveSourceRef.current) {
+      liveSourceRef.current.close();
+      liveSourceRef.current = null;
+    }
+  }, []);
 
   const load = useCallback(() => {
+    closeLive();
     setState({ status: "loading" });
+
+    // Live mode is special — it streams updates rather than resolving once.
+    const liveParams = readLiveParams();
+    if (liveParams && isEditorMode()) {
+      startLiveStream(liveParams, liveSourceRef, setState);
+      return;
+    }
+
     loadSession().then(
       (result) => {
         if (result === "dashboard") {
@@ -42,20 +78,104 @@ export function useSessionLoader(): LoadState {
       },
       (err) => setState({ status: "error", message: String(err.message || err) }),
     );
-  }, []);
+  }, [closeLive]);
 
   useEffect(() => {
     load();
     const onPopState = () => load();
     window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
-  }, [load]);
+    return () => {
+      window.removeEventListener("popstate", onPopState);
+      closeLive();
+    };
+  }, [load, closeLive]);
 
   return state;
 }
 
 function isEditorMode(): boolean {
   return !!window.__VIBE_REPLAY_EDITOR__;
+}
+
+interface LiveParams {
+  provider: string;
+  sessionId: string;
+}
+
+function readLiveParams(): LiveParams | null {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("live") !== "1") return null;
+  const provider = params.get("provider");
+  const sessionId = params.get("sessionId");
+  if (!provider || !sessionId) return null;
+  // Tighten input — these go straight onto a server query string and into a
+  // file-watcher path, so reject anything that doesn't look like a normal id.
+  if (!/^[a-zA-Z0-9_.-]{1,64}$/.test(provider)) return null;
+  if (!/^[a-zA-Z0-9_.-]{1,128}$/.test(sessionId)) return null;
+  return { provider, sessionId };
+}
+
+function startLiveStream(
+  params: LiveParams,
+  ref: React.MutableRefObject<EventSource | null>,
+  setState: (s: LoadState) => void,
+): void {
+  const url = `/api/live?provider=${encodeURIComponent(params.provider)}&sessionId=${encodeURIComponent(params.sessionId)}`;
+  const source = new EventSource(url);
+  ref.current = source;
+
+  let lastSession: ReplaySession | null = null;
+  let liveStatus: LiveStatus = { state: "connecting", scenes: 0 };
+
+  const emit = () => {
+    if (lastSession) {
+      setState({
+        status: "ready",
+        session: lastSession,
+        mode: "editor",
+        live: liveStatus,
+      });
+    } else if (liveStatus.state === "error" && liveStatus.error) {
+      setState({ status: "error", message: liveStatus.error });
+    }
+  };
+
+  source.onopen = () => {
+    liveStatus = { ...liveStatus, state: "open", error: undefined };
+    emit();
+  };
+
+  source.onmessage = (ev) => {
+    let payload: { type?: string; session?: ReplaySession; message?: string };
+    try {
+      payload = JSON.parse(ev.data);
+    } catch {
+      return;
+    }
+    if (payload.type === "session" && payload.session) {
+      lastSession = payload.session;
+      liveStatus = {
+        state: "open",
+        scenes: payload.session.scenes.length,
+        lastUpdate: Date.now(),
+        error: undefined,
+      };
+      emit();
+    } else if (payload.type === "error") {
+      liveStatus = {
+        ...liveStatus,
+        state: "error",
+        error: payload.message || "Live stream error",
+      };
+      emit();
+    }
+  };
+
+  source.onerror = () => {
+    // EventSource auto-reconnects; surface the disconnected state until then.
+    liveStatus = { ...liveStatus, state: "error", error: liveStatus.error || "Disconnected" };
+    emit();
+  };
 }
 
 async function loadSession(): Promise<LoadResult | "dashboard"> {

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -54,6 +54,8 @@ export interface SessionSummary {
 
 export interface SourceSession {
   provider: string;
+  /** Stable per-session id from the provider (e.g. Claude Code JSONL `sessionId`). */
+  sessionId?: string;
   slug: string;
   title?: string;
   project: string;

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -39,11 +39,14 @@ export default defineConfig({
     target: "es2022",
   },
   server: {
+    // Force IPv4 — rolldown-vite 7.3.x's default binds to [::1] on macOS but
+    // doesn't accept incoming connections, leaving curl/browsers hung at "Trying ::1".
+    host: "127.0.0.1",
     port: process.env.VITE_PORT ? Number(process.env.VITE_PORT) : undefined,
     strictPort: !!process.env.VITE_PORT,
     proxy: {
       "/api": {
-        target: `http://localhost:${process.env.VITE_API_PORT || "13456"}`,
+        target: `http://127.0.0.1:${process.env.VITE_API_PORT || "13456"}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Adds a **live mode** that streams a currently-running Claude Code (or other JSONL-based) session into the viewer over SSE, with the viewer pinned to the tail. Inspired by `claude-devtools-research`'s file-watcher approach.

### Entry points

- **CLI**: `vibe-replay live` (auto-picks the most recent session) or `vibe-replay live -p claude-code -s <sessionId>`
- **UI**: "Watch live" button on the dashboard session popup (visible when `s.sessionId` is set)
- **URL**: `?live=1&provider=<>&sessionId=<>` in editor mode

### Architecture

- New `/api/live` SSE endpoint in `packages/cli/src/server.ts`. Per-file byte-offset tail cache: `fs.read()` from cached offset → append complete lines, hold incomplete trailing fragment as a `Buffer` (survives UTF-8 boundaries split across writes).
- Falls back to full `provider.parse()` for non-Claude (Cursor SQLite, Codex, etc.).
- 100ms debounce, 15s slow-cadence re-discover (catches `/resume` shards without paying full discovery cost on every save).
- Viewer uses `EventSource`, hot-swaps the session, `useLayoutEffect` tail-pins so `currentIndex` syncs before paint.

### Live UX

- Always pin to the latest scene (no "stuck on old turn" surprise).
- Force `displayMode: "all"` while live (compact mode hides thinking + collapses tools, makes streaming look idle).
- Trailing "the end / session replay complete" card replaced with a pulsing `BUSY` indicator + "waiting for the next turn to land on disk" — Claude Code's JSONL is per-content-block, so 5–30s gaps during streaming are real and "the end" was misleading.
- Instant `scrollTop = scrollHeight` (not smooth) — stacked smooth animations from back-to-back SSE ticks were visibly jittering.

### Streaming-cadence note

Verified directly in `claude-code/src/services/api/claude.ts`: `content_block_delta` only mutates the in-memory content block; only `content_block_stop` calls `recordTranscript → enqueueWrite → JSONL`. So token-level streaming via the JSONL file is impossible by construction — anything that watches `~/.claude/projects/**/*.jsonl` (including `claude-devtools-research`) sees per-content-block updates at best.

### Bonus fix

- `packages/viewer/vite.config.ts`: pin `host: "127.0.0.1"`. rolldown-vite 7.3.x defaults to `[::1]` on macOS, the IPv6 socket listens but never accepts connections, `pnpm dev` reports "ready" yet curl/browsers hang at "Trying ::1". Unrelated to live mode but was blocking dev.

## Test plan

- [x] `pnpm test` — 701/702 unit tests pass (1 pre-existing skip)
- [x] `pnpm test:e2e e2e/live-mode.test.ts` — 2/2 (real CLI server + Playwright; SSE delivers initial baseline, file append triggers delta with new scene, LIVE badge renders, tail follows when JSONL grows)
- [x] `pnpm test:e2e e2e/generated-html.test.ts` — 11/11 (no static-HTML regressions)
- [x] `pnpm lint:check` — clean
- [x] Manual: dashboard "Watch live" → URL switches to `?live=1` → SSE opens → BUSY badge during idle, new turn appears at tail
- [ ] /cc @claude please review the live mode implementation, especially the byte-offset tail logic (`server.ts:1389-1450`) — UTF-8 boundary handling, file-truncation fallback, and resource cleanup on disconnect. Also flag any lint, perf, or UX regressions you spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)