### PR TITLE
chore(cli): drop unused getInsightsStorePath export

### DIFF
--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -307,11 +307,6 @@ export function aggregateDailyInsights(store: InsightsStore): {
   };
 }
 
-/** Get store file path (for display/debugging) */
-export function getInsightsStorePath(): string {
-  return STORE_PATH;
-}
-
 /** Get store stats */
 export function getInsightsStats(store: InsightsStore): {
   total: number;


### PR DESCRIPTION
## Summary

- Remove dead \`getInsightsStorePath\` export from \`packages/cli/src/insights.ts\` — has zero references across the monorepo and tests.
- Net diff: -5 lines, 1 file.

## Motivation

\`getInsightsStorePath\` is exported with the comment \"for display/debugging\" but is never imported anywhere — not in CLI src, server.ts dynamic imports, viewer, cloudflare, website, or any test. Removing it has no possible runtime impact (no callers exist), and the constant \`STORE_PATH\` it returned is still in scope for any future use.

\`\`\`
$ rg -n "getInsightsStorePath" packages/ cloudflare/ website/
packages/cli/src/insights.ts:311:export function getInsightsStorePath(): string {
\`\`\`

## Test plan

- [x] \`pnpm test\` — all green (40 CLI files + 6 viewer files)
- [x] \`pnpm lint:check\` — 0 warnings, 0 errors
- [x] \`pnpm --filter vibe-replay exec tsc --noEmit\` — clean
- [x] \`pnpm build\` — viewer 804.95 kB (unchanged from main, pre-existing), CLI 421.42 KB
- [x] \`pnpm test:e2e\` — 30 passed, all relevant E2E suites green

> Daily auto-quality routine. Self-merged after AI review per routine policy.