### PR TITLE
chore(cli): drop export from internal-only interfaces

### DIFF
--- a/packages/cli/src/cleanup-warning.ts
+++ b/packages/cli/src/cleanup-warning.ts
@@ -6,7 +6,7 @@ import type { SessionInfo } from "./types.js";
 const DEFAULT_CLEANUP_PERIOD_DAYS = 30;
 export const WARNING_THRESHOLD_DAYS = 7;
 
-export interface CleanupWarningResult {
+interface CleanupWarningResult {
   expiringCount: number;
   soonestDays: number;
   cleanupPeriodDays: number;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -80,7 +80,7 @@ export interface SessionScanResult {
   turnDurations?: number[];
 }
 
-export interface ScanCacheEntry {
+interface ScanCacheEntry {
   mtimeMs: number;
   fileSize: number;
   scannedAt: string;
@@ -259,7 +259,7 @@ export interface ScanInput {
   firstPrompt?: string;
 }
 
-export interface ScanProgress {
+interface ScanProgress {
   scanned: number;
   total: number;
   currentSession?: string;


### PR DESCRIPTION
## Summary

- Remove `export` from `CleanupWarningResult`, `ScanCacheEntry`, `ScanProgress`.
- Net diff: **-3 +3** across 2 files.

## Motivation

These three interfaces are exported but never imported by name anywhere in the repo:

- `CleanupWarningResult` — used only as the return type of `checkCleanupWarnings` in the same file.
- `ScanCacheEntry` — used only as a field type of `ScanCacheData` in the same file.
- `ScanProgress` — used only as a callback parameter type of `runBackgroundScan`. The single external caller (`server.ts`) passes an inline arrow whose param type is inferred — it never imports `ScanProgress`.

Dropping `export` is type-only. Public API surface shrinks; runtime is identical (TypeScript erases interfaces). If any external consumer ever needs the shape, `ReturnType<typeof checkCleanupWarnings>` / `Parameters<typeof runBackgroundScan>` recover it.

## Test plan

- [x] `pnpm test` — 686 CLI tests + 130 viewer tests pass.
- [x] `pnpm lint:check` — 0 warnings, 0 errors.
- [x] `pnpm exec tsc --noEmit` (CLI + viewer) — clean.
- [x] `pnpm build` — viewer + CLI build succeed.
- [x] E2E: skipped (type-only change, zero runtime impact).

> Daily auto-quality routine. Self-merged after AI review.