### PR TITLE
docs: add Claude Desktop, Cowork, and Codex to supported providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 | Provider | Status |
 |----------|--------|
 | Claude Code | Supported |
+| Claude Desktop | Supported |
+| Claude Cowork | Supported (agent-mode sessions) |
+| Codex | Supported |
 | Cursor | Supported (SQLite + JSONL, auto-discovered) |
 | More coming soon | — |
 


### PR DESCRIPTION
## Summary

- Added three new rows to the **Supported Providers** table in README.md: Claude Desktop, Claude Cowork, and Codex.
- Corresponding feature PRs already merged: #205 (Codex), #187 (Claude Desktop / Cowork).

## Why now

The `Supported Providers` table is the canonical place new users look to confirm their tool is supported. Three providers shipped over the past week (Codex, Claude Desktop, Claude Cowork) but the table still listed only Claude Code and Cursor — newcomers checking the README would assume support is missing.

## Files touched

- `README.md` (+3 / -0 lines) — three new rows in the existing Supported Providers table.

## Out of scope (intentionally)

- Did not update the landing page (`website/src/pages/index.astro`) hero copy or SEO meta description (still says "Claude Code and Cursor"). Hero/meta changes are out of scope for the auto-docs routine and worth a deliberate marketing decision.
- Did not update the "Features" bullet that mentions "Claude Code + Cursor — both providers auto-discovered." The routine forbids rewording existing sentences. The Supported Providers table already serves as the canonical list.
- Did not add screenshots or GIFs for the new providers.

> Weekly auto-docs routine. Needs human review before merge.