### PR TITLE
refactor(cli): extract previewPrompt helper for cleanPromptText().slice(0, 200)

### DIFF
--- a/packages/cli/src/clean-prompt.ts
+++ b/packages/cli/src/clean-prompt.ts
@@ -15,6 +15,11 @@ export function isSystemGeneratedMessage(text: string): boolean {
   );
 }
 
+/** Cleaned prompt clipped to ~200 chars for list/preview display. */
+export function previewPrompt(text: string): string {
+  return cleanPromptText(text).slice(0, 200);
+}
+
 /**
  * Strip system-injected boilerplate from user prompts.
  * Shared by discover (session scanning) and server (API responses).

--- a/packages/cli/src/providers/claude-cowork/discover.ts
+++ b/packages/cli/src/providers/claude-cowork/discover.ts
@@ -3,7 +3,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { cleanPromptText, isSystemGeneratedMessage } from "../../clean-prompt.js";
+import { isSystemGeneratedMessage, previewPrompt } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
 
 /**
@@ -219,7 +219,7 @@ function collectPromptsFromLines(lines: string[], initialMessage?: string): stri
   const pushCleaned = (text: string | undefined): void => {
     if (!text) return;
     if (isSystemGeneratedMessage(text)) return;
-    const cleaned = cleanPromptText(text).slice(0, 200);
+    const cleaned = previewPrompt(text);
     if (cleaned.length < 10) return;
     if (prompts.includes(cleaned)) return;
     prompts.push(cleaned);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -11,7 +11,7 @@ import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
 import { readFileCache, writeFileCache } from "./cache.js";
-import { cleanPromptText } from "./clean-prompt.js";
+import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
 import { computeDaysUntilCleanup, getClaudeCodeCleanupPeriod } from "./cleanup-warning.js";
 import {
   detectFeedbackTools,
@@ -261,7 +261,7 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
 
       const userPrompts = (session.scenes || [])
         .filter((sc) => sc.type === "user-prompt")
-        .map((sc) => cleanPromptText(sc.content).slice(0, 200))
+        .map((sc) => previewPrompt(sc.content))
         .filter((m) => m.length >= 10);
       const firstMessage = userPrompts[0] || undefined;
       const messages = userPrompts.length > 0 ? userPrompts.slice(0, 2) : undefined;
@@ -532,7 +532,7 @@ function extractPromptPreviewsFromTurns(turns: ParsedTurn[], limit = 3): string[
       .map((block) => block.text)
       .join("\n")
       .trim();
-    const cleaned = cleanPromptText(text).slice(0, 200);
+    const cleaned = previewPrompt(text);
     if (cleaned.length < 8 || prompts.includes(cleaned)) continue;
     prompts.push(cleaned);
     if (prompts.length >= limit) break;
@@ -627,8 +627,8 @@ async function buildSourcesResult(
       lineCount: s.lineCount,
       promptCount,
       toolCallCount,
-      firstPrompt: cleanPromptText(s.firstPrompt).slice(0, 200),
-      prompts: s.prompts?.map((p) => cleanPromptText(p).slice(0, 200)),
+      firstPrompt: previewPrompt(s.firstPrompt),
+      prompts: s.prompts?.map((p) => previewPrompt(p)),
       filePaths: s.filePaths,
       toolPaths: s.toolPaths,
       hasSqlite: s.hasSqlite,
@@ -895,8 +895,8 @@ export async function startServer(
             normalizeTitle(promptPreviews[0] || "");
           const enrichedFirstPrompt =
             promptPreviews[0] ||
-            cleanPromptText(parsed.title || "").slice(0, 200) ||
-            cleanPromptText(session.firstPrompt).slice(0, 200);
+            previewPrompt(parsed.title || "") ||
+            previewPrompt(session.firstPrompt);
           const target = pickSourceRecordForSession(session, bySessionId, byKey);
           if (target) {
             let targetChanged = false;


### PR DESCRIPTION
## Summary

- The pattern `cleanPromptText(x).slice(0, 200)` was duplicated in 7 places across `server.ts` (6) and `providers/claude-cowork/discover.ts` (1) for list/preview strings.
- Extract into a single `previewPrompt(text)` helper in `clean-prompt.ts`.
- Net change: +14 / -9 (3 files).

## Motivation

Same expression repeated in many places — collapsing makes call sites read more clearly (`previewPrompt(s.firstPrompt)` vs `cleanPromptText(s.firstPrompt).slice(0, 200)`) and keeps the 200-char preview limit in one place. Semantically the helper just `return cleanPromptText(text).slice(0, 200);` — pure, mechanical equivalence.

## Test plan

- [x] `pnpm test` — 686 + 130 tests passing
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — succeeds (CLI 421KB, viewer 805KB unchanged)
- [x] `pnpm test:e2e` — 30 passed, 40 skipped (skipped require credentials)

> 🤖 Daily auto-quality routine. Self-merged after AI review.