### PR TITLE
chore: ignore plan symlink and wrangler-generated types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ _tmp_*
 packages/viewer/public/demo.json
 packages/viewer/dist/
 packages/cli/assets/viewer.html
-plan/
+plan
 .claude/*
 !.claude/settings.json
 !.claude/skills
@@ -32,6 +32,7 @@ plan/
 # Cloudflare
 cloudflare/.wrangler/
 cloudflare/.dev.vars
+cloudflare/worker-configuration.d.ts
 
 # Environment
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ _tmp_*
 packages/viewer/public/demo.json
 packages/viewer/dist/
 packages/cli/assets/viewer.html
-plan
+/plan
 .claude/*
 !.claude/settings.json
 !.claude/skills


### PR DESCRIPTION
## Summary

- `plan/` was already in `.gitignore` but kept showing up as untracked because some devs (me) symlink `plan` to an external plan repo (`/Users/tuo/Code/vibe-replay/plan`). The trailing slash made the rule directory-only, so symlinks weren't matched. Dropped the slash.
- Added `cloudflare/worker-configuration.d.ts` — this is regenerated locally by `wrangler types` from the bindings declared in wrangler config; the hash differs per machine, so it should never be committed.

## Test plan

- [x] `git status` clean after the change (both files ignored)
- [x] `pnpm lint:check` not affected (only `.gitignore` touched)