### PR TITLE
fix(seo): unify trailing slash on internal links + 301 short URL redirects

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -2016,11 +2016,21 @@ app.get("/r/:id", (c) => {
 // Fallback — serve static assets (Astro website)
 // ---------------------------------------------------------------------------
 
-app.all("*", (c) => {
+app.all("*", async (c) => {
   if (!c.env.ASSETS) {
     return c.text("Not Found", 404);
   }
-  return c.env.ASSETS.fetch(c.req.raw);
+  const res = await c.env.ASSETS.fetch(c.req.raw);
+  // Workers Assets returns 307/308 for trailing-slash canonicalization. Promote to
+  // 301 so search engines treat the canonical URL as permanent and pass link equity.
+  if (res.status === 307 || res.status === 308) {
+    const location = res.headers.get("location");
+    if (location) {
+      const headers = new Headers(res.headers);
+      return new Response(null, { status: 301, headers });
+    }
+  }
+  return res;
 });
 
 // ---------------------------------------------------------------------------

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -7,6 +7,12 @@ routes = [{ pattern = "vibe-replay.com", custom_domain = true }]
 
 [assets]
 directory = "../website/dist"
+binding = "ASSETS"
+# Run the worker before serving assets so we can intercept the default 307
+# trailing-slash redirect from Workers Assets and promote it to a 301 (see
+# worker.ts fallback handler). Search engines treat 301 as permanent and pass
+# link equity to the canonical URL.
+run_worker_first = true
 
 [[d1_databases]]
 binding = "DB"

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -115,7 +115,7 @@
             <span class="w-8 h-8 rounded-lg bg-gradient-to-br from-accent/10 to-cyan-400/5 flex items-center justify-center text-accent font-mono text-sm font-bold">5</span>
             <h3 class="text-xl font-semibold">Share anywhere</h3>
           </div>
-          <p class="text-text-secondary leading-relaxed">Export as a self-contained HTML file, animated SVG, GIF, or markdown summary. Publish to GitHub Gist for a shareable link on <a href="/explore" class="text-accent hover:underline">vibe-replay.com</a>, or upload to the cloud. Everything works offline &mdash; zero external requests.</p>
+          <p class="text-text-secondary leading-relaxed">Export as a self-contained HTML file, animated SVG, GIF, or markdown summary. Publish to GitHub Gist for a shareable link on <a href="/explore/" class="text-accent hover:underline">vibe-replay.com</a>, or upload to the cloud. Everything works offline &mdash; zero external requests.</p>
           <!-- Export format badges -->
           <div class="flex flex-wrap gap-2 mt-4">
             <span class="px-2.5 py-1 rounded-md bg-accent/10 text-accent text-xs font-mono font-medium">HTML</span>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -23,9 +23,9 @@ const mobileLinkClass = (page: string) =>
     <div class="flex items-center gap-4">
       <a href="/" class="font-mono font-bold text-sm hover:opacity-80 transition-opacity bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</a>
       <span class="text-border hidden sm:inline">|</span>
-      <a href="/blog" class={linkClass("blog")}>Blog</a>
-      <a href="/explore" class={linkClass("explore")}>Explore</a>
-      <a href="/insights" class={linkClass("insights")}>Insights</a>
+      <a href="/blog/" class={linkClass("blog")}>Blog</a>
+      <a href="/explore/" class={linkClass("explore")}>Explore</a>
+      <a href="/insights/" class={linkClass("insights")}>Insights</a>
     </div>
 
     <!-- Desktop: GitHub star + Auth -->
@@ -41,8 +41,8 @@ const mobileLinkClass = (page: string) =>
             <img id="auth-avatar" class="w-full h-full rounded-full object-cover" alt="" />
           </button>
           <div id="auth-dropdown" class="hidden absolute right-0 top-full mt-2 min-w-[160px] bg-surface-1 border border-border rounded-lg shadow-lg py-1 z-50">
-            <a id="auth-username" href="/profile" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
-            <a href="/profile" class="block px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-colors">Profile</a>
+            <a id="auth-username" href="/profile/" class="block px-3 py-2 text-xs text-text-secondary border-b border-border truncate hover:text-accent transition-colors"></a>
+            <a href="/profile/" class="block px-3 py-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface-2 transition-colors">Profile</a>
             <button id="auth-logout" class="w-full text-left px-3 py-2 text-sm text-text-secondary hover:text-red-400 hover:bg-surface-2 transition-colors cursor-pointer">Logout</button>
           </div>
         </div>
@@ -59,9 +59,9 @@ const mobileLinkClass = (page: string) =>
   <!-- Mobile dropdown -->
   <div id="nav-menu" class="hidden sm:hidden mt-3 pt-3 border-t border-border/50">
     <div class="flex flex-col gap-3">
-      <a href="/blog" class={mobileLinkClass("blog")}>Blog</a>
-      <a href="/explore" class={mobileLinkClass("explore")}>Explore Replays</a>
-      <a href="/insights" class={mobileLinkClass("insights")}>Insights</a>
+      <a href="/blog/" class={mobileLinkClass("blog")}>Blog</a>
+      <a href="/explore/" class={mobileLinkClass("explore")}>Explore Replays</a>
+      <a href="/insights/" class={mobileLinkClass("insights")}>Insights</a>
       <a href="https://github.com/tuo-lei/vibe-replay" target="_blank" rel="noopener" class="text-text-secondary hover:text-accent text-sm transition-colors flex items-center gap-2">
         <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
@@ -74,7 +74,7 @@ const mobileLinkClass = (page: string) =>
         </button>
         <div id="nav-mobile-user" style="display:none" class="flex items-center gap-3">
           <img id="nav-mobile-avatar" class="w-6 h-6 rounded-full object-cover" alt="" />
-          <a href="/profile" class="text-text-secondary hover:text-accent text-sm transition-colors flex-1">Profile</a>
+          <a href="/profile/" class="text-text-secondary hover:text-accent text-sm transition-colors flex-1">Profile</a>
           <button id="nav-mobile-logout" class="text-sm text-text-secondary hover:text-red-400 transition-colors cursor-pointer">Logout</button>
         </div>
       </div>

--- a/website/src/content/blog/claude-code-local-storage.md
+++ b/website/src/content/blog/claude-code-local-storage.md
@@ -14,7 +14,7 @@ du -sh ~/.claude/
 
 Mine says **858 MB**. Three weeks of usage. 129 sessions (plus hundreds of sub-agent files), 1,642 prompts, 17,487 tool calls — all stored as plain text on my local machine.
 
-Most [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) users never look inside this directory. I did, because I needed to parse it for [vibe-replay](/blog/introducing-vibe-replay). What I found was more than I expected — a complete record of every AI coding session, with data that reveals things Claude Code's own UI never shows you.
+Most [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) users never look inside this directory. I did, because I needed to parse it for [vibe-replay](/blog/introducing-vibe-replay/). What I found was more than I expected — a complete record of every AI coding session, with data that reveals things Claude Code's own UI never shows you.
 
 ---
 
@@ -198,8 +198,8 @@ For the full picture — token burn over time, context window growth, tool distr
 npx vibe-replay
 ```
 
-One command. It discovers your Claude Code (and Cursor) sessions, you pick one, and it generates a self-contained HTML replay. No server, no account, no external requests. Open it in any browser, share it with your team, or [publish it to the cloud](https://vibe-replay.com/explore).
+One command. It discovers your Claude Code (and Cursor) sessions, you pick one, and it generates a self-contained HTML replay. No server, no account, no external requests. Open it in any browser, share it with your team, or [publish it to the cloud](/explore/).
 
 Your `~/.claude/` directory is a goldmine. Stop grepping through JSONL.
 
-**[Try it on your own sessions](https://github.com/tuo-lei/vibe-replay)** · **[Watch a live demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore public replays](https://vibe-replay.com/explore)**
+**[Try it on your own sessions](https://github.com/tuo-lei/vibe-replay)** · **[Watch a live demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore public replays](/explore/)**

--- a/website/src/content/blog/introducing-vibe-replay.md
+++ b/website/src/content/blog/introducing-vibe-replay.md
@@ -101,6 +101,6 @@ npx vibe-replay
 
 One command. It discovers your Claude Code and Cursor sessions, picks the one you want, and generates an interactive replay.
 
-The output is a single self-contained HTML file. No server, no account, no external requests. Open it in any browser, share it anywhere. Or sign in and [share it to the cloud](/explore).
+The output is a single self-contained HTML file. No server, no account, no external requests. Open it in any browser, share it anywhere. Or sign in and [share it to the cloud](/explore/).
 
-**[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Live Demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore Public Replays](/explore)**
+**[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Live Demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore Public Replays](/explore/)**

--- a/website/src/content/blog/personal-insights.md
+++ b/website/src/content/blog/personal-insights.md
@@ -103,4 +103,4 @@ npx vibe-replay
 
 Sign in from the dashboard, and your insights page builds automatically from your local session history. No manual tracking, no configuration. If you've been vibe coding with Claude Code or Cursor, the data is already on your machine — insights just surfaces it.
 
-**[See my insights](https://vibe-replay.com/shared-insights/?s=tuo-lei)** · **[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Explore public replays](/explore)**
+**[See my insights](https://vibe-replay.com/shared-insights/?s=tuo-lei)** · **[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Explore public replays](/explore/)**

--- a/website/src/content/blog/simplify-codebase-with-ai.md
+++ b/website/src/content/blog/simplify-codebase-with-ai.md
@@ -97,4 +97,4 @@ The more complex the AI session, the more valuable the replay. `/simplify` is a 
 
 **[Watch the interactive replay](https://vibe-replay.com/view/?gist=e5b2731d90cfa20fee4f3f7ab980cbb1)**
 
-**[GitHub](https://github.com/tuo-lei/vibe-replay)** | **[Explore Public Replays](/explore)**
+**[GitHub](https://github.com/tuo-lei/vibe-replay)** | **[Explore Public Replays](/explore/)**

--- a/website/src/pages/insights.astro
+++ b/website/src/pages/insights.astro
@@ -1148,12 +1148,12 @@ import Layout from "../layouts/Layout.astro";
           method: "POST",
           headers: { "Content-Type": "application/json" },
           credentials: "include",
-          body: JSON.stringify({ provider: "github", callbackURL: "/insights" }),
+          body: JSON.stringify({ provider: "github", callbackURL: "/insights/" }),
         });
         const data = await res.json();
         if (data?.url) window.location.href = data.url;
       } catch {
-        window.location.href = "/auth/login?callback=/insights";
+        window.location.href = "/auth/login?callback=/insights/";
       }
     });
   }

--- a/website/src/pages/profile.astro
+++ b/website/src/pages/profile.astro
@@ -452,7 +452,7 @@ import Layout from "../layouts/Layout.astro";
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ provider: "github", callbackURL: "/profile" }),
+        body: JSON.stringify({ provider: "github", callbackURL: "/profile/" }),
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;


### PR DESCRIPTION
## Summary

GSC currently indexes only **2 of 11** sitemap URLs. Audit found two SEO crawl-budget leaks:

1. **`Nav.astro`** (rendered on every page) plus a few blog posts and `HowItWorks.astro` link to `/blog`, `/explore`, `/insights`, `/profile` **without** the canonical trailing slash. Every Nav click traversed a redirect, draining a small site's tiny crawl budget.
2. **Workers Assets** answered those short URLs with a default **307 Temporary Redirect**, which search engines do not pass link equity through.

## Changes

- Add trailing slash to every internal `/blog`, `/explore`, `/insights`, `/profile`, `/shared-insights` link in `Nav.astro`, `HowItWorks.astro`, and three blog markdown files.
- Promote the trailing-slash redirect from **307 → 301** in the worker fallback so external short URLs still pass link equity to the canonical URL.
- Set `[assets].binding = "ASSETS"` and `run_worker_first = true` in `wrangler.toml` so the worker fallback actually runs for asset paths (otherwise Workers Assets short-circuits the request before our handler can see it).

## Test plan

Verified locally with `wrangler dev` + Playwright:

- [x] `/blog`, `/explore`, `/insights`, `/profile`, `/shared-insights`, `/blog/<slug>` return **301** (was 307).
- [x] `/`, `/blog/`, `/explore/`, `/insights/`, `/blog/<slug>/` return **200**.
- [x] `/og.png`, `/robots.txt`, `/sitemap-index.xml`, `/llms.txt` return **200**.
- [x] `/api/replays` still routed to the worker (200).
- [x] In a real browser, short URLs follow 301 → 200 transparently and the page renders.
- [x] In a real browser, clicking the Nav links from `/` hits the target page directly with **no redirect** in the response chain.
- [x] Built HTML across 7 representative pages contains zero remaining missing-trailing-slash internal links.
- [x] `pnpm lint` clean.
- [x] `pnpm test:e2e` — 30 passed, 0 failed.

## Notes

`run_worker_first = true` means every request (including static assets) traverses the worker once. Cost: a sub-millisecond V8 isolate hop per request — negligible for our traffic and worth it for permanent (vs. temporary) redirect semantics that pass PageRank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)