### PR TITLE
Improve Cursor live replay update latency

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -354,6 +354,52 @@ async function findStoreDb(sessionId: string): Promise<string | null> {
   return refreshed.get(sessionId)?.dbPath || null;
 }
 
+async function existingPath(path: string): Promise<string | null> {
+  const s = await stat(path).catch(() => null);
+  return s ? path : null;
+}
+
+/**
+ * Files that should wake Cursor live mode promptly when SQLite-backed data changes.
+ *
+ * Cursor often writes active conversation state into SQLite WAL files before the
+ * main DB mtime moves. These paths are triggers only; parsing still goes through
+ * the normal SQLite/global-state reader so we keep one source of truth.
+ */
+export async function resolveCursorLiveWatchPaths(sessionId: string): Promise<string[]> {
+  const paths = new Set<string>();
+
+  const addIfExists = async (path: string) => {
+    const existing = await existingPath(path);
+    if (existing) paths.add(existing);
+  };
+
+  const storeDb = await findStoreDb(sessionId);
+  if (storeDb) {
+    await addIfExists(storeDb);
+    await addIfExists(`${storeDb}-wal`);
+    await addIfExists(`${storeDb}-shm`);
+    // Session-scoped directory catches WAL creation when it does not exist yet.
+    await addIfExists(dirname(storeDb));
+  }
+
+  const globalStateDb = await openGlobalStateDb();
+  if (globalStateDb && (await hasGlobalStateSession(globalStateDb, sessionId))) {
+    await addIfExists(globalStateDb.dbPath);
+    const beforeWal = paths.size;
+    await addIfExists(`${globalStateDb.dbPath}-wal`);
+    await addIfExists(`${globalStateDb.dbPath}-shm`);
+    // The global WAL may be created lazily. Watch the directory only when there
+    // is no WAL/SHM file to watch yet; otherwise the shared globalStorage folder
+    // is noisier than the specific SQLite files.
+    if (paths.size === beforeWal) {
+      await addIfExists(dirname(globalStateDb.dbPath));
+    }
+  }
+
+  return [...paths];
+}
+
 export async function storeDbExists(_workspacePath: string, sessionId: string): Promise<boolean> {
   const dbPath = await findStoreDb(sessionId);
   return dbPath !== null;
@@ -1114,15 +1160,24 @@ async function parseCursorStoreDb(
   sessionId: string,
   workspacePath = "",
 ): Promise<ProviderParseResult | null> {
+  const dbPath = await findStoreDb(sessionId);
+  if (!dbPath) return null;
+
+  if (await canUseSqliteCli(dbPath)) {
+    try {
+      return await parseCursorStoreDbWithSqliteCli(dbPath, sessionId, workspacePath);
+    } catch {
+      // Fall through to sql.js. Some machines may have sqlite3 installed but
+      // unable to read this specific DB/WAL state in readonly mode.
+    }
+  }
+
   let SQL: any;
   try {
     SQL = await getSqlJs();
   } catch {
     return null;
   }
-
-  const dbPath = await findStoreDb(sessionId);
-  if (!dbPath) return null;
 
   const dbBuffer = await readFile(dbPath);
   const db = new SQL.Database(dbBuffer);
@@ -1163,42 +1218,103 @@ async function parseCursorStoreDb(
     }
     stmt.free();
 
-    const { turns, turnStats, totalDurationMs } = messagesToTurns(messages);
-    const slug = sessionId.slice(0, 8);
-
-    const title = metaJson.name || firstUserTextSnippet(turns);
-    const hasDurationStats = turnStats.some((stat) => (stat.durationMs || 0) > 0);
-
-    const notes: string[] = [];
-    if (hasDurationStats) {
-      notes.push("Per-turn duration is estimated from Cursor tool execution metadata.");
-    } else {
-      notes.push("Per-turn duration metrics are unavailable for this Cursor SQLite session.");
-    }
-    notes.push("Token usage is unavailable for this Cursor SQLite session.");
-
-    return {
-      sessionId,
-      slug,
-      title,
-      cwd: workspacePath,
-      model:
-        normalizeCursorModelName(metaJson.lastUsedModel) ||
-        turnStats.find((stat) => typeof stat.model === "string" && stat.model)?.model,
-      startTime: metaJson.createdAt ? new Date(metaJson.createdAt).toISOString() : undefined,
-      ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
-      ...(turnStats.length > 0 ? { turnStats } : {}),
-      turns,
-      dataSource: "sqlite",
-      dataSourceInfo: {
-        primary: "sqlite",
-        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
-        notes,
-      },
-    };
+    return buildCursorStoreResult(sessionId, workspacePath, metaJson, messages);
   } finally {
     db.close();
   }
+}
+
+async function parseCursorStoreDbWithSqliteCli(
+  dbPath: string,
+  sessionId: string,
+  workspacePath: string,
+): Promise<ProviderParseResult | null> {
+  const metaRows = await querySqliteCli(dbPath, "SELECT value FROM meta WHERE key = '0'");
+  const metaHex = typeof metaRows[0]?.value === "string" ? metaRows[0].value : "";
+  if (!metaHex) return null;
+
+  const metaJson: ChatMeta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
+  const rootId = metaJson.latestRootBlobId;
+  if (!rootId) return null;
+
+  const rootRows = await querySqliteCli(
+    dbPath,
+    `SELECT hex(data) AS dataHex FROM blobs WHERE id = ${sqlString(rootId)}`,
+  );
+  const rootDataHex = typeof rootRows[0]?.dataHex === "string" ? rootRows[0].dataHex : "";
+  if (!rootDataHex) return null;
+
+  const childIds = extractChildBlobIds(Buffer.from(rootDataHex, "hex"));
+  if (childIds.length === 0) return null;
+
+  const blobHexById = new Map<string, string>();
+  const chunkSize = 200;
+  for (let i = 0; i < childIds.length; i += chunkSize) {
+    const chunk = childIds.slice(i, i + chunkSize);
+    const rows = await querySqliteCli(
+      dbPath,
+      `SELECT id, hex(data) AS dataHex FROM blobs WHERE id IN (${chunk.map(sqlString).join(",")})`,
+    );
+    for (const row of rows) {
+      if (typeof row.id === "string" && typeof row.dataHex === "string") {
+        blobHexById.set(row.id, row.dataHex);
+      }
+    }
+  }
+
+  const messages: CursorMessage[] = [];
+  for (const cid of childIds) {
+    const dataHex = blobHexById.get(cid);
+    if (!dataHex) continue;
+    try {
+      const text = Buffer.from(dataHex, "hex").toString("utf-8");
+      messages.push(JSON.parse(text));
+    } catch {
+      // binary or corrupted blob, skip
+    }
+  }
+
+  return buildCursorStoreResult(sessionId, workspacePath, metaJson, messages);
+}
+
+function buildCursorStoreResult(
+  sessionId: string,
+  workspacePath: string,
+  metaJson: ChatMeta,
+  messages: CursorMessage[],
+): ProviderParseResult {
+  const { turns, turnStats, totalDurationMs } = messagesToTurns(messages);
+  const slug = sessionId.slice(0, 8);
+  const title = metaJson.name || firstUserTextSnippet(turns);
+  const hasDurationStats = turnStats.some((stat) => (stat.durationMs || 0) > 0);
+
+  const notes: string[] = [];
+  if (hasDurationStats) {
+    notes.push("Per-turn duration is estimated from Cursor tool execution metadata.");
+  } else {
+    notes.push("Per-turn duration metrics are unavailable for this Cursor SQLite session.");
+  }
+  notes.push("Token usage is unavailable for this Cursor SQLite session.");
+
+  return {
+    sessionId,
+    slug,
+    title,
+    cwd: workspacePath,
+    model:
+      normalizeCursorModelName(metaJson.lastUsedModel) ||
+      turnStats.find((stat) => typeof stat.model === "string" && stat.model)?.model,
+    startTime: metaJson.createdAt ? new Date(metaJson.createdAt).toISOString() : undefined,
+    ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
+    ...(turnStats.length > 0 ? { turnStats } : {}),
+    turns,
+    dataSource: "sqlite",
+    dataSourceInfo: {
+      primary: "sqlite",
+      sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      notes,
+    },
+  };
 }
 
 function bubbleTypeToRole(type: unknown): "user" | "assistant" {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -181,11 +181,18 @@ function projectedCursorBubbleSelectSql(): string {
   ].join(", ");
 }
 
-const sqliteCliUsabilityCache = new Map<string, boolean>();
+interface SqliteCliUsabilityCacheEntry {
+  canUse: boolean;
+  checkedAt: number;
+}
+
+const SQLITE_CLI_NEGATIVE_CACHE_TTL_MS = 30_000;
+const sqliteCliUsabilityCache = new Map<string, SqliteCliUsabilityCacheEntry>();
 
 async function canUseSqliteCli(dbPath: string): Promise<boolean> {
   const cached = sqliteCliUsabilityCache.get(dbPath);
-  if (cached !== undefined) return cached;
+  if (cached?.canUse) return true;
+  if (cached && Date.now() - cached.checkedAt < SQLITE_CLI_NEGATIVE_CACHE_TTL_MS) return false;
 
   let canUse = false;
   try {
@@ -201,7 +208,7 @@ async function canUseSqliteCli(dbPath: string): Promise<boolean> {
   } catch {
     canUse = false;
   }
-  sqliteCliUsabilityCache.set(dbPath, canUse);
+  sqliteCliUsabilityCache.set(dbPath, { canUse, checkedAt: Date.now() });
   return canUse;
 }
 

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -181,7 +181,13 @@ function projectedCursorBubbleSelectSql(): string {
   ].join(", ");
 }
 
+const sqliteCliUsabilityCache = new Map<string, boolean>();
+
 async function canUseSqliteCli(dbPath: string): Promise<boolean> {
+  const cached = sqliteCliUsabilityCache.get(dbPath);
+  if (cached !== undefined) return cached;
+
+  let canUse = false;
   try {
     const { stdout } = await execFileAsync(
       "sqlite3",
@@ -191,10 +197,12 @@ async function canUseSqliteCli(dbPath: string): Promise<boolean> {
       },
     );
     const rows = JSON.parse(stdout.trim()) as Array<{ ok?: number }>;
-    return rows[0]?.ok === 1;
+    canUse = rows[0]?.ok === 1;
   } catch {
-    return false;
+    canUse = false;
   }
+  sqliteCliUsabilityCache.set(dbPath, canUse);
+  return canUse;
 }
 
 async function querySqliteCli(dbPath: string, sql: string): Promise<Record<string, any>[]> {
@@ -1233,6 +1241,8 @@ async function parseCursorStoreDbWithSqliteCli(
   const metaHex = typeof metaRows[0]?.value === "string" ? metaRows[0].value : "";
   if (!metaHex) return null;
 
+  // If sqlite3 returns malformed data, let the caller fall back to the sql.js
+  // path below; that path has historically handled store.db quirks well.
   const metaJson: ChatMeta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
   const rootId = metaJson.latestRootBlobId;
   if (!rootId) return null;
@@ -1251,6 +1261,8 @@ async function parseCursorStoreDbWithSqliteCli(
   const chunkSize = 200;
   for (let i = 0; i < childIds.length; i += chunkSize) {
     const chunk = childIds.slice(i, i + chunkSize);
+    // Keep the sqlite3 path WAL-aware by querying through SQLite itself. Chunk
+    // the blob lookup so large conversations do not create huge IN clauses.
     const rows = await querySqliteCli(
       dbPath,
       `SELECT id, hex(data) AS dataHex FROM blobs WHERE id IN (${chunk.map(sqlString).join(",")})`,

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -393,7 +393,6 @@ export async function resolveCursorLiveWatchPaths(sessionId: string): Promise<st
   if (storeDb) {
     await addIfExists(storeDb);
     await addIfExists(`${storeDb}-wal`);
-    await addIfExists(`${storeDb}-shm`);
     // Session-scoped directory catches WAL creation when it does not exist yet.
     await addIfExists(dirname(storeDb));
   }
@@ -403,10 +402,9 @@ export async function resolveCursorLiveWatchPaths(sessionId: string): Promise<st
     await addIfExists(globalStateDb.dbPath);
     const beforeWal = paths.size;
     await addIfExists(`${globalStateDb.dbPath}-wal`);
-    await addIfExists(`${globalStateDb.dbPath}-shm`);
     // The global WAL may be created lazily. Watch the directory only when there
-    // is no WAL/SHM file to watch yet; otherwise the shared globalStorage folder
-    // is noisier than the specific SQLite files.
+    // is no WAL file to watch yet; otherwise the shared globalStorage folder is
+    // noisier than the specific SQLite files.
     if (paths.size === beforeWal) {
       await addIfExists(dirname(globalStateDb.dbPath));
     }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -34,6 +34,7 @@ import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
+import { resolveCursorLiveWatchPaths } from "./providers/cursor/sqlite-reader.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
@@ -1436,7 +1437,9 @@ export async function startServer(
       // don't write that file, so they get "unknown" and the viewer keeps
       // the existing always-live UI rather than misreporting "stopped".
       const isClaudeProvider = providerName === "claude-code";
+      const isCursorProvider = providerName === "cursor";
       let lastLiveState: LiveSessionState = isClaudeProvider ? "busy" : "unknown";
+      let cursorDbWatchAttached = false;
 
       const ensureWatchersFor = (paths: Iterable<string>): void => {
         for (const fp of paths) {
@@ -1449,6 +1452,22 @@ export async function startServer(
           } catch {
             // best-effort — if a path can't be watched, the others may still work
           }
+        }
+      };
+
+      const ensureCursorDbWatchersFor = async (info: SessionInfo): Promise<void> => {
+        if (!isCursorProvider || !info.hasSqlite) return;
+        try {
+          const paths = await resolveCursorLiveWatchPaths(info.sessionId);
+          const before = watchedPaths.size;
+          ensureWatchersFor(paths);
+          cursorDbWatchAttached =
+            cursorDbWatchAttached ||
+            watchedPaths.size > before ||
+            paths.some((p) => watchedPaths.has(p));
+        } catch {
+          // Best-effort. If DB/WAL watchers cannot be resolved, the polling
+          // fallback below keeps SQLite-backed Cursor live sessions updating.
         }
       };
 
@@ -1563,6 +1582,7 @@ export async function startServer(
           // would never trigger another scheduleRebuild and the stream would
           // silently go stale.
           ensureWatchersFor(paths);
+          await ensureCursorDbWatchersFor(info);
           let parsed;
           if (isClaudeJsonl) {
             // Tail-based fast path. Concat already-cached lines from every
@@ -1650,17 +1670,14 @@ export async function startServer(
       // every reported file path on this first call.
       await buildAndSend();
 
-      // Polling fallback for sources we can't directly fs.watch. Two cases:
-      //   1. `watchedPaths.size === 0` — Cursor SQLite-only sessions report
-      //      `filePaths: []` (SQLite file is discovered separately and isn't
-      //      in `paths`).
-      //   2. `sessionInfo?.hasSqlite` — Cursor sessions where SQLite is
-      //      authoritative but transcript / tool sidecars are *also* watched.
-      //      Updates landing only in SQLite (no sidecar write) wouldn't
-      //      trigger any fs.watch event, so the stream would silently stall.
-      // The 3s cadence still feels live enough for human reading, and the
-      // dedup signature suppresses redundant emits when nothing changed.
-      const needsPolling = watchedPaths.size === 0 || !!sessionInfo?.hasSqlite;
+      // Polling fallback for sources we still cannot directly fs.watch.
+      //
+      // Cursor SQLite/global-state sessions now try to watch store.db/state.vscdb
+      // plus their WAL files, which gives near-immediate rebuild triggers when
+      // Cursor flushes DB updates. Keep the 3s timer only when no watcher exists
+      // or when SQLite is present but those DB/WAL watchers could not be attached.
+      const needsPolling =
+        watchedPaths.size === 0 || (!!sessionInfo?.hasSqlite && !cursorDbWatchAttached);
       const pollInterval = needsPolling
         ? setInterval(() => {
             if (aborted) return;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1440,6 +1440,9 @@ export async function startServer(
       const isCursorProvider = providerName === "cursor";
       let lastLiveState: LiveSessionState = isClaudeProvider ? "busy" : "unknown";
       let cursorDbWatchAttached = false;
+      const cursorDbWatchedSessionIds = new Set<string>();
+      const cursorDbWatchAttemptedAt = new Map<string, number>();
+      const CURSOR_DB_WATCH_RETRY_MS = 15_000;
 
       const ensureWatchersFor = (paths: Iterable<string>): void => {
         for (const fp of paths) {
@@ -1456,15 +1459,23 @@ export async function startServer(
       };
 
       const ensureCursorDbWatchersFor = async (info: SessionInfo): Promise<void> => {
-        if (!isCursorProvider || !info.hasSqlite || cursorDbWatchAttached) return;
+        if (!isCursorProvider || !info.hasSqlite || cursorDbWatchedSessionIds.has(info.sessionId)) {
+          return;
+        }
+        const now = Date.now();
+        const lastAttempt = cursorDbWatchAttemptedAt.get(info.sessionId) || 0;
+        if (now - lastAttempt < CURSOR_DB_WATCH_RETRY_MS) return;
+        cursorDbWatchAttemptedAt.set(info.sessionId, now);
+
         try {
           const paths = await resolveCursorLiveWatchPaths(info.sessionId);
           const before = watchedPaths.size;
           ensureWatchersFor(paths);
-          cursorDbWatchAttached =
-            cursorDbWatchAttached ||
-            watchedPaths.size > before ||
-            paths.some((p) => watchedPaths.has(p));
+          const attached = watchedPaths.size > before || paths.some((p) => watchedPaths.has(p));
+          if (attached) {
+            cursorDbWatchAttached = true;
+            cursorDbWatchedSessionIds.add(info.sessionId);
+          }
         } catch {
           // Best-effort. If DB/WAL watchers cannot be resolved, the polling
           // fallback below keeps SQLite-backed Cursor live sessions updating.

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1456,7 +1456,7 @@ export async function startServer(
       };
 
       const ensureCursorDbWatchersFor = async (info: SessionInfo): Promise<void> => {
-        if (!isCursorProvider || !info.hasSqlite) return;
+        if (!isCursorProvider || !info.hasSqlite || cursorDbWatchAttached) return;
         try {
           const paths = await resolveCursorLiveWatchPaths(info.sessionId);
           const before = watchedPaths.size;
@@ -1674,15 +1674,23 @@ export async function startServer(
       //
       // Cursor SQLite/global-state sessions now try to watch store.db/state.vscdb
       // plus their WAL files, which gives near-immediate rebuild triggers when
-      // Cursor flushes DB updates. Keep the 3s timer only when no watcher exists
-      // or when SQLite is present but those DB/WAL watchers could not be attached.
-      const needsPolling =
-        watchedPaths.size === 0 || (!!sessionInfo?.hasSqlite && !cursorDbWatchAttached);
-      const pollInterval = needsPolling
+      // Cursor flushes DB updates. Keep a slower watchdog even after DB/WAL
+      // watchers attach: SQLite can rotate WAL/SHM files and macOS file events
+      // can miss in-place WAL writes, so this prevents a permanently stale stream
+      // without making polling the primary update path.
+      const POLL_INTERVAL_MS = 3_000;
+      const CURSOR_SQLITE_WATCHDOG_MS = 10_000;
+      const pollIntervalMs =
+        watchedPaths.size === 0 || (!!sessionInfo?.hasSqlite && !cursorDbWatchAttached)
+          ? POLL_INTERVAL_MS
+          : isCursorProvider && !!sessionInfo?.hasSqlite
+            ? CURSOR_SQLITE_WATCHDOG_MS
+            : null;
+      const pollInterval = pollIntervalMs
         ? setInterval(() => {
             if (aborted) return;
             scheduleRebuild(0);
-          }, 3_000)
+          }, pollIntervalMs)
         : null;
 
       // SSE keepalive — proxies (and some browsers) drop idle connections.


### PR DESCRIPTION
## Summary
- Watch Cursor SQLite DB/WAL files for live replay rebuild triggers instead of relying on the 3s SQLite polling path.
- Prefer sqlite3 reads for Cursor store.db so committed WAL changes are visible before checkpointing, with sql.js as a fallback.
- Scope global state watchers to sessions that actually exist in Cursor global state to reduce unrelated rebuilds.

## Test plan
- pnpm --filter vibe-replay build
- pnpm --filter vibe-replay test
- pnpm lint:check


Made with [Cursor](https://cursor.com)