### PR TITLE
[codex] Add Codex live mode compatibility

### DIFF
--- a/e2e/live-mode.test.ts
+++ b/e2e/live-mode.test.ts
@@ -1,6 +1,6 @@
 // E2E for live mode (`/api/live` SSE endpoint)
 // — boots the *real* CLI server with a temp $HOME containing a fake
-//   Claude Code JSONL session, opens an SSE connection, then appends new
+//   Claude Code and Codex JSONL sessions, opens an SSE connection, then appends new
 //   turns to the JSONL and asserts the stream delivers updated payloads.
 //
 // HOME is overridden BEFORE the dynamic import so the Claude Code provider's
@@ -55,10 +55,12 @@ async function* readSse(
 
 describe("Live mode SSE", () => {
   const sessionId = "live-test-session-001";
+  const codexSessionId = "codex-live-test-session-001";
   const projectPath = "/Users/test/live-project";
   const projectDirEncoded = "-Users-test-live-project";
   let tmpHome: string;
   let jsonlPath: string;
+  let codexJsonlPath: string;
   let serverProcess: ReturnType<typeof spawn> | null = null;
   let serverPort: number | null = null;
   let browser: Browser | null = null;
@@ -96,6 +98,49 @@ describe("Live mode SSE", () => {
       }),
     ];
     await writeFile(jsonlPath, `${initialLines.join("\n")}\n`, "utf-8");
+
+    const codexSessionsDir = join(tmpHome, ".codex", "sessions", "2026", "04", "26");
+    await mkdir(codexSessionsDir, { recursive: true });
+    codexJsonlPath = join(codexSessionsDir, `rollout-2026-04-26T10-00-00-${codexSessionId}.jsonl`);
+    const codexInitialLines = [
+      JSON.stringify({
+        timestamp: "2026-04-26T10:00:00.000Z",
+        type: "session_meta",
+        payload: {
+          id: codexSessionId,
+          timestamp: "2026-04-26T10:00:00.000Z",
+          cwd: projectPath,
+          originator: "codex-tui",
+          cli_version: "0.125.0",
+          source: "cli",
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-04-26T10:00:00.100Z",
+        type: "turn_context",
+        payload: { model: "gpt-5.5", approval_policy: "on-request" },
+      }),
+      JSON.stringify({
+        timestamp: "2026-04-26T10:00:01.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "Hello from Codex live.",
+          images: [],
+          local_images: [],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-04-26T10:00:02.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Codex live is connected." }],
+        },
+      }),
+    ];
+    await writeFile(codexJsonlPath, `${codexInitialLines.join("\n")}\n`, "utf-8");
 
     // Spawn the real CLI server with our temp HOME so Claude Code's discover()
     // points at the fixture. We use a bootstrap script that calls startServer
@@ -221,6 +266,75 @@ describe("Live mode SSE", () => {
     expect(events.length).toBeGreaterThanOrEqual(2);
     expect(events[1].type).toBe("session");
     expect(events[1].session.scenes.length).toBeGreaterThan(initialScenes);
+  }, 30_000);
+
+  it("streams a Codex rollout and a delta after the JSONL grows", async () => {
+    expect(serverPort).not.toBeNull();
+    const ac = new AbortController();
+    const url = `http://127.0.0.1:${serverPort}/api/live?provider=codex&sessionId=${encodeURIComponent(codexSessionId)}`;
+
+    const events: any[] = [];
+    const collect = (async () => {
+      for await (const ev of readSse(url, ac.signal)) {
+        if (ev.data.type === "ping") continue;
+        events.push(ev.data);
+        if (events.length >= 2) {
+          ac.abort();
+          break;
+        }
+      }
+    })().catch((err) => {
+      if (err?.name !== "AbortError") throw err;
+    });
+
+    const waitForCount = async (n: number, timeoutMs: number) => {
+      const start = Date.now();
+      while (events.length < n && Date.now() - start < timeoutMs) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    };
+
+    await waitForCount(1, 5_000);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0].type).toBe("session");
+    expect(events[0].state).toBe("unknown");
+    const initialScenes = events[0].session.scenes.length;
+    expect(initialScenes).toBeGreaterThan(0);
+
+    const { appendFile } = await import("node:fs/promises");
+    const codexNewLines = [
+      JSON.stringify({
+        timestamp: "2026-04-26T10:01:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "user_message",
+          message: "Tell me a Codex live joke.",
+          images: [],
+          local_images: [],
+        },
+      }),
+      JSON.stringify({
+        timestamp: "2026-04-26T10:01:01.000Z",
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Codex streamed the punchline." }],
+        },
+      }),
+    ];
+    await appendFile(codexJsonlPath, `${codexNewLines.join("\n")}\n`, "utf-8");
+
+    await waitForCount(2, 5_000);
+    await collect;
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[1].type).toBe("session");
+    expect(JSON.stringify(events[1].session.scenes)).toContain("Tell me a Codex live joke.");
+    expect(JSON.stringify(events[1].session.scenes)).toContain("Codex streamed the punchline.");
+    expect(JSON.stringify(events[1].session.scenes)).not.toBe(
+      JSON.stringify(events[0].session.scenes),
+    );
   }, 30_000);
 
   it("renders the LIVE badge in the viewer and follows tail when JSONL grows", async () => {

--- a/e2e/live-mode.test.ts
+++ b/e2e/live-mode.test.ts
@@ -5,6 +5,7 @@
 //
 // HOME is overridden BEFORE the dynamic import so the Claude Code provider's
 // module-level `CLAUDE_DIR = join(homedir(), ...)` resolves to the temp dir.
+// Codex resolves homedir at discovery time, but shares the same fixture HOME.
 
 import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -50,6 +51,13 @@ async function* readSse(
         // Ignore malformed lines (e.g., keep-alive comments)
       }
     }
+  }
+}
+
+async function waitForCount(events: any[], n: number, timeoutMs: number): Promise<void> {
+  const start = Date.now();
+  while (events.length < n && Date.now() - start < timeoutMs) {
+    await new Promise((r) => setTimeout(r, 50));
   }
 }
 
@@ -227,13 +235,7 @@ describe("Live mode SSE", () => {
     });
 
     // Wait for initial event
-    const waitForCount = async (n: number, timeoutMs: number) => {
-      const start = Date.now();
-      while (events.length < n && Date.now() - start < timeoutMs) {
-        await new Promise((r) => setTimeout(r, 50));
-      }
-    };
-    await waitForCount(1, 5_000);
+    await waitForCount(events, 1, 5_000);
     expect(events.length).toBeGreaterThanOrEqual(1);
     expect(events[0].type).toBe("session");
     const initialScenes = events[0].session.scenes.length;
@@ -260,7 +262,7 @@ describe("Live mode SSE", () => {
     await appendFile(jsonlPath, `${newLines.join("\n")}\n`, "utf-8");
 
     // Wait for delta event (debounce is 100ms so allow generous timeout)
-    await waitForCount(2, 5_000);
+    await waitForCount(events, 2, 5_000);
     await collect;
 
     expect(events.length).toBeGreaterThanOrEqual(2);
@@ -287,14 +289,7 @@ describe("Live mode SSE", () => {
       if (err?.name !== "AbortError") throw err;
     });
 
-    const waitForCount = async (n: number, timeoutMs: number) => {
-      const start = Date.now();
-      while (events.length < n && Date.now() - start < timeoutMs) {
-        await new Promise((r) => setTimeout(r, 50));
-      }
-    };
-
-    await waitForCount(1, 5_000);
+    await waitForCount(events, 1, 5_000);
     expect(events.length).toBeGreaterThanOrEqual(1);
     expect(events[0].type).toBe("session");
     expect(events[0].state).toBe("unknown");
@@ -325,7 +320,7 @@ describe("Live mode SSE", () => {
     ];
     await appendFile(codexJsonlPath, `${codexNewLines.join("\n")}\n`, "utf-8");
 
-    await waitForCount(2, 5_000);
+    await waitForCount(events, 2, 5_000);
     await collect;
 
     expect(events.length).toBeGreaterThanOrEqual(2);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -34,6 +34,7 @@ import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
+import { parseCodexLines } from "./providers/codex/parser.js";
 import { resolveCursorLiveWatchPaths } from "./providers/cursor/sqlite-reader.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
@@ -1371,7 +1372,7 @@ export async function startServer(
   });
 
   // --- Live: stream a session as it's being written to disk ---
-  // For Claude (JSONL) we tail each shard at the byte level — fs.read() at
+  // For append-only JSONL providers we tail each shard at the byte level — fs.read() at
   // the cached offset, accumulate complete lines, hold an incomplete trailing
   // fragment until the next newline arrives. Other providers fall back to
   // full provider.parse() on every change (their formats aren't pure JSONL).
@@ -1564,11 +1565,12 @@ export async function startServer(
         return cached.lines;
       };
 
-      // Claude is the only provider with a pure-JSONL transcript that's
-      // safe to incrementally tail. Cursor / Codex / Cowork stay on full
-      // provider.parse() each tick — their formats aren't append-only or
-      // need provider-specific decoding (SQLite, encoded blobs, etc.).
-      const isClaudeJsonl = isClaudeProvider;
+      // Claude Code and Codex both persist append-only JSONL transcripts.
+      // Cursor / Cowork stay on full provider.parse() each tick — their
+      // formats aren't append-only or need provider-specific decoding
+      // (SQLite, encoded blobs, etc.).
+      const isCodexProvider = providerName === "codex";
+      const isJsonlLiveProvider = isClaudeProvider || isCodexProvider;
 
       const buildAndSend = async () => {
         if (aborted) return;
@@ -1595,7 +1597,7 @@ export async function startServer(
           ensureWatchersFor(paths);
           await ensureCursorDbWatchersFor(info);
           let parsed;
-          if (isClaudeJsonl) {
+          if (isJsonlLiveProvider) {
             // Tail-based fast path. Concat already-cached lines from every
             // shard (filePaths is sorted chronologically by mergeSameSessions)
             // and parse them as one stream — the parser handles cross-shard
@@ -1606,7 +1608,9 @@ export async function startServer(
               const lines = await tailReadJsonl(fp);
               allLines.push(...lines);
             }
-            parsed = await parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] });
+            parsed = isClaudeProvider
+              ? await parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] })
+              : parseCodexLines(allLines, info, paths);
           } else {
             parsed = await provider.parse(paths, info);
           }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1439,6 +1439,8 @@ export async function startServer(
       // the existing always-live UI rather than misreporting "stopped".
       const isClaudeProvider = providerName === "claude-code";
       const isCursorProvider = providerName === "cursor";
+      const isCodexProvider = providerName === "codex";
+      const isJsonlLiveProvider = isClaudeProvider || isCodexProvider;
       let lastLiveState: LiveSessionState = isClaudeProvider ? "busy" : "unknown";
       let cursorDbWatchAttached = false;
       const cursorDbWatchedSessionIds = new Set<string>();
@@ -1565,13 +1567,6 @@ export async function startServer(
         return cached.lines;
       };
 
-      // Claude Code and Codex both persist append-only JSONL transcripts.
-      // Cursor / Cowork stay on full provider.parse() each tick — their
-      // formats aren't append-only or need provider-specific decoding
-      // (SQLite, encoded blobs, etc.).
-      const isCodexProvider = providerName === "codex";
-      const isJsonlLiveProvider = isClaudeProvider || isCodexProvider;
-
       const buildAndSend = async () => {
         if (aborted) return;
         if (inFlight) {
@@ -1634,6 +1629,8 @@ export async function startServer(
           // the latest session metadata. This is the only state read tied to
           // file changes — the standalone 2s poller below catches busy↔idle
           // and idle→stopped transitions that don't touch the JSONL.
+          // Codex has no sidecar state file, so it intentionally remains
+          // "unknown" and keeps the viewer's always-live UI.
           if (isClaudeProvider) {
             lastLiveState = await readClaudeSessionState(sessionId);
           }


### PR DESCRIPTION
## Summary

Adds Codex support to the live-mode SSE tail path now that live mode has landed on `main`.

- Treats Codex rollouts as append-only JSONL for `/api/live`, sharing the byte-level tail cache with Claude Code.
- Parses tailed Codex lines with the existing Codex parser while preserving the new Cursor DB watcher behavior from latest `main`.
- Extends the live-mode e2e fixture to cover a Codex rollout and verifies appended JSONL turns stream as updated session payloads.

## Validation

- `./node_modules/.bin/oxfmt --check packages/cli/src/server.ts e2e/live-mode.test.ts`
- `./node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json`
- `./node_modules/.bin/vitest run packages/cli/test/codex-parser.test.ts`
- `./node_modules/.bin/vitest run --config e2e/vitest.config.ts e2e/live-mode.test.ts`

Also manually smoke-tested a real local Codex session through `/api/live?provider=codex&sessionId=...` and confirmed an appended command produced a changed SSE session payload.