### PR TITLE
chore: pre-release quality sweep for 0.2.0

### DIFF
--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -33,7 +33,7 @@ interface CodexTokenSnapshot {
 }
 
 function asCodexTokenInfo(value: unknown): CodexTokenInfo | undefined {
-  if (!value || typeof value !== "object") return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   return value as CodexTokenInfo;
 }
 

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -20,6 +20,23 @@ interface ToolResult {
   durationMs?: number;
 }
 
+interface CodexTokenInfo {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+}
+
+interface CodexTokenSnapshot {
+  timestamp?: string;
+  total?: CodexTokenInfo;
+  last?: CodexTokenInfo;
+}
+
+function asCodexTokenInfo(value: unknown): CodexTokenInfo | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  return value as CodexTokenInfo;
+}
+
 export async function parseCodexSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
@@ -55,7 +72,7 @@ export function parseCodexLines(
   const compactions: Compaction[] = [];
   const tools = new Map<string, PendingTool>();
   const toolResults = new Map<string, ToolResult>();
-  const tokenSnapshots: Array<{ timestamp?: string; total?: any; last?: any }> = [];
+  const tokenSnapshots: CodexTokenSnapshot[] = [];
   const mcpServersUsed = new Set<string>();
   const skillsUsed = new Set<string>();
   const gitBranches: string[] = [];
@@ -127,8 +144,8 @@ export function parseCodexLines(
       if (p.type === "token_count") {
         tokenSnapshots.push({
           timestamp: obj.timestamp,
-          total: p.info?.total_token_usage,
-          last: p.info?.last_token_usage,
+          total: asCodexTokenInfo(p.info?.total_token_usage),
+          last: asCodexTokenInfo(p.info?.last_token_usage),
         });
         continue;
       }
@@ -425,9 +442,7 @@ function durationToMs(duration: any): number | undefined {
   return ms > 0 ? ms : undefined;
 }
 
-function tokenUsageFromSnapshots(
-  snapshots: Array<{ total?: any; last?: any }>,
-): TokenUsage | undefined {
+function tokenUsageFromSnapshots(snapshots: CodexTokenSnapshot[]): TokenUsage | undefined {
   const latest = [...snapshots].toReversed().find((s) => s.total)?.total;
   if (!latest) return undefined;
   const input = latest.input_tokens || 0;
@@ -440,11 +455,7 @@ function tokenUsageFromSnapshots(
   };
 }
 
-function buildCodexTurnStats(
-  turns: ParsedTurn[],
-  snapshots: Array<{ timestamp?: string; last?: any }>,
-  model?: string,
-) {
+function buildCodexTurnStats(turns: ParsedTurn[], snapshots: CodexTokenSnapshot[], model?: string) {
   const userTurns = turns.filter((t) => t.role === "user");
   const usable = snapshots.filter((s) => s.last);
   return userTurns.map((turn, i) => {

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -96,6 +96,7 @@ function closeCachedSqlJsDb(): void {
     // ignore — we're discarding the reference next anyway
   }
 }
+
 let cachedStoreDbIndex: Map<string, StoreDbIndexEntry> | null = null;
 const resolvedProjectRootCache = new Map<string, Promise<string | null>>();
 const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v3";

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -84,6 +84,18 @@ interface GlobalStateDiscoveryCache {
 }
 
 let cachedGlobalStateDb: CachedGlobalStateDb | null = null;
+
+// Releasing a sql.js Database can throw if the underlying memory was already
+// freed (e.g. by a previous close() in a refresh path). Swallow defensively —
+// we drop the cache slot either way.
+function closeCachedSqlJsDb(): void {
+  if (cachedGlobalStateDb?.backend !== "sqljs") return;
+  try {
+    cachedGlobalStateDb.db.close();
+  } catch {
+    // ignore — we're discarding the reference next anyway
+  }
+}
 let cachedStoreDbIndex: Map<string, StoreDbIndexEntry> | null = null;
 const resolvedProjectRootCache = new Map<string, Promise<string | null>>();
 const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v3";
@@ -265,7 +277,7 @@ async function openGlobalStateDb(): Promise<CachedGlobalStateDb | null> {
   }
 
   if (await canUseSqliteCli(dbPath)) {
-    if (cachedGlobalStateDb?.backend === "sqljs") cachedGlobalStateDb.db.close();
+    closeCachedSqlJsDb();
     cachedGlobalStateDb = {
       dbPath,
       backend: "sqlite-cli",
@@ -287,7 +299,7 @@ async function openGlobalStateDb(): Promise<CachedGlobalStateDb | null> {
   if (!dbBuffer) return null;
 
   const db = new SQL.Database(dbBuffer);
-  if (cachedGlobalStateDb?.backend === "sqljs") cachedGlobalStateDb.db.close();
+  closeCachedSqlJsDb();
   cachedGlobalStateDb = {
     dbPath,
     backend: "sqljs",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1719,12 +1719,19 @@ export async function startServer(
       const stateInterval = isClaudeProvider
         ? setInterval(async () => {
             if (aborted) return;
-            const next = await readClaudeSessionState(sessionId);
-            if (next === lastLiveState) return;
-            lastLiveState = next;
-            await stream
-              .writeSSE({ data: JSON.stringify({ type: "state", state: next }) })
-              .catch(() => {});
+            try {
+              const next = await readClaudeSessionState(sessionId);
+              if (next === lastLiveState) return;
+              lastLiveState = next;
+              await stream
+                .writeSSE({ data: JSON.stringify({ type: "state", state: next }) })
+                .catch(() => {});
+            } catch {
+              // Transient state-file read failures shouldn't surface as an
+              // unhandled rejection — the next tick will retry. Worst case the
+              // viewer keeps showing the previous state, which is correct
+              // until we observe a transition.
+            }
           }, 2_000)
         : null;
 


### PR DESCRIPTION
## Summary

A small, targeted quality sweep before cutting `v0.2.0`. Audited PRs #212–#228 (everything since the 0.1.8 bump in #211) and pulled three real defensive fixes out of that review — everything else either turned out to be a false positive on closer reading or was already covered by the existing E2E live-mode tests.

### Fixes

- **`packages/cli/src/providers/cursor/sqlite-reader.ts`** — Wrap cached `sql.js` `db.close()` calls in try/catch via a tiny `closeCachedSqlJsDb()` helper. sql.js can throw when releasing memory that was already freed by a prior close in the refresh path; we drop the cache slot regardless, so swallowing is safe and avoids a crash during Cursor session discovery.
- **`packages/cli/src/server.ts`** — Wrap the Claude live-mode `stateInterval` async body in try/catch. A transient `~/.claude/sessions/<pid>.json` read failure was reaching the event loop as an unhandled promise rejection; the next 2s tick retries on its own and the viewer keeps showing the previous state, which is correct until we observe a transition.
- **`packages/cli/src/providers/codex/parser.ts`** — Replace `total?: any; last?: any` on `tokenSnapshots` with a typed `CodexTokenSnapshot` shape, and route token info through an `asCodexTokenInfo()` guard before consumption. Removes two of the lingering `any` shapes added by the recent Codex provider PRs (#205, #226).

### What was looked at and intentionally not changed

- Live SSE rebuild loop — `void buildAndSend()` already has try/catch + finally inside; the ping/poll/rediscover intervals are sync-wrapped.
- Codex `inputForResponseItem` malformed-JSON path — already returns `{ value }` on parse failure, no silent loss.
- Cursor `resolveCursorLiveWatchPaths` export — verified it's only consumed by `server.ts`, but it's already exported for the tests covering Cursor live watch attachment.
- Viewer bundle is at 810 KB, just over the 800 KB soft target. That's a separate optimization pass — out of scope for a release-prep sweep.

## Test plan

- [x] `pnpm lint:check` — clean
- [x] `pnpm typecheck` — clean (all 4 projects)
- [x] `pnpm test` — 701 (CLI) + 130 (viewer) passing, 1 skipped
- [x] `pnpm build && pnpm test:e2e` — 73 E2E passing across 7 files (live-mode, generated-html, editor-server, cli-smoke, cloud-auth, auth-worker, file-storage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)