### PR TITLE
chore(cli): bump version to 0.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Bumps `packages/cli/package.json` from `0.1.8` → `0.2.0` for the next minor release.
- Verified `node packages/cli/dist/index.js --version` prints `0.2.0` after `pnpm --filter vibe-replay build`.

The 0.1.8 → 0.2.0 window covers live mode (#215, #225, #226) streaming Claude Code, Cursor, and Codex sessions over SSE; the cloud-share picker + standalone `share` command (#210); the Codex provider (#205); the Projects Work Map dashboard refresh (#191); plus assorted Cursor parity fixes and the pre-release quality sweep (#229).

## Test plan

- [x] `node packages/cli/dist/index.js --version` → `0.2.0`
- [x] CI lint / test / build / e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)