### PR TITLE
chore(cloudflare): drop redundant `as any` in profile config sanitizer

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1440,7 +1440,7 @@ app.post("/api/insights/profile", async (c) => {
   // Sanitize: only allow boolean values
   for (const key of Object.keys(config) as (keyof ProfileConfig)[]) {
     if (typeof config[key] !== "boolean") {
-      (config as any)[key] = DEFAULT_PROFILE_CONFIG[key];
+      config[key] = DEFAULT_PROFILE_CONFIG[key];
     }
   }
 


### PR DESCRIPTION
## Summary

- Removes an unnecessary `(config as any)[key] = ...` cast in the profile-config sanitization loop in `cloudflare/src/worker.ts`.
- Net diff: -1 +1 (single line).

## Motivation

`config: ProfileConfig` and `ProfileConfig = typeof DEFAULT_PROFILE_CONFIG` whose fields are all `boolean`. With `key: keyof ProfileConfig`, both `config[key]` and `DEFAULT_PROFILE_CONFIG[key]` are typed as `boolean`, so direct assignment compiles cleanly under strict mode — the `as any` cast was redundant. Pure type-level cleanup, no runtime behavior change.

## Test plan

- [x] `pnpm test` — 830 unit tests green
- [x] `pnpm lint:check` — 0 warnings / 0 errors
- [x] `npx tsc --noEmit -p cloudflare/tsconfig.json` — clean (was clean before)
- [x] `pnpm build` — success (CLI 449.41 KB, viewer 810.83 kB unchanged from main)
- [x] `pnpm test:e2e` — 33 tests passed

> 🤖 Daily auto-quality routine. Self-merged after AI review.