### PR TITLE
chore(cursor): drop two redundant `as any` casts in cursor parsers

### DIFF
--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -182,7 +182,7 @@ async function parseCursorJsonl(
               result: extractToolResultText(block),
               timestamp: typeof obj.timestamp === "string" ? obj.timestamp : undefined,
             });
-            if ((block as any).is_error) toolErrors.set(toolUseId, true);
+            if (block.is_error) toolErrors.set(toolUseId, true);
             const images = extractToolResultImages(block);
             if (images.length > 0) toolImages.set(toolUseId, images);
           }

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2114,7 +2114,7 @@ function extractBubbleModelName(
 
 function extractBubbleDurationMs(bubble: Record<string, any>): number | undefined {
   const thinkingMs = toPositiveMs(bubble.thinkingDurationMs);
-  const toolMs = extractToolExecutionTimeMs((bubble.toolFormerData as any)?.result);
+  const toolMs = extractToolExecutionTimeMs(bubble.toolFormerData?.result);
   if (thinkingMs !== undefined && toolMs !== undefined) return thinkingMs + toolMs;
   return thinkingMs ?? toolMs;
 }


### PR DESCRIPTION
## Summary

- Remove two `as any` casts that were no-ops because the receiver was already typed `any`.
- Net: -2 +2 across two files in `packages/cli/src/providers/cursor/`.

## Motivation

Both call sites cast a value to `any` before reading a property, but the value already had `any` (or `any` via `Record<string, any>`) flowing in:

- `parser.ts:185` — `block` comes from a `JSON.parse` line that flows in as `any`, so `(block as any).is_error` and `block.is_error` are identical.
- `sqlite-reader.ts:2117` — `bubble: Record<string, any>`, so `bubble.toolFormerData` is `any` already; `(bubble.toolFormerData as any)?.result` is the same as `bubble.toolFormerData?.result`.

Pure type-redundancy cleanup, no runtime behavior change.

## Test plan

- [x] `pnpm test` — all green (CLI + viewer)
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm build` — succeeds, viewer size unchanged (810.83 KB, same as main)
- [x] `pnpm test:e2e` — all green (33 passed)

> 🤖 Daily auto-quality routine. Self-merged after AI review.