### PR TITLE
refactor(cli): extract getDevViewerOpts helper for DEV_MENU dev-server URL

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -124,6 +124,11 @@ async function runGitHubExport(
 }
 
 const DEV_MENU_ENABLED = process.env.VIBE_REPLAY_DEV_MENU === "1";
+
+function getDevViewerOpts(): { externalViewerUrl: string } | undefined {
+  if (!DEV_MENU_ENABLED) return undefined;
+  return { externalViewerUrl: `http://localhost:${process.env.VIBE_VIEWER_PORT || "5173"}` };
+}
 // Bumped v2 → v3 alongside the Cowork sessionId fix (see server.ts
 // sourcesCacheKey comment). Old caches carry the wrong Cowork identity and
 // must be thrown out so the next discovery sweep writes a correct one.
@@ -212,12 +217,7 @@ program
 
     // --dashboard: open Dashboard directly
     if (opts.dashboard) {
-      await startDashboard(
-        replayBaseDir,
-        DEV_MENU_ENABLED
-          ? { externalViewerUrl: `http://localhost:${process.env.VIBE_VIEWER_PORT || "5173"}` }
-          : undefined,
-      );
+      await startDashboard(replayBaseDir, getDevViewerOpts());
       return;
     }
 
@@ -255,12 +255,7 @@ program
       });
 
       if (topChoice === "dashboard") {
-        await startDashboard(
-          replayBaseDir,
-          DEV_MENU_ENABLED
-            ? { externalViewerUrl: `http://localhost:${process.env.VIBE_VIEWER_PORT || "5173"}` }
-            : undefined,
-        );
+        await startDashboard(replayBaseDir, getDevViewerOpts());
         return;
       }
 
@@ -627,9 +622,7 @@ program
     } else if (target === "editor") {
       await startServer(join(home, ".vibe-replay"), {
         openSlug: slug,
-        externalViewerUrl: DEV_MENU_ENABLED
-          ? `http://localhost:${process.env.VIBE_VIEWER_PORT || "5173"}`
-          : undefined,
+        ...getDevViewerOpts(),
       });
       return; // startServer blocks until Ctrl+C
     } else if (target === "cloud") {


### PR DESCRIPTION
## Summary

- The pattern `DEV_MENU_ENABLED ? { externalViewerUrl: \`http://localhost:${process.env.VIBE_VIEWER_PORT || "5173"}\` } : undefined` was duplicated in 3 places in `packages/cli/src/index.ts` (the two `startDashboard` call sites and the `startServer` editor branch).
- Extract a single `getDevViewerOpts()` helper next to `DEV_MENU_ENABLED` returning `{ externalViewerUrl: string } | undefined`.
- Net change: +8 / -15 (one file).

## Motivation

Same expression repeated three times — collapsing into one helper means future tweaks (port, host, env-var name) need to change in only one place. Mechanical refactor with no behavior change:

- The two `startDashboard` sites pass the helper result directly — same shape as before.
- The `startServer` site spreads the helper result (`...getDevViewerOpts()`). When `DEV_MENU_ENABLED=false`, the original passed `externalViewerUrl: undefined`; the spread version omits the key. `startServer`/`startDashboard` only do `opts?.externalViewerUrl` truthiness checks (server.ts:846, 3220, 3251), so the two are observably identical.

## Test plan

- [x] `pnpm test` — 700 + 130 tests passing, 0 failures
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — succeeds (CLI 449KB, viewer 810KB unchanged)
- [x] `pnpm test:e2e` — 33 passed, 40 skipped (skipped require credentials)

> 🤖 Daily auto-quality routine. Self-merged after AI review.