### PR TITLE
[codex] Cover cloud API storage flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+      - run: pnpm test:cloudflare
 
   build:
     runs-on: ubuntu-latest

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "vitest run --config vitest.config.ts",
     "deploy": "wrangler deploy",
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply vibe-replay-db --local",
@@ -17,7 +18,10 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260501.1",
+    "@types/node": "^22.10.0",
     "drizzle-kit": "^0.31.0",
+    "miniflare": "^4.20260430.0",
+    "vitest": "^4.0.18",
     "wrangler": "^4.87.0"
   }
 }

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -44,6 +44,10 @@ type Env = AuthEnv & {
   GITHUB_APP_ID?: string;
   GITHUB_APP_PRIVATE_KEY?: string;
   GITHUB_APP_INSTALLATION_ID?: string;
+  /** Test-only auth bypass. Honored only for localhost Better Auth URLs. */
+  TEST_AUTH_USER_ID?: string;
+  TEST_AUTH_USER_EMAIL?: string;
+  TEST_AUTH_USER_NAME?: string;
 };
 
 type HonoEnv = { Bindings: Env };
@@ -393,6 +397,16 @@ fetch('http://127.0.0.1:${encodeURIComponent(port)}/callback',{method:'POST',hea
 async function requireAuth(
   c: Context<HonoEnv>,
 ): Promise<{ userId: string; user: { id: string; name: string; email: string } } | Response> {
+  if (isDev(c.env) && c.env.TEST_AUTH_USER_ID && c.req.header("x-vibe-replay-test-auth") === "1") {
+    const id = c.req.header("x-vibe-replay-test-user-id") || c.env.TEST_AUTH_USER_ID;
+    const user = {
+      id,
+      name: c.env.TEST_AUTH_USER_NAME || "Test User",
+      email: c.env.TEST_AUTH_USER_EMAIL || `${id}@example.com`,
+    };
+    return { userId: user.id, user };
+  }
+
   const auth = createAuth(c.env);
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   if (!session) {
@@ -2138,15 +2152,27 @@ export default {
     // Cron deletes R2 objects after grace period, zeros sizeBytes to free quota.
     // D1 rows are kept permanently for history/analytics.
     const GRACE_DAYS = 7;
+    const cleanupCutoff = new Date(Date.now() - GRACE_DAYS * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    const expiredReplayFilter = sql`
+      ${cloudReplays.expiresAt} IS NOT NULL
+      AND ${cloudReplays.expiresAt} < ${cleanupCutoff}
+      AND ${cloudReplays.sizeBytes} > 0
+    `;
+    const expiredFileFilter = sql`
+      ${userFiles.expiresAt} IS NOT NULL
+      AND ${userFiles.expiresAt} < ${cleanupCutoff}
+      AND ${userFiles.sizeBytes} > 0
+    `;
 
     // Clean expired cloud replays
     for (;;) {
       const expired = await db
         .select({ id: cloudReplays.id })
         .from(cloudReplays)
-        .where(
-          sql`${cloudReplays.expiresAt} IS NOT NULL AND ${cloudReplays.expiresAt} < datetime('now', '-${GRACE_DAYS} days') AND ${cloudReplays.sizeBytes} > 0`,
-        )
+        .where(expiredReplayFilter)
         .limit(BATCH);
 
       if (expired.length === 0) break;
@@ -2168,9 +2194,7 @@ export default {
       const expired = await db
         .select({ id: userFiles.id, contentType: userFiles.contentType })
         .from(userFiles)
-        .where(
-          sql`${userFiles.expiresAt} IS NOT NULL AND ${userFiles.expiresAt} < datetime('now', '-${GRACE_DAYS} days') AND ${userFiles.sizeBytes} > 0`,
-        )
+        .where(expiredFileFilter)
         .limit(BATCH);
 
       if (expired.length === 0) break;

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -1,0 +1,395 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import worker from "../src/worker";
+
+const TEST_USER_ID = "user-test-1";
+const OTHER_USER_ID = "user-test-2";
+
+interface TestEnv {
+  ASSETS: Fetcher;
+  DB: D1Database;
+  REPLAY_BUCKET: R2Bucket;
+  BETTER_AUTH_SECRET: string;
+  BETTER_AUTH_URL: string;
+  GITHUB_CLIENT_ID: string;
+  GITHUB_CLIENT_SECRET: string;
+  TEST_AUTH_USER_ID: string;
+  TEST_AUTH_USER_EMAIL: string;
+  TEST_AUTH_USER_NAME: string;
+}
+
+interface TestExecutionContext extends ExecutionContext {
+  promises: Promise<unknown>[];
+}
+
+let mf: Miniflare;
+let env: TestEnv;
+
+function createCtx(): TestExecutionContext {
+  const promises: Promise<unknown>[] = [];
+  return {
+    promises,
+    waitUntil(promise) {
+      promises.push(Promise.resolve(promise));
+    },
+    passThroughOnException() {},
+    props: {},
+  } as TestExecutionContext;
+}
+
+async function waitOnCtx(ctx: TestExecutionContext) {
+  await Promise.all(ctx.promises);
+}
+
+async function dispatch(path: string, init: RequestInit = {}, userId = TEST_USER_ID) {
+  const headers = new Headers(init.headers);
+  headers.set("x-vibe-replay-test-auth", "1");
+  headers.set("x-vibe-replay-test-user-id", userId);
+  const ctx = createCtx();
+  const response = await worker.fetch(
+    new Request(`http://localhost${path}`, { ...init, headers }),
+    env,
+    ctx,
+  );
+  await waitOnCtx(ctx);
+  return response;
+}
+
+async function applyMigrations(db: D1Database) {
+  const migrationsDir = join(process.cwd(), "drizzle");
+  const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
+  for (const file of files) {
+    const sql = await readFile(join(migrationsDir, file), "utf-8");
+    const statements = sql
+      .split("--> statement-breakpoint")
+      .map((statement) => statement.trim())
+      .filter(Boolean);
+    for (const statement of statements) {
+      await db.prepare(statement).run();
+    }
+  }
+}
+
+async function resetDb() {
+  await env.DB.exec("PRAGMA foreign_keys = OFF");
+  for (const table of [
+    "cloud_replays",
+    "user_files",
+    "daily_insights",
+    "insight_profiles",
+    "account",
+    "session",
+    "verification",
+    "replays",
+    "user",
+  ]) {
+    await env.DB.exec(`DELETE FROM ${table}`);
+  }
+  await env.DB.exec("PRAGMA foreign_keys = ON");
+  await env.DB.prepare(
+    `INSERT INTO user (id, name, email, email_verified) VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+  )
+    .bind(
+      TEST_USER_ID,
+      "Test User",
+      "test@example.com",
+      1,
+      OTHER_USER_ID,
+      "Other User",
+      "other@example.com",
+      1,
+    )
+    .run();
+}
+
+async function clearR2() {
+  const listed = await env.REPLAY_BUCKET.list();
+  await Promise.all(listed.objects.map((object) => env.REPLAY_BUCKET.delete(object.key)));
+}
+
+function sampleReplay() {
+  return {
+    meta: {
+      sessionId: "session-cloud-api-e2e",
+      provider: "claude-code",
+      title: "Cloud API E2E",
+      model: "claude-sonnet-4-5",
+      stats: {
+        sceneCount: 2,
+        userPrompts: 1,
+        toolCalls: 1,
+        durationMs: 1234,
+        costEstimate: 0.42,
+      },
+    },
+    scenes: [
+      { type: "user-prompt", content: "Cover the cloud API." },
+      { type: "text-response", content: "Done." },
+    ],
+  };
+}
+
+async function uploadReplay(visibility = "unlisted") {
+  const response = await dispatch("/api/cloud-replays", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ replay: sampleReplay(), visibility }),
+  });
+  expect(response.status).toBe(200);
+  return (await response.json()) as { id: string; url: string; expiresAt: string };
+}
+
+describe("Cloud API integration", () => {
+  beforeAll(async () => {
+    mf = new Miniflare({
+      // The real worker is imported above. Miniflare only provides local D1/R2 bindings here.
+      script: "export default { fetch() { return new Response('ok'); } }",
+      modules: true,
+      compatibilityDate: "2024-12-01",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: ["DB"],
+      r2Buckets: ["REPLAY_BUCKET"],
+      bindings: {
+        BETTER_AUTH_SECRET: "test-secret",
+        BETTER_AUTH_URL: "http://localhost",
+        GITHUB_CLIENT_ID: "test-client",
+        GITHUB_CLIENT_SECRET: "test-secret",
+        TEST_AUTH_USER_ID: TEST_USER_ID,
+        TEST_AUTH_USER_EMAIL: "test@example.com",
+        TEST_AUTH_USER_NAME: "Test User",
+      },
+    });
+    env = {
+      ...(await mf.getBindings()),
+      ASSETS: {
+        fetch: async () => new Response("Not Found", { status: 404 }),
+      } as unknown as Fetcher,
+    } as TestEnv;
+    await applyMigrations(env.DB);
+  });
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  beforeEach(async () => {
+    await resetDb();
+    await clearR2();
+  });
+
+  it("uploads, reads, lists, updates, and deletes an R2-backed replay", async () => {
+    const uploaded = await uploadReplay();
+    expect(uploaded.id).toMatch(/^[a-zA-Z0-9_-]{12}$/);
+    expect(uploaded.url).toBe(`http://localhost/r/${uploaded.id}`);
+
+    const read = await dispatch(`/api/cloud-replays/${uploaded.id}`);
+    expect(read.status).toBe(200);
+    expect(read.headers.get("content-type")).toContain("application/json");
+    const readBody = (await read.json()) as ReturnType<typeof sampleReplay>;
+    expect(readBody.meta.sessionId).toBe("session-cloud-api-e2e");
+    expect(readBody.scenes[0]).toMatchObject({ type: "user-prompt" });
+
+    const list = await dispatch("/api/cloud-replays");
+    expect(list.status).toBe(200);
+    const listBody = (await list.json()) as {
+      replays: { id: string }[];
+      storage: { used: number };
+    };
+    expect(listBody.replays.map((replay) => replay.id)).toEqual([uploaded.id]);
+    expect(listBody.storage.used).toBeGreaterThan(0);
+
+    const patch = await dispatch(`/api/cloud-replays/${uploaded.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ visibility: "private" }),
+    });
+    expect(patch.status).toBe(200);
+    await expect(patch.json()).resolves.toMatchObject({ ok: true, visibility: "private" });
+
+    const deleted = await dispatch(`/api/cloud-replays/${uploaded.id}`, { method: "DELETE" });
+    expect(deleted.status).toBe(200);
+    expect(await env.REPLAY_BUCKET.get(`replays/${uploaded.id}.json`)).toBeNull();
+  });
+
+  it("hides private replays from other authenticated users", async () => {
+    const uploaded = await uploadReplay("private");
+
+    const otherRead = await dispatch(`/api/cloud-replays/${uploaded.id}`, {}, OTHER_USER_ID);
+    expect(otherRead.status).toBe(404);
+
+    const ownerRead = await dispatch(`/api/cloud-replays/${uploaded.id}`);
+    expect(ownerRead.status).toBe(200);
+  });
+
+  it("uploads and serves SVG files through the short file URL", async () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20"><text x="0" y="15">ok</text></svg>`;
+    const upload = await dispatch("/api/files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: btoa(svg),
+        contentType: "image/svg+xml",
+        filename: "preview.svg",
+        visibility: "unlisted",
+      }),
+    });
+    expect(upload.status).toBe(200);
+    const body = (await upload.json()) as { id: string; url: string; sizeBytes: number };
+    expect(body.url).toBe(`http://localhost/f/${body.id}`);
+    expect(body.sizeBytes).toBeGreaterThan(0);
+
+    const file = await dispatch(`/f/${body.id}.svg`);
+    expect(file.status).toBe(200);
+    expect(file.headers.get("content-type")).toContain("image/svg+xml");
+    expect(file.headers.get("content-security-policy")).toContain("default-src 'none'");
+    await expect(file.text()).resolves.toContain("<svg");
+
+    const files = await dispatch("/api/files");
+    expect(files.status).toBe(200);
+    await expect(files.json()).resolves.toMatchObject({ files: [{ id: body.id }] });
+
+    const deleted = await dispatch(`/api/files/${body.id}`, { method: "DELETE" });
+    expect(deleted.status).toBe(200);
+    expect(await env.REPLAY_BUCKET.get(`files/${body.id}.svg`)).toBeNull();
+  });
+
+  it("syncs daily insights and returns aggregate summary data", async () => {
+    const sync = await dispatch("/api/insights/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        machineId: "machine-a",
+        machineName: "Work Laptop",
+        days: [
+          {
+            date: "2026-05-01",
+            sessions: 2,
+            prompts: 5,
+            toolCalls: 12,
+            edits: 3,
+            durationMs: 10_000,
+            cost: 1.25,
+            projects: JSON.stringify({
+              "/repo": {
+                sessions: 2,
+                cost: 1.25,
+                prompts: 5,
+                toolCalls: 12,
+                edits: 3,
+                durationMs: 10_000,
+              },
+            }),
+            models: JSON.stringify({ "claude-sonnet-4-5": { sessions: 2, cost: 1.25 } }),
+            providers: JSON.stringify({ "claude-code": { sessions: 2, cost: 1.25 } }),
+          },
+        ],
+      }),
+    });
+    expect(sync.status).toBe(200);
+    await expect(sync.json()).resolves.toEqual({ synced: 1 });
+
+    const dates = await dispatch("/api/insights/dates?machineId=machine-a");
+    expect(dates.status).toBe(200);
+    await expect(dates.json()).resolves.toEqual({ dates: ["2026-05-01"] });
+
+    const summary = await dispatch("/api/insights/summary");
+    expect(summary.status).toBe(200);
+    await expect(summary.json()).resolves.toMatchObject({
+      totalSessions: 2,
+      totalProjects: 1,
+      totalPrompts: 5,
+      totalToolCalls: 12,
+      totalEdits: 3,
+      providers: { "claude-code": 2 },
+      models: { "claude-sonnet-4-5": 2 },
+      sessionsPerDay: { "2026-05-01": 2 },
+      topProjects: [{ project: "/repo", sessions: 2 }],
+    });
+  });
+
+  it("scheduled cleanup removes expired R2 objects and frees quota", async () => {
+    const replay = await uploadReplay();
+    const fileUpload = await dispatch("/api/files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: btoa("GIF89a-test"),
+        contentType: "image/gif",
+        filename: "preview.gif",
+      }),
+    });
+    expect(fileUpload.status).toBe(200);
+    const file = (await fileUpload.json()) as { id: string };
+
+    await env.DB.prepare(
+      "UPDATE cloud_replays SET expires_at = datetime('now', '-15 days') WHERE id = ?",
+    )
+      .bind(replay.id)
+      .run();
+    await env.DB.prepare(
+      "UPDATE user_files SET expires_at = datetime('now', '-15 days') WHERE id = ?",
+    )
+      .bind(file.id)
+      .run();
+
+    await worker.scheduled(
+      { scheduledTime: Date.now(), cron: "0 */6 * * *", noRetry() {} } as ScheduledEvent,
+      env,
+    );
+
+    expect(await env.REPLAY_BUCKET.get(`replays/${replay.id}.json`)).toBeNull();
+    expect(await env.REPLAY_BUCKET.get(`files/${file.id}.gif`)).toBeNull();
+
+    const replayRow = await env.DB.prepare("SELECT size_bytes FROM cloud_replays WHERE id = ?")
+      .bind(replay.id)
+      .first<{ size_bytes: number }>();
+    const fileRow = await env.DB.prepare("SELECT size_bytes FROM user_files WHERE id = ?")
+      .bind(file.id)
+      .first<{ size_bytes: number }>();
+    expect(replayRow?.size_bytes).toBe(0);
+    expect(fileRow?.size_bytes).toBe(0);
+  });
+
+  it("ignores the test auth bypass outside localhost dev mode", async () => {
+    const prodMf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok'); } }",
+      modules: true,
+      compatibilityDate: "2024-12-01",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: ["DB"],
+      r2Buckets: ["REPLAY_BUCKET"],
+      bindings: {
+        BETTER_AUTH_SECRET: "test-secret",
+        BETTER_AUTH_URL: "https://vibe-replay.com",
+        GITHUB_CLIENT_ID: "test-client",
+        GITHUB_CLIENT_SECRET: "test-secret",
+        TEST_AUTH_USER_ID: TEST_USER_ID,
+      },
+    });
+
+    try {
+      const prodEnv = {
+        ...(await prodMf.getBindings()),
+        ASSETS: {
+          fetch: async () => new Response("Not Found", { status: 404 }),
+        } as unknown as Fetcher,
+      } as TestEnv;
+      const ctx = createCtx();
+      const response = await worker.fetch(
+        new Request("https://vibe-replay.com/api/cloud-replays", {
+          headers: { "x-vibe-replay-test-auth": "1" },
+        }),
+        prodEnv,
+        ctx,
+      );
+      await waitOnCtx(ctx);
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    } finally {
+      await prodMf.dispose();
+    }
+  });
+});

--- a/cloudflare/vitest.config.ts
+++ b/cloudflare/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    hookTimeout: 30_000,
+    testTimeout: 30_000,
+    sequence: { concurrent: false },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:dashboard": "node scripts/dev.mjs -d",
     "dev:website": "node scripts/dev-website.mjs",
     "test": "pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
+    "test:cloudflare": "pnpm --filter @vibe-replay/cloudflare test",
     "test:e2e": "vitest run --config e2e/vitest.config.ts",
     "lint": "oxlint --fix packages/ website/src cloudflare/src && oxfmt packages/ website/src cloudflare/src",
     "lint:check": "oxlint packages/ website/src cloudflare/src && oxfmt --check packages/ website/src cloudflare/src",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,18 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260501.1
         version: 4.20260501.1
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.13
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.9
+      miniflare:
+        specifier: ^4.20260430.0
+        version: 4.20260430.0
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.13)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.87.0
         version: 4.87.0(@cloudflare/workers-types@4.20260501.1)


### PR DESCRIPTION
## What changed

- Added a Cloudflare-local Vitest suite for authenticated cloud API flows using Miniflare D1/R2 bindings.
- Covered R2 replay upload/read/list/update/delete, private replay authorization, SVG file upload + `/f/:id` serving, daily insights sync/summary, and scheduled cleanup of expired replay/file objects.
- Added a localhost-only test auth bypass binding so tests can exercise authenticated endpoints without Better Auth cookies or real OAuth tokens.
- Fixed an existing scheduled cleanup D1 query bug where the grace-period date modifier was interpolated as `'-? days'`, causing D1 binding errors.
- Wired `pnpm test:cloudflare` into CI after the existing unit test job.

## Why

The previous cloud API coverage depended on real local auth state and skipped in CI, so core sharing/storage paths could regress while CI stayed green. These tests run fully locally against Miniflare bindings and do not require network login, GitHub OAuth, R2, or production D1.

## Validation

- `../node_modules/.bin/tsc --noEmit -p tsconfig.json` from `cloudflare/`
- `../node_modules/.bin/tsc --noEmit --ignoreConfig --target ES2022 --module ESNext --moduleResolution Bundler --types node,vitest,@cloudflare/workers-types --skipLibCheck --allowSyntheticDefaultImports test/cloud-api.test.ts` from `cloudflare/`
- Manual `tsx` Miniflare smoke covering replay upload/read, file upload/serve, insights sync/summary, and scheduled cleanup

Local caveat: this desktop shell has no `pnpm`, and `vitest`/`oxlint`/`oxfmt` native bindings fail to load under the Codex macOS app runtime due code-signing Team ID mismatch. CI should run the full `pnpm lint:check`, `pnpm test`, and new `pnpm test:cloudflare` path on Ubuntu.
