### PR TITLE
chore(codex): drop dynamic node:fs/promises import in state-db reader

### DIFF
--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { createInterface } from "node:readline";
@@ -216,7 +216,7 @@ async function readThreadRowsFromStateDb(): Promise<CodexThreadRow[]> {
   try {
     const mod = await import("sql.js");
     const SQL = await mod.default();
-    const dbBuffer = await import("node:fs/promises").then((fs) => fs.readFile(stateDbPath));
+    const dbBuffer = await readFile(stateDbPath);
     const db = new SQL.Database(dbBuffer);
     try {
       const result = db.exec(`


### PR DESCRIPTION
## Summary

- `readThreadRowsFromStateDb` in `packages/cli/src/providers/codex/discover.ts` was the only place using `await import("node:fs/promises").then((fs) => fs.readFile(...))` — an outlier syntax. Added `readFile` to the existing top-of-file static import and call it directly.
- Net: -1/+1 line (effectively 2 trivial line edits).

## Motivation

`node:fs/promises` is already eagerly loaded via the existing `import { readdir, stat } from "node:fs/promises"` at the top of the file, so the dynamic import provided zero lazy-load value. Every other dynamic import in the codebase uses `const { x } = await import(...)` destructuring; the `.then()` chain here was the lone exception.

Semantically equivalent: ESM module imports are cached, so `await import("node:fs/promises")` returns the same module record whose `readFile` named export points to the same function as the static `readFile` import.

## Test plan

- [x] `pnpm test` — all green (CLI 710 passed, viewer 130 passed)
- [x] `pnpm lint:check` — 0 warnings 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — clean
- [x] `pnpm build` — success (viewer 810.83 KB, unchanged from main; CLI bundle unchanged)
- [x] `pnpm test:e2e` — 33 passed (40 skipped: cloud/optional)

> 🤖 Daily auto-quality routine. Self-merged after AI review per decision tree.