### PR TITLE
docs: add live mode to README features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 - **Share & export** — GitHub Gist, animated SVG, GIF, markdown summary, or cloud upload. Secret redaction built in
 - **Sub-agent visualization** — see delegated tool calls and sub-agent trees rendered inline
 - **Comments** — leave notes on any scene. Comments persist in the HTML and travel with the replay
+- **Live mode** — `vibe-replay live` streams a running Claude Code or Codex session into the viewer, pinned to the latest turn as it lands on disk
 
 ## Supported Providers
 


### PR DESCRIPTION
## Summary

- Adds a `Live mode` bullet to the README Features list, covering the new `vibe-replay live` command that streams running sessions into the viewer.
- Corresponding feature PRs already merged: #215 (initial Claude Code live SSE) and #226 (Codex live mode compatibility).

## Why now

Live mode is a major user-facing addition (new CLI subcommand + dashboard "Watch live" button + SSE endpoint) but is currently absent from README, the website docs surface, and the supported providers section. New users browsing the README have no way to discover it.

This patch only adds one objective bullet to the existing Features list — same style and tone as the other bullets, no marketing claims.

## Files touched

- README.md (+1 / -0)

## Out of scope (intentionally)

- Did not update `website/src/pages/index.astro` or its `Features.astro` component — landing-page copy is off-limits for the auto-docs routine and should be a deliberate human edit.
- Did not add screenshots or a GIF for live mode.
- Did not rewrite the existing `Claude Code + Cursor` Features bullet, even though the README's Supported Providers table now lists more providers — kept changes additive only.

> Weekly auto-docs routine. Needs human review before merge.