### PR TITLE
refactor(codex): dedupe stripUserMessagePrefix + stripLeadingCodexContextBlocks

### DIFF
--- a/packages/cli/src/providers/codex/constants.ts
+++ b/packages/cli/src/providers/codex/constants.ts
@@ -19,3 +19,27 @@ export function isCodexToolCallType(type?: string): boolean {
     type === "image_generation_call"
   );
 }
+
+export function stripUserMessagePrefix(text: string): string {
+  const idx = text.indexOf(USER_MESSAGE_BEGIN);
+  return idx === -1 ? text : text.slice(idx + USER_MESSAGE_BEGIN.length);
+}
+
+export function stripLeadingCodexContextBlocks(text: string): string {
+  let remaining = text.trim();
+  let stripped = true;
+  while (stripped) {
+    stripped = false;
+    for (const tag of CODEX_CONTEXT_TAGS) {
+      const open = `<${tag}>`;
+      const close = `</${tag}>`;
+      if (!remaining.startsWith(open)) continue;
+      const closeIndex = remaining.indexOf(close);
+      if (closeIndex === -1) return "";
+      remaining = remaining.slice(closeIndex + close.length).trim();
+      stripped = true;
+      break;
+    }
+  }
+  return remaining;
+}

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -6,7 +6,12 @@ import { createInterface } from "node:readline";
 import { cleanPromptText } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
 import { shortenPath } from "../../utils.js";
-import { CODEX_CONTEXT_TAGS, isCodexToolCallType, USER_MESSAGE_BEGIN } from "./constants.js";
+import {
+  CODEX_CONTEXT_TAGS,
+  isCodexToolCallType,
+  stripLeadingCodexContextBlocks,
+  stripUserMessagePrefix,
+} from "./constants.js";
 
 const STATE_DB_FILENAME = "state_5.sqlite";
 
@@ -297,11 +302,6 @@ function normalizeDiscoveredUserMessage(text: string): string {
   return cleanPromptText(normalized);
 }
 
-function stripUserMessagePrefix(text: string): string {
-  const idx = text.indexOf(USER_MESSAGE_BEGIN);
-  return idx === -1 ? text : text.slice(idx + USER_MESSAGE_BEGIN.length);
-}
-
 function recordDiscoveredPrompt(
   promptSeen: Map<string, number[]>,
   prompts: string[],
@@ -342,25 +342,6 @@ function contentText(content: any): string {
 function isCodexContextMessage(text: string): boolean {
   const trimmed = text.trim();
   return CODEX_CONTEXT_TAGS.some((tag) => trimmed.startsWith(`<${tag}>`));
-}
-
-function stripLeadingCodexContextBlocks(text: string): string {
-  let remaining = text.trim();
-  let stripped = true;
-  while (stripped) {
-    stripped = false;
-    for (const tag of CODEX_CONTEXT_TAGS) {
-      const open = `<${tag}>`;
-      const close = `</${tag}>`;
-      if (!remaining.startsWith(open)) continue;
-      const closeIndex = remaining.indexOf(close);
-      if (closeIndex === -1) return "";
-      remaining = remaining.slice(closeIndex + close.length).trim();
-      stripped = true;
-      break;
-    }
-  }
-  return remaining;
 }
 
 function userImageDedupeKey(payload: any): string {

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -4,7 +4,11 @@ import { extname } from "node:path";
 import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
 import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
-import { CODEX_CONTEXT_TAGS, isCodexToolCallType, USER_MESSAGE_BEGIN } from "./constants.js";
+import {
+  isCodexToolCallType,
+  stripLeadingCodexContextBlocks,
+  stripUserMessagePrefix,
+} from "./constants.js";
 
 interface PendingTool {
   id: string;
@@ -666,30 +670,6 @@ function normalizeUserMessageText(text: string): string {
     normalized = stripUserMessagePrefix(stripLeadingCodexContextBlocks(normalized)).trim();
   }
   return normalized;
-}
-
-function stripLeadingCodexContextBlocks(text: string): string {
-  let remaining = text.trim();
-  let stripped = true;
-  while (stripped) {
-    stripped = false;
-    for (const tag of CODEX_CONTEXT_TAGS) {
-      const open = `<${tag}>`;
-      const close = `</${tag}>`;
-      if (!remaining.startsWith(open)) continue;
-      const closeIndex = remaining.indexOf(close);
-      if (closeIndex === -1) return "";
-      remaining = remaining.slice(closeIndex + close.length).trim();
-      stripped = true;
-      break;
-    }
-  }
-  return remaining;
-}
-
-function stripUserMessagePrefix(text: string): string {
-  const idx = text.indexOf(USER_MESSAGE_BEGIN);
-  return idx === -1 ? text : text.slice(idx + USER_MESSAGE_BEGIN.length);
 }
 
 function localImageToDataUrl(path: string): string | undefined {


### PR DESCRIPTION
## Summary

- `stripUserMessagePrefix` and `stripLeadingCodexContextBlocks` were defined **byte-for-byte identically** in both `packages/cli/src/providers/codex/discover.ts` and `packages/cli/src/providers/codex/parser.ts`. Move both to `codex/constants.ts` (which already exposes the related pure helper `isCodexToolCallType`) and import from there.
- Net diff: +35 / -50 lines (-15 net).
- 3 files touched, all under `packages/cli/src/providers/codex/`.

## Motivation

Pure helpers — same inputs always produce the same outputs, no I/O, no closures over module state. Keeping two identical copies in adjacent files is just maintenance friction (any fix to one has to be remembered in the other). Centralizing in `constants.ts` is consistent with how `isCodexToolCallType` is already exposed.

Why this is semantically equivalent: the function bodies are unchanged; only their declaration site moved. Both consumers were already importing from `./constants.js`, so this is purely an import-list adjustment plus a relocation.

## Test plan

- [x] `pnpm test` — 710 + 130 unit tests pass
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — viewer 810KB, CLI 458KB
- [x] `pnpm test:e2e` — 33 passed (cli-smoke, editor-server, generated-html, live-mode, cloud-auth, file-storage)

> 🤖 Daily auto-quality routine. Self-merged after AI review.