### PR TITLE
chore(cli): drop export from internal-only scanner interfaces

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -121,13 +121,13 @@ export interface ProjectInsights {
   };
 }
 
-export interface BranchInfo {
+interface BranchInfo {
   branch: string;
   sessionIds: string[];
   prLinks?: PrLink[];
 }
 
-export interface ProjectMemory {
+interface ProjectMemory {
   memoryFiles: Array<{
     name: string;
     description?: string;
@@ -189,7 +189,7 @@ function percentile(sorted: number[], p: number): number {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
-export interface TurnDurationBucket {
+interface TurnDurationBucket {
   label: string;
   minMs: number;
   maxMs: number; // Infinity for last bucket (serialized as -1)
@@ -197,7 +197,7 @@ export interface TurnDurationBucket {
   pct: number; // 0-100
 }
 
-export interface TurnDurationHistogram {
+interface TurnDurationHistogram {
   buckets: TurnDurationBucket[];
   percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
   totalTurns: number;


### PR DESCRIPTION
## Summary

- Drop `export` from 4 interfaces in `packages/cli/src/scanner.ts` that are only used inside the same file: `BranchInfo`, `ProjectMemory`, `TurnDurationBucket`, `TurnDurationHistogram`.
- Net diff: **-4 export, +4 non-export** (4 line modifications, 1 file).

## Motivation

The viewer's `InsightsPanel.tsx` declares its own local copies of these interfaces; `server.ts`, `insights.ts`, and the test suite never import them by name. The exports were dead public surface. Dropping them makes the module's intent clearer without touching any runtime behaviour — TypeScript export modifiers are erased at compile time, so this is a pure structural change.

`readProjectMemory()` continues to return `Promise<ProjectMemory | null>`; consumers infer the type via `await` without needing to name it, exactly like before.

## Test plan

- [x] `pnpm typecheck` — all four projects pass
- [x] `pnpm lint:check` — zero warnings, zero errors
- [x] `pnpm --filter vibe-replay test` — 710 tests passed
- [x] `pnpm --filter @vibe-replay/viewer test` — 130 tests passed
- [x] `pnpm build` — viewer 810.83 kB (unchanged from main, this PR is CLI-only)
- [x] `pnpm test:e2e` — 33 passed / 40 skipped, including `editor-server` and `generated-html`

> 🤖 Daily auto-quality routine. Self-merged after AI review.