### PR TITLE
chore(cursor): drop redundant `as any` from parseToolFormerBlock return

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1492,7 +1492,7 @@ function parseToolFormerBlock(
     input: mapToolArgs(name, paramsRaw, result),
     _result: result,
     ...(hasToolError(toolFormerData.result) ? { _isError: true } : {}),
-  } as any;
+  };
 }
 
 interface GlobalStateTurnEntry {


### PR DESCRIPTION
## Summary

- Remove a redundant `as any` cast from `parseToolFormerBlock` in `packages/cli/src/providers/cursor/sqlite-reader.ts`. The returned object literal already matches the `tool_use` variant of `ContentBlock`; the cast was widening a structurally-correct value.
- Net diff: -1 +1 (1 file).

## Motivation

Type safety: removing the `as any` lets TypeScript actually verify the shape going forward — if someone adds a wrong field, tsc will catch it instead of being silenced. Verified semantic equivalence: `as any` is purely a compile-time annotation; the runtime value is byte-identical, and `tsc --noEmit` is clean without the cast.

## Test plan

- [x] `pnpm test` — 710 (cli) + 130 (viewer) passed
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — clean
- [x] `pnpm build` — success
- [x] `pnpm test:e2e` — 33 passed (40 skipped, env-gated)

> 🤖 Daily auto-quality routine. Self-merged after AI review.