### PR TITLE
refactor(feedback): extract collectTranslatableScenes helper

### DIFF
--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import type { Annotation, OverlaySource, ReplaySession, SceneOverlay } from "./types.js";
+import type { Annotation, OverlaySource, ReplaySession, Scene, SceneOverlay } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -888,17 +888,21 @@ export async function generateFeedback(
 // Translation
 // ---------------------------------------------------------------------------
 
-function buildTranslationPrompt(
-  session: ReplaySession,
-  opts: { targetLang: string; sourceLang?: string },
-): { prompt: string; translatableScenes: Array<{ index: number; content: string }> } {
-  const translatableScenes = session.scenes
+function collectTranslatableScenes(scenes: Scene[]): Array<{ index: number; content: string }> {
+  return scenes
     .map((s, i) =>
       s.type === "user-prompt" || s.type === "text-response"
         ? { index: i, content: s.content }
         : null,
     )
     .filter((s): s is { index: number; content: string } => s !== null);
+}
+
+function buildTranslationPrompt(
+  session: ReplaySession,
+  opts: { targetLang: string; sourceLang?: string },
+): { prompt: string; translatableScenes: Array<{ index: number; content: string }> } {
+  const translatableScenes = collectTranslatableScenes(session.scenes);
 
   const scenesBlock = translatableScenes
     .map((s) => `--- SCENE ${s.index} ---\n${s.content}`)
@@ -1018,13 +1022,7 @@ export async function generateTranslation(
   if (session.scenes.length === 0) return null;
 
   // Collect all translatable scenes
-  const allScenes = session.scenes
-    .map((s, i) =>
-      s.type === "user-prompt" || s.type === "text-response"
-        ? { index: i, content: s.content }
-        : null,
-    )
-    .filter((s): s is { index: number; content: string } => s !== null);
+  const allScenes = collectTranslatableScenes(session.scenes);
 
   if (allScenes.length === 0) return null;
 


### PR DESCRIPTION
## Summary

- Extract identical 6-line filter pattern (appeared twice in `feedback.ts`) into a private `collectTranslatableScenes` helper
- Net change: -2 lines (11 inserted, 13 deleted)

## Motivation

`buildTranslationPrompt` and `generateTranslation` both had the exact same `.map().filter()` chain to collect `{ index, content }` from `user-prompt` and `text-response` scenes. Extracting it gives the pattern a name and removes the duplication. Semantically equivalent: pure structural refactor, no runtime behavior changes.

## Test plan

- [x] `pnpm test` — 710 + 130 tests pass
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — succeeds (viewer 810KB pre-existing, unchanged by this PR)
- [x] E2E: not run (CLI-only change, no HTML/UI output affected)

> 🤖 Daily auto-quality routine. Self-merged after AI review.