### PR TITLE
chore(cursor): drop redundant Record<string,any> casts in inferEditStringsFromResult

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2774,10 +2774,8 @@ function inferEditStringsFromResult(resultText: string): {
   }
 
   const chunks =
-    parsed.diff &&
-    typeof parsed.diff === "object" &&
-    Array.isArray((parsed.diff as Record<string, any>).chunks)
-      ? ((parsed.diff as Record<string, any>).chunks as any[])
+    parsed.diff && typeof parsed.diff === "object" && Array.isArray(parsed.diff.chunks)
+      ? parsed.diff.chunks
       : [];
   const oldParts: string[] = [];
   const newParts: string[] = [];


### PR DESCRIPTION
## Summary

- Remove two `as Record<string, any>` casts and one `as any[]` cast from `inferEditStringsFromResult` in `packages/cli/src/providers/cursor/sqlite-reader.ts`
- Net diff: -4 +2 lines

## Motivation

`parsed` is typed as `Record<string, any>`, so `parsed.diff` already has type `any`. Casting an `any` value to `Record<string, any>` before accessing `.chunks`, and then casting `.chunks` to `any[]`, are both compile-time no-ops — TypeScript already allows any property access on `any` and the resulting value is also `any`. Removing the redundant casts lets tsc naturally flow types without manual overrides, consistent with the project's pattern of keeping casts only where they're structurally necessary.

Semantic equivalence: `as Record<string, any>` on an `any`-typed value and `as any[]` on an `any`-typed property are purely compile-time annotations with zero runtime effect.

## Test plan

- [x] `pnpm test` — all passed (CLI 720+ tests, viewer 130 tests)
- [x] `pnpm lint:check` — 0 warnings, 0 errors
- [x] `tsc --noEmit` — clean (run from packages/cli with local tsc)
- [x] `pnpm build` — success (viewer size unchanged at 810KB, pre-existing)
- [x] E2E: skipped — pure type-annotation removal, no runtime behavior change

> 🤖 Daily auto-quality routine. Self-merged after AI review.