### PR TITLE
fix(cowork): preserve new metadata fields

### DIFF
--- a/packages/cli/src/providers/claude-cowork/discover.ts
+++ b/packages/cli/src/providers/claude-cowork/discover.ts
@@ -35,8 +35,14 @@ interface CoworkSessionJson {
   model?: string;
   title?: string;
   isArchived?: boolean;
+  isStarred?: boolean;
   initialMessage?: string;
   processName?: string;
+  fsDetectedFiles?: unknown;
+  pluginsEnabled?: boolean;
+  skillsEnabled?: boolean;
+  spaceId?: string;
+  spaceIdSetBy?: string;
 }
 
 export async function discoverClaudeCoworkSessions(): Promise<SessionInfo[]> {
@@ -178,6 +184,9 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
 
   // Normalize model: strip Cowork-style suffixes (e.g. "claude-opus-4-6[1m]").
   const model = meta.model ? meta.model.replace(/\[[^\]]*\]$/, "") : undefined;
+  const fsDetectedFiles = Array.isArray(meta.fsDetectedFiles)
+    ? meta.fsDetectedFiles.filter((file): file is string => typeof file === "string")
+    : undefined;
 
   // Project label: every Cowork session runs inside its own sandbox dir, so the
   // real cwd is noise in the picker. Group all Cowork sessions under a single
@@ -202,6 +211,12 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
     promptCount,
     toolCallCount,
     model,
+    isStarred: meta.isStarred,
+    spaceId: meta.spaceId,
+    spaceIdSetBy: meta.spaceIdSetBy,
+    pluginsEnabled: meta.pluginsEnabled,
+    skillsEnabled: meta.skillsEnabled,
+    fsDetectedFiles,
   };
 }
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -401,6 +401,12 @@ interface SourceSummaryRecord {
   filePaths: string[];
   toolPaths?: string[];
   hasSqlite?: boolean;
+  isStarred?: boolean;
+  spaceId?: string;
+  spaceIdSetBy?: string;
+  pluginsEnabled?: boolean;
+  skillsEnabled?: boolean;
+  fsDetectedFiles?: string[];
   timestamp: string;
   [key: string]: unknown;
 }
@@ -649,6 +655,12 @@ async function buildSourcesResult(
       durationMsEst: s.durationMsEst,
       editCountEst: s.editCountEst,
       hasPR: s.hasPR,
+      isStarred: s.isStarred,
+      spaceId: s.spaceId,
+      spaceIdSetBy: s.spaceIdSetBy,
+      pluginsEnabled: s.pluginsEnabled,
+      skillsEnabled: s.skillsEnabled,
+      fsDetectedFiles: s.fsDetectedFiles,
       expiresInDays:
         s.provider === "claude-code" && cleanupPeriodDays > 0
           ? computeDaysUntilCleanup(s.timestamp, cleanupPeriodDays)
@@ -3289,6 +3301,7 @@ export async function startDashboard(
 }
 
 export const __testables = {
+  buildSourcesResult,
   buildInsightsSyncBatches,
   countSessionStats,
   pickSourceRecordForSession,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -50,6 +50,12 @@ export interface SessionInfo {
   durationMsEst?: number; // sum of turn_duration durationMs values
   editCountEst?: number; // count of file-editing tool_use blocks (Edit/Write/MultiEdit etc.)
   hasPR?: boolean; // whether a pr-link event exists in the session
+  isStarred?: boolean; // provider-level favorite/star marker
+  spaceId?: string; // provider workspace/space identifier
+  spaceIdSetBy?: string; // source of provider workspace/space assignment
+  pluginsEnabled?: boolean; // provider session had plugins enabled
+  skillsEnabled?: boolean; // provider session had skills enabled
+  fsDetectedFiles?: string[]; // files detected by the provider during the session
 }
 
 export interface ParsedTurn {

--- a/packages/cli/test/claude-cowork-discover.test.ts
+++ b/packages/cli/test/claude-cowork-discover.test.ts
@@ -123,6 +123,40 @@ describe("extractCoworkSessionInfo", () => {
     expect(info?.toolCallCount).toBe(1);
     expect((info?.promptCount ?? 0) >= 1).toBe(true);
   });
+
+  it("preserves newly observed Cowork metadata fields", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-cowork-meta-"));
+    const metadataPath = join(root, "local_cowork-session-xyz789.json");
+    await writeFile(
+      metadataPath,
+      JSON.stringify({
+        sessionId: "local_cowork-session-002",
+        cwd: "/sessions/magical-laughing-wright/mnt/outputs",
+        createdAt: 1750000000000,
+        lastActivityAt: 1750000200000,
+        model: "claude-opus-4-6[1m]",
+        title: "Research Cowork session storage",
+        initialMessage:
+          "Please investigate how Cowork stores session data locally and summarize the format for me.",
+        isStarred: true,
+        pluginsEnabled: true,
+        skillsEnabled: true,
+        spaceId: "space_123",
+        spaceIdSetBy: "user",
+        fsDetectedFiles: ["README.md", "src/index.ts", 42],
+      }),
+    );
+
+    const { jsonPath } = await buildCoworkLayout({ metadataPath });
+    const info = await extractCoworkSessionInfo(jsonPath);
+
+    expect(info?.isStarred).toBe(true);
+    expect(info?.pluginsEnabled).toBe(true);
+    expect(info?.skillsEnabled).toBe(true);
+    expect(info?.spaceId).toBe("space_123");
+    expect(info?.spaceIdSetBy).toBe("user");
+    expect(info?.fsDetectedFiles).toEqual(["README.md", "src/index.ts"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { __testables } from "../src/server.js";
 import type { SessionInfo } from "../src/types.js";
@@ -160,5 +163,35 @@ describe("sources enrichment helpers", () => {
     ] as any);
 
     expect(counts).toEqual({ promptCount: 1, toolCallCount: 2 });
+  });
+
+  it("preserves Cowork metadata in source API records", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "vr-sources-result-"));
+    const [source] = await __testables.buildSourcesResult(
+      [
+        makeCursorSession({
+          provider: "claude-cowork",
+          sessionId: "cowork-session-002",
+          slug: "cowork-s",
+          project: "Cowork",
+          cwd: "/sessions/cowork/mnt/outputs",
+          isStarred: true,
+          pluginsEnabled: true,
+          skillsEnabled: true,
+          spaceId: "space_123456",
+          spaceIdSetBy: "user",
+          fsDetectedFiles: ["README.md", "src/index.ts"],
+        }),
+      ],
+      baseDir,
+      tmpdir(),
+    );
+
+    expect(source?.isStarred).toBe(true);
+    expect(source?.pluginsEnabled).toBe(true);
+    expect(source?.skillsEnabled).toBe(true);
+    expect(source?.spaceId).toBe("space_123456");
+    expect(source?.spaceIdSetBy).toBe("user");
+    expect(source?.fsDetectedFiles).toEqual(["README.md", "src/index.ts"]);
   });
 });

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -300,6 +300,11 @@ function nonDefaultBranch(branch?: string): string | undefined {
   return branch && branch !== "main" && branch !== "master" ? branch : undefined;
 }
 
+function shortCoworkSpaceId(spaceId: string): string {
+  const compact = spaceId.replace(/^space[_-]?/, "");
+  return compact.slice(0, 6) || spaceId.slice(0, 6);
+}
+
 function dataSourceBadgeClass(dataSource?: string, hasSqlite?: boolean): string {
   if (dataSource === "jsonl") return "bg-terminal-orange-subtle text-terminal-orange";
   if (dataSource === "global-state") return "bg-terminal-blue-subtle text-terminal-blue";
@@ -2065,6 +2070,8 @@ function SessionsPanel() {
                       displayDurationMs ||
                       displayEditCount ||
                       s.hasPR ||
+                      s.isStarred ||
+                      (s.fsDetectedFiles && s.fsDetectedFiles.length > 0) ||
                       (s.expiresInDays != null && s.expiresInDays <= EXPIRY_WARN_DAYS)) && (
                       <div className="flex items-center gap-1.5 flex-wrap">
                         {!!displayPromptCount && (
@@ -2101,6 +2108,22 @@ function SessionsPanel() {
                             PR
                           </span>
                         )}
+                        {s.isStarred && (
+                          <span
+                            className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-orange-subtle text-terminal-orange"
+                            title="Starred in Claude Cowork"
+                          >
+                            starred
+                          </span>
+                        )}
+                        {s.fsDetectedFiles && s.fsDetectedFiles.length > 0 && (
+                          <span
+                            className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim"
+                            title={s.fsDetectedFiles.join("\n")}
+                          >
+                            {s.fsDetectedFiles.length} files
+                          </span>
+                        )}
                         {s.expiresInDays != null && s.expiresInDays <= EXPIRY_WARN_DAYS && (
                           <span
                             className={`inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md ${
@@ -2133,6 +2156,34 @@ function SessionsPanel() {
                       {displayModel && (
                         <span className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
                           {shortModelName(displayModel)}
+                        </span>
+                      )}
+                      {s.spaceId && (
+                        <span
+                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          title={
+                            s.spaceIdSetBy
+                              ? `Cowork space ${s.spaceId} (${s.spaceIdSetBy})`
+                              : `Cowork space ${s.spaceId}`
+                          }
+                        >
+                          space-{shortCoworkSpaceId(s.spaceId)}
+                        </span>
+                      )}
+                      {s.pluginsEnabled && (
+                        <span
+                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          title="Claude Cowork plugins enabled"
+                        >
+                          plugins
+                        </span>
+                      )}
+                      {s.skillsEnabled && (
+                        <span
+                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          title="Claude Cowork skills enabled"
+                        >
+                          skills
                         </span>
                       )}
                       <span className="text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -79,6 +79,12 @@ export interface SourceSession {
   durationMsEst?: number;
   editCountEst?: number;
   hasPR?: boolean;
+  isStarred?: boolean;
+  spaceId?: string;
+  spaceIdSetBy?: string;
+  pluginsEnabled?: boolean;
+  skillsEnabled?: boolean;
+  fsDetectedFiles?: string[];
   // Days until Claude Code cleanup (undefined for non-claude-code or if disabled)
   expiresInDays?: number;
 }


### PR DESCRIPTION
## Summary
- Preserve newly observed Claude Cowork metadata fields during discovery: `isStarred`, `spaceId`, `spaceIdSetBy`, `pluginsEnabled`, `skillsEnabled`, and sanitized `fsDetectedFiles`.
- Surface useful Cowork source-session badges in the Sessions dashboard.
- Add discovery coverage for the new metadata shape.

Fixes #240

## Verification
- `pnpm --filter vibe-replay test -- claude-cowork-discover.test.ts claude-cowork-parser.test.ts` (runs CLI suite: 40 files, 711 passed, 2 skipped)
- `pnpm --filter @vibe-replay/viewer test`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm build`