### PR TITLE
chore(publishers): hoist shared auth headers in publishGist

### DIFF
--- a/packages/cli/src/publishers/gist.ts
+++ b/packages/cli/src/publishers/gist.ts
@@ -49,6 +49,10 @@ export async function publishGist(
   const filename = overwrite?.filename || `${sanitizeFilename(title)}.json`;
   const description = `vibe-replay: ${title}`;
   const apiUrl = getApiUrl();
+  const headers = {
+    "Content-Type": "application/json",
+    Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
+  };
 
   let gistId: string;
   let gistUrl: string;
@@ -59,10 +63,7 @@ export async function publishGist(
     // Update existing gist
     const resp = await fetch(`${apiUrl}/api/gists/${overwrite.gistId}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
-      },
+      headers,
       body: JSON.stringify({ filename, content, description }),
     });
     if (!resp.ok) {
@@ -80,10 +81,7 @@ export async function publishGist(
     // Create new gist
     const resp = await fetch(`${apiUrl}/api/gists`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Cookie: `${getSessionCookieName(apiUrl)}=${auth.token}`,
-      },
+      headers,
       body: JSON.stringify({ filename, content, description, public: true }),
     });
     if (!resp.ok) {


### PR DESCRIPTION
## Summary

- Hoist identical `headers` object before the `if (overwrite)` branch in `publishGist`
- Both the PATCH (update) and POST (create) paths used the same `{ "Content-Type": "application/json", Cookie: ... }` object — now built once
- Net: -2 lines (+6 / -8)

## Motivation

The same headers literal appeared twice in the same function (and a third time in `publishCloud`). Hoisting it before the branch removes the duplication without changing behavior: `apiUrl` and `auth.token` are both in scope and unchanged across the branch.

## Test plan

- [x] `pnpm test` 全绿 (CLI: 713 passed, viewer: 130 passed)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功
- [x] E2E: 跑了 — 33 passed (40 skipped)

> 🤖 Daily auto-quality routine. Self-merged after AI review.