### PR TITLE
feat(cursor): support SDK-backed sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ pnpm db:migrate:remote    # Apply to production D1 (requires auth)
 - **Self-contained HTML**: Output must make zero external requests. Everything inlined.
 - **Multi-file sessions**: Claude Code `/resume` creates new JSONL files. Parser accepts `string | string[]` and merges by slug+project.
 - **Cursor tri-source**: Sessions come from SQLite `store.db` (primary), `globalStorage/state.vscdb`, or JSONL (fallback). Discovery merges all sources. DB data is source of truth; JSONL supplements missing thinking/images.
+- **Cursor SDK**: SDK agents (TypeScript `@cursor/sdk`) write to `~/.cursor/projects/<workspace>/sdk-agent-store/<projectHash>/index.db` (tables: `agents`, `runs`, `run_events`) and a parallel JSONL transcript at `agent-transcripts/<agentId>/<agentId>.jsonl`. The transcript is the source of user prompts (SDK doesn't store them in events) and the SDK index.db supplies tool *results*, structured per-run timing, and per-turn model. See `providers/cursor/sdk-reader.ts`. Detection is by sessionId prefix `agent-` — IDE chat sessions (UUID-only) skip the SDK SQLite probe.
 - **Skip `progress` lines**: These are subagent streaming artifacts in JSONL.
 - **sql.js (WASM)**: Used instead of native SQLite bindings for portability — no C++ compiler needed.
 - **Session discovery cache**: CLI picker + local dashboard use file cache at `~/.vibe-replay/cache/*.json` (stale-while-refresh UX). Cache validity is tied to CLI release version (`CLI_VERSION`) plus envelope version, so caches auto-invalidate across releases. Keep cache writes best-effort and never block generation/parsing on cache failures.
@@ -97,6 +98,7 @@ If tag/release is updated but `packages/cli/package.json` is not, CLI will still
 | HTML generation | `packages/cli/src/generator.ts` |
 | Editor server | `packages/cli/src/server.ts` |
 | Provider interface | `packages/cli/src/providers/types.ts` |
+| Cursor SDK reader | `packages/cli/src/providers/cursor/sdk-reader.ts` |
 | Viewer entry | `packages/viewer/src/App.tsx` |
 | Playback engine (pure) | `packages/viewer/src/engine/` |
 | Playback hook | `packages/viewer/src/hooks/usePlayback.ts` |

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -8,6 +8,7 @@ import {
   discoverSqliteOnlySessions,
   listStoreDbSessionIds,
 } from "./sqlite-reader.js";
+import { discoverSdkAgents, type SdkAgent } from "./sdk-reader.js";
 import { sanitizeCursorUserText } from "./sanitize.js";
 
 const CURSOR_DIR = join(homedir(), ".cursor", "projects");
@@ -76,8 +77,40 @@ export async function discoverCursorSessions(): Promise<SessionInfo[]> {
     session.hasSqlite = hasStoreDb || globalState.sessionIds.has(session.sessionId);
   }
 
+  // Cursor SDK sessions live alongside Cursor IDE chats but in their own SQLite
+  // store. Mark transcripts that also have an SDK record so the parser can enrich
+  // them with structured tool results, run timing, and per-turn model.
+  await enrichWithSdkAgents(sessions);
+
   sessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return sessions;
+}
+
+async function enrichWithSdkAgents(sessions: SessionInfo[]): Promise<void> {
+  let sdkAgents: SdkAgent[] = [];
+  try {
+    sdkAgents = await discoverSdkAgents();
+  } catch {
+    return;
+  }
+  if (sdkAgents.length === 0) return;
+
+  const sessionsByAgentId = new Map<string, SessionInfo>();
+  for (const session of sessions) {
+    sessionsByAgentId.set(session.sessionId, session);
+  }
+
+  for (const agent of sdkAgents) {
+    const existing = sessionsByAgentId.get(agent.agentId);
+    if (!existing) continue;
+    existing.hasSdk = true;
+    // SDK store knows the workspace path authoritatively — backfill if the
+    // transcript-only path was best-effort guessed.
+    if (agent.workspaceRef && (!existing.cwd || existing.cwd.startsWith("/-"))) {
+      existing.cwd = agent.workspaceRef;
+      existing.workspacePath = agent.workspaceRef;
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -9,6 +9,12 @@ import {
   sanitizeCursorUserText,
 } from "./sanitize.js";
 import {
+  applySdkEnrichmentToTurns,
+  findSdkAgentById,
+  loadSdkAgentEnrichment,
+  type SdkAgentEnrichment,
+} from "./sdk-reader.js";
+import {
   isSystemContextText,
   mapCursorToolName,
   mapToolArgs,
@@ -103,7 +109,67 @@ export async function parseCursorSession(
       sqliteFallbackNote,
     );
   }
+
+  // Cursor SDK enrichment — Cursor SDK agents only have a JSONL transcript
+  // (no IDE chat store.db), so the SDK index.db is the only place tool *results*
+  // are recorded. Apply now so the replay has results, durations, and per-turn model.
+  // We accept the sessionId from explicit sessionInfo OR from the transcript filename
+  // (Cursor names SDK transcripts `<agentId>.jsonl`, which is exactly what the SDK
+  // store keys agents on).
+  const sdkSessionId = sessionInfo?.sessionId || deriveSessionIdFromTranscript(transcriptPaths);
+  if (sdkSessionId) {
+    const enrichment = await tryLoadSdkEnrichment(sdkSessionId);
+    if (enrichment) {
+      const { toolCallsEnriched, assistantTurnsModelTagged } = applySdkEnrichmentToTurns(
+        jsonlResult.turns,
+        enrichment,
+      );
+      if (toolCallsEnriched > 0 || assistantTurnsModelTagged > 0) {
+        jsonlResult.dataSourceInfo = withSupplement(
+          jsonlResult.dataSourceInfo || defaultDataSourceInfo(jsonlResult.dataSource),
+          `cursor-sdk index.db (tool results +${toolCallsEnriched}, model tags +${assistantTurnsModelTagged})`,
+        );
+      }
+      if (enrichment.primaryModel && !jsonlResult.model) {
+        jsonlResult.model = enrichment.primaryModel;
+      }
+      if (enrichment.startedAt && !jsonlResult.startTime) {
+        jsonlResult.startTime = enrichment.startedAt;
+      }
+      if (enrichment.finishedAt && !jsonlResult.endTime) {
+        jsonlResult.endTime = enrichment.finishedAt;
+      }
+      if (enrichment.totalDurationMs && !jsonlResult.totalDurationMs) {
+        jsonlResult.totalDurationMs = enrichment.totalDurationMs;
+      }
+    }
+  }
   return jsonlResult;
+}
+
+async function tryLoadSdkEnrichment(sessionId: string): Promise<SdkAgentEnrichment | null> {
+  // SDK agent IDs are prefixed `agent-`. Skip the lookup for plain UUID sessions
+  // (Cursor IDE chats) to avoid touching SDK SQLite when we know it won't match.
+  if (!sessionId.startsWith("agent-")) return null;
+  try {
+    const agent = await findSdkAgentById(sessionId);
+    if (!agent) return null;
+    return await loadSdkAgentEnrichment(agent);
+  } catch {
+    return null;
+  }
+}
+
+function deriveSessionIdFromTranscript(transcriptPaths: string[]): string | null {
+  // Pick the latest transcript by name (sortedTranscriptPaths inside parseCursorJsonl
+  // sorts by mtime, but here we only need *some* transcript to extract the agent id;
+  // for SDK sessions every transcript filename is identical to the agent id).
+  for (let i = transcriptPaths.length - 1; i >= 0; i--) {
+    const p = transcriptPaths[i];
+    const base = basename(p, ".jsonl");
+    if (base.startsWith("agent-")) return base;
+  }
+  return null;
 }
 
 interface ParseJsonlOptions {

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -113,6 +113,9 @@ export async function parseCursorSession(
   // Cursor SDK enrichment — Cursor SDK agents only have a JSONL transcript
   // (no IDE chat store.db), so the SDK index.db is the only place tool *results*
   // are recorded. Apply now so the replay has results, durations, and per-turn model.
+  // If Cursor ever also backfills SDK agents into IDE store.db, keep that path
+  // SQLite-first and only add SDK enrichment after deciding how to reconcile
+  // duplicate tool streams.
   // We accept the sessionId from explicit sessionInfo OR from the transcript filename
   // (Cursor names SDK transcripts `<agentId>.jsonl`, which is exactly what the SDK
   // store keys agents on).
@@ -130,8 +133,8 @@ export async function parseCursorSession(
           `cursor-sdk index.db (tool results +${toolCallsEnriched}, model tags +${assistantTurnsModelTagged})`,
         );
       }
-      if (enrichment.primaryModel && !jsonlResult.model) {
-        jsonlResult.model = enrichment.primaryModel;
+      if (enrichment.latestModel && !jsonlResult.model) {
+        jsonlResult.model = enrichment.latestModel;
       }
       if (enrichment.startedAt && !jsonlResult.startTime) {
         jsonlResult.startTime = enrichment.startedAt;

--- a/packages/cli/src/providers/cursor/sdk-reader.ts
+++ b/packages/cli/src/providers/cursor/sdk-reader.ts
@@ -1,0 +1,599 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { ParsedTurn } from "../../types.js";
+import { mapCursorToolName, mapToolArgs } from "./sqlite-reader.js";
+
+/**
+ * Cursor SDK local agent state lives at:
+ *   ~/.cursor/projects/<workspace-slug>/sdk-agent-store/<projectHash>/index.db
+ *
+ * Schema (as of Cursor SDK schemaVersion 1):
+ *   agents      — agent_id, workspace_ref, status, name, latest_checkpoint_ref_json, ...
+ *   runs        — run_id, agent_id, turn_number, status, model, started_at, finished_at, result
+ *   run_events  — run_id, seq, event_type='run_stream_event', payload_json (sdk_message envelope)
+ *
+ * Per-agent blob/checkpoint store lives at:
+ *   ~/.cursor/projects/<workspace-slug>/sdk-agent-store/<projectHash>/agents/<sha256(agentId)>/store.db
+ * but we don't need the blobs to enrich a replay — runs + run_events have everything we render.
+ *
+ * The Cursor IDE also writes a human-readable JSONL transcript at:
+ *   ~/.cursor/projects/<workspace-slug>/agent-transcripts/<agentId>/<agentId>.jsonl
+ * which the existing Cursor provider already discovers. The SDK store is what gives us
+ * the missing tool *results*, structured per-run timing, and per-run model names.
+ */
+
+const CURSOR_PROJECTS_ROOT = join(homedir(), ".cursor", "projects");
+const SDK_STORE_SUBDIR = "sdk-agent-store";
+const SDK_INDEX_DB_BASENAME = "index.db";
+const MIN_INDEX_DB_SIZE = 1024;
+
+const execFileAsync = promisify(execFile);
+
+const getSqlJs = (() => {
+  let promise: Promise<any> | null = null;
+  return async () => {
+    if (!promise) {
+      promise = (async () => {
+        const mod = await import("sql.js");
+        return mod.default();
+      })().catch((err) => {
+        promise = null;
+        throw err;
+      });
+    }
+    return promise;
+  };
+})();
+
+export interface SdkAgent {
+  agentId: string;
+  workspaceRef: string;
+  status: string;
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+  /** Absolute path to the SDK index.db file backing this agent. */
+  dbPath: string;
+}
+
+export interface SdkRun {
+  runId: string;
+  agentId: string;
+  turnNumber: number;
+  status: string;
+  model?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  /** Final assistant text (if recorded by the SDK). */
+  result?: string;
+}
+
+export interface SdkToolCall {
+  callId: string;
+  runId: string;
+  /** Sequence number of the *first* event for this call (the "running" one). */
+  firstSeq: number;
+  /** Sequence number of the terminal event (completed/error). */
+  lastSeq: number;
+  name: string;
+  args: Record<string, any>;
+  status: string;
+  /** Stringified result body — already shaped for downstream tool-arg inference. */
+  result?: string;
+  isError?: boolean;
+  durationMs?: number;
+}
+
+export interface SdkAgentEnrichment {
+  agent: SdkAgent;
+  runs: SdkRun[];
+  /** Tool calls keyed by runId, in event order (first observation wins). */
+  toolCallsByRun: Map<string, SdkToolCall[]>;
+  /** Earliest started_at across runs. */
+  startedAt?: string;
+  /** Latest finished_at across runs. */
+  finishedAt?: string;
+  /** Sum of per-run durations (ms). */
+  totalDurationMs?: number;
+  /** Most-recent model seen across runs. */
+  primaryModel?: string;
+}
+
+interface IndexDbHandle {
+  dbPath: string;
+  backend: "sqlite-cli" | "sqljs";
+  /** sql.js Database instance — only present when backend === "sqljs". */
+  db?: any;
+}
+
+let cachedAgentIndex: Map<string, SdkAgent> | null = null;
+let cachedAgentIndexAt = 0;
+const AGENT_INDEX_TTL_MS = 5_000;
+
+/**
+ * Best-effort discovery of every SDK agent on this machine. Safe to call repeatedly —
+ * results are cached for a short window so live mode doesn't pay full SQLite cost.
+ */
+export async function discoverSdkAgents(): Promise<SdkAgent[]> {
+  const index = await getSdkAgentIndex();
+  return [...index.values()];
+}
+
+export async function findSdkAgentById(agentId: string): Promise<SdkAgent | null> {
+  if (!agentId) return null;
+  const index = await getSdkAgentIndex();
+  return index.get(agentId) || null;
+}
+
+/** Force-clear the SDK agent index cache. Useful for tests and live mode. */
+export function invalidateSdkAgentIndexCache(): void {
+  cachedAgentIndex = null;
+  cachedAgentIndexAt = 0;
+}
+
+async function getSdkAgentIndex(): Promise<Map<string, SdkAgent>> {
+  if (cachedAgentIndex && Date.now() - cachedAgentIndexAt < AGENT_INDEX_TTL_MS) {
+    return cachedAgentIndex;
+  }
+  const dbPaths = await listSdkIndexDbPaths(CURSOR_PROJECTS_ROOT);
+  const index = new Map<string, SdkAgent>();
+  for (const dbPath of dbPaths) {
+    let handle: IndexDbHandle | null = null;
+    try {
+      handle = await openIndexDb(dbPath);
+      if (!handle) continue;
+      const rows = await queryIndexDb(
+        handle,
+        "SELECT agent_id, workspace_ref, status, name, created_at, updated_at FROM agents",
+      );
+      for (const row of rows) {
+        const agentId = stringOrEmpty(row.agent_id);
+        if (!agentId) continue;
+        index.set(agentId, {
+          agentId,
+          workspaceRef: stringOrEmpty(row.workspace_ref),
+          status: stringOrEmpty(row.status) || "UNKNOWN",
+          name: typeof row.name === "string" ? row.name : undefined,
+          createdAt: stringOrEmpty(row.created_at),
+          updatedAt: stringOrEmpty(row.updated_at),
+          dbPath,
+        });
+      }
+    } catch {
+      // SDK schema differs across Cursor versions; skip databases we can't read.
+    } finally {
+      closeIndexDb(handle);
+    }
+  }
+  cachedAgentIndex = index;
+  cachedAgentIndexAt = Date.now();
+  return index;
+}
+
+/**
+ * Read a single agent's runs + stream events and assemble the structured
+ * enrichment record used to augment the JSONL transcript.
+ */
+export async function loadSdkAgentEnrichment(agent: SdkAgent): Promise<SdkAgentEnrichment | null> {
+  let handle: IndexDbHandle | null = null;
+  try {
+    handle = await openIndexDb(agent.dbPath);
+    if (!handle) return null;
+
+    const runRows = await queryIndexDb(
+      handle,
+      [
+        "SELECT run_id, agent_id, turn_number, status, model,",
+        "started_at, finished_at, result",
+        `FROM runs WHERE agent_id = ${sqlString(agent.agentId)}`,
+        "ORDER BY turn_number ASC, created_at ASC",
+      ].join(" "),
+    );
+    if (runRows.length === 0) return null;
+
+    const runs: SdkRun[] = runRows.map((row) => ({
+      runId: stringOrEmpty(row.run_id),
+      agentId: stringOrEmpty(row.agent_id),
+      turnNumber: typeof row.turn_number === "number" ? row.turn_number : Number(row.turn_number),
+      status: stringOrEmpty(row.status),
+      model: row.model ? String(row.model) : undefined,
+      startedAt: row.started_at ? String(row.started_at) : undefined,
+      finishedAt: row.finished_at ? String(row.finished_at) : undefined,
+      result: row.result ? String(row.result) : undefined,
+    }));
+
+    const runIds = runs.map((r) => r.runId).filter(Boolean);
+    if (runIds.length === 0) return { agent, runs, toolCallsByRun: new Map() };
+    const inList = runIds.map(sqlString).join(", ");
+    const eventRows = await queryIndexDb(
+      handle,
+      [
+        "SELECT run_id, seq, payload_json FROM run_events",
+        `WHERE run_id IN (${inList}) ORDER BY run_id, seq`,
+      ].join(" "),
+    );
+
+    const toolCallsByRun = collectToolCalls(eventRows);
+
+    return finalizeEnrichment(agent, runs, toolCallsByRun);
+  } catch {
+    return null;
+  } finally {
+    closeIndexDb(handle);
+  }
+}
+
+function finalizeEnrichment(
+  agent: SdkAgent,
+  runs: SdkRun[],
+  toolCallsByRun: Map<string, SdkToolCall[]>,
+): SdkAgentEnrichment {
+  let startedAt: string | undefined;
+  let finishedAt: string | undefined;
+  let totalDurationMs = 0;
+  let totalDurationSeen = false;
+  let primaryModel: string | undefined;
+
+  for (const run of runs) {
+    if (run.startedAt && (!startedAt || run.startedAt < startedAt)) startedAt = run.startedAt;
+    if (run.finishedAt && (!finishedAt || run.finishedAt > finishedAt)) finishedAt = run.finishedAt;
+    if (run.startedAt && run.finishedAt) {
+      const startMs = Date.parse(run.startedAt);
+      const endMs = Date.parse(run.finishedAt);
+      if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
+        totalDurationMs += endMs - startMs;
+        totalDurationSeen = true;
+      }
+    }
+    if (run.model) primaryModel = run.model;
+  }
+
+  return {
+    agent,
+    runs,
+    toolCallsByRun,
+    startedAt,
+    finishedAt,
+    totalDurationMs: totalDurationSeen ? totalDurationMs : undefined,
+    primaryModel,
+  };
+}
+
+interface RunEventRow {
+  run_id?: string;
+  payload_json?: string;
+  seq?: number | string;
+}
+
+function collectToolCalls(rows: Record<string, any>[]): Map<string, SdkToolCall[]> {
+  const out = new Map<string, SdkToolCall[]>();
+  // Track the call we're building per (runId, callId).
+  const inProgress = new Map<string, SdkToolCall>();
+
+  for (const rawRow of rows) {
+    const row = rawRow as RunEventRow;
+    const payload = row.payload_json;
+    if (typeof payload !== "string" || !payload) continue;
+    const parsed = safeJsonParse(payload);
+    const message = parsed?.message;
+    if (!message || message.type !== "tool_call") continue;
+
+    const runId = stringOrEmpty(row.run_id);
+    const callId = stringOrEmpty(message.call_id);
+    if (!runId || !callId) continue;
+    const seq = typeof row.seq === "number" ? row.seq : Number(row.seq);
+    if (!Number.isFinite(seq)) continue;
+
+    const key = `${runId}::${callId}`;
+    const rawName = typeof message.name === "string" ? message.name : "Tool";
+    const mappedName = mapCursorToolName(rawName);
+    const argsObj = isPlainObject(message.args) ? message.args : {};
+    const status = typeof message.status === "string" ? message.status : "unknown";
+
+    let entry = inProgress.get(key);
+    if (!entry) {
+      entry = {
+        callId,
+        runId,
+        firstSeq: seq,
+        lastSeq: seq,
+        name: mappedName,
+        args: argsObj,
+        status,
+      };
+      inProgress.set(key, entry);
+      const list = out.get(runId) || [];
+      list.push(entry);
+      out.set(runId, list);
+    } else {
+      entry.lastSeq = seq;
+      entry.status = status;
+      // Args sometimes get fleshed out across "running" updates — prefer the latest non-empty payload.
+      if (Object.keys(argsObj).length > Object.keys(entry.args).length) {
+        entry.args = argsObj;
+      }
+    }
+
+    if (status === "completed" || status === "error" || message.result !== undefined) {
+      const formatted = formatSdkToolResult(rawName, message.result);
+      entry.result = formatted.text;
+      entry.isError = formatted.isError || status === "error";
+    }
+  }
+
+  // Sort calls within each run by their first appearance.
+  for (const [runId, list] of out) {
+    list.sort((a, b) => a.firstSeq - b.firstSeq);
+    out.set(runId, list);
+  }
+  return out;
+}
+
+interface FormattedToolResult {
+  text: string;
+  isError: boolean;
+}
+
+/**
+ * The SDK records tool results as structured `{ status, value }` objects. Downstream
+ * Cursor parsing expects a string — but for Edit-family tools the existing inference
+ * helpers parse a JSON shape with `diff.chunks[].diffString`. We reshape so they hit.
+ */
+export function formatSdkToolResult(rawToolName: string, result: unknown): FormattedToolResult {
+  if (result === null || result === undefined) return { text: "", isError: false };
+  if (typeof result === "string") return { text: result, isError: false };
+  if (!isPlainObject(result)) {
+    return { text: safeJsonStringify(result), isError: false };
+  }
+
+  const status = typeof result.status === "string" ? result.status : "";
+  const isError = status === "error" || status === "failed" || result.error !== undefined;
+  const value = result.value !== undefined ? result.value : result;
+
+  const mapped = mapCursorToolName(rawToolName);
+
+  if (isError && typeof result.error === "string") {
+    return { text: result.error, isError: true };
+  }
+
+  if (mapped === "Bash" && isPlainObject(value)) {
+    const stdout = typeof value.stdout === "string" ? value.stdout : "";
+    const stderr = typeof value.stderr === "string" ? value.stderr : "";
+    const exitCode = typeof value.exitCode === "number" ? value.exitCode : undefined;
+    const parts: string[] = [];
+    if (stdout) parts.push(stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout);
+    if (stderr) parts.push(`[stderr]\n${stderr}`);
+    if (parts.length === 0 && typeof exitCode === "number") parts.push(`exit ${exitCode}`);
+    return {
+      text: parts.join("\n"),
+      isError: isError || (exitCode !== undefined && exitCode !== 0),
+    };
+  }
+
+  if (mapped === "Read" && isPlainObject(value) && typeof value.content === "string") {
+    return { text: value.content, isError };
+  }
+
+  if ((mapped === "Edit" || mapped === "Write" || mapped === "MultiEdit") && isPlainObject(value)) {
+    const diffString = typeof value.diffString === "string" ? value.diffString : "";
+    if (diffString) {
+      // Wrap in the `diff.chunks[].diffString` shape that inferEditStringsFromResult understands,
+      // and keep the raw stats for downstream use.
+      const wrapped = {
+        ...value,
+        diff: { chunks: [{ diffString }] },
+      };
+      return { text: safeJsonStringify(wrapped), isError };
+    }
+  }
+
+  return { text: safeJsonStringify(value), isError };
+}
+
+/**
+ * Apply SDK tool results onto a JSONL-parsed turn list in place. Pairing strategy:
+ *   - SDK runs are processed in turn-number order.
+ *   - JSONL turns are processed in their existing order, with each user prompt advancing
+ *     to the next SDK run.
+ *   - Within a run, JSONL `tool_use` blocks (across the assistant turns belonging to that
+ *     run, in order) are paired one-to-one with SDK tool_calls in the same run.
+ *
+ * We never *create* new blocks — we only enrich existing ones. This keeps the user-facing
+ * JSONL transcript as the source of truth for what the user saw, and uses the SDK store
+ * solely to fill in tool results, durations, and per-turn model.
+ */
+export function applySdkEnrichmentToTurns(
+  turns: ParsedTurn[],
+  enrichment: SdkAgentEnrichment,
+): { turns: ParsedTurn[]; toolCallsEnriched: number; assistantTurnsModelTagged: number } {
+  const sortedRuns = [...enrichment.runs].sort((a, b) => a.turnNumber - b.turnNumber);
+  if (sortedRuns.length === 0) {
+    return { turns, toolCallsEnriched: 0, assistantTurnsModelTagged: 0 };
+  }
+
+  // Walk JSONL turns; each user turn (after the first) advances to the next SDK run.
+  let runIdx = -1;
+  let toolUseIdx = 0;
+  let toolCallsEnriched = 0;
+  let assistantTurnsModelTagged = 0;
+
+  for (const turn of turns) {
+    if (turn.role === "user") {
+      runIdx++;
+      toolUseIdx = 0;
+      continue;
+    }
+    if (turn.role !== "assistant") continue;
+    if (runIdx < 0) {
+      // Assistant text appearing before any user prompt — leave alone.
+      continue;
+    }
+    const run = sortedRuns[runIdx];
+    if (!run) continue;
+
+    if (run.model && !turn.model) {
+      turn.model = run.model;
+      assistantTurnsModelTagged++;
+    }
+
+    const sdkCalls = enrichment.toolCallsByRun.get(run.runId) || [];
+    for (const block of turn.blocks) {
+      if (block.type !== "tool_use") continue;
+      const sdkCall = sdkCalls[toolUseIdx];
+      toolUseIdx++;
+      if (!sdkCall) continue;
+
+      // Only enrich when the JSONL block lacks a result. JSONL tool_use blocks come
+      // without tool_result entries for SDK sessions, so this is the common case.
+      if (typeof block._result === "string" && block._result.length > 0) continue;
+
+      block._result = sdkCall.result || "";
+      if (sdkCall.isError) block._isError = true;
+      // Re-run the Cursor arg mapper so Edit blocks pick up old/new strings from the
+      // result we just attached.
+      try {
+        block.input = mapToolArgs(block.name, block.input, block._result);
+      } catch {
+        // mapToolArgs is defensive but never throws in practice; ignore if it does.
+      }
+      toolCallsEnriched++;
+    }
+  }
+
+  return { turns, toolCallsEnriched, assistantTurnsModelTagged };
+}
+
+// ---------------------------------------------------------------------------
+// SQLite plumbing — kept minimal and isolated from the IDE-chat reader.
+// ---------------------------------------------------------------------------
+
+async function openIndexDb(dbPath: string): Promise<IndexDbHandle | null> {
+  const st = await stat(dbPath).catch(() => null);
+  if (!st?.isFile() || st.size < MIN_INDEX_DB_SIZE) return null;
+
+  if (await canUseSqliteCliFor(dbPath)) {
+    return { dbPath, backend: "sqlite-cli" };
+  }
+
+  let SQL: any;
+  try {
+    SQL = await getSqlJs();
+  } catch {
+    return null;
+  }
+  const buffer = await readFile(dbPath).catch(() => null);
+  if (!buffer) return null;
+  const db = new SQL.Database(buffer);
+  return { dbPath, backend: "sqljs", db };
+}
+
+function closeIndexDb(handle: IndexDbHandle | null): void {
+  if (!handle || handle.backend !== "sqljs" || !handle.db) return;
+  try {
+    handle.db.close();
+  } catch {
+    // ignore — we drop the reference either way
+  }
+}
+
+async function queryIndexDb(handle: IndexDbHandle, sql: string): Promise<Record<string, any>[]> {
+  if (handle.backend === "sqlite-cli") {
+    const { stdout } = await execFileAsync("sqlite3", ["-readonly", "-json", handle.dbPath, sql], {
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 60_000,
+    });
+    const trimmed = stdout.trim();
+    if (!trimmed) return [];
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? (parsed as Record<string, any>[]) : [];
+  }
+  const result = handle.db.exec(sql);
+  if (!Array.isArray(result) || result.length === 0) return [];
+  const [{ columns, values }] = result;
+  return values.map((row: unknown[]) => {
+    const record: Record<string, any> = {};
+    columns.forEach((column: string, index: number) => {
+      record[column] = row[index];
+    });
+    return record;
+  });
+}
+
+const sqliteCliCheckCache = new Map<string, { canUse: boolean; checkedAt: number }>();
+const SQLITE_CLI_CHECK_TTL_MS = 30_000;
+
+async function canUseSqliteCliFor(dbPath: string): Promise<boolean> {
+  const cached = sqliteCliCheckCache.get(dbPath);
+  if (cached?.canUse) return true;
+  if (cached && Date.now() - cached.checkedAt < SQLITE_CLI_CHECK_TTL_MS) return false;
+
+  let canUse = false;
+  try {
+    const { stdout } = await execFileAsync(
+      "sqlite3",
+      ["-readonly", "-json", dbPath, "SELECT json_valid('{}') AS ok;"],
+      { maxBuffer: 1024 * 1024 },
+    );
+    const rows = JSON.parse(stdout.trim()) as Array<{ ok?: number }>;
+    canUse = rows[0]?.ok === 1;
+  } catch {
+    canUse = false;
+  }
+  sqliteCliCheckCache.set(dbPath, { canUse, checkedAt: Date.now() });
+  return canUse;
+}
+
+async function listSdkIndexDbPaths(projectsRoot: string): Promise<string[]> {
+  const projects = await readdir(projectsRoot).catch(() => [] as string[]);
+  const out: string[] = [];
+  for (const project of projects) {
+    const sdkRoot = join(projectsRoot, project, SDK_STORE_SUBDIR);
+    const sdkStat = await stat(sdkRoot).catch(() => null);
+    if (!sdkStat?.isDirectory()) continue;
+    const projectHashes = await readdir(sdkRoot).catch(() => [] as string[]);
+    for (const hash of projectHashes) {
+      const dbPath = join(sdkRoot, hash, SDK_INDEX_DB_BASENAME);
+      const dbStat = await stat(dbPath).catch(() => null);
+      if (!dbStat?.isFile() || dbStat.size < MIN_INDEX_DB_SIZE) continue;
+      out.push(dbPath);
+    }
+  }
+  return out;
+}
+
+function sqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeJsonParse(text: string): any {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export const __testables = {
+  collectToolCalls,
+  finalizeEnrichment,
+  listSdkIndexDbPaths,
+};

--- a/packages/cli/src/providers/cursor/sdk-reader.ts
+++ b/packages/cli/src/providers/cursor/sdk-reader.ts
@@ -449,9 +449,9 @@ export function applySdkEnrichmentToTurns(
     const sdkCalls = enrichment.toolCallsByRun.get(run.runId) || [];
     for (const block of turn.blocks) {
       if (block.type !== "tool_use") continue;
-      // Only enrich when the JSONL block lacks a result. JSONL tool_use blocks come
-      // without tool_result entries for SDK sessions, so this is the common case.
-      if (typeof block._result === "string" && block._result.length > 0) continue;
+      // Only enrich when the JSONL block lacks a result. Empty-string results
+      // are valid tool outputs, so any string `_result` counts as already resolved.
+      if (typeof block._result === "string") continue;
 
       const sdkCall = sdkCalls[toolUseIdx];
       toolUseIdx++;

--- a/packages/cli/src/providers/cursor/sdk-reader.ts
+++ b/packages/cli/src/providers/cursor/sdk-reader.ts
@@ -29,6 +29,7 @@ const CURSOR_PROJECTS_ROOT = join(homedir(), ".cursor", "projects");
 const SDK_STORE_SUBDIR = "sdk-agent-store";
 const SDK_INDEX_DB_BASENAME = "index.db";
 const MIN_INDEX_DB_SIZE = 1024;
+const MAX_SQLJS_DB_BYTES = 128 * 1024 * 1024;
 
 const execFileAsync = promisify(execFile);
 
@@ -495,6 +496,7 @@ async function openIndexDb(dbPath: string): Promise<IndexDbHandle | null> {
   } catch {
     return null;
   }
+  if (st.size > MAX_SQLJS_DB_BYTES) return null;
   const buffer = await readFile(dbPath).catch(() => null);
   if (!buffer) return null;
   const db = new SQL.Database(buffer);
@@ -538,8 +540,7 @@ const SQLITE_CLI_CHECK_TTL_MS = 30_000;
 
 async function canUseSqliteCliFor(dbPath: string): Promise<boolean> {
   const cached = sqliteCliCheckCache.get(dbPath);
-  if (cached?.canUse) return true;
-  if (cached && Date.now() - cached.checkedAt < SQLITE_CLI_CHECK_TTL_MS) return false;
+  if (cached && Date.now() - cached.checkedAt < SQLITE_CLI_CHECK_TTL_MS) return cached.canUse;
 
   let canUse = false;
   try {
@@ -559,20 +560,23 @@ async function canUseSqliteCliFor(dbPath: string): Promise<boolean> {
 
 async function listSdkIndexDbPaths(projectsRoot: string): Promise<string[]> {
   const projects = await readdir(projectsRoot).catch(() => [] as string[]);
-  const out: string[] = [];
-  for (const project of projects) {
-    const sdkRoot = join(projectsRoot, project, SDK_STORE_SUBDIR);
-    const sdkStat = await stat(sdkRoot).catch(() => null);
-    if (!sdkStat?.isDirectory()) continue;
-    const projectHashes = await readdir(sdkRoot).catch(() => [] as string[]);
-    for (const hash of projectHashes) {
-      const dbPath = join(sdkRoot, hash, SDK_INDEX_DB_BASENAME);
-      const dbStat = await stat(dbPath).catch(() => null);
-      if (!dbStat?.isFile() || dbStat.size < MIN_INDEX_DB_SIZE) continue;
-      out.push(dbPath);
-    }
-  }
-  return out;
+  const perProjectPaths = await Promise.all(
+    projects.map(async (project) => {
+      const out: string[] = [];
+      const sdkRoot = join(projectsRoot, project, SDK_STORE_SUBDIR);
+      const sdkStat = await stat(sdkRoot).catch(() => null);
+      if (!sdkStat?.isDirectory()) return out;
+      const projectHashes = await readdir(sdkRoot).catch(() => [] as string[]);
+      for (const hash of projectHashes) {
+        const dbPath = join(sdkRoot, hash, SDK_INDEX_DB_BASENAME);
+        const dbStat = await stat(dbPath).catch(() => null);
+        if (!dbStat?.isFile() || dbStat.size < MIN_INDEX_DB_SIZE) continue;
+        out.push(dbPath);
+      }
+      return out;
+    }),
+  );
+  return perProjectPaths.flat();
 }
 
 function sqlString(value: string): string {

--- a/packages/cli/src/providers/cursor/sdk-reader.ts
+++ b/packages/cli/src/providers/cursor/sdk-reader.ts
@@ -449,13 +449,14 @@ export function applySdkEnrichmentToTurns(
     const sdkCalls = enrichment.toolCallsByRun.get(run.runId) || [];
     for (const block of turn.blocks) {
       if (block.type !== "tool_use") continue;
+      // Only enrich when the JSONL block lacks a result. JSONL tool_use blocks come
+      // without tool_result entries for SDK sessions, so this is the common case.
+      if (typeof block._result === "string" && block._result.length > 0) continue;
+
       const sdkCall = sdkCalls[toolUseIdx];
       toolUseIdx++;
       if (!sdkCall) continue;
 
-      // Only enrich when the JSONL block lacks a result. JSONL tool_use blocks come
-      // without tool_result entries for SDK sessions, so this is the common case.
-      if (typeof block._result === "string" && block._result.length > 0) continue;
       // A running-only SDK event has no result payload. Leave it missing rather
       // than converting "not yet known" into a concrete empty result.
       if (sdkCall.result === undefined) continue;

--- a/packages/cli/src/providers/cursor/sdk-reader.ts
+++ b/packages/cli/src/providers/cursor/sdk-reader.ts
@@ -99,7 +99,7 @@ export interface SdkAgentEnrichment {
   /** Sum of per-run durations (ms). */
   totalDurationMs?: number;
   /** Most-recent model seen across runs. */
-  primaryModel?: string;
+  latestModel?: string;
 }
 
 interface IndexDbHandle {
@@ -207,6 +207,9 @@ export async function loadSdkAgentEnrichment(agent: SdkAgent): Promise<SdkAgentE
 
     const runIds = runs.map((r) => r.runId).filter(Boolean);
     if (runIds.length === 0) return { agent, runs, toolCallsByRun: new Map() };
+    // The dynamic IN list is built from run_id values read from this same local
+    // DB. Values are still SQLite-escaped, and the sqlite3 backend uses execFile
+    // (no shell), so this stays local-data-only and shell-injection safe.
     const inList = runIds.map(sqlString).join(", ");
     const eventRows = await queryIndexDb(
       handle,
@@ -235,7 +238,7 @@ function finalizeEnrichment(
   let finishedAt: string | undefined;
   let totalDurationMs = 0;
   let totalDurationSeen = false;
-  let primaryModel: string | undefined;
+  let latestModel: string | undefined;
 
   for (const run of runs) {
     if (run.startedAt && (!startedAt || run.startedAt < startedAt)) startedAt = run.startedAt;
@@ -248,7 +251,7 @@ function finalizeEnrichment(
         totalDurationSeen = true;
       }
     }
-    if (run.model) primaryModel = run.model;
+    if (run.model) latestModel = run.model;
   }
 
   return {
@@ -258,7 +261,7 @@ function finalizeEnrichment(
     startedAt,
     finishedAt,
     totalDurationMs: totalDurationSeen ? totalDurationMs : undefined,
-    primaryModel,
+    latestModel,
   };
 }
 
@@ -311,13 +314,14 @@ function collectToolCalls(rows: Record<string, any>[]): Map<string, SdkToolCall[
     } else {
       entry.lastSeq = seq;
       entry.status = status;
-      // Args sometimes get fleshed out across "running" updates — prefer the latest non-empty payload.
-      if (Object.keys(argsObj).length > Object.keys(entry.args).length) {
+      // Args sometimes get fleshed out across "running" updates — prefer the
+      // latest non-empty payload even when the key count stays the same.
+      if (Object.keys(argsObj).length > 0) {
         entry.args = argsObj;
       }
     }
 
-    if (status === "completed" || status === "error" || message.result !== undefined) {
+    if (message.result !== undefined) {
       const formatted = formatSdkToolResult(rawName, message.result);
       entry.result = formatted.text;
       entry.isError = formatted.isError || status === "error";
@@ -415,6 +419,9 @@ export function applySdkEnrichmentToTurns(
   }
 
   // Walk JSONL turns; each user turn (after the first) advances to the next SDK run.
+  // toolUseIdx intentionally spans assistant-turn boundaries within a run: the
+  // SDK call stream is flat per run, while JSONL can split one run across
+  // multiple assistant messages.
   let runIdx = -1;
   let toolUseIdx = 0;
   let toolCallsEnriched = 0;
@@ -449,8 +456,11 @@ export function applySdkEnrichmentToTurns(
       // Only enrich when the JSONL block lacks a result. JSONL tool_use blocks come
       // without tool_result entries for SDK sessions, so this is the common case.
       if (typeof block._result === "string" && block._result.length > 0) continue;
+      // A running-only SDK event has no result payload. Leave it missing rather
+      // than converting "not yet known" into a concrete empty result.
+      if (sdkCall.result === undefined) continue;
 
-      block._result = sdkCall.result || "";
+      block._result = sdkCall.result;
       if (sdkCall.isError) block._isError = true;
       // Re-run the Cursor arg mapper so Edit blocks pick up old/new strings from the
       // result we just attached.

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2685,10 +2685,12 @@ function buildStoreTurnStats(turns: ParsedTurn[]): TurnStat[] {
 export function mapCursorToolName(name: string): string {
   const mapping: Record<string, string> = {
     Shell: "Bash",
+    shell: "Bash", // Cursor SDK lowercase tool name
     run_terminal_command_v2: "Bash",
     run_terminal_cmd: "Bash",
     Read: "Read",
     ReadFile: "Read",
+    read: "Read", // Cursor SDK lowercase tool name
     read_file_v2: "Read",
     read_file: "Read",
     read_lints: "ReadLints",
@@ -2706,6 +2708,7 @@ export function mapCursorToolName(name: string): string {
     LS: "Glob",
     StrReplace: "Edit",
     EditFile: "Edit",
+    edit: "Edit", // Cursor SDK lowercase tool name
     edit_file_v2: "Edit",
     edit_file: "Edit",
     search_replace: "Edit",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -401,6 +401,7 @@ interface SourceSummaryRecord {
   filePaths: string[];
   toolPaths?: string[];
   hasSqlite?: boolean;
+  hasSdk?: boolean;
   isStarred?: boolean;
   spaceId?: string;
   spaceIdSetBy?: string;
@@ -650,6 +651,7 @@ async function buildSourcesResult(
       filePaths: s.filePaths,
       toolPaths: s.toolPaths,
       hasSqlite: s.hasSqlite,
+      hasSdk: s.hasSdk,
       gitBranch: s.gitBranch,
       model: s.model,
       durationMsEst: s.durationMsEst,
@@ -865,7 +867,9 @@ export async function startServer(
   // caches stored cliSessionId (inner-subprocess UUID) as the Cowork session's
   // identity, which never matches what the parser reads from audit.jsonl and
   // permanently broke replay-to-source linking. Bumping discards those caches.
-  const sourcesCacheKey = `dashboard-sources-v3-${cacheKeySuffix}`;
+  // v3 → v4: added `hasSdk` flag for Cursor SDK-backed sessions; old caches
+  // omit the field so the dashboard can't render the SDK badge until refreshed.
+  const sourcesCacheKey = `dashboard-sources-v4-${cacheKeySuffix}`;
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
   const scanResultsCacheKey = `dashboard-scan-results-v1-${cacheKeySuffix}`;
   const insightsCacheKey = `dashboard-insights-v1-${cacheKeySuffix}`;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -41,6 +41,7 @@ export interface SessionInfo {
   toolPaths?: string[]; // cursor tool outputs associated with this session
   workspacePath?: string; // absolute workspace path for Cursor lookup
   hasSqlite?: boolean; // true if any Cursor SQLite source exists (store.db or global state DB)
+  hasSdk?: boolean; // true if a Cursor SDK agent record exists in sdk-agent-store/index.db
   firstPrompt: string;
   prompts?: string[]; // first N meaningful user prompts (cleaned)
   promptCount?: number; // total user prompts (counted via lightweight scan)

--- a/packages/cli/test/cursor-sdk-reader.test.ts
+++ b/packages/cli/test/cursor-sdk-reader.test.ts
@@ -271,6 +271,62 @@ describe("collectToolCalls", () => {
     expect(__testables.collectToolCalls(rows).size).toBe(0);
   });
 
+  it("keeps latest non-empty args even when key count does not change", () => {
+    const rows = [
+      {
+        run_id: "r1",
+        seq: 1,
+        payload_json: JSON.stringify({
+          message: {
+            type: "tool_call",
+            call_id: "call_a",
+            name: "shell",
+            status: "running",
+            args: { command: "echo partial" },
+          },
+        }),
+      },
+      {
+        run_id: "r1",
+        seq: 2,
+        payload_json: JSON.stringify({
+          message: {
+            type: "tool_call",
+            call_id: "call_a",
+            name: "shell",
+            status: "completed",
+            args: { command: "echo full command" },
+            result: { status: "success", value: { exitCode: 0, stdout: "ok\n", stderr: "" } },
+          },
+        }),
+      },
+    ];
+    const list = __testables.collectToolCalls(rows).get("r1") ?? [];
+    expect(list[0].args).toEqual({ command: "echo full command" });
+  });
+
+  it("does not synthesize an empty result from running-only events", () => {
+    const rows = [
+      {
+        run_id: "r1",
+        seq: 1,
+        payload_json: JSON.stringify({
+          message: {
+            type: "tool_call",
+            call_id: "call_running",
+            name: "shell",
+            status: "running",
+            args: { command: "sleep 10" },
+          },
+        }),
+      },
+    ];
+    const list = __testables.collectToolCalls(rows).get("r1") ?? [];
+    expect(list).toHaveLength(1);
+    expect(list[0].status).toBe("running");
+    expect(list[0].result).toBeUndefined();
+  });
+
   it("preserves intra-run ordering by firstSeq", () => {
     const rows = [
       {
@@ -362,7 +418,7 @@ describe("applySdkEnrichmentToTurns", () => {
       startedAt: "2026-01-01T00:00:00.000Z",
       finishedAt: "2026-01-01T00:00:15.000Z",
       totalDurationMs: 10000,
-      primaryModel: "composer-2",
+      latestModel: "composer-2",
     };
   }
 
@@ -416,6 +472,29 @@ describe("applySdkEnrichmentToTurns", () => {
     const block = turns[1].blocks[0];
     if (block.type !== "tool_use") throw new Error("type narrow");
     expect(block._result).toBe("preexisting");
+  });
+
+  it("does not enrich running-only SDK calls as empty results", () => {
+    const enrichment = makeEnrichment();
+    const calls = enrichment.toolCallsByRun.get("r1") ?? [];
+    calls[0] = {
+      ...calls[0],
+      status: "running",
+      result: undefined,
+    };
+
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "prompt" }] },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", id: "j1", name: "Bash", input: { command: "sleep 10" } }],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, enrichment);
+    expect(result.toolCallsEnriched).toBe(0);
+    const block = turns[1].blocks[0];
+    if (block.type !== "tool_use") throw new Error("type narrow");
+    expect(block._result).toBeUndefined();
   });
 
   it("handles JSONL having more tool_use blocks than SDK calls", () => {
@@ -557,7 +636,7 @@ describe("loadSdkAgentEnrichment + listSdkIndexDbPaths (integration with synthet
     expect(enrichment.runs).toHaveLength(1);
     expect(enrichment.runs[0].runId).toBe("run-fixture-r1");
     expect(enrichment.runs[0].model).toBe("composer-2");
-    expect(enrichment.primaryModel).toBe("composer-2");
+    expect(enrichment.latestModel).toBe("composer-2");
     expect(enrichment.totalDurationMs).toBe(29000);
 
     const calls = enrichment.toolCallsByRun.get("run-fixture-r1") ?? [];

--- a/packages/cli/test/cursor-sdk-reader.test.ts
+++ b/packages/cli/test/cursor-sdk-reader.test.ts
@@ -499,6 +499,31 @@ describe("applySdkEnrichmentToTurns", () => {
     expect(blocks[1]._result).toBe("file1\nfile2");
   });
 
+  it("treats empty-string _result blocks as already resolved", () => {
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "prompt" }] },
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "empty-result",
+            name: "Bash",
+            input: { command: "true" },
+            _result: "",
+          },
+          { type: "tool_use", id: "needs-sdk", name: "Bash", input: { command: "ls" } },
+        ],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    expect(result.toolCallsEnriched).toBe(1);
+    const blocks = turns[1].blocks;
+    if (blocks[0].type !== "tool_use" || blocks[1].type !== "tool_use") throw new Error("narrow");
+    expect(blocks[0]._result).toBe("");
+    expect(blocks[1]._result).toBe("file1\nfile2");
+  });
+
   it("does not enrich running-only SDK calls as empty results", () => {
     const enrichment = makeEnrichment();
     const calls = enrichment.toolCallsByRun.get("r1") ?? [];

--- a/packages/cli/test/cursor-sdk-reader.test.ts
+++ b/packages/cli/test/cursor-sdk-reader.test.ts
@@ -1,0 +1,569 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  __testables,
+  applySdkEnrichmentToTurns,
+  formatSdkToolResult,
+  type SdkAgent,
+  type SdkAgentEnrichment,
+} from "../src/providers/cursor/sdk-reader.js";
+import type { ParsedTurn } from "../src/types.js";
+
+/**
+ * Build a synthetic Cursor SDK index.db on disk that matches the real schema:
+ *   agents      (agent_id, workspace_ref, status, name, ...)
+ *   runs        (run_id, agent_id, turn_number, status, model, started_at, finished_at, result)
+ *   run_events  (run_id, seq, event_type, payload_json, ...)
+ *
+ * Returns the file path so tests can pass it to readers.
+ */
+async function createSyntheticSdkIndexDb(
+  dir: string,
+  data: {
+    agents: Array<{
+      agent_id: string;
+      workspace_ref: string;
+      status?: string;
+      name?: string;
+      created_at?: string;
+      updated_at?: string;
+    }>;
+    runs: Array<{
+      run_id: string;
+      agent_id: string;
+      turn_number: number;
+      status?: string;
+      model?: string;
+      started_at?: string;
+      finished_at?: string;
+      result?: string;
+    }>;
+    events: Array<{
+      run_id: string;
+      seq: number;
+      payload: Record<string, any>;
+    }>;
+  },
+): Promise<string> {
+  const initSqlJs = (await import("sql.js")).default;
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+
+  db.run(`
+    CREATE TABLE agents (
+      agent_id TEXT PRIMARY KEY,
+      workspace_ref TEXT NOT NULL,
+      status TEXT NOT NULL,
+      active_run_id TEXT,
+      latest_checkpoint_ref_json TEXT,
+      name TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE runs (
+      run_id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+      turn_number INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      model TEXT,
+      model_params_json TEXT,
+      start_checkpoint_ref_json TEXT,
+      latest_checkpoint_ref_json TEXT,
+      error_code TEXT,
+      usage_ref TEXT,
+      result TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      started_at TEXT,
+      finished_at TEXT,
+      cancelled_at TEXT,
+      expired_at TEXT,
+      UNIQUE(agent_id, turn_number)
+    )
+  `);
+  db.run(`
+    CREATE TABLE run_events (
+      run_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      offset TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload_json TEXT,
+      payload_ref TEXT,
+      idempotency_key TEXT,
+      created_at TEXT NOT NULL,
+      PRIMARY KEY (run_id, seq)
+    )
+  `);
+
+  for (const a of data.agents) {
+    db.run(
+      `INSERT INTO agents (agent_id, workspace_ref, status, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        a.agent_id,
+        a.workspace_ref,
+        a.status ?? "IDLE",
+        a.name ?? null,
+        a.created_at ?? "2026-01-01T00:00:00.000Z",
+        a.updated_at ?? "2026-01-01T00:00:01.000Z",
+      ],
+    );
+  }
+  for (const r of data.runs) {
+    db.run(
+      `INSERT INTO runs (run_id, agent_id, turn_number, status, model, started_at, finished_at, result, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        r.run_id,
+        r.agent_id,
+        r.turn_number,
+        r.status ?? "FINISHED",
+        r.model ?? null,
+        r.started_at ?? null,
+        r.finished_at ?? null,
+        r.result ?? null,
+        r.started_at ?? "2026-01-01T00:00:00.000Z",
+        r.finished_at ?? "2026-01-01T00:00:01.000Z",
+      ],
+    );
+  }
+  for (const e of data.events) {
+    db.run(
+      `INSERT INTO run_events (run_id, seq, offset, event_type, payload_json, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        e.run_id,
+        e.seq,
+        String(e.seq),
+        "run_stream_event",
+        JSON.stringify(e.payload),
+        "2026-01-01T00:00:00.000Z",
+      ],
+    );
+  }
+
+  const bytes = db.export();
+  const dbPath = join(dir, "index.db");
+  await writeFile(dbPath, Buffer.from(bytes));
+  db.close();
+  return dbPath;
+}
+
+describe("formatSdkToolResult", () => {
+  it("extracts stdout from shell tool results", () => {
+    const formatted = formatSdkToolResult("Shell", {
+      status: "success",
+      value: { exitCode: 0, stdout: "hello world\n", stderr: "" },
+    });
+    expect(formatted.text).toBe("hello world");
+    expect(formatted.isError).toBe(false);
+  });
+
+  it("flags non-zero exit codes as errors", () => {
+    const formatted = formatSdkToolResult("Shell", {
+      status: "success",
+      value: { exitCode: 1, stdout: "", stderr: "boom" },
+    });
+    expect(formatted.text).toContain("[stderr]");
+    expect(formatted.text).toContain("boom");
+    expect(formatted.isError).toBe(true);
+  });
+
+  it("returns Read content verbatim", () => {
+    const formatted = formatSdkToolResult("ReadFile", {
+      status: "success",
+      value: { content: "line1\nline2\n", totalLines: 2, fileSize: 12 },
+    });
+    expect(formatted.text).toBe("line1\nline2\n");
+  });
+
+  it("wraps Edit diff so downstream inferEditStringsFromResult picks it up", () => {
+    const formatted = formatSdkToolResult("ApplyPatch", {
+      status: "success",
+      value: {
+        linesAdded: 1,
+        linesRemoved: 0,
+        diffString: "@@ -1,1 +1,2 @@\n existing\n+new line",
+      },
+    });
+    const parsed = JSON.parse(formatted.text);
+    expect(parsed.diff.chunks[0].diffString).toBe("@@ -1,1 +1,2 @@\n existing\n+new line");
+    expect(parsed.linesAdded).toBe(1);
+  });
+
+  it("falls back to JSON for unknown shapes", () => {
+    const formatted = formatSdkToolResult("UnknownTool", {
+      status: "success",
+      value: { foo: "bar" },
+    });
+    expect(JSON.parse(formatted.text)).toEqual({ foo: "bar" });
+    expect(formatted.isError).toBe(false);
+  });
+
+  it("treats string results as-is", () => {
+    expect(formatSdkToolResult("Shell", "raw text").text).toBe("raw text");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(formatSdkToolResult("Shell", null).text).toBe("");
+    expect(formatSdkToolResult("Shell", undefined).text).toBe("");
+  });
+});
+
+describe("collectToolCalls", () => {
+  it("pairs running + completed events on the same call_id", () => {
+    const rows = [
+      {
+        run_id: "r1",
+        seq: 10,
+        payload_json: JSON.stringify({
+          message: {
+            type: "tool_call",
+            call_id: "call_a",
+            name: "shell",
+            status: "running",
+            args: { command: "ls" },
+          },
+        }),
+      },
+      {
+        run_id: "r1",
+        seq: 11,
+        payload_json: JSON.stringify({
+          message: {
+            type: "tool_call",
+            call_id: "call_a",
+            name: "shell",
+            status: "completed",
+            args: { command: "ls" },
+            result: { status: "success", value: { exitCode: 0, stdout: "ok\n", stderr: "" } },
+          },
+        }),
+      },
+    ];
+    const calls = __testables.collectToolCalls(rows);
+    const r1 = calls.get("r1") ?? [];
+    expect(r1).toHaveLength(1);
+    expect(r1[0].callId).toBe("call_a");
+    expect(r1[0].name).toBe("Bash"); // mapCursorToolName("shell")
+    expect(r1[0].status).toBe("completed");
+    expect(r1[0].result).toBe("ok");
+    expect(r1[0].isError).toBe(false);
+    expect(r1[0].firstSeq).toBe(10);
+    expect(r1[0].lastSeq).toBe(11);
+  });
+
+  it("ignores non-tool_call events", () => {
+    const rows = [
+      {
+        run_id: "r1",
+        seq: 1,
+        payload_json: JSON.stringify({ message: { type: "thinking", text: "..." } }),
+      },
+      {
+        run_id: "r1",
+        seq: 2,
+        payload_json: JSON.stringify({ message: { type: "assistant", message: { content: [] } } }),
+      },
+    ];
+    expect(__testables.collectToolCalls(rows).size).toBe(0);
+  });
+
+  it("preserves intra-run ordering by firstSeq", () => {
+    const rows = [
+      {
+        run_id: "r1",
+        seq: 5,
+        payload_json: JSON.stringify({
+          message: { type: "tool_call", call_id: "b", name: "edit", status: "running", args: {} },
+        }),
+      },
+      {
+        run_id: "r1",
+        seq: 3,
+        payload_json: JSON.stringify({
+          message: { type: "tool_call", call_id: "a", name: "read", status: "running", args: {} },
+        }),
+      },
+    ];
+    const list = __testables.collectToolCalls(rows).get("r1") ?? [];
+    expect(list.map((c) => c.callId)).toEqual(["a", "b"]);
+  });
+});
+
+describe("applySdkEnrichmentToTurns", () => {
+  function makeEnrichment(): SdkAgentEnrichment {
+    const agent: SdkAgent = {
+      agentId: "agent-x",
+      workspaceRef: "/tmp/ws",
+      status: "IDLE",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:30.000Z",
+      dbPath: "/tmp/ws/sdk/index.db",
+    };
+    return {
+      agent,
+      runs: [
+        {
+          runId: "r1",
+          agentId: "agent-x",
+          turnNumber: 1,
+          status: "FINISHED",
+          model: "composer-2",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:00:05.000Z",
+        },
+        {
+          runId: "r2",
+          agentId: "agent-x",
+          turnNumber: 2,
+          status: "FINISHED",
+          model: "composer-2",
+          startedAt: "2026-01-01T00:00:10.000Z",
+          finishedAt: "2026-01-01T00:00:15.000Z",
+        },
+      ],
+      toolCallsByRun: new Map([
+        [
+          "r1",
+          [
+            {
+              callId: "c1",
+              runId: "r1",
+              firstSeq: 1,
+              lastSeq: 2,
+              name: "Bash",
+              args: { command: "ls" },
+              status: "completed",
+              result: "file1\nfile2",
+              isError: false,
+            },
+          ],
+        ],
+        [
+          "r2",
+          [
+            {
+              callId: "c2",
+              runId: "r2",
+              firstSeq: 3,
+              lastSeq: 4,
+              name: "Read",
+              args: { file_path: "/tmp/x.txt" },
+              status: "completed",
+              result: "contents",
+              isError: false,
+            },
+          ],
+        ],
+      ]),
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:15.000Z",
+      totalDurationMs: 10000,
+      primaryModel: "composer-2",
+    };
+  }
+
+  it("attaches results to JSONL tool_use blocks in turn order", () => {
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "first prompt" }] },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", id: "j1", name: "Bash", input: { command: "ls" } }],
+      },
+      { role: "user", blocks: [{ type: "text", text: "second prompt" }] },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", id: "j2", name: "Read", input: { file_path: "/tmp/x.txt" } }],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    expect(result.toolCallsEnriched).toBe(2);
+    expect(result.assistantTurnsModelTagged).toBe(2);
+
+    const a1 = turns[1].blocks[0];
+    expect(a1.type).toBe("tool_use");
+    if (a1.type !== "tool_use") throw new Error("type narrow");
+    expect(a1._result).toBe("file1\nfile2");
+
+    const a2 = turns[3].blocks[0];
+    if (a2.type !== "tool_use") throw new Error("type narrow");
+    expect(a2._result).toBe("contents");
+    expect(turns[1].model).toBe("composer-2");
+    expect(turns[3].model).toBe("composer-2");
+  });
+
+  it("does not overwrite an existing _result", () => {
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "prompt" }] },
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "j1",
+            name: "Bash",
+            input: { command: "ls" },
+            _result: "preexisting",
+          },
+        ],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    expect(result.toolCallsEnriched).toBe(0);
+    const block = turns[1].blocks[0];
+    if (block.type !== "tool_use") throw new Error("type narrow");
+    expect(block._result).toBe("preexisting");
+  });
+
+  it("handles JSONL having more tool_use blocks than SDK calls", () => {
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "p1" }] },
+      {
+        role: "assistant",
+        blocks: [
+          { type: "tool_use", id: "a", name: "Bash", input: {} },
+          { type: "tool_use", id: "b", name: "Bash", input: {} },
+        ],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    // Only one SDK call in run r1 → first block enriched, second untouched.
+    expect(result.toolCallsEnriched).toBe(1);
+    const blocks = turns[1].blocks;
+    if (blocks[0].type !== "tool_use" || blocks[1].type !== "tool_use") throw new Error("narrow");
+    expect(blocks[0]._result).toBe("file1\nfile2");
+    expect(blocks[1]._result).toBeUndefined();
+  });
+
+  it("ignores assistant text that appears before any user prompt", () => {
+    const turns: ParsedTurn[] = [
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", id: "stray", name: "Bash", input: {} }],
+      },
+      { role: "user", blocks: [{ type: "text", text: "p1" }] },
+      {
+        role: "assistant",
+        blocks: [{ type: "tool_use", id: "j1", name: "Bash", input: {} }],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    expect(result.toolCallsEnriched).toBe(1);
+    const stray = turns[0].blocks[0];
+    if (stray.type !== "tool_use") throw new Error("narrow");
+    expect(stray._result).toBeUndefined();
+  });
+});
+
+describe("loadSdkAgentEnrichment + listSdkIndexDbPaths (integration with synthetic db)", () => {
+  let tempRoot: string;
+  let dbPath: string;
+
+  beforeAll(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "vibe-replay-sdk-"));
+    const projectDir = join(
+      tempRoot,
+      ".cursor",
+      "projects",
+      "Users-tlei-fixture-ws",
+      "sdk-agent-store",
+      "abc123",
+    );
+    await mkdir(projectDir, { recursive: true });
+    dbPath = await createSyntheticSdkIndexDb(projectDir, {
+      agents: [
+        {
+          agent_id: "agent-fixture-1",
+          workspace_ref: "/Users/tlei/fixture/ws",
+          status: "IDLE",
+          name: "fixture-agent",
+          created_at: "2026-01-01T00:00:00.000Z",
+          updated_at: "2026-01-01T00:01:00.000Z",
+        },
+      ],
+      runs: [
+        {
+          run_id: "run-fixture-r1",
+          agent_id: "agent-fixture-1",
+          turn_number: 1,
+          status: "FINISHED",
+          model: "composer-2",
+          started_at: "2026-01-01T00:00:01.000Z",
+          finished_at: "2026-01-01T00:00:30.000Z",
+          result: "done",
+        },
+      ],
+      events: [
+        {
+          run_id: "run-fixture-r1",
+          seq: 1,
+          payload: {
+            schemaVersion: 1,
+            type: "sdk_message",
+            message: {
+              type: "tool_call",
+              call_id: "call_synthetic_1",
+              name: "shell",
+              status: "running",
+              args: { command: "echo hi" },
+            },
+          },
+        },
+        {
+          run_id: "run-fixture-r1",
+          seq: 2,
+          payload: {
+            schemaVersion: 1,
+            type: "sdk_message",
+            message: {
+              type: "tool_call",
+              call_id: "call_synthetic_1",
+              name: "shell",
+              status: "completed",
+              args: { command: "echo hi" },
+              result: { status: "success", value: { exitCode: 0, stdout: "hi\n", stderr: "" } },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("listSdkIndexDbPaths walks sdk-agent-store/<hash>/index.db files", async () => {
+    const paths = await __testables.listSdkIndexDbPaths(join(tempRoot, ".cursor", "projects"));
+    expect(paths).toContain(dbPath);
+  });
+
+  it("loadSdkAgentEnrichment reconstructs runs and tool calls", async () => {
+    const { loadSdkAgentEnrichment } = await import("../src/providers/cursor/sdk-reader.js");
+    const enrichment = await loadSdkAgentEnrichment({
+      agentId: "agent-fixture-1",
+      workspaceRef: "/Users/tlei/fixture/ws",
+      status: "IDLE",
+      name: "fixture-agent",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:01:00.000Z",
+      dbPath,
+    });
+    expect(enrichment).not.toBeNull();
+    if (!enrichment) throw new Error("guard");
+    expect(enrichment.runs).toHaveLength(1);
+    expect(enrichment.runs[0].runId).toBe("run-fixture-r1");
+    expect(enrichment.runs[0].model).toBe("composer-2");
+    expect(enrichment.primaryModel).toBe("composer-2");
+    expect(enrichment.totalDurationMs).toBe(29000);
+
+    const calls = enrichment.toolCallsByRun.get("run-fixture-r1") ?? [];
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("Bash");
+    expect(calls[0].result).toBe("hi");
+    expect(calls[0].status).toBe("completed");
+  });
+});

--- a/packages/cli/test/cursor-sdk-reader.test.ts
+++ b/packages/cli/test/cursor-sdk-reader.test.ts
@@ -474,6 +474,31 @@ describe("applySdkEnrichmentToTurns", () => {
     expect(block._result).toBe("preexisting");
   });
 
+  it("does not consume SDK call slots for already-resolved tool blocks", () => {
+    const turns: ParsedTurn[] = [
+      { role: "user", blocks: [{ type: "text", text: "prompt" }] },
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "already-resolved",
+            name: "ToolOutput",
+            input: {},
+            _result: "preexisting sidecar result",
+          },
+          { type: "tool_use", id: "needs-sdk", name: "Bash", input: { command: "ls" } },
+        ],
+      },
+    ];
+    const result = applySdkEnrichmentToTurns(turns, makeEnrichment());
+    expect(result.toolCallsEnriched).toBe(1);
+    const blocks = turns[1].blocks;
+    if (blocks[0].type !== "tool_use" || blocks[1].type !== "tool_use") throw new Error("narrow");
+    expect(blocks[0]._result).toBe("preexisting sidecar result");
+    expect(blocks[1]._result).toBe("file1\nfile2");
+  });
+
   it("does not enrich running-only SDK calls as empty results", () => {
     const enrichment = makeEnrichment();
     const calls = enrichment.toolCallsByRun.get("r1") ?? [];

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -305,7 +305,11 @@ function shortCoworkSpaceId(spaceId: string): string {
   return compact.slice(0, 6) || spaceId.slice(0, 6);
 }
 
-function dataSourceBadgeClass(dataSource?: string, hasSqlite?: boolean): string {
+function dataSourceBadgeClass(dataSource?: string, hasSqlite?: boolean, hasSdk?: boolean): string {
+  // SDK gets its own distinct purple badge so users can spot Cursor SDK sessions
+  // at a glance (they're functionally different from IDE chats — different store,
+  // different agent runtime, different lifecycle).
+  if (hasSdk) return "bg-terminal-purple-subtle text-terminal-purple";
   if (dataSource === "jsonl") return "bg-terminal-orange-subtle text-terminal-orange";
   if (dataSource === "global-state") return "bg-terminal-blue-subtle text-terminal-blue";
   if (dataSource === "sqlite" || hasSqlite) return "bg-terminal-green-subtle text-terminal-green";
@@ -451,11 +455,11 @@ export function SessionDetailPopup({
                 {shortModelName(model)}
               </span>
             )}
-            {scanData?.dataSource && (
+            {(scanData?.dataSource || s.hasSdk) && (
               <span
-                className={`text-[10px] font-mono px-1.5 py-0.5 rounded-full ${dataSourceBadgeClass(scanData.dataSource, s.hasSqlite)}`}
+                className={`text-[10px] font-mono px-1.5 py-0.5 rounded-full ${dataSourceBadgeClass(scanData?.dataSource, s.hasSqlite, s.hasSdk)}`}
               >
-                {formatDataSourceLabel(s.hasSqlite, scanData.dataSource)}
+                {formatDataSourceLabel(s.hasSqlite, scanData?.dataSource, s.hasSdk)}
               </span>
             )}
             {scanData?.entrypoint && (
@@ -576,7 +580,7 @@ export function SessionDetailPopup({
               )}
               <InfoRow
                 label="Data"
-                value={formatDataSourceLabel(s.hasSqlite, scanData?.dataSource)}
+                value={formatDataSourceLabel(s.hasSqlite, scanData?.dataSource, s.hasSdk)}
               />
             </div>
 
@@ -1970,7 +1974,11 @@ function SessionsPanel() {
                 const displayDurationMs = scanData?.durationMs ?? s.durationMsEst;
                 const displayEditCount = scanData?.editCount ?? s.editCountEst;
                 const displayModel = scanData?.model || s.model;
-                const dataSourceLabel = formatDataSourceLabel(s.hasSqlite, scanData?.dataSource);
+                const dataSourceLabel = formatDataSourceLabel(
+                  s.hasSqlite,
+                  scanData?.dataSource,
+                  s.hasSdk,
+                );
                 const isArchived = archivedSlugs.has(s.slug);
                 return (
                   <div
@@ -2194,9 +2202,9 @@ function SessionsPanel() {
                           {s.filePaths.length} parts
                         </span>
                       )}
-                      {(s.hasSqlite || scanData?.dataSource) && (
+                      {(s.hasSqlite || s.hasSdk || scanData?.dataSource) && (
                         <span
-                          className={`text-xs font-mono px-1.5 py-0.5 rounded-md ${dataSourceBadgeClass(scanData?.dataSource, s.hasSqlite)}`}
+                          className={`text-xs font-mono px-1.5 py-0.5 rounded-md ${dataSourceBadgeClass(scanData?.dataSource, s.hasSqlite, s.hasSdk)}`}
                           title={dataSourceLabel}
                         >
                           {dataSourceLabel}

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   agentWorktreeParent,
+  formatDataSourceLabel,
   rollupProject,
   rollupTopProjects,
   type TopProjectEntry,
@@ -184,5 +185,25 @@ describe("rollupTopProjects", () => {
     rollupTopProjects([parent, worktree]);
     expect(parent.sessions).toBe(1);
     expect(parent.sessionsPerDay).toEqual({ "2026-04-01": 1 });
+  });
+});
+
+describe("formatDataSourceLabel", () => {
+  it("labels Cursor SDK sessions distinctly when hasSdk is true", () => {
+    expect(formatDataSourceLabel(false, "jsonl+tools", true)).toBe(
+      "Cursor SDK + JSONL + agent-tools",
+    );
+    expect(formatDataSourceLabel(false, "jsonl", true)).toBe("Cursor SDK + JSONL");
+    expect(formatDataSourceLabel(false, undefined, true)).toBe("Cursor SDK");
+  });
+
+  it("falls back to existing labels when hasSdk is not set", () => {
+    expect(formatDataSourceLabel(false, "jsonl+tools")).toBe("JSONL + agent-tools");
+    expect(formatDataSourceLabel(true, "jsonl+tools")).toBe("JSONL + agent-tools fallback");
+    expect(formatDataSourceLabel(false, "jsonl")).toBe("JSONL transcript");
+    expect(formatDataSourceLabel(true, "sqlite")).toBe("SQLite + JSONL supplement");
+    expect(formatDataSourceLabel(false, "global-state")).toBe("Cursor global state");
+    expect(formatDataSourceLabel(true)).toBe("SQLite + JSONL");
+    expect(formatDataSourceLabel()).toBe("JSONL");
   });
 });

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -525,7 +525,19 @@ export function computeProjectLabels(projects: string[]): Map<string, string> {
   return labels;
 }
 
-export function formatDataSourceLabel(hasSqlite?: boolean, dataSource?: string): string {
+export function formatDataSourceLabel(
+  hasSqlite?: boolean,
+  dataSource?: string,
+  hasSdk?: boolean,
+): string {
+  // Cursor SDK gets a dedicated label whenever the SDK store is present, since
+  // its agent stream is the source of structured tool results — independent of
+  // whether an IDE chat store.db also exists for the same workspace.
+  if (hasSdk) {
+    if (dataSource === "jsonl+tools") return "Cursor SDK + JSONL + agent-tools";
+    if (dataSource === "jsonl") return "Cursor SDK + JSONL";
+    return "Cursor SDK";
+  }
   if (dataSource === "sqlite") return hasSqlite ? "SQLite + JSONL supplement" : "SQLite";
   if (dataSource === "global-state") return "Cursor global state";
   if (dataSource === "jsonl") return hasSqlite ? "JSONL fallback" : "JSONL transcript";

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -69,6 +69,7 @@ export interface SourceSession {
   filePaths: string[];
   toolPaths?: string[];
   hasSqlite?: boolean;
+  hasSdk?: boolean;
   gitBranch?: string;
   existingReplay: string | null;
   projectExists?: boolean;


### PR DESCRIPTION
## Summary
- Add a Cursor SDK store reader for `sdk-agent-store/*/index.db` so SDK transcripts get run metadata, model names, timing, and structured tool results.
- Mark SDK-backed sessions in discovery/API responses and render them in the dashboard with a distinct Cursor SDK data-source label.
- Cover SDK result formatting, event pairing, replay enrichment, and dashboard data-source labels with tests.

## Test plan
- `pnpm lint:check`
- `pnpm test`
- `pnpm build`
- `pnpm test:e2e`
- Manual dashboard smoke: `/api/sources` returns 22 `hasSdk=true` sessions; browser search for `Cursor SDK` finds visible dashboard matches; filtering `agent-59` keeps SDK labels visible.


Made with [Cursor](https://cursor.com)