### PR TITLE
chore(cli): normalize trailing slash in getApiUrl and remove redundant call-site strips

### DIFF
--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -148,7 +148,7 @@ export function getAuthFilePath(): string {
 }
 
 export function getApiUrl(): string {
-  return process.env.VIBE_REPLAY_API_URL || DEFAULT_API_URL;
+  return (process.env.VIBE_REPLAY_API_URL || DEFAULT_API_URL).replace(/\/$/, "");
 }
 
 /** HTTPS targets use __Secure- prefixed cookie names (Better Auth convention) */

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -2260,7 +2260,7 @@ export async function startServer(
   // The BFF proxy follows the TOKEN, not the env var: if no token for the
   // current VIBE_REPLAY_API_URL, it uses whatever token is available and
   // proxies to that token's origin (e.g. production) instead.
-  const cloudApiBaseUrl = getApiUrl().replace(/\/$/, "");
+  const cloudApiBaseUrl = getApiUrl();
 
   function readLocalAuthSession(): {
     token: string;
@@ -2283,7 +2283,7 @@ export async function startServer(
       return {
         token: fallback.token,
         user: fallback.user as { id: string; name: string; email?: string; image?: string },
-        targetApi: fallback.origin.replace(/\/$/, ""),
+        targetApi: fallback.origin,
       };
     }
     return null;
@@ -2305,7 +2305,7 @@ export async function startServer(
     if (exact) candidates.push({ token: exact.token, apiUrl: cloudApiBaseUrl });
     const fallback = loadAnyAuthToken();
     if (fallback) {
-      const fallbackApi = fallback.origin.replace(/\/$/, "");
+      const fallbackApi = fallback.origin;
       if (fallbackApi !== cloudApiBaseUrl) {
         candidates.push({ token: fallback.token, apiUrl: fallbackApi });
       }


### PR DESCRIPTION
## Summary

- Normalize trailing slash inside `getApiUrl()` itself instead of at every call site
- Remove 3 now-redundant `.replace(/\/$/, "")` in `server.ts` (after `getApiUrl()` and on `fallback.origin`)
- Net: -3 lines, no new logic

## Motivation

`getApiUrl()` is called in `publishCloud`, `publishGist`, and the BFF proxy in `server.ts` — all of which interpolate the URL into fetch paths like `${apiUrl}/api/...`. A trailing slash would produce double-slash URLs. Centralizing the normalization in `getApiUrl()` is more robust than relying on every call site to strip it.

The `fallback.origin` strips are also redundant: that value comes from `loadAnyAuthToken()`, which returns an account key stored via `authOrigin()` (`new URL(url).origin`). A URL `origin` property never carries a trailing slash.

## Test plan

- [x] `pnpm test` 全绿 (734 tests + 132 viewer tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 812 kB — pre-existing size, not a regression from this PR)
- [x] E2E: not run (CLI-only change, no rendering path involved)

> 🤖 Daily auto-quality routine. Self-merged after AI review.