### PR TITLE
refactor(formatters): extract buildSvgFooter to dedupe footer computation

### DIFF
--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -632,6 +632,21 @@ function selectKeyPhases(phases: Phase[], max: number): Phase[] {
   return phases.slice(0, max);
 }
 
+function buildSvgFooter(
+  session: ReplaySession,
+  opts: GitHubFormatOptions,
+): { footerLeft: string; footerRight: string } {
+  const duration = formatDuration(session.meta.stats.durationMs);
+  const tStats = computeToolStats(session.scenes);
+  const parts: (string | null)[] = [duration];
+  if (tStats.responses > 0) parts.push(`${tStats.responses} responses`);
+  if (tStats.totalTools > 0) parts.push(`${tStats.totalTools} tools`);
+  return {
+    footerLeft: parts.filter(Boolean).join(" · "),
+    footerRight: opts.replayUrl ? "View full replay →" : "vibe-replay.com",
+  };
+}
+
 function renderSvg(
   frames: SvgFrame[],
   session: ReplaySession,
@@ -657,14 +672,7 @@ function renderSvg(
     })
     .join("\n");
 
-  // Footer
-  const duration = formatDuration(session.meta.stats.durationMs);
-  const tStats = computeToolStats(session.scenes);
-  const footerParts = [duration];
-  if (tStats.responses > 0) footerParts.push(`${tStats.responses} responses`);
-  if (tStats.totalTools > 0) footerParts.push(`${tStats.totalTools} tools`);
-  const footerLeft = footerParts.filter(Boolean).join(" · ");
-  const footerRight = opts.replayUrl ? "View full replay →" : "vibe-replay.com";
+  const { footerLeft, footerRight } = buildSvgFooter(session, opts);
 
   // Build frame SVG content
   const framesSvg = frames.map((f, i) => renderFrame(f, i)).join("\n\n");
@@ -906,13 +914,7 @@ export function renderStaticFrameSvg(
   session: ReplaySession,
   opts: GitHubFormatOptions = {},
 ): string {
-  const duration = formatDuration(session.meta.stats.durationMs);
-  const tStats = computeToolStats(session.scenes);
-  const footerParts = [duration];
-  if (tStats.responses > 0) footerParts.push(`${tStats.responses} responses`);
-  if (tStats.totalTools > 0) footerParts.push(`${tStats.totalTools} tools`);
-  const footerLeft = footerParts.filter(Boolean).join(" · ");
-  const footerRight = opts.replayUrl ? "View full replay →" : "vibe-replay.com";
+  const { footerLeft, footerRight } = buildSvgFooter(session, opts);
 
   // Reuse shared rendering logic (no animation class needed)
   let frameContent: string;


### PR DESCRIPTION
## Summary

- Extract `buildSvgFooter` helper in `packages/cli/src/formatters/github.ts`
- `renderSvg` and `renderStaticFrameSvg` both had identical 7-line blocks computing `footerLeft`/`footerRight`; now both call the shared helper
- Net: -15 +17 (+1 line total, removes 14 lines of duplication)

## Motivation

The two SVG rendering functions shared byte-for-byte identical footer computation logic. Extracting it prevents future divergence if the footer format changes.
Semantically equivalent: the helper is a pure function with no observable side-effects, and the call sites pass the same arguments.

## Test plan

- [x] `pnpm test` 全绿 (866 tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm build` 成功 (CLI 474KB)
- [x] E2E: 未跑（改动是纯结构提取，不涉及 HTML 输出或 CLI 行为）

> 🤖 Daily auto-quality routine. Self-merged after AI review.