### PR TITLE
chore(cursor): drop dead storeDbExists function from sqlite-reader

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -426,11 +426,6 @@ export async function resolveCursorLiveWatchPaths(sessionId: string): Promise<st
   return [...paths];
 }
 
-export async function storeDbExists(_workspacePath: string, sessionId: string): Promise<boolean> {
-  const dbPath = await findStoreDb(sessionId);
-  return dbPath !== null;
-}
-
 export async function listStoreDbSessionIds(forceRefresh = false): Promise<Set<string>> {
   return new Set((await getStoreDbIndex(forceRefresh)).keys());
 }


### PR DESCRIPTION
## Summary

- Delete `storeDbExists` from `packages/cli/src/providers/cursor/sqlite-reader.ts`
- The function has zero callers across the entire repo (verified with `rg`)
- Its `_workspacePath` parameter was already prefixed with `_` indicating it was unused even within the function body
- -5 lines net

## Motivation

`storeDbExists` was exported but never invoked — not from production code, not from tests, not from any other package. Deleting it removes a dead branch from the module's call graph without changing any runtime behavior.

## Test plan

- [x] `pnpm test` 全绿 (734 passed, 1 skipped)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 812kB pre-existing, CLI ESM 474kB)
- [x] E2E: 未跑 — 改动仅删除从未被调用的函数，零运行时行为变化，tsc 可证明类型等价

> 🤖 Daily auto-quality routine. Self-merged after AI review.