### PR TITLE
refactor(codex): extract codexStripTwoPass to dedupe two-pass strip loop

### DIFF
--- a/packages/cli/src/providers/codex/constants.ts
+++ b/packages/cli/src/providers/codex/constants.ts
@@ -43,3 +43,11 @@ export function stripLeadingCodexContextBlocks(text: string): string {
   }
   return remaining;
 }
+
+export function codexStripTwoPass(text: string): string {
+  let result = text;
+  for (let i = 0; i < 2; i++) {
+    result = stripUserMessagePrefix(stripLeadingCodexContextBlocks(result)).trim();
+  }
+  return result;
+}

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -6,11 +6,7 @@ import { createInterface } from "node:readline";
 import { cleanPromptText } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
 import { shortenPath } from "../../utils.js";
-import {
-  CODEX_CONTEXT_TAGS,
-  codexStripTwoPass,
-  isCodexToolCallType,
-} from "./constants.js";
+import { CODEX_CONTEXT_TAGS, codexStripTwoPass, isCodexToolCallType } from "./constants.js";
 
 const STATE_DB_FILENAME = "state_5.sqlite";
 

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -8,9 +8,8 @@ import type { SessionInfo } from "../../types.js";
 import { shortenPath } from "../../utils.js";
 import {
   CODEX_CONTEXT_TAGS,
+  codexStripTwoPass,
   isCodexToolCallType,
-  stripLeadingCodexContextBlocks,
-  stripUserMessagePrefix,
 } from "./constants.js";
 
 const STATE_DB_FILENAME = "state_5.sqlite";
@@ -295,11 +294,7 @@ function isEditTool(name?: string): boolean {
 }
 
 function normalizeDiscoveredUserMessage(text: string): string {
-  let normalized = text;
-  for (let i = 0; i < 2; i++) {
-    normalized = stripUserMessagePrefix(stripLeadingCodexContextBlocks(normalized)).trim();
-  }
-  return cleanPromptText(normalized);
+  return cleanPromptText(codexStripTwoPass(text));
 }
 
 function recordDiscoveredPrompt(

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -4,11 +4,7 @@ import { extname } from "node:path";
 import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
 import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
-import {
-  isCodexToolCallType,
-  stripLeadingCodexContextBlocks,
-  stripUserMessagePrefix,
-} from "./constants.js";
+import { codexStripTwoPass, isCodexToolCallType } from "./constants.js";
 
 interface PendingTool {
   id: string;
@@ -665,11 +661,7 @@ function pushUnique(items: string[], value: string): void {
 }
 
 function normalizeUserMessageText(text: string): string {
-  let normalized = text;
-  for (let i = 0; i < 2; i++) {
-    normalized = stripUserMessagePrefix(stripLeadingCodexContextBlocks(normalized)).trim();
-  }
-  return normalized;
+  return codexStripTwoPass(text);
 }
 
 function localImageToDataUrl(path: string): string | undefined {


### PR DESCRIPTION
## Summary

- Extract the identical 3-line two-pass strip loop from `normalizeDiscoveredUserMessage` (discover.ts) and `normalizeUserMessageText` (parser.ts) into `codexStripTwoPass` in constants.ts
- Net change: -5 lines, 3 files

## Motivation

Both functions ran `stripUserMessagePrefix(stripLeadingCodexContextBlocks(x)).trim()` twice in a for-loop — identical bodies. Extracting to a shared helper eliminates the duplication. Both callers delegate to it; no runtime behavior changes.

## Test plan

- [x] `pnpm test` 全绿 (41 test files, 734 tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer unchanged, CLI only)
- [x] E2E: 未跑 (CLI-only helper refactor, no behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.