### PR TITLE
perf(cursor): speed up local session loading

### DIFF
--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -145,6 +145,8 @@ async function enrichWithSdkAgents(sessions: SessionInfo[]): Promise<void> {
 async function decodeProjectDir(encoded: string): Promise<string> {
   let cached = decodedProjectDirCache.get(encoded);
   if (!cached) {
+    // Cursor project dirs are stable for the lifetime of the CLI/server process;
+    // cache the resolved path so repeated discovery doesn't re-walk the same tree.
     cached = decodeProjectDirUncached(encoded).catch((err) => {
       decodedProjectDirCache.delete(encoded);
       throw err;
@@ -156,7 +158,11 @@ async function decodeProjectDir(encoded: string): Promise<string> {
 
 async function decodeProjectDirUncached(encoded: string): Promise<string> {
   const parts = encoded.split("-");
-  const resolved = await resolveEncodedProjectParts(parts, 0, "/");
+  // Match the old resolver's root handling:
+  //   "Users-me-proj"  -> start at "/Users"
+  //   "-Users-me-proj" -> start at "/"
+  const startPath = parts[0] ? `/${parts[0]}` : "/";
+  const resolved = await resolveEncodedProjectParts(parts, 1, startPath);
   return resolved || `/${encoded.replace(/-/g, "/")}`;
 }
 
@@ -165,7 +171,10 @@ async function resolveEncodedProjectParts(
   idx: number,
   current: string,
 ): Promise<string | null> {
-  if (idx >= parts.length) return current;
+  if (idx >= parts.length) {
+    const currentStat = await stat(current).catch(() => null);
+    return currentStat?.isDirectory() ? current : null;
+  }
 
   const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
   if (entries.length === 0) return null;

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -158,11 +158,8 @@ async function decodeProjectDir(encoded: string): Promise<string> {
 
 async function decodeProjectDirUncached(encoded: string): Promise<string> {
   const parts = encoded.split("-");
-  // Match the old resolver's root handling:
-  //   "Users-me-proj"  -> start at "/Users"
-  //   "-Users-me-proj" -> start at "/"
-  const startPath = parts[0] ? `/${parts[0]}` : "/";
-  const resolved = await resolveEncodedProjectParts(parts, 1, startPath);
+  const startIdx = parts[0] ? 0 : 1;
+  const resolved = await resolveEncodedProjectParts(parts, startIdx, "/");
   return resolved || `/${encoded.replace(/-/g, "/")}`;
 }
 

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -12,6 +12,10 @@ import { discoverSdkAgents, type SdkAgent } from "./sdk-reader.js";
 import { sanitizeCursorUserText } from "./sanitize.js";
 
 const CURSOR_DIR = join(homedir(), ".cursor", "projects");
+const PROJECT_DISCOVERY_CONCURRENCY = 6;
+const TRANSCRIPT_INFO_CONCURRENCY = 6;
+const ENTRY_STAT_CONCURRENCY = 32;
+const decodedProjectDirCache = new Map<string, Promise<string>>();
 
 export async function discoverCursorSessions(): Promise<SessionInfo[]> {
   const sessions: SessionInfo[] = [];
@@ -23,39 +27,11 @@ export async function discoverCursorSessions(): Promise<SessionInfo[]> {
     return sessions;
   }
 
-  for (const projDir of projectDirs) {
-    const transcriptsDir = join(CURSOR_DIR, projDir, "agent-transcripts");
-    const dirStat = await stat(transcriptsDir).catch(() => null);
-    if (!dirStat?.isDirectory()) continue;
-
-    const project = await decodeProjectDir(projDir);
-    const transcriptEntries = await collectTranscriptEntries(transcriptsDir);
-    if (transcriptEntries.length === 0) continue;
-    transcriptEntries.sort((a, b) => a.mtimeMs - b.mtimeMs);
-
-    const toolEntries = await collectToolEntries(join(CURSOR_DIR, projDir, "agent-tools"));
-    toolEntries.sort((a, b) => a.mtimeMs - b.mtimeMs);
-
-    for (let i = 0; i < transcriptEntries.length; i++) {
-      const transcript = transcriptEntries[i];
-      const prevMtimeMs = i === 0 ? Number.NEGATIVE_INFINITY : transcriptEntries[i - 1].mtimeMs;
-      const toolPaths = toolEntries
-        .filter((t) => t.mtimeMs > prevMtimeMs && t.mtimeMs <= transcript.mtimeMs)
-        .map((t) => t.path);
-
-      const info = await extractSessionInfo(
-        transcript.path,
-        transcript.fileSize,
-        transcript.mtimeMs,
-        project,
-        toolPaths,
-      );
-      if (!info) continue;
-
-      info.workspacePath = project;
-      info.hasSqlite = false;
-      sessions.push(info);
-    }
+  const projectSessions = await mapLimit(projectDirs, PROJECT_DISCOVERY_CONCURRENCY, (projDir) =>
+    discoverProjectSessions(projDir),
+  );
+  for (const projectSessionList of projectSessions) {
+    sessions.push(...projectSessionList);
   }
 
   // Discover SQLite-only sessions (devcontainer, SSH-remote, etc.)
@@ -84,6 +60,54 @@ export async function discoverCursorSessions(): Promise<SessionInfo[]> {
 
   sessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return sessions;
+}
+
+async function discoverProjectSessions(projDir: string): Promise<SessionInfo[]> {
+  const transcriptsDir = join(CURSOR_DIR, projDir, "agent-transcripts");
+  const dirStat = await stat(transcriptsDir).catch(() => null);
+  if (!dirStat?.isDirectory()) return [];
+
+  const project = await decodeProjectDir(projDir);
+  const transcriptEntries = await collectTranscriptEntries(transcriptsDir);
+  if (transcriptEntries.length === 0) return [];
+  transcriptEntries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  const toolEntries = await collectToolEntries(join(CURSOR_DIR, projDir, "agent-tools"));
+  toolEntries.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  const jobs: Array<TranscriptEntry & { toolPaths: string[] }> = [];
+  let toolStart = 0;
+  let toolEnd = 0;
+  for (let i = 0; i < transcriptEntries.length; i++) {
+    const transcript = transcriptEntries[i];
+    const prevMtimeMs = i === 0 ? Number.NEGATIVE_INFINITY : transcriptEntries[i - 1].mtimeMs;
+    while (toolStart < toolEntries.length && toolEntries[toolStart].mtimeMs <= prevMtimeMs) {
+      toolStart++;
+    }
+    while (toolEnd < toolEntries.length && toolEntries[toolEnd].mtimeMs <= transcript.mtimeMs) {
+      toolEnd++;
+    }
+    jobs.push({
+      ...transcript,
+      toolPaths: toolEntries.slice(toolStart, toolEnd).map((tool) => tool.path),
+    });
+  }
+
+  const infos = await mapLimit(jobs, TRANSCRIPT_INFO_CONCURRENCY, async (job) => {
+    const info = await extractSessionInfo(
+      job.path,
+      job.fileSize,
+      job.mtimeMs,
+      project,
+      job.toolPaths,
+    );
+    if (!info) return null;
+    info.workspacePath = project;
+    info.hasSqlite = false;
+    return info;
+  });
+
+  return infos.filter((info): info is SessionInfo => info !== null);
 }
 
 async function enrichWithSdkAgents(sessions: SessionInfo[]): Promise<void> {
@@ -119,24 +143,47 @@ async function enrichWithSdkAgents(sessions: SessionInfo[]): Promise<void> {
  * so we resolve ambiguity by checking which paths actually exist on disk.
  */
 async function decodeProjectDir(encoded: string): Promise<string> {
-  const parts = encoded.split("-");
+  let cached = decodedProjectDirCache.get(encoded);
+  if (!cached) {
+    cached = decodeProjectDirUncached(encoded).catch((err) => {
+      decodedProjectDirCache.delete(encoded);
+      throw err;
+    });
+    decodedProjectDirCache.set(encoded, cached);
+  }
+  return cached;
+}
 
-  async function resolve(idx: number, current: string): Promise<string | null> {
-    if (idx >= parts.length) {
-      const s = await stat(current).catch(() => null);
-      return s?.isDirectory() ? current : null;
-    }
-    // Try `/` (path separator) first — more common
-    const withSlash = `${current}/${parts[idx]}`;
-    const slashResult = await resolve(idx + 1, withSlash);
-    if (slashResult) return slashResult;
-    // Try `-` (literal hyphen in directory name)
-    const withHyphen = `${current}-${parts[idx]}`;
-    return resolve(idx + 1, withHyphen);
+async function decodeProjectDirUncached(encoded: string): Promise<string> {
+  const parts = encoded.split("-");
+  const resolved = await resolveEncodedProjectParts(parts, 0, "/");
+  return resolved || `/${encoded.replace(/-/g, "/")}`;
+}
+
+async function resolveEncodedProjectParts(
+  parts: string[],
+  idx: number,
+  current: string,
+): Promise<string | null> {
+  if (idx >= parts.length) return current;
+
+  const entries = await readdir(current, { withFileTypes: true }).catch(() => []);
+  if (entries.length === 0) return null;
+
+  const dirNames = new Set(
+    entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name),
+  );
+
+  // Try slash boundaries first to preserve the old behavior, but only explore
+  // names that are real child directories instead of stat-ing every split.
+  for (let end = idx + 1; end <= parts.length; end++) {
+    const candidate = parts.slice(idx, end).join("-");
+    if (!dirNames.has(candidate)) continue;
+    const resolved = await resolveEncodedProjectParts(parts, end, join(current, candidate));
+    if (resolved) return resolved;
   }
 
-  const result = await resolve(1, `/${parts[0]}`);
-  return result || `/${encoded.replace(/-/g, "/")}`;
+  return null;
 }
 
 async function extractSessionInfo(
@@ -148,27 +195,9 @@ async function extractSessionInfo(
 ): Promise<SessionInfo | null> {
   try {
     const content = await readFile(filePath, "utf-8");
-    const lines = content.split("\n").filter((l) => l.trim());
-    if (lines.length < 2) return null; // too short to be useful
 
     const sessionId = basename(filePath, ".jsonl");
     let firstPrompt = "";
-
-    // Find first user prompt
-    for (const line of lines.slice(0, 10)) {
-      try {
-        const obj = JSON.parse(line);
-        if (obj.role === "user") {
-          const textBlock = obj.message?.content?.find?.((b: any) => b.type === "text");
-          if (textBlock?.text) {
-            firstPrompt = sanitizeCursorUserText(textBlock.text).slice(0, 200);
-            break;
-          }
-        }
-      } catch {}
-    }
-
-    if (!firstPrompt) return null;
 
     // Count user prompts and tool calls — data already in memory, zero extra I/O
     // Only count user messages that are actual prompts, not tool_result messages.
@@ -180,10 +209,29 @@ async function extractSessionInfo(
     let toolCallCount = 0;
     let editCountEst = 0;
     let model: string | undefined;
+    let lineCount = 0;
+    let promptScanCount = 0;
     const toolUseRe = /"type"\s*:\s*"tool_use"/g;
     const editToolRe = /"name"\s*:\s*"(edit_file|file_edit|create_file)"/;
     const modelRe = /"model(?:Id)?"\s*:\s*"([^"]+)"/;
-    for (const line of lines) {
+    for (const rawLine of content.split("\n")) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      lineCount++;
+
+      if (!firstPrompt && promptScanCount < 10) {
+        promptScanCount++;
+        try {
+          const obj = JSON.parse(line);
+          if (obj.role === "user") {
+            const textBlock = obj.message?.content?.find?.((b: any) => b.type === "text");
+            if (textBlock?.text) {
+              firstPrompt = sanitizeCursorUserText(textBlock.text).slice(0, 200);
+            }
+          }
+        } catch {}
+      }
+
       if (
         (line.includes('"role":"user"') || line.includes('"role": "user"')) &&
         !line.includes('"tool_result"')
@@ -201,6 +249,9 @@ async function extractSessionInfo(
         if (m) model = m[1];
       }
     }
+    if (lineCount < 2) return null; // too short to be useful
+    if (!firstPrompt) return null;
+
     // Cursor transcript markers can be missing in some flows; tool artifacts are
     // a better lower bound for real tool activity in the same time window.
     toolCallCount = Math.max(toolCallCount, toolPaths.length);
@@ -216,7 +267,7 @@ async function extractSessionInfo(
       cwd: project,
       version: "",
       timestamp,
-      lineCount: lines.length,
+      lineCount,
       fileSize,
       filePath,
       filePaths: [filePath],
@@ -251,34 +302,32 @@ async function collectTranscriptEntries(transcriptsDir: string): Promise<Transcr
     return [];
   }
 
-  const transcripts: TranscriptEntry[] = [];
-  for (const entry of entries) {
+  const transcripts = await mapLimit(entries, ENTRY_STAT_CONCURRENCY, async (entry) => {
     const entryPath = join(transcriptsDir, entry);
     const entryStat = await stat(entryPath).catch(() => null);
-    if (!entryStat) continue;
+    if (!entryStat) return null;
 
     if (entry.endsWith(".jsonl") && entryStat.isFile()) {
-      transcripts.push({
+      return {
         path: entryPath,
         fileSize: entryStat.size,
         mtimeMs: entryStat.mtimeMs,
-      });
-      continue;
+      };
     }
 
-    if (!entryStat.isDirectory()) continue;
+    if (!entryStat.isDirectory()) return null;
 
     // Nested transcript form: agent-transcripts/<id>/<id>.jsonl
     const innerPath = join(entryPath, `${entry}.jsonl`);
     const innerStat = await stat(innerPath).catch(() => null);
-    if (!innerStat?.isFile()) continue;
-    transcripts.push({
+    if (!innerStat?.isFile()) return null;
+    return {
       path: innerPath,
       fileSize: innerStat.size,
       mtimeMs: innerStat.mtimeMs,
-    });
-  }
-  return transcripts;
+    };
+  });
+  return transcripts.filter((entry): entry is TranscriptEntry => entry !== null);
 }
 
 async function collectToolEntries(toolDir: string): Promise<ToolEntry[]> {
@@ -292,13 +341,35 @@ async function collectToolEntries(toolDir: string): Promise<ToolEntry[]> {
     return [];
   }
 
-  const tools: ToolEntry[] = [];
-  for (const entry of entries) {
-    if (!entry.endsWith(".txt")) continue;
+  const toolFiles = entries.filter((entry) => entry.endsWith(".txt"));
+  const tools = await mapLimit(toolFiles, ENTRY_STAT_CONCURRENCY, async (entry) => {
     const entryPath = join(toolDir, entry);
     const entryStat = await stat(entryPath).catch(() => null);
-    if (!entryStat?.isFile()) continue;
-    tools.push({ path: entryPath, mtimeMs: entryStat.mtimeMs });
-  }
-  return tools;
+    if (!entryStat?.isFile()) return null;
+    return { path: entryPath, mtimeMs: entryStat.mtimeMs };
+  });
+  return tools.filter((entry): entry is ToolEntry => entry !== null);
+}
+
+async function mapLimit<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = [];
+  results.length = items.length;
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++;
+        results[index] = await worker(items[index], index);
+      }
+    }),
+  );
+
+  return results;
 }

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -37,6 +37,19 @@ describe("countComposerConversationHeaders", () => {
 });
 
 describe("cursor sqlite metrics helpers", () => {
+  it("builds index-friendly key prefix ranges", () => {
+    expect(__testables.sqlKeyPrefixRange("composerData:")).toBe(
+      "key >= 'composerData:' AND key < 'composerData;'",
+    );
+    expect(__testables.sqlKeyPrefixRange("checkpointId:abc:")).toBe(
+      "key >= 'checkpointId:abc:' AND key < 'checkpointId:abc;'",
+    );
+  });
+
+  it("does not build invalid surrogate prefix bounds", () => {
+    expect(__testables.nextStringPrefix("\ud7ff")).toBeNull();
+  });
+
   it("projects global-state bubble values with bounded tool results", () => {
     const sql = __testables.projectedCursorBubbleSelectSql();
 

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -160,7 +160,9 @@ function nextStringPrefix(prefix: string): string | null {
   if (!last) return null;
   const codePoint = last.codePointAt(0);
   if (codePoint === undefined || codePoint >= 0x10ffff) return null;
-  return `${chars.join("")}${String.fromCodePoint(codePoint + 1)}`;
+  const next = codePoint + 1;
+  if (next >= 0xd800 && next <= 0xdfff) return null;
+  return `${chars.join("")}${String.fromCodePoint(next)}`;
 }
 
 function sqlKeyPrefixRange(prefix: string): string {
@@ -251,7 +253,7 @@ async function querySqliteCliText(dbPath: string, sql: string): Promise<string> 
     maxBuffer: SQLITE_CLI_MAX_BUFFER,
     timeout: SQLITE_CLI_QUERY_TIMEOUT_MS,
   });
-  return stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout;
+  return stdout.replace(/\r?\n$/, "");
 }
 
 function sqlJsRows(db: any, sql: string): Record<string, any>[] {
@@ -294,7 +296,7 @@ async function queryGlobalStateTextValue(
     `SELECT value FROM cursorDiskKV WHERE key = ${sqlString(key)} LIMIT 1`,
   );
   if (rows.length === 0) return null;
-  return valueToString(rows[0].value);
+  return valueToString(rows[0].value) || null;
 }
 
 async function openGlobalStateDb(): Promise<CachedGlobalStateDb | null> {
@@ -2451,6 +2453,8 @@ async function parseCursorGlobalStateDb(
         bubbleIds.map((bubbleId) => `bubbleId:${sessionId}:${bubbleId}`),
       );
       const bubblesByKey = new Map<string, Record<string, any>>();
+      // The composer header list is the authoritative conversation order, so
+      // only fetch referenced bubble rows instead of every stale key for the session.
       const rows = await loadProjectedBubbleRowsByKeys(resolvedGlobalStateDb, [
         ...expectedBubbleKeys,
       ]);
@@ -3128,9 +3132,11 @@ export const __testables = {
   inferProjectRootFromPathHint,
   normalizeTurnText,
   normalizeCursorModelName,
+  nextStringPrefix,
   bubbleToTurn,
   parseThinking,
   parseUserContent,
   projectedCursorBubbleRowToBubble,
   projectedCursorBubbleSelectSql,
+  sqlKeyPrefixRange,
 };

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -23,6 +23,7 @@ const MAX_CURSOR_REQUEST_CONTEXT_ROWS = 500;
 const SQLITE_CLI_MAX_BUFFER = 256 * 1024 * 1024;
 const SQLITE_CLI_QUERY_TIMEOUT_MS = 120_000;
 const MAX_CURSOR_GLOBAL_STATE_TOOL_RESULT_CHARS = 10_000;
+const GLOBAL_STATE_BUBBLE_KEY_CHUNK_SIZE = 200;
 const execFileAsync = promisify(execFile);
 
 function createRetryableInit<T>(factory: () => Promise<T>): () => Promise<T> {
@@ -152,10 +153,20 @@ function sqlString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-function sqlLikePrefix(prefix: string): string {
-  return sqlString(
-    `${prefix.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`,
-  );
+function nextStringPrefix(prefix: string): string | null {
+  if (!prefix) return null;
+  const chars = [...prefix];
+  const last = chars.pop();
+  if (!last) return null;
+  const codePoint = last.codePointAt(0);
+  if (codePoint === undefined || codePoint >= 0x10ffff) return null;
+  return `${chars.join("")}${String.fromCodePoint(codePoint + 1)}`;
+}
+
+function sqlKeyPrefixRange(prefix: string): string {
+  const upperBound = nextStringPrefix(prefix);
+  if (!upperBound) return `key >= ${sqlString(prefix)}`;
+  return `key >= ${sqlString(prefix)} AND key < ${sqlString(upperBound)}`;
 }
 
 function projectedCursorBubbleSelectSql(): string {
@@ -235,6 +246,14 @@ async function querySqliteCli(dbPath: string, sql: string): Promise<Record<strin
   return JSON.parse(trimmed) as Record<string, any>[];
 }
 
+async function querySqliteCliText(dbPath: string, sql: string): Promise<string> {
+  const { stdout } = await execFileAsync("sqlite3", ["-readonly", dbPath, sql], {
+    maxBuffer: SQLITE_CLI_MAX_BUFFER,
+    timeout: SQLITE_CLI_QUERY_TIMEOUT_MS,
+  });
+  return stdout.endsWith("\n") ? stdout.slice(0, -1) : stdout;
+}
+
 function sqlJsRows(db: any, sql: string): Record<string, any>[] {
   const result = db.exec(sql);
   if (!result.length) return [];
@@ -256,6 +275,26 @@ async function queryGlobalStateRows(
     return querySqliteCli(globalStateDb.dbPath, sql);
   }
   return sqlJsRows(globalStateDb.db, sql);
+}
+
+async function queryGlobalStateTextValue(
+  globalStateDb: CachedGlobalStateDb,
+  key: string,
+): Promise<string | null> {
+  if (globalStateDb.backend === "sqlite-cli") {
+    const value = await querySqliteCliText(
+      globalStateDb.dbPath,
+      `SELECT CAST(value AS TEXT) FROM cursorDiskKV WHERE key = ${sqlString(key)} LIMIT 1`,
+    );
+    return value || null;
+  }
+
+  const rows = sqlJsRows(
+    globalStateDb.db,
+    `SELECT value FROM cursorDiskKV WHERE key = ${sqlString(key)} LIMIT 1`,
+  );
+  if (rows.length === 0) return null;
+  return valueToString(rows[0].value);
 }
 
 async function openGlobalStateDb(): Promise<CachedGlobalStateDb | null> {
@@ -1031,9 +1070,9 @@ export async function discoverGlobalStateOnlySessions(
             "json_extract(value,'$.createdAt') AS createdAt,",
             "json_extract(value,'$.name') AS title,",
             "length(value) AS fileSize",
-            "FROM cursorDiskKV WHERE key LIKE 'composerData:%' AND json_valid(value)",
+            `FROM cursorDiskKV WHERE ${sqlKeyPrefixRange("composerData:")} AND json_valid(value)`,
           ].join(" ")
-        : "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'";
+        : `SELECT key, value FROM cursorDiskKV WHERE ${sqlKeyPrefixRange("composerData:")}`;
     const rows = await queryGlobalStateRows(globalStateDb, composerDiscoverySql);
     if (rows.length === 0) return { sessions: [], sessionIds };
 
@@ -1859,9 +1898,9 @@ async function loadCursorRequestContexts(
 ): Promise<Record<string, any>[]> {
   const rows = await queryGlobalStateRows(
     globalStateDb,
-    `SELECT value FROM cursorDiskKV WHERE key LIKE ${sqlLikePrefix(
+    `SELECT value FROM cursorDiskKV WHERE ${sqlKeyPrefixRange(
       `messageRequestContext:${sessionId}:`,
-    )} ESCAPE '\\' LIMIT ${MAX_CURSOR_REQUEST_CONTEXT_ROWS}`,
+    )} LIMIT ${MAX_CURSOR_REQUEST_CONTEXT_ROWS}`,
   );
 
   const contexts: Record<string, any>[] = [];
@@ -1879,11 +1918,30 @@ async function countCursorCheckpointEntries(
 ): Promise<number> {
   const rows = await queryGlobalStateRows(
     globalStateDb,
-    `SELECT COUNT(*) AS count FROM cursorDiskKV WHERE key LIKE ${sqlLikePrefix(
+    `SELECT COUNT(*) AS count FROM cursorDiskKV WHERE ${sqlKeyPrefixRange(
       `checkpointId:${sessionId}:`,
-    )} ESCAPE '\\'`,
+    )}`,
   );
   return toNonNegativeInt(rows[0]?.count);
+}
+
+async function loadProjectedBubbleRowsByKeys(
+  globalStateDb: CachedGlobalStateDb,
+  keys: string[],
+): Promise<Record<string, any>[]> {
+  const rows: Record<string, any>[] = [];
+  for (let i = 0; i < keys.length; i += GLOBAL_STATE_BUBBLE_KEY_CHUNK_SIZE) {
+    const chunk = keys.slice(i, i + GLOBAL_STATE_BUBBLE_KEY_CHUNK_SIZE);
+    rows.push(
+      ...(await queryGlobalStateRows(
+        globalStateDb,
+        `SELECT ${projectedCursorBubbleSelectSql()} FROM cursorDiskKV WHERE key IN (${chunk
+          .map(sqlString)
+          .join(",")}) AND json_valid(value)`,
+      )),
+    );
+  }
+  return rows;
 }
 
 function mergeUniqueStrings(...groups: Array<string[] | undefined>): string[] | undefined {
@@ -2358,13 +2416,11 @@ async function parseCursorGlobalStateDb(
   if (!resolvedGlobalStateDb) return null;
 
   try {
-    const composerRows = await queryGlobalStateRows(
+    const rawComposer = await queryGlobalStateTextValue(
       resolvedGlobalStateDb,
-      `SELECT value FROM cursorDiskKV WHERE key = ${sqlString(`composerData:${sessionId}`)}`,
+      `composerData:${sessionId}`,
     );
-    if (composerRows.length === 0) return null;
-
-    const rawComposer = valueToString(composerRows[0].value);
+    if (!rawComposer) return null;
     const composer = parseJson<Record<string, any>>(rawComposer);
     if (!composer) return null;
 
@@ -2395,10 +2451,9 @@ async function parseCursorGlobalStateDb(
         bubbleIds.map((bubbleId) => `bubbleId:${sessionId}:${bubbleId}`),
       );
       const bubblesByKey = new Map<string, Record<string, any>>();
-      const rows = await queryGlobalStateRows(
-        resolvedGlobalStateDb,
-        `SELECT ${projectedCursorBubbleSelectSql()} FROM cursorDiskKV WHERE key LIKE ${sqlLikePrefix(`bubbleId:${sessionId}:`)} AND json_valid(value)`,
-      );
+      const rows = await loadProjectedBubbleRowsByKeys(resolvedGlobalStateDb, [
+        ...expectedBubbleKeys,
+      ]);
       for (const row of rows) {
         const key = valueToString(row.key);
         if (!expectedBubbleKeys.has(key)) continue;


### PR DESCRIPTION
## Summary
- Speed up Cursor discovery by replacing exponential project path probing with directory-entry based resolution and bounded concurrency.
- Speed up Cursor global-state parsing by using indexed key lookups/ranges and raw sqlite text reads for large composer payloads.
- Preserve the same session selection and parsing semantics while reducing unnecessary filesystem and SQLite work.

## Test plan
- `pnpm lint:check`
- `pnpm exec tsc --noEmit -p packages/cli/tsconfig.json`
- `pnpm --filter vibe-replay test -- src/providers/cursor/sqlite-reader.test.ts test/cursor-sqlite.test.ts test/cursor-parser.test.ts`
- `pnpm --filter vibe-replay build`
- Local profiling on Cursor session data: uncached discovery ~532ms; large global-state parse ~830-870ms.


Made with [Cursor](https://cursor.com)