### PR TITLE
fix(codex): surface session memory mode

### DIFF
--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -37,6 +37,10 @@ function asCodexTokenInfo(value: unknown): CodexTokenInfo | undefined {
   return value as CodexTokenInfo;
 }
 
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
 export async function parseCodexSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
@@ -350,10 +354,6 @@ export function parseCodexLines(
       notes: ["Discovered from Codex state and parsed from rollout JSONL (local beta)."],
     },
   };
-}
-
-function asOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function userMessageBlocks(payload: any): ContentBlock[] {

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -66,6 +66,7 @@ export function parseCodexLines(
   let entrypoint: string | undefined;
   let permissionMode: string | undefined;
   let approvalPolicy: string | undefined;
+  let memoryMode: string | undefined;
 
   const turns: ParsedTurn[] = [];
   const allTimestamps: string[] = [];
@@ -102,6 +103,7 @@ export function parseCodexLines(
       gitBranch = gitBranch || p.git?.branch || p.git_branch;
       if (gitBranch) pushUnique(gitBranches, gitBranch);
       entrypoint = entrypoint || p.originator || p.source;
+      memoryMode = memoryMode || asOptionalString(p.memory_mode);
       continue;
     }
 
@@ -337,6 +339,7 @@ export function parseCodexLines(
     gitBranches: gitBranches.length > 1 ? gitBranches : undefined,
     entrypoint,
     permissionMode: approvalPolicy || permissionMode,
+    memoryMode,
     skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
     dataSource: "jsonl",
@@ -347,6 +350,10 @@ export function parseCodexLines(
       notes: ["Discovered from Codex state and parsed from rollout JSONL (local beta)."],
     },
   };
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function userMessageBlocks(payload: any): ContentBlock[] {

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -49,6 +49,8 @@ export interface ProviderParseResult {
   gitBranches?: string[];
   entrypoint?: string;
   permissionMode?: string;
+  /** Codex session memory setting from session_meta.memory_mode */
+  memoryMode?: string;
   apiErrors?: Array<{
     timestamp: string;
     statusCode?: number;

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -183,6 +183,7 @@ export function transformToReplay(
       ...(parsed.gitBranches ? { gitBranches: parsed.gitBranches } : {}),
       ...(parsed.entrypoint ? { entrypoint: parsed.entrypoint } : {}),
       ...(parsed.permissionMode ? { permissionMode: parsed.permissionMode } : {}),
+      ...(parsed.memoryMode ? { memoryMode: parsed.memoryMode } : {}),
       ...(parsed.apiErrors && parsed.apiErrors.length > 0 ? { apiErrors: parsed.apiErrors } : {}),
       ...(parsed.trackedFiles && parsed.trackedFiles.length > 0
         ? { trackedFiles: parsed.trackedFiles.map(redactPath) }

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -17,6 +17,7 @@ const lines = [
       originator: "Codex CLI",
       cli_version: "0.125.0",
       source: "cli",
+      memory_mode: "enabled",
       git: { branch: "main" },
     },
   },
@@ -92,6 +93,7 @@ describe("Codex parser", () => {
     expect(result.cwd).toBe("/Users/test/project");
     expect(result.model).toBe("gpt-5.4");
     expect(result.gitBranch).toBe("main");
+    expect(result.memoryMode).toBe("enabled");
     expect(result.tokenUsage).toMatchObject({
       inputTokens: 700,
       cacheReadTokens: 300,
@@ -114,6 +116,7 @@ describe("Codex parser", () => {
     const replay = transformToReplay(parsed, "codex", "~/project");
 
     expect(replay.meta.provider).toBe("codex");
+    expect(replay.meta.memoryMode).toBe("enabled");
     expect(replay.scenes.some((scene) => scene.type === "user-prompt")).toBe(true);
     const bash = replay.scenes.find(
       (scene) => scene.type === "tool-call" && scene.toolName === "Bash",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -286,6 +286,8 @@ export interface ReplaySession {
     entrypoint?: string;
     /** Permission mode: "default" | "bypassPermissions" */
     permissionMode?: string;
+    /** Codex memory mode, when reported by session_meta.memory_mode */
+    memoryMode?: string;
     /** API errors encountered during the session */
     apiErrors?: Array<{
       timestamp: string;

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -141,11 +141,16 @@ export default function StatsPanel({ session }: Props) {
             )}
           </div>
         )}
-        {(meta.entrypoint || meta.permissionMode) && (
+        {(meta.entrypoint || meta.permissionMode || meta.memoryMode) && (
           <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap text-[10px]">
             {meta.entrypoint && (
               <span className="px-1 py-0.5 rounded bg-terminal-surface text-terminal-dim">
                 {meta.entrypoint}
+              </span>
+            )}
+            {meta.memoryMode && (
+              <span className="px-1 py-0.5 rounded bg-terminal-surface text-terminal-dim">
+                memory: {meta.memoryMode}
               </span>
             )}
             {meta.permissionMode === "bypassPermissions" && (


### PR DESCRIPTION
## Summary
- Preserve Codex `session_meta.memory_mode` as replay metadata.
- Surface the memory mode in the viewer stats badge when present.
- Add parser/transform coverage for the new schema field.

Fixes #253

## Test plan
- `pnpm --filter vibe-replay test -- codex-parser.test.ts`
- `pnpm lint:check`
- `pnpm build`


Made with [Cursor](https://cursor.com)