### PR TITLE
fix(codex): improve replay feature parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is this
 
-vibe-replay turns AI coding sessions into animated, interactive web replays as self-contained HTML files. Supports Claude Code and Cursor.
+vibe-replay turns AI coding sessions into animated, interactive web replays as self-contained HTML files. Supports Claude Code, Cursor, and Codex.
 
 pnpm monorepo: `packages/cli` (npm: `vibe-replay`), `packages/viewer` (React → single HTML), `packages/types` (shared types), `website/` (Astro), `cloudflare/` (Workers API).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/vibe-replay)](https://www.npmjs.com/package/vibe-replay)
 [![license](https://img.shields.io/npm/l/vibe-replay)](./LICENSE)
 
-Turn Claude Code and Cursor sessions into shareable, interactive replays.
+Turn Claude Code, Cursor, and Codex sessions into shareable, interactive replays.
 
 ### The problem
 
@@ -31,7 +31,7 @@ npx vibe-replay
 
 ### All your sessions, one place
 
-Launch with `npx vibe-replay -d` and see every Claude Code and Cursor session across all projects — with activity heatmaps, cost totals, and project analytics.
+Launch with `npx vibe-replay -d` and see every Claude Code, Cursor, and Codex session across all projects — with activity heatmaps, cost totals, and project analytics.
 
 <p align="center">
   <img src="docs/screenshots/dashboard.png" alt="Local dashboard — browse sessions, activity heatmap, project analytics" width="800" />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,7 +62,7 @@ https://your-host/viewer.html?url=https://example.com/replay.json
 |----------|--------|
 | Claude Code | Supported |
 | Cursor | Supported |
-| Codex | Planned |
+| Codex | Supported |
 | Gemini CLI | Planned |
 
 ## Options

--- a/packages/cli/src/formatters/github.ts
+++ b/packages/cli/src/formatters/github.ts
@@ -107,7 +107,7 @@ export function generateGitHubMarkdown(
   }
 
   // Risk signals
-  const risks = detectRiskSignals(session.scenes, filesChanged);
+  const risks = detectRiskSignals(session, filesChanged);
   if (risks.length > 0) {
     lines.push("**Signals:**");
     for (const risk of risks) {
@@ -323,10 +323,10 @@ function parseToolCall(scene: Extract<Scene, { type: "tool-call" }>): RawAction 
       return { kind: "read", file: baseName(input.file_path || input.path || "") };
 
     case "Edit":
-      return { kind: "edit", file: baseName(input.file_path || "") };
+      return { kind: "edit", file: baseName(firstFilePath(input) || "") };
 
     case "Write":
-      return { kind: "create", file: baseName(input.file_path || "") };
+      return { kind: "create", file: baseName(firstFilePath(input) || "") };
 
     case "Bash": {
       const cmd = (input.command || "").split("\n")[0];
@@ -416,8 +416,9 @@ function groupActions(raw: RawAction[]): GroupedAction[] {
 
 // ─── Risk signals ──────────────────────────────────────────
 
-function detectRiskSignals(scenes: Scene[], filesChanged: Map<string, number>): string[] {
+function detectRiskSignals(session: ReplaySession, filesChanged: Map<string, number>): string[] {
   const risks: string[] = [];
+  const { scenes } = session;
 
   // Files modified many times (possible struggle)
   for (const [file, count] of filesChanged) {
@@ -452,7 +453,10 @@ function detectRiskSignals(scenes: Scene[], filesChanged: Map<string, number>): 
   }
 
   // Compactions
-  if (scenes.some((s) => s.type === "compaction-summary")) {
+  if (
+    scenes.some((s) => s.type === "compaction-summary") ||
+    (session.meta.compactions?.length || 0) > 0
+  ) {
     risks.push("Session was compacted (very long conversation)");
   }
 
@@ -957,14 +961,27 @@ function collectFilesChanged(scenes: Scene[]): Map<string, number> {
   for (const scene of scenes) {
     if (scene.type !== "tool-call") continue;
     if (scene.toolName === "Edit" || scene.toolName === "Write") {
-      const fp = scene.input.file_path;
-      if (fp) {
+      for (const fp of filePathsFromInput(scene.input)) {
         const name = shortPath(fp);
         files.set(name, (files.get(name) || 0) + 1);
       }
     }
   }
   return files;
+}
+
+function firstFilePath(input: Record<string, any>): string | undefined {
+  return filePathsFromInput(input)[0];
+}
+
+function filePathsFromInput(input: Record<string, any>): string[] {
+  const plural = input.file_paths || input.filePaths || input.paths;
+  const paths = Array.isArray(plural)
+    ? plural.filter((fp): fp is string => typeof fp === "string" && fp.trim().length > 0)
+    : [];
+  const singular = input.file_path || input.filePath || input.path || input.relativeWorkspacePath;
+  if (typeof singular === "string" && singular.trim()) paths.unshift(singular);
+  return [...new Set(paths)];
 }
 
 /** Show last 2 path segments for disambiguation (avoids basename collisions) */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -292,7 +292,9 @@ program
                       ? chalk.hex("#F472B6")("cowork")
                       : provider === "cursor"
                         ? chalk.hex("#0096FF")("cursor")
-                        : chalk.yellow(provider);
+                        : provider === "codex"
+                          ? chalk.hex("#B392F0")("codex")
+                          : chalk.yellow(provider);
               replayEntries.push({
                 name: `${providerBadge} ${chalk.dim(`[${time}]`)} ${chalk.white(title)} ${chalk.dim(`(${scenes} scenes)`)}`,
                 value: slug,
@@ -1157,7 +1159,7 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
       const prompt = s.firstPrompt.replace(/\n/g, " ").slice(0, 50);
 
       // Claude: orange-brown (#D97706), Desktop: purple (#C084FC),
-      // Cowork: pink (#F472B6), Cursor: blue (#0096FF)
+      // Cowork: pink (#F472B6), Cursor: blue (#0096FF), Codex: purple (#B392F0)
       const providerBadge =
         s.provider === "claude-code"
           ? chalk.hex("#D97706")("claude")
@@ -1167,7 +1169,9 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
               ? chalk.hex("#F472B6")("cowork")
               : s.provider === "cursor"
                 ? chalk.hex("#0096FF")("cursor")
-                : chalk.yellow(s.provider);
+                : s.provider === "codex"
+                  ? chalk.hex("#B392F0")("codex")
+                  : chalk.yellow(s.provider);
 
       const titleStr = s.title ? chalk.white(` "${s.title}"`) : "";
 

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -114,6 +114,7 @@ export function getModelPricing(model: string): ModelPricing {
 // Non-Claude context window limits. Claude models are handled by name detection below.
 const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "gpt-5.5": 270_000,
+  "gpt-5.4-mini": 270_000,
   "gpt-5.4": 270_000,
   "gpt-4o": 128_000,
   "gpt-4-turbo": 128_000,

--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -11,8 +11,28 @@ interface ModelPricing {
 // Tiered pricing (higher rates above 200k tokens) exists per-request but we only
 // have aggregate token counts, so we use base rates which match per-message reality
 // (individual messages rarely exceed the 200k threshold).
-// Source: LiteLLM model pricing data (used by ccusage).
+// Sources:
+// - Claude: LiteLLM model pricing data (used by ccusage).
+// - GPT-5.x: OpenAI API pricing page (standard rates for context lengths under 270K).
 const MODEL_PRICING: Record<string, ModelPricing> = {
+  "gpt-5.5": {
+    inputRate: 5,
+    outputRate: 30,
+    cacheCreateRate: 5,
+    cacheReadRate: 0.5,
+  },
+  "gpt-5.4": {
+    inputRate: 2.5,
+    outputRate: 15,
+    cacheCreateRate: 2.5,
+    cacheReadRate: 0.25,
+  },
+  "gpt-5.4-mini": {
+    inputRate: 0.75,
+    outputRate: 4.5,
+    cacheCreateRate: 0.75,
+    cacheReadRate: 0.075,
+  },
   // Opus 4.6/4.5
   "opus-4-new": {
     inputRate: 5,
@@ -72,6 +92,11 @@ const DEFAULT_PRICING = MODEL_PRICING.sonnet;
  */
 export function getModelPricing(model: string): ModelPricing {
   const lower = model.toLowerCase();
+  // GPT-5.x prices from OpenAI's public API pricing table.
+  // Check mini before gpt-5.4 so "gpt-5.4-mini" is not shadowed.
+  if (lower.includes("gpt-5.4-mini")) return MODEL_PRICING["gpt-5.4-mini"];
+  if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];
+  if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   // Opus: 4.6/4.5 → new pricing, 4.1 and earlier → legacy
   if (lower.includes("opus-4-6") || lower.includes("opus-4-5")) return MODEL_PRICING["opus-4-new"];
   if (lower.includes("opus")) return MODEL_PRICING.opus;
@@ -88,6 +113,8 @@ export function getModelPricing(model: string): ModelPricing {
 
 // Non-Claude context window limits. Claude models are handled by name detection below.
 const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  "gpt-5.5": 270_000,
+  "gpt-5.4": 270_000,
   "gpt-4o": 128_000,
   "gpt-4-turbo": 128_000,
   "gpt-4": 8_192,

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -715,10 +715,24 @@ function findWebSearchToolId(
 
 function sameWebSearchAction(a: any, b: any): boolean {
   try {
-    return JSON.stringify(a || {}) === JSON.stringify(b || {});
+    return stableStringify(a || {}) === stableStringify(b || {});
   } catch {
     return false;
   }
+}
+
+function stableStringify(value: any): string {
+  return JSON.stringify(stableNormalize(value));
+}
+
+function stableNormalize(value: any): any {
+  if (Array.isArray(value)) return value.map(stableNormalize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, nested]) => [key, stableNormalize(nested)]),
+  );
 }
 
 function compactedSummaryText(payload: any): string {
@@ -728,13 +742,25 @@ function compactedSummaryText(payload: any): string {
 
 function recordCompaction(compactions: Compaction[], timestamp: string, trigger: string): void {
   const time = Date.parse(timestamp);
-  const isDuplicate = compactions.some((compaction) => {
+  const duplicateIndex = compactions.findIndex((compaction) => {
     const previous = Date.parse(compaction.timestamp);
     return Number.isFinite(time) && Number.isFinite(previous)
       ? Math.abs(time - previous) <= 2_000
       : compaction.timestamp === timestamp;
   });
-  if (!isDuplicate) compactions.push({ timestamp, trigger });
+  if (duplicateIndex >= 0) {
+    if (compactionPriority(trigger) > compactionPriority(compactions[duplicateIndex].trigger)) {
+      compactions[duplicateIndex] = { ...compactions[duplicateIndex], trigger };
+    }
+    return;
+  }
+  compactions.push({ timestamp, trigger });
+}
+
+function compactionPriority(trigger: string): number {
+  if (trigger === "codex-context") return 2;
+  if (trigger === "codex") return 1;
+  return 0;
 }
 
 function formatContentItems(items: any[]): string {
@@ -777,7 +803,7 @@ function buildCodexTurnStats(
   taskDurations: number[],
   model?: string,
 ) {
-  const userTurns = turns.filter((t) => t.role === "user");
+  const userTurns = turns.filter((t) => t.role === "user" && !t.subtype);
   const usable = snapshots.filter((s) => s.last);
   return userTurns.map((turn, i) => {
     const usage = usable[i]?.last;

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -30,6 +30,7 @@ interface CodexTokenSnapshot {
   timestamp?: string;
   total?: CodexTokenInfo;
   last?: CodexTokenInfo;
+  contextLimit?: number;
 }
 
 function asCodexTokenInfo(value: unknown): CodexTokenInfo | undefined {
@@ -78,6 +79,7 @@ export function parseCodexLines(
   const tools = new Map<string, PendingTool>();
   const toolResults = new Map<string, ToolResult>();
   const tokenSnapshots: CodexTokenSnapshot[] = [];
+  const taskDurations: number[] = [];
   const mcpServersUsed = new Set<string>();
   const skillsUsed = new Set<string>();
   const gitBranches: string[] = [];
@@ -174,11 +176,40 @@ export function parseCodexLines(
           timestamp: obj.timestamp,
           total: asCodexTokenInfo(p.info?.total_token_usage),
           last: asCodexTokenInfo(p.info?.last_token_usage),
+          contextLimit:
+            typeof p.info?.model_context_window === "number"
+              ? p.info.model_context_window
+              : undefined,
         });
         continue;
       }
-      if (p.type === "web_search_end" && p.query) {
-        const callId = p.call_id || `web_search:${obj.timestamp}`;
+      if (p.type === "task_complete" && typeof p.duration_ms === "number") {
+        if (p.duration_ms > 0) taskDurations.push(p.duration_ms);
+        continue;
+      }
+      if (p.type === "context_compacted") {
+        recordCompaction(compactions, obj.timestamp || "", "codex-context");
+        continue;
+      }
+      if (p.type === "patch_apply_end" && p.call_id) {
+        const tool = tools.get(p.call_id);
+        const changedFiles = patchApplyChangedFiles(p);
+        if (tool && changedFiles.length > 0) {
+          tool.input = mergeToolFilePaths(tool.input, changedFiles);
+        }
+        mergeToolResult(toolResults, p.call_id, {
+          result: formatPatchApplyResult(p),
+          isError: typeof p.success === "boolean" ? !p.success : undefined,
+          timestamp: obj.timestamp,
+        });
+        continue;
+      }
+      if (p.type === "web_search_end") {
+        const callId =
+          (p.call_id && tools.has(p.call_id) ? p.call_id : undefined) ||
+          findWebSearchToolId(tools, toolResults, p, obj.timestamp) ||
+          p.call_id ||
+          `web_search:${obj.timestamp}`;
         if (!tools.has(callId)) {
           tools.set(callId, {
             id: callId,
@@ -188,7 +219,7 @@ export function parseCodexLines(
           });
         }
         mergeToolResult(toolResults, callId, {
-          result: `[Search: ${typeof p.query === "string" ? p.query : JSON.stringify(p.query)}]`,
+          result: formatWebSearchResult(p),
           timestamp: obj.timestamp,
         });
       }
@@ -211,8 +242,35 @@ export function parseCodexLines(
       continue;
     }
 
+    if (obj.type === "compacted") {
+      recordCompaction(compactions, obj.timestamp || "", "codex");
+      const text = compactedSummaryText(obj.payload);
+      if (text) {
+        turns.push({
+          role: "user",
+          subtype: "compaction-summary",
+          timestamp: obj.timestamp,
+          blocks: [{ type: "text", text }],
+        });
+      }
+      continue;
+    }
+
     if (obj.type !== "response_item") continue;
     const p = obj.payload || {};
+
+    if (p.type === "message" && p.role === "developer") {
+      const text = contentText(p.content);
+      if (text.trim()) {
+        turns.push({
+          role: "user",
+          subtype: "context-injection",
+          timestamp: obj.timestamp,
+          blocks: [{ type: "text", text }],
+        });
+      }
+      continue;
+    }
 
     if (p.type === "message" && p.role === "user") {
       const blocks = userMessageBlocksFromContent(p.content);
@@ -243,10 +301,7 @@ export function parseCodexLines(
     }
 
     if (p.type === "compaction") {
-      compactions.push({
-        timestamp: obj.timestamp || "",
-        trigger: "codex",
-      });
+      recordCompaction(compactions, obj.timestamp || "", "codex");
       continue;
     }
 
@@ -263,7 +318,12 @@ export function parseCodexLines(
     }
 
     if (isCodexToolCallType(p.type)) {
-      const callId = p.call_id || p.id || `${p.type}:${obj.timestamp}:${tools.size}`;
+      const existingWebSearchId =
+        p.type === "web_search_call" && !p.call_id && !p.id
+          ? findWebSearchToolId(tools, toolResults, p, obj.timestamp, { includeResolved: true })
+          : undefined;
+      const callId =
+        p.call_id || p.id || existingWebSearchId || `${p.type}:${obj.timestamp}:${tools.size}`;
       const name = p.name || normalizeCodexToolName(p.type);
       const input = inputForResponseItem(p);
       tools.set(callId, { id: callId, name, input, timestamp: obj.timestamp });
@@ -317,13 +377,15 @@ export function parseCodexLines(
   turns.sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
 
   const tokenUsage = tokenUsageFromSnapshots(tokenSnapshots);
+  const contextLimit = [...tokenSnapshots].toReversed().find((s) => s.contextLimit)?.contextLimit;
   const tokenUsageByModel =
     tokenUsage && model
       ? {
           [model]: tokenUsage,
         }
       : undefined;
-  const turnStats = buildCodexTurnStats(turns, tokenSnapshots, model);
+  const turnStats = buildCodexTurnStats(turns, tokenSnapshots, taskDurations, model);
+  const summedTaskDurationMs = taskDurations.reduce((sum, duration) => sum + duration, 0);
 
   return {
     sessionId,
@@ -333,12 +395,13 @@ export function parseCodexLines(
     model,
     startTime,
     endTime,
-    totalDurationMs: estimateActiveDuration(allTimestamps),
+    totalDurationMs: summedTaskDurationMs || estimateActiveDuration(allTimestamps),
     turns,
     tokenUsage,
     tokenUsageByModel,
     compactions: compactions.length > 0 ? compactions : undefined,
     turnStats: turnStats.length > 0 ? turnStats : undefined,
+    contextLimit,
     gitBranch,
     gitBranches: gitBranches.length > 1 ? gitBranches : undefined,
     entrypoint,
@@ -503,6 +566,22 @@ function inputForResponseItem(payload: any): Record<string, any> {
   return parseArguments(payload.arguments ?? payload.action ?? {});
 }
 
+function patchApplyChangedFiles(payload: any): string[] {
+  const changes = payload?.changes;
+  if (!changes || typeof changes !== "object" || Array.isArray(changes)) return [];
+  return Object.keys(changes).filter((file) => file.trim().length > 0);
+}
+
+function mergeToolFilePaths(input: Record<string, any>, filePaths: string[]): Record<string, any> {
+  const unique = [...new Set(filePaths)];
+  if (unique.length === 0) return input;
+  return {
+    ...input,
+    file_paths: unique,
+    ...(input.file_path || unique.length !== 1 ? {} : { file_path: unique[0] }),
+  };
+}
+
 function localShellActionInput(action: any): Record<string, any> {
   const command = Array.isArray(action?.command)
     ? action.command.map(String).join(" ")
@@ -549,6 +628,29 @@ function formatExecResult(payload: any): string {
   return [output, status, exit].filter(Boolean).join("\n");
 }
 
+function formatPatchApplyResult(payload: any): string {
+  const status = payload.status ? `Status: ${payload.status}` : "";
+  const stdout = payload.stdout || "";
+  const stderr = payload.stderr || "";
+  const files = patchApplyChangedFiles(payload);
+  const changed =
+    files.length > 0 ? `Changed files:\n${files.map((file) => `- ${file}`).join("\n")}` : "";
+  return [stdout, stderr, status, changed].filter(Boolean).join("\n");
+}
+
+function formatWebSearchResult(payload: any): string {
+  if (typeof payload.query === "string" && payload.query.trim()) {
+    return `[Search: ${payload.query}]`;
+  }
+  const action = payload.action || {};
+  if (typeof action.url === "string" && action.url.trim()) return `[Open: ${action.url}]`;
+  if (typeof action.pattern === "string" && action.pattern.trim())
+    return `[Find: ${action.pattern}]`;
+  if (typeof action.query === "string" && action.query.trim()) return `[Search: ${action.query}]`;
+  if (typeof action.type === "string" && action.type.trim()) return `[Web search: ${action.type}]`;
+  return "[Web search]";
+}
+
 function formatOutputPayload(payload: any): string {
   if (typeof payload.output === "string") return payload.output;
   if (Array.isArray(payload.output)) return formatContentItems(payload.output);
@@ -593,6 +695,48 @@ function isMcpToolError(payload: any): boolean {
   );
 }
 
+function findWebSearchToolId(
+  tools: Map<string, PendingTool>,
+  toolResults: Map<string, ToolResult>,
+  payload: any,
+  timestamp?: string,
+  options: { includeResolved?: boolean } = {},
+): string | undefined {
+  for (const tool of tools.values()) {
+    if (tool.name !== "web_search") continue;
+    if (!options.includeResolved && toolResults.has(tool.id)) continue;
+    if (!sameWebSearchAction(tool.input, payload.action || { query: payload.query })) continue;
+    if (!timestamp || !tool.timestamp) return tool.id;
+    const diff = Math.abs(Date.parse(timestamp) - Date.parse(tool.timestamp));
+    if (!Number.isFinite(diff) || diff <= 5_000) return tool.id;
+  }
+  return undefined;
+}
+
+function sameWebSearchAction(a: any, b: any): boolean {
+  try {
+    return JSON.stringify(a || {}) === JSON.stringify(b || {});
+  } catch {
+    return false;
+  }
+}
+
+function compactedSummaryText(payload: any): string {
+  if (typeof payload?.message === "string" && payload.message.trim()) return payload.message.trim();
+  return "";
+}
+
+function recordCompaction(compactions: Compaction[], timestamp: string, trigger: string): void {
+  const time = Date.parse(timestamp);
+  const isDuplicate = compactions.some((compaction) => {
+    const previous = Date.parse(compaction.timestamp);
+    return Number.isFinite(time) && Number.isFinite(previous)
+      ? Math.abs(time - previous) <= 2_000
+      : compaction.timestamp === timestamp;
+  });
+  if (!isDuplicate) compactions.push({ timestamp, trigger });
+}
+
 function formatContentItems(items: any[]): string {
   return items
     .map((item) => {
@@ -627,7 +771,12 @@ function tokenUsageFromSnapshots(snapshots: CodexTokenSnapshot[]): TokenUsage | 
   };
 }
 
-function buildCodexTurnStats(turns: ParsedTurn[], snapshots: CodexTokenSnapshot[], model?: string) {
+function buildCodexTurnStats(
+  turns: ParsedTurn[],
+  snapshots: CodexTokenSnapshot[],
+  taskDurations: number[],
+  model?: string,
+) {
   const userTurns = turns.filter((t) => t.role === "user");
   const usable = snapshots.filter((s) => s.last);
   return userTurns.map((turn, i) => {
@@ -652,7 +801,10 @@ function buildCodexTurnStats(turns: ParsedTurn[], snapshots: CodexTokenSnapshot[
       stat.contextTokens = input;
     }
     const nextUser = userTurns[i + 1]?.timestamp;
-    if (turn.timestamp) {
+    const taskDuration = taskDurations[i];
+    if (typeof taskDuration === "number" && taskDuration > 0) {
+      stat.durationMs = taskDuration;
+    } else if (turn.timestamp) {
       const end = nextUser || usable[i]?.timestamp;
       if (end) {
         const diff = Date.parse(end) - Date.parse(turn.timestamp);

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -386,6 +386,11 @@ export function parseCodexLines(
       : undefined;
   const turnStats = buildCodexTurnStats(turns, tokenSnapshots, taskDurations, model);
   const summedTaskDurationMs = taskDurations.reduce((sum, duration) => sum + duration, 0);
+  const userPromptTurnCount = turns.filter((turn) => turn.role === "user" && !turn.subtype).length;
+  const completeTaskDurationMs =
+    userPromptTurnCount > 0 && taskDurations.length >= userPromptTurnCount
+      ? summedTaskDurationMs
+      : undefined;
 
   return {
     sessionId,
@@ -395,7 +400,7 @@ export function parseCodexLines(
     model,
     startTime,
     endTime,
-    totalDurationMs: summedTaskDurationMs || estimateActiveDuration(allTimestamps),
+    totalDurationMs: completeTaskDurationMs || estimateActiveDuration(allTimestamps),
     turns,
     tokenUsage,
     tokenUsageByModel,

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -34,6 +34,8 @@ export interface ProviderParseResult {
   compactions?: Compaction[];
   /** Per-turn metrics (indexed by user-prompt turn, 0-based) */
   turnStats?: TurnStat[];
+  /** Provider-reported context window limit for the primary model, if available */
+  contextLimit?: number;
   /** PR links associated with the session */
   prLinks?: PrLink[];
   /** Summary of subagents used in this session */

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -20,7 +20,13 @@ import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
-import { FILE_EDIT_TOOLS, extractToolFilePath, localDayKey, shortenPath } from "./utils.js";
+import {
+  FILE_EDIT_TOOLS,
+  extractToolFilePath,
+  extractToolFilePaths,
+  localDayKey,
+  shortenPath,
+} from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
 const SCANNER_VERSION = 8;
@@ -743,11 +749,13 @@ function buildScanResultFromParsed(
 
       if (!FILE_EDIT_TOOLS.has(block.name)) continue;
 
-      const rawPath = extractToolFilePath(block.input);
-      if (!rawPath) continue;
+      const rawPaths = extractToolFilePaths(block.input);
+      if (rawPaths.length === 0) continue;
       editCount++;
-      const short = shortenPath(rawPath);
-      fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
+      for (const rawPath of rawPaths) {
+        const short = shortenPath(rawPath);
+        fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
+      }
     }
   }
 

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -709,7 +709,7 @@ function buildScanResultFromParsed(
   const fileEditCounts = new Map<string, number>();
 
   for (const turn of parsed.turns) {
-    if (turn.role === "user" && turn.subtype !== "compaction-summary") {
+    if (turn.role === "user" && !turn.subtype) {
       const hasText = turn.blocks.some(
         (block) =>
           block.type === "text" && typeof block.text === "string" && block.text.trim().length > 0,
@@ -805,7 +805,7 @@ function buildScanResultFromParsed(
 
 function firstUserPrompt(turns: ProviderParseResult["turns"]): string | undefined {
   for (const turn of turns) {
-    if (turn.role !== "user" || turn.subtype === "compaction-summary") continue;
+    if (turn.role !== "user" || turn.subtype) continue;
     for (const block of turn.blocks) {
       if (block.type !== "text") continue;
       const text = block.text.replace(/\s+/g, " ").trim();

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -170,7 +170,9 @@ export function transformToReplay(
         costEstimate,
         ...(parsed.turnStats ? { turnStats: parsed.turnStats } : {}),
       },
-      ...(parsed.model ? { contextLimit: getModelContextLimit(parsed.model) } : {}),
+      ...(parsed.contextLimit || parsed.model
+        ? { contextLimit: parsed.contextLimit || getModelContextLimit(parsed.model || "") }
+        : {}),
       ...(parsed.tokenUsageByModel ? { tokenUsageByModel: parsed.tokenUsageByModel } : {}),
       ...(parsed.prLinks && parsed.prLinks.length > 0 ? { prLinks: parsed.prLinks } : {}),
       compactions: parsed.compactions,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -28,8 +28,19 @@ export const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
 export function extractToolFilePath(
   input: Record<string, unknown> | undefined,
 ): string | undefined {
-  const fp = input?.file_path ?? input?.filePath ?? input?.path ?? input?.relativeWorkspacePath;
-  return typeof fp === "string" && fp.trim() ? fp : undefined;
+  return extractToolFilePaths(input)[0];
+}
+
+/** Extract one or more file paths from tool input, handling provider-specific field names. */
+export function extractToolFilePaths(input: Record<string, unknown> | undefined): string[] {
+  if (!input) return [];
+  const plural = input.file_paths ?? input.filePaths ?? input.paths;
+  const paths = Array.isArray(plural)
+    ? plural.filter((fp): fp is string => typeof fp === "string" && fp.trim().length > 0)
+    : [];
+  const singular = input.file_path ?? input.filePath ?? input.path ?? input.relativeWorkspacePath;
+  if (typeof singular === "string" && singular.trim()) paths.unshift(singular);
+  return [...new Set(paths)];
 }
 
 /**

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -80,7 +80,17 @@ const lines = [
           output_tokens: 50,
           total_tokens: 1050,
         },
+        model_context_window: 258400,
       },
+    },
+  },
+  {
+    timestamp: "2026-04-26T05:00:06.000Z",
+    type: "event_msg",
+    payload: {
+      type: "task_complete",
+      duration_ms: 12345,
+      turn_id: "turn-1",
     },
   },
 ].map((line) => JSON.stringify(line));
@@ -93,6 +103,9 @@ describe("Codex parser", () => {
     expect(result.cwd).toBe("/Users/test/project");
     expect(result.model).toBe("gpt-5.4");
     expect(result.gitBranch).toBe("main");
+    expect(result.contextLimit).toBe(258400);
+    expect(result.totalDurationMs).toBe(12345);
+    expect(result.turnStats?.[0]?.durationMs).toBe(12345);
     expect(result.memoryMode).toBe("enabled");
     expect(result.tokenUsage).toMatchObject({
       inputTokens: 700,
@@ -595,6 +608,192 @@ describe("Codex parser", () => {
       name: "web_search",
       _result: "[Search: Codex rollout schema]",
     });
+  });
+
+  it("merges Codex web_search_call with matching web_search_end events", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:10:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-web", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:10:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "web_search_call",
+            status: "completed",
+            action: { type: "search", query: "Codex rollout schema" },
+          },
+        },
+        {
+          timestamp: "2026-04-26T10:10:01.100Z",
+          type: "event_msg",
+          payload: {
+            type: "web_search_end",
+            call_id: "ws_1",
+            query: "Codex rollout schema",
+            action: { type: "search", query: "Codex rollout schema" },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tools = result.turns.flatMap((turn) =>
+      turn.blocks.filter((block) => block.type === "tool_use"),
+    );
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      type: "tool_use",
+      name: "web_search",
+      _result: "[Search: Codex rollout schema]",
+    });
+  });
+
+  it("keeps Codex web_search_end events that omit query text", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:11:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-web-empty", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:11:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "web_search_end",
+            call_id: "ws_empty",
+            query: "",
+            action: { type: "open_page" },
+          },
+        },
+        {
+          timestamp: "2026-04-26T10:11:01.001Z",
+          type: "response_item",
+          payload: {
+            type: "web_search_call",
+            status: "completed",
+            action: { type: "open_page" },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tools = result.turns.flatMap((turn) =>
+      turn.blocks.filter((block) => block.type === "tool_use"),
+    );
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      type: "tool_use",
+      name: "web_search",
+      _result: "[Web search: open_page]",
+    });
+  });
+
+  it("uses Codex patch_apply_end metadata to attribute edited files", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:20:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-patch", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:20:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "custom_tool_call",
+            name: "apply_patch",
+            call_id: "patch_1",
+            input: "*** Begin Patch\n*** Update File: src/app.ts\n*** End Patch",
+          },
+        },
+        {
+          timestamp: "2026-04-26T10:20:02.000Z",
+          type: "event_msg",
+          payload: {
+            type: "patch_apply_end",
+            call_id: "patch_1",
+            status: "completed",
+            success: true,
+            changes: {
+              "/Users/test/project/src/app.ts": { status: "modified" },
+              "/Users/test/project/src/auth.ts": { status: "modified" },
+            },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "Edit",
+      input: {
+        file_paths: ["/Users/test/project/src/app.ts", "/Users/test/project/src/auth.ts"],
+      },
+      _result: expect.stringContaining("Changed files:"),
+    });
+  });
+
+  it("parses Codex developer messages as context injections", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:30:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-dev", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:30:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "Use the repo testing instructions." }],
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.turns[0]).toMatchObject({
+      role: "user",
+      subtype: "context-injection",
+    });
+    const replay = transformToReplay(result, "codex", "~/project");
+    expect(replay.scenes[0]).toMatchObject({
+      type: "context-injection",
+      content: "Use the repo testing instructions.",
+    });
+    expect(replay.meta.stats.userPrompts).toBe(0);
+  });
+
+  it("tracks current Codex compaction events", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:40:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-compact", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:40:01.000Z",
+          type: "event_msg",
+          payload: { type: "context_compacted" },
+        },
+        {
+          timestamp: "2026-04-26T10:40:02.000Z",
+          type: "compacted",
+          payload: { message: "", replacement_history: [] },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.compactions).toMatchObject([{ trigger: "codex-context" }]);
   });
 
   it("parses current Codex response-item user messages without duplicating event messages", () => {

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -634,7 +634,7 @@ describe("Codex parser", () => {
             type: "web_search_end",
             call_id: "ws_1",
             query: "Codex rollout schema",
-            action: { type: "search", query: "Codex rollout schema" },
+            action: { query: "Codex rollout schema", type: "search" },
           },
         },
       ].map((line) => JSON.stringify(line)),
@@ -772,6 +772,40 @@ describe("Codex parser", () => {
     expect(replay.meta.stats.userPrompts).toBe(0);
   });
 
+  it("does not align task durations against Codex context injections", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:35:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-duration", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:35:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "Use project rules." }],
+          },
+        },
+        {
+          timestamp: "2026-04-26T10:35:02.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "Run the tests." },
+        },
+        {
+          timestamp: "2026-04-26T10:35:05.000Z",
+          type: "event_msg",
+          payload: { type: "task_complete", duration_ms: 5000 },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.turnStats).toHaveLength(1);
+    expect(result.turnStats?.[0]).toMatchObject({ turnIndex: 0, durationMs: 5000 });
+  });
+
   it("tracks current Codex compaction events", () => {
     const result = parseCodexLines(
       [
@@ -789,6 +823,30 @@ describe("Codex parser", () => {
           timestamp: "2026-04-26T10:40:02.000Z",
           type: "compacted",
           payload: { message: "", replacement_history: [] },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.compactions).toMatchObject([{ trigger: "codex-context" }]);
+  });
+
+  it("prefers the specific Codex context compaction trigger when duplicate events arrive", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:41:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-compact-order", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:41:01.000Z",
+          type: "compacted",
+          payload: { message: "", replacement_history: [] },
+        },
+        {
+          timestamp: "2026-04-26T10:41:02.000Z",
+          type: "event_msg",
+          payload: { type: "context_compacted" },
         },
       ].map((line) => JSON.stringify(line)),
     );

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -806,6 +806,36 @@ describe("Codex parser", () => {
     expect(result.turnStats?.[0]).toMatchObject({ turnIndex: 0, durationMs: 5000 });
   });
 
+  it("keeps timestamp fallback duration when Codex task_complete coverage is partial", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:36:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-partial-duration", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T10:36:01.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "First prompt." },
+        },
+        {
+          timestamp: "2026-04-26T10:36:03.000Z",
+          type: "event_msg",
+          payload: { type: "task_complete", duration_ms: 1000 },
+        },
+        {
+          timestamp: "2026-04-26T10:36:10.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "Second prompt." },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.turnStats).toHaveLength(2);
+    expect(result.totalDurationMs).toBe(10_000);
+  });
+
   it("tracks current Codex compaction events", () => {
     const result = parseCodexLines(
       [

--- a/packages/cli/test/github-format.test.ts
+++ b/packages/cli/test/github-format.test.ts
@@ -210,6 +210,43 @@ describe("generateGitHubMarkdown", () => {
     expect(md).toContain("`src/app.ts` modified 5x");
   });
 
+  it("counts provider edit tools that report multiple file paths", () => {
+    const session = makeSession({
+      scenes: [
+        { type: "user-prompt", content: "Patch two files" },
+        {
+          type: "tool-call",
+          toolName: "Edit",
+          input: {
+            file_paths: ["~/project/src/app.ts", "~/project/src/auth.ts"],
+          },
+          result: "Changed files",
+        },
+      ],
+      meta: {
+        ...makeSession().meta,
+        stats: { sceneCount: 2, userPrompts: 1, toolCalls: 1 },
+      },
+    });
+
+    const md = generateGitHubMarkdown(session);
+    expect(md).toContain("2 files changed");
+  });
+
+  it("shows compaction signal when provider reports compaction metadata only", () => {
+    const session = makeSession({
+      scenes: [{ type: "user-prompt", content: "Continue after compaction" }],
+      meta: {
+        ...makeSession().meta,
+        compactions: [{ timestamp: "2026-01-01T00:00:00Z", trigger: "codex" }],
+        stats: { sceneCount: 1, userPrompts: 1, toolCalls: 0 },
+      },
+    });
+
+    const md = generateGitHubMarkdown(session);
+    expect(md).toContain("Session was compacted");
+  });
+
   it("handles empty sessions gracefully", () => {
     const session = makeSession({
       scenes: [],

--- a/packages/cli/test/pricing.test.ts
+++ b/packages/cli/test/pricing.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { estimateCost, estimateCostSimple, getModelPricing } from "../src/pricing.js";
+import {
+  estimateCost,
+  estimateCostSimple,
+  getModelContextLimit,
+  getModelPricing,
+} from "../src/pricing.js";
 import type { TokenUsage } from "../src/providers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -54,6 +59,30 @@ describe("getModelPricing — model family detection", () => {
     expect(p.cacheReadRate).toBe(0.1);
   });
 
+  it("returns GPT-5.5 pricing for Codex model IDs", () => {
+    const p = getModelPricing("gpt-5.5");
+    expect(p.inputRate).toBe(5);
+    expect(p.outputRate).toBe(30);
+    expect(p.cacheCreateRate).toBe(5);
+    expect(p.cacheReadRate).toBe(0.5);
+  });
+
+  it("returns GPT-5.4 pricing for Codex model IDs", () => {
+    const p = getModelPricing("gpt-5.4-high");
+    expect(p.inputRate).toBe(2.5);
+    expect(p.outputRate).toBe(15);
+    expect(p.cacheCreateRate).toBe(2.5);
+    expect(p.cacheReadRate).toBe(0.25);
+  });
+
+  it("returns GPT-5.4 mini pricing before generic GPT-5.4", () => {
+    const p = getModelPricing("gpt-5.4-mini");
+    expect(p.inputRate).toBe(0.75);
+    expect(p.outputRate).toBe(4.5);
+    expect(p.cacheCreateRate).toBe(0.75);
+    expect(p.cacheReadRate).toBe(0.075);
+  });
+
   it("returns legacy Haiku pricing for haiku-3-5", () => {
     const p = getModelPricing("claude-3-5-haiku-20241022");
     expect(p.inputRate).toBe(0.8);
@@ -76,6 +105,14 @@ describe("getModelPricing — model family detection", () => {
     expect(getModelPricing("Claude-OPUS-4-6").inputRate).toBe(5);
     expect(getModelPricing("CLAUDE-SONNET-4-6").inputRate).toBe(3);
     expect(getModelPricing("claude-HAIKU-4-5").inputRate).toBe(1);
+  });
+});
+
+describe("getModelContextLimit", () => {
+  it("returns GPT-5.x public pricing threshold as fallback context limit", () => {
+    expect(getModelContextLimit("gpt-5.5")).toBe(270_000);
+    expect(getModelContextLimit("gpt-5.4-high")).toBe(270_000);
+    expect(getModelContextLimit("gpt-5.4-mini")).toBe(270_000);
   });
 });
 

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -338,6 +338,47 @@ describe("scanSession", () => {
     expect(result.filesModified).toEqual([]);
   });
 
+  it("excludes Codex developer context injections from prompt analytics", async () => {
+    const codexFixturePath = join(tmpDir, "codex-context-session.jsonl");
+    await writeFile(
+      codexFixturePath,
+      [
+        makeLine({
+          timestamp: "2026-04-26T10:30:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-context-session", cwd: "/Users/test/project", source: "cli" },
+        }),
+        makeLine({
+          timestamp: "2026-04-26T10:30:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "Use the repo testing instructions." }],
+          },
+        }),
+        makeLine({
+          timestamp: "2026-04-26T10:30:02.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "Run the tests." },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "codex-context-session",
+      provider: "codex",
+      project: "~/test/project",
+      slug: "codex-context",
+      filePaths: [codexFixturePath],
+      timestamp: "2026-04-26T10:30:00.000Z",
+    });
+
+    expect(result.promptCount).toBe(1);
+    expect(result.firstPrompt).toBe("Run the tests.");
+  });
+
   it("defers rich Cursor SQLite parsing for background scans", async () => {
     const result = await scanSession({
       sessionId: "cursor-sqlite-session",

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1623,7 +1623,7 @@ function SessionsPanel() {
         <div className="text-center space-y-2">
           <div className="text-terminal-dim font-mono text-sm">No AI sessions found</div>
           <div className="text-terminal-dimmer font-mono text-xs">
-            Start a coding session with Claude Code or Cursor, then come back here
+            Start Claude, Cursor, or Codex, then come back here
           </div>
         </div>
       </div>

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -358,9 +358,7 @@ function RecentSessionsList({
   if (sessions.length === 0) {
     return (
       <div className="text-center py-6 text-terminal-dimmer text-xs font-mono">
-        {isLoading
-          ? "Loading sessions..."
-          : "No sessions found. Start a coding session with Claude Code or Cursor."}
+        {isLoading ? "Loading sessions..." : "No sessions found. Start Claude, Cursor, or Codex."}
       </div>
     );
   }

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   agentWorktreeParent,
   formatDataSourceLabel,
+  providerBadgeClass,
+  providerBadgeLabel,
+  providerBarClass,
+  providerDisplayName,
+  providerFamily,
   rollupProject,
   rollupTopProjects,
   type TopProjectEntry,
@@ -205,5 +210,15 @@ describe("formatDataSourceLabel", () => {
     expect(formatDataSourceLabel(false, "global-state")).toBe("Cursor global state");
     expect(formatDataSourceLabel(true)).toBe("SQLite + JSONL");
     expect(formatDataSourceLabel()).toBe("JSONL");
+  });
+});
+
+describe("provider display helpers", () => {
+  it("labels Codex as a first-class provider", () => {
+    expect(providerBadgeLabel("codex")).toBe("Codex");
+    expect(providerDisplayName("codex")).toBe("Codex");
+    expect(providerBadgeClass("codex")).toContain("terminal-purple");
+    expect(providerBarClass("codex")).toBe("bg-terminal-purple");
+    expect(providerFamily("codex")).toBe("purple");
   });
 });

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -402,6 +402,7 @@ export const PROVIDER_BADGE_COLORS: Record<string, string> = {
   "claude-code": "bg-terminal-orange-subtle text-terminal-orange",
   "claude-desktop": "bg-terminal-orange-subtle text-terminal-orange",
   "claude-cowork": "bg-terminal-orange-subtle text-terminal-orange",
+  codex: "bg-terminal-purple-subtle text-terminal-purple",
   cursor: "bg-terminal-blue-subtle text-terminal-blue",
 };
 
@@ -409,6 +410,7 @@ const PROVIDER_BADGE_LABELS: Record<string, string> = {
   "claude-code": "Claude",
   "claude-desktop": "Desktop",
   "claude-cowork": "Cowork",
+  codex: "Codex",
   cursor: "Cursor",
 };
 
@@ -418,6 +420,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   "claude-code": "Claude Code",
   "claude-desktop": "Claude Desktop",
   "claude-cowork": "Claude Cowork",
+  codex: "Codex",
   cursor: "Cursor",
 };
 
@@ -427,20 +430,22 @@ const PROVIDER_BAR_COLORS: Record<string, string> = {
   "claude-code": "bg-terminal-orange",
   "claude-desktop": "bg-terminal-orange",
   "claude-cowork": "bg-terminal-orange",
+  codex: "bg-terminal-purple",
   cursor: "bg-terminal-blue",
 };
 
 // Provider "color family" for home-page chip UI that composes several tint
 // variants together (bg/8, text/80, text, dot). Returning the token name keeps
 // Tailwind's static-class extraction happy and avoids template-string bugs.
-const PROVIDER_FAMILY: Record<string, "orange" | "blue" | "dim"> = {
+const PROVIDER_FAMILY: Record<string, "orange" | "blue" | "purple" | "dim"> = {
   "claude-code": "orange",
   "claude-desktop": "orange",
   "claude-cowork": "orange",
+  codex: "purple",
   cursor: "blue",
 };
 
-export function providerFamily(provider: string): "orange" | "blue" | "dim" {
+export function providerFamily(provider: string): "orange" | "blue" | "purple" | "dim" {
   return PROVIDER_FAMILY[provider] || "dim";
 }
 


### PR DESCRIPTION
## Summary
- Promote Codex to a supported provider in docs, CLI badges, dashboard labels, and provider color helpers.
- Parse newer Codex rollout events for task durations, context windows, compactions, developer context, patch metadata, and web search results.
- Count multi-file edit tools in scans/GitHub summaries and add GPT-5.x pricing/context defaults.

## Test plan
- pnpm --filter vibe-replay exec vitest run test/codex-parser.test.ts test/github-format.test.ts test/pricing.test.ts
- pnpm --filter @vibe-replay/viewer exec vitest run src/components/__tests__/dashboard-utils.test.ts
- pnpm lint:check
- pnpm typecheck


Made with [Cursor](https://cursor.com)