### PR TITLE
docs: add Codex capabilities to Features list and Supported Providers table

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 
 - **Zero config** — one command, no setup, no account. Works instantly with existing sessions
 - **Single HTML file** — self-contained, works offline, zero external requests. Drop it in Slack, email it, open it anywhere
-- **Claude Code + Cursor** — both providers auto-discovered, including multi-file and resumed sessions
+- **Claude Code, Cursor, and Codex** — all providers auto-discovered, including multi-file and resumed sessions
 - **Share & export** — GitHub Gist, animated SVG, GIF, markdown summary, or cloud upload. Secret redaction built in
 - **Sub-agent visualization** — see delegated tool calls and sub-agent trees rendered inline
 - **Comments** — leave notes on any scene. Comments persist in the HTML and travel with the replay
@@ -126,7 +126,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 | Claude Code | Supported |
 | Claude Desktop | Supported |
 | Claude Cowork | Supported (agent-mode sessions) |
-| Codex | Supported |
+| Codex | Supported (web search, GPT-5.x models, task timings, memory mode) |
 | Cursor | Supported (SQLite + JSONL + SDK store, auto-discovered) |
 | More coming soon | — |
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 ```
 AI session files  →  vibe-replay  →  self-contained HTML
 (Claude Code,        (discover,       (animated viewer,
- Cursor)              parse,           insights panel,
+ Cursor, Codex)       parse,           insights panel,
                       redact,          offline-ready,
                       transform)       shareable)
 ```


### PR DESCRIPTION
## Summary

- Features section still said **Claude Code + Cursor** after PR #269 promoted Codex to full provider — updated to **Claude Code, Cursor, and Codex**
- Supported Providers table had no capability notes for Codex (unlike Cursor and Cowork rows) — added parenthetical describing key Codex-specific capabilities

## Why now

PR #269 (`fix(codex): improve replay feature parity`) and PR #268 (`fix(codex): surface session memory mode`) made Codex a first-class provider with web search results, GPT-5.x model pricing, task timings, and memory mode. PR #269 updated the opening line and dashboard description but left the Features bullet and Supported Providers table without matching updates.

## Files touched

- README.md (+2 / -2 lines)

## Out of scope (intentionally)

- Did not touch landing page / website pages (off-limits for this routine)
- Did not add screenshots or extended Codex prose
- Existing Cursor/Cowork description formats kept as-is; only appended to the Codex row

> 🤖 Weekly auto-docs routine. Needs human review before merge.