### PR TITLE
chore(tests): replace as any with TextBlock in source-insights test

### DIFF
--- a/packages/cli/test/claude-code-source-insights.test.ts
+++ b/packages/cli/test/claude-code-source-insights.test.ts
@@ -9,6 +9,9 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseClaudeCodeSession } from "../src/providers/claude-code/parser.js";
 import { transformToReplay } from "../src/transform.js";
+import type { ContentBlock } from "../src/types.js";
+
+type TextBlock = Extract<ContentBlock, { type: "text" }>;
 
 const FIXTURE = join(import.meta.dirname, "fixtures/claude-code-source-insights.jsonl");
 
@@ -19,7 +22,9 @@ describe("Claude Code source insights: isCompactSummary flag", () => {
       (t) => t.role === "user" && t.subtype === "compaction-summary",
     );
     expect(compactionTurns).toHaveLength(1);
-    expect((compactionTurns[0].blocks[0] as any).text).toContain("This session is being continued");
+    expect((compactionTurns[0].blocks[0] as TextBlock).text).toContain(
+      "This session is being continued",
+    );
   });
 
   it("transforms compaction summary to compaction-summary scene", async () => {
@@ -37,13 +42,13 @@ describe("Claude Code source insights: isMeta as context-injection", () => {
       (t) => t.role === "user" && t.subtype === "context-injection",
     );
     expect(injections).toHaveLength(1);
-    expect((injections[0].blocks[0] as any).text).toContain("Base directory for this skill");
+    expect((injections[0].blocks[0] as TextBlock).text).toContain("Base directory for this skill");
   });
 
   it("does not include isMeta messages in regular user turns", async () => {
     const result = await parseClaudeCodeSession(FIXTURE);
     const regularTurns = result.turns.filter((t) => t.role === "user" && !t.subtype);
-    const texts = regularTurns.map((t) => (t.blocks[0] as any).text);
+    const texts = regularTurns.map((t) => (t.blocks[0] as TextBlock).text);
     expect(texts).toContain("Build the auth system");
     expect(texts).toContain("Continue building the auth middleware");
     expect(regularTurns).toHaveLength(2);
@@ -98,7 +103,7 @@ describe("Claude Code source insights: stop_reason tracking", () => {
     const parsed = await parseClaudeCodeSession(FIXTURE);
     const replay = transformToReplay(parsed, "claude-code", "~/test");
     const truncatedScene = replay.scenes.find(
-      (s) => s.type === "text-response" && (s as any).isTruncated === true,
+      (s) => s.type === "text-response" && s.isTruncated === true,
     );
     expect(truncatedScene).toBeDefined();
     expect(truncatedScene!.type === "text-response" && truncatedScene!.content).toContain(


### PR DESCRIPTION
## Summary

- Replace 3× `(block as any).text` with `(block as TextBlock).text` by importing `ContentBlock` and deriving a local `TextBlock` alias
- Replace `(s as any).isTruncated` with `s.isTruncated` — TypeScript discriminated union narrows `s` after the `s.type === "text-response" &&` guard, so no cast is needed
- Net: -4 `as any` / `as unknown` casts, +2 lines (import + type alias), 1 file

## Motivation

These `as any` casts are weaker than necessary; `TextBlock = Extract<ContentBlock, { type: "text" }>` is the correct narrowing the same pattern used in `claude-code-parser-comprehensive.test.ts` (PR #266). Semantics are identical — no runtime behavior change.

## Test plan

- [x] `pnpm test` 全绿 (755 passed)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 485KB, well under 800KB limit)
- [x] E2E: not run — only test file changed, no production code touched

> 🤖 Daily auto-quality routine. Self-merged after AI review.