### PR TITLE
chore(cli): widen cleanPromptText parameter from string to unknown

### DIFF
--- a/packages/cli/src/clean-prompt.ts
+++ b/packages/cli/src/clean-prompt.ts
@@ -24,7 +24,7 @@ export function previewPrompt(text: string): string {
  * Strip system-injected boilerplate from user prompts.
  * Shared by discover (session scanning) and server (API responses).
  */
-export function cleanPromptText(text: string): string {
+export function cleanPromptText(text: unknown): string {
   if (typeof text !== "string") return "";
 
   let cleaned = text.trim();

--- a/packages/cli/test/clean-prompt.test.ts
+++ b/packages/cli/test/clean-prompt.test.ts
@@ -3,9 +3,9 @@ import { cleanPromptText } from "../src/clean-prompt.js";
 
 describe("cleanPromptText", () => {
   it("returns empty string for non-string input", () => {
-    expect(cleanPromptText(42 as any)).toBe("");
-    expect(cleanPromptText(null as any)).toBe("");
-    expect(cleanPromptText(undefined as any)).toBe("");
+    expect(cleanPromptText(42)).toBe("");
+    expect(cleanPromptText(null)).toBe("");
+    expect(cleanPromptText(undefined)).toBe("");
   });
 
   it("passes through normal user prompts unchanged", () => {


### PR DESCRIPTION
## Summary

- Widen `cleanPromptText(text: string)` to `cleanPromptText(text: unknown)` in `clean-prompt.ts`
- Remove 3 `as any` casts in `clean-prompt.test.ts` that tested this runtime guard
- Net: -4 +4 (no line count change, just type precision)

## Motivation

The function already has `if (typeof text !== "string") return ""` on line 28, so it handles non-string input gracefully at runtime. The `string` signature was misleading: the test had to force `42 as any`, `null as any`, `undefined as any` to verify the guard existed. Widening to `unknown` makes the type match the implementation.

All callers pass `string` values and remain unaffected — `string` is assignable to `unknown`.

## Test plan

- [x] `pnpm test` all green (755 passed)
- [x] `pnpm lint:check` 0 warnings, 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 0 errors
- [x] `pnpm build` success
- [x] E2E: not run (CLI-only type change, no runtime behaviour affected)

> 🤖 Daily auto-quality routine. Self-merged after AI review.