### PR TITLE
chore(codex): drop export from internal-only helpers in constants.ts

### DIFF
--- a/packages/cli/src/providers/codex/constants.ts
+++ b/packages/cli/src/providers/codex/constants.ts
@@ -1,4 +1,4 @@
-export const USER_MESSAGE_BEGIN = "## My request for Codex:";
+const USER_MESSAGE_BEGIN = "## My request for Codex:";
 export const CODEX_CONTEXT_TAGS = [
   "environment_context",
   "permissions instructions",
@@ -20,12 +20,12 @@ export function isCodexToolCallType(type?: string): boolean {
   );
 }
 
-export function stripUserMessagePrefix(text: string): string {
+function stripUserMessagePrefix(text: string): string {
   const idx = text.indexOf(USER_MESSAGE_BEGIN);
   return idx === -1 ? text : text.slice(idx + USER_MESSAGE_BEGIN.length);
 }
 
-export function stripLeadingCodexContextBlocks(text: string): string {
+function stripLeadingCodexContextBlocks(text: string): string {
   let remaining = text.trim();
   let stripped = true;
   while (stripped) {


### PR DESCRIPTION
## Summary

- Remove `export` from `USER_MESSAGE_BEGIN`, `stripUserMessagePrefix`, and `stripLeadingCodexContextBlocks` in `packages/cli/src/providers/codex/constants.ts`
- These three symbols are only referenced internally within `constants.ts`; `parser.ts` and `discover.ts` import only `codexStripTwoPass` and `isCodexToolCallType`
- Net change: -3 exported symbols, same runtime behavior

## Motivation

Removing unused exports keeps the module's public API minimal and prevents accidental external coupling to implementation details. Semantically equivalent — no callers outside the file exist.

## Test plan

- [x] `pnpm test` 全绿 (755 passed, 1 skipped)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 814kB — pre-existing, unaffected by this CLI-only change)
- [x] E2E: not run (CLI-only change to internal helper exports, zero behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.