### PR TITLE
chore(cli): replace hardcoded api-url defaults with DEFAULT_API_URL

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -740,7 +740,7 @@ const authCmd = program.command("auth").description("Manage authentication");
 authCmd
   .command("login")
   .description("Log in to vibe-replay with GitHub")
-  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
   .action(async (opts) => {
     const crypto = await import("node:crypto");
     const apiUrl = opts.apiUrl.replace(/\/$/, "");
@@ -853,7 +853,7 @@ authCmd
 authCmd
   .command("logout")
   .description("Log out of vibe-replay")
-  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
   .action(async (opts) => {
     const apiUrl = opts.apiUrl.replace(/\/$/, "");
     const auth = loadAuthToken(apiUrl);
@@ -869,7 +869,7 @@ authCmd
 authCmd
   .command("status")
   .description("Show current authentication status")
-  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
   .action(async (opts) => {
     const apiUrl = opts.apiUrl.replace(/\/$/, "");
     const auth = loadAuthToken(apiUrl);
@@ -1114,7 +1114,7 @@ program
 program
   .command("login", { hidden: true })
   .description("Log in to vibe-replay (alias for auth login)")
-  .option("--api-url <url>", "API base URL", "https://vibe-replay.com")
+  .option("--api-url <url>", "API base URL", DEFAULT_API_URL)
   .action(async () => {
     // Delegate to auth login
     await authCmd.commands


### PR DESCRIPTION
## Summary

- Replace 4 hardcoded `"https://vibe-replay.com"` string literals in `--api-url` option declarations with the already-imported `DEFAULT_API_URL` constant
- Affected commands: `auth login`, `auth logout`, `auth status`, and the hidden `login` alias
- Net: -4 +4 lines (pure substitution, no logic change)

## Motivation

`DEFAULT_API_URL` was already imported and used at line 911 for the `share` command's option description. The four auth-related commands were the only spots still inlining the raw string. If the default URL ever changes, all five commands now stay in sync automatically.

## Test plan

- [x] `pnpm test` 全绿 (797 tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer pre-existing at 814 kB — not affected by this CLI-only change)
- [x] E2E: not run (CLI-only constant substitution, no behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.