### PR TITLE
Add local session search and enrichment cues

### DIFF
--- a/.cursor/skills/local-session-search/SKILL.md
+++ b/.cursor/skills/local-session-search/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: local-session-search
+description: Search and analyze local AI coding sessions with vibe-replay. Use when the user asks to find past sessions, inspect agent history, remember prior work, run a retro, analyze prompt quality or agent efficiency, compare sessions, locate a transcript, or choose a session for replay.
+---
+
+# Local Session Search
+
+Use `vibe-replay sessions` as the first tool for finding or analyzing past local AI coding sessions. It gives the agent a structured local-session index instead of making the user or agent manually browse Cursor/Claude history.
+
+Prefer `--json` so results can be ranked and summarized without scraping terminal text.
+
+## When To Use
+
+Use this skill when the user asks to:
+
+- Find a previous session, transcript, replay, branch discussion, bug investigation, PR, or design thread.
+- Remember what happened in a past agent conversation.
+- Retro a session for prompt quality, agent efficiency, repeated intent, tool usage, errors, compactions, or cost.
+- Compare multiple sessions or identify which session should be replayed/shared.
+- Locate the raw `filePath` / `filePaths` needed for a deeper replay or transcript read.
+
+Do not use this for live dashboard enrichment behavior. Dashboard enrichment is handled by the local server APIs; this skill is for agent-driven lookup and retros.
+
+## Quick Commands
+
+From this repo during development:
+
+```bash
+pnpm --filter vibe-replay dev -- sessions --query "<terms>" --limit 10 --json
+```
+
+After building from source:
+
+```bash
+node packages/cli/dist/index.js sessions --query "<terms>" --limit 10 --json
+```
+
+With an installed CLI:
+
+```bash
+npx vibe-replay sessions --query "<terms>" --limit 10 --json
+```
+
+Useful filters:
+
+```bash
+vibe-replay sessions --project "vibe-replay" --json
+vibe-replay sessions --provider cursor --query "auth bug" --json
+vibe-replay sessions --query "codex parser" --scan --json
+```
+
+## Workflow
+
+1. Start shallow: use `--query` or `--project`, `--limit 10`, and `--json`.
+2. Rank matches by timestamp, project, title/first prompt match quality, provider, and user intent.
+3. Only add `--scan` for the narrowed candidate set when the user asks about retro, efficiency, prompt quality, cost, tool usage, compactions, API errors, files modified, or session quality.
+4. Summarize the best matching sessions with provider, timestamp, project, title, first prompt preview, file path, and why each matched.
+5. For deep review of one session, use the returned `filePath` or `filePaths` with the replay skill or `vibe-replay --provider <provider> --session <path> --github`.
+
+Avoid broad `--scan` over many sessions. It is intentionally available, but expensive compared with metadata search.
+
+## Retro Guidance
+
+For efficiency analysis, look at:
+
+- Prompt count and whether the user had to repeat intent.
+- Tool calls per prompt and edit count per prompt.
+- Long duration, API errors, compactions, and subagent count.
+- First prompt clarity: goal, constraints, files, expected verification, and merge/review instructions.
+
+When giving retro feedback, separate observations from recommendations. Prefer actionable advice such as "the first prompt had a clear goal but missed verification criteria" or "the session became expensive because it searched broadly before narrowing to one file."
+
+## Output Guidance
+
+For search results, return a short ranked list. Include:
+
+- Title or prompt preview.
+- Provider, project, timestamp, and slug/session id.
+- Why it matched.
+- Whether deeper scan/replay is recommended.
+
+For retros, include the key metrics from `--scan` and a concise prompt/process diagnosis.
+
+## Privacy And Limits
+
+- Do not dump full raw prompts unless the user asks.
+- Session data may contain private code, credentials, internal links, or frustrated wording; quote only the minimum needed.
+- Treat `vibe-replay sessions` as metadata/subsequence search, not semantic search. If results are weak, broaden terms, filter by project/provider, or inspect a small number of returned transcripts.
+- The CLI is independent of dashboard enrichment APIs; do not require the local dashboard server for this workflow.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,6 +78,17 @@ Options:
   -h, --help              Display help
 ```
 
+## Search Local Sessions
+
+For agent-friendly lookup and retros:
+
+```bash
+vibe-replay sessions --query "codex parser" --limit 10 --json
+vibe-replay sessions --project "vibe-replay" --scan --json
+```
+
+Use `--scan` to include efficiency metrics such as prompt count, tool calls, edits, duration, compactions, and API errors.
+
 ## Run from Source
 
 ```bash

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -757,7 +757,7 @@ program
   .action(async (opts: SessionsCommandOptions) => {
     const discoverSpinner = opts.json ? undefined : ora("Discovering local sessions...").start();
     try {
-      const sessions = await discoverAllSessions();
+      const sessions = mergeSameSessions(await discoverAllSessions());
       discoverSpinner?.succeed(`Found ${sessions.length} sessions`);
 
       const scanSpinner =

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { publishLocal } from "./publishers/local.js";
 import { scanForSecrets } from "./scan.js";
 import { startDashboard, startServer } from "./server.js";
+import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
 import { transformToReplay } from "./transform.js";
 import type { ReplaySession, SessionInfo } from "./types.js";
 import { normalizeTitle } from "./utils.js";
@@ -729,6 +730,58 @@ program
     console.log(chalk.bold.green("  ✓ Done!"));
     console.log(chalk.dim("  File: ") + chalk.white(outputPath));
     console.log();
+  });
+
+// ---------------------------------------------------------------------------
+// sessions — agent-friendly local session search
+// ---------------------------------------------------------------------------
+
+interface SessionsCommandOptions {
+  query?: string;
+  project?: string;
+  provider?: string;
+  limit?: number;
+  scan?: boolean;
+  json?: boolean;
+}
+
+program
+  .command("sessions")
+  .description("Search local AI coding sessions (agent-friendly)")
+  .option("-q, --query <text>", "Search title, prompt, project, branch, model, or slug")
+  .option("--project <text>", "Filter by project path substring")
+  .option("-p, --provider <name>", "Filter by provider (claude-code, cursor, codex, ...)")
+  .option("-l, --limit <number>", "Maximum sessions to return", (value) => Number(value), 10)
+  .option("--scan", "Run richer per-session scan for efficiency metrics")
+  .option("--json", "Print machine-readable JSON")
+  .action(async (opts: SessionsCommandOptions) => {
+    const discoverSpinner = opts.json ? undefined : ora("Discovering local sessions...").start();
+    try {
+      const sessions = await discoverAllSessions();
+      discoverSpinner?.succeed(`Found ${sessions.length} sessions`);
+
+      const scanSpinner =
+        opts.scan && !opts.json ? ora("Scanning matching sessions...").start() : undefined;
+      const matches = await queryLocalSessions(sessions, opts);
+      scanSpinner?.succeed(`Prepared ${matches.length} session result(s)`);
+
+      if (opts.json) {
+        console.log(JSON.stringify({ sessions: matches }, null, 2));
+      } else {
+        console.log();
+        console.log(formatSessionQueryText(matches));
+        console.log();
+      }
+    } catch (err) {
+      discoverSpinner?.fail("Session search failed");
+      const message = err instanceof Error ? err.message : String(err);
+      if (opts.json) {
+        console.error(message);
+      } else {
+        console.error(chalk.red(`\n  ✗ ${message}\n`));
+      }
+      process.exit(1);
+    }
   });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -467,6 +467,13 @@ interface PersistedInsightsCache {
   computedAt: string | null;
 }
 
+interface EnrichmentHints {
+  sessionIds?: string[];
+  slugs?: string[];
+  projects?: string[];
+  limit?: number;
+}
+
 function sourceSessionKey(provider: string, project: string, slug: string): string {
   return `${provider}::${project}::${slug}`;
 }
@@ -486,8 +493,13 @@ function pickSourceRecordForSession(
 function selectCursorEnrichmentCandidates(
   merged: SessionInfo[],
   baseSources: SourceSummaryRecord[],
-  limit = 30,
+  limitOrHints: number | EnrichmentHints = 30,
 ): SessionInfo[] {
+  const hints = typeof limitOrHints === "number" ? { limit: limitOrHints } : limitOrHints;
+  const limit = Math.max(1, Math.min(hints.limit ?? 30, 100));
+  const preferredSessionIds = new Set(hints.sessionIds || []);
+  const preferredSlugs = new Set(hints.slugs || []);
+  const preferredProjects = new Set(hints.projects || []);
   const mergedBySessionId = new Map<string, SessionInfo>();
   const mergedByKey = new Map<string, SessionInfo>();
   for (const session of merged) {
@@ -514,8 +526,114 @@ function selectCursorEnrichmentCandidates(
       return byId || mergedByKey.get(sourceSessionKey(s.provider, s.project, s.slug));
     })
     .filter((s): s is SessionInfo => Boolean(s))
-    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    .sort((a, b) => {
+      const scoreDelta =
+        enrichmentPriorityScore(b, preferredSessionIds, preferredSlugs, preferredProjects) -
+        enrichmentPriorityScore(a, preferredSessionIds, preferredSlugs, preferredProjects);
+      return scoreDelta || b.timestamp.localeCompare(a.timestamp);
+    })
     .slice(0, limit);
+}
+
+function enrichmentPriorityScore(
+  session: SessionInfo,
+  preferredSessionIds: Set<string>,
+  preferredSlugs: Set<string>,
+  preferredProjects: Set<string>,
+): number {
+  let score = 0;
+  if (preferredSessionIds.has(session.sessionId)) score += 1000;
+  if (preferredSlugs.has(session.slug)) score += 800;
+  if (preferredProjects.has(session.project)) score += 400;
+  if (session.timestamp && Date.now() - Date.parse(session.timestamp) <= 24 * 60 * 60 * 1000) {
+    score += 100;
+  }
+  if (session.hasPR) score += 25;
+  if (session.hasSqlite) score += 10;
+  return score;
+}
+
+function prioritizeScanInputs(
+  inputs: ScanInput[],
+  previousResults: SessionScanResult[],
+  hints: EnrichmentHints = {},
+): ScanInput[] {
+  const previousSessionIds = new Set(previousResults.map((result) => result.sessionId));
+  const preferredSessionIds = new Set(hints.sessionIds || []);
+  const preferredSlugs = new Set(hints.slugs || []);
+  const preferredProjects = new Set(hints.projects || []);
+
+  return [...inputs].sort((a, b) => {
+    const scoreDelta =
+      scanInputPriorityScore(
+        b,
+        previousSessionIds,
+        preferredSessionIds,
+        preferredSlugs,
+        preferredProjects,
+      ) -
+      scanInputPriorityScore(
+        a,
+        previousSessionIds,
+        preferredSessionIds,
+        preferredSlugs,
+        preferredProjects,
+      );
+    return scoreDelta || (b.timestamp || "").localeCompare(a.timestamp || "");
+  });
+}
+
+function scanInputPriorityScore(
+  input: ScanInput,
+  previousSessionIds: Set<string>,
+  preferredSessionIds: Set<string>,
+  preferredSlugs: Set<string>,
+  preferredProjects: Set<string>,
+): number {
+  let score = 0;
+  if (!previousSessionIds.has(input.sessionId)) score += 1000;
+  if (preferredSessionIds.has(input.sessionId)) score += 2000;
+  if (preferredSlugs.has(input.slug)) score += 1600;
+  if (preferredProjects.has(input.project)) score += 400;
+  if (input.timestamp && Date.now() - Date.parse(input.timestamp) <= 24 * 60 * 60 * 1000) {
+    score += 100;
+  }
+  return score;
+}
+
+function mergeEnrichmentHints(
+  existing: EnrichmentHints | undefined,
+  next: EnrichmentHints,
+): EnrichmentHints {
+  return {
+    sessionIds: uniqueStrings([...(existing?.sessionIds || []), ...(next.sessionIds || [])]),
+    slugs: uniqueStrings([...(existing?.slugs || []), ...(next.slugs || [])]),
+    projects: uniqueStrings([...(existing?.projects || []), ...(next.projects || [])]),
+    limit: Math.max(existing?.limit || 0, next.limit || 0) || undefined,
+  };
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.filter((value) => typeof value === "string" && value.trim()))];
+}
+
+function enrichmentHintsFromBody(value: unknown): EnrichmentHints {
+  if (!value || typeof value !== "object") return {};
+  const body = value as Record<string, unknown>;
+  return {
+    sessionIds: stringArrayFromUnknown(body.sessionIds),
+    slugs: stringArrayFromUnknown(body.slugs),
+    projects: stringArrayFromUnknown(body.projects),
+    limit: typeof body.limit === "number" ? body.limit : undefined,
+  };
+}
+
+function stringArrayFromUnknown(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter(
+    (item): item is string => typeof item === "string" && item.trim().length > 0,
+  );
+  return strings.length > 0 ? [...new Set(strings)] : undefined;
 }
 
 function countSessionStats(turns: ParsedTurn[]): {
@@ -944,16 +1062,29 @@ export async function startServer(
     total: 0,
     updated: 0,
   };
+  let pendingSourcesEnrichment: {
+    merged: SessionInfo[];
+    baseSources: SourceSummaryRecord[];
+    hints: EnrichmentHints;
+  } | null = null;
 
   const enrichCursorStatsInBackground = (
     merged: SessionInfo[],
     baseSources: SourceSummaryRecord[],
+    hints: EnrichmentHints = {},
   ): void => {
-    if (sourcesEnrichmentStatus.running) return;
+    if (sourcesEnrichmentStatus.running) {
+      pendingSourcesEnrichment = {
+        merged,
+        baseSources,
+        hints: mergeEnrichmentHints(pendingSourcesEnrichment?.hints, hints),
+      };
+      return;
+    }
     const cursorProvider = getProvider("cursor");
     if (!cursorProvider) return;
 
-    const candidates = selectCursorEnrichmentCandidates(merged, baseSources);
+    const candidates = selectCursorEnrichmentCandidates(merged, baseSources, hints);
 
     sourcesEnrichmentStatus = {
       running: true,
@@ -1062,6 +1193,11 @@ export async function startServer(
         running: false,
         finishedAt: new Date().toISOString(),
       };
+      const pending = pendingSourcesEnrichment;
+      pendingSourcesEnrichment = null;
+      if (pending) {
+        enrichCursorStatsInBackground(pending.merged, enrichedSources, pending.hints);
+      }
     })().catch(() => {
       sourcesEnrichmentStatus = {
         ...sourcesEnrichmentStatus,
@@ -1069,6 +1205,11 @@ export async function startServer(
         finishedAt: new Date().toISOString(),
         message: "Cursor stat backfill failed",
       };
+      const pending = pendingSourcesEnrichment;
+      pendingSourcesEnrichment = null;
+      if (pending) {
+        enrichCursorStatsInBackground(pending.merged, pending.baseSources, pending.hints);
+      }
     });
   };
 
@@ -1258,7 +1399,7 @@ export async function startServer(
    * each one (newest first) to extract metadata for insights. Uses cache
    * so unchanged sessions are skipped.
    */
-  const startBackgroundScan = (): void => {
+  const startBackgroundScan = (hints: EnrichmentHints = {}): void => {
     if (scanState.running) return;
     const previousResults = scanState.results;
     const previousFinishedAt = scanState.finishedAt;
@@ -1291,24 +1432,29 @@ export async function startServer(
           }
         }
 
-        // Build scan inputs (newest first — already sorted by discovery)
-        const scanInputs: ScanInput[] = merged.map((s) => ({
-          sessionId: s.sessionId,
-          provider: s.provider,
-          project: s.project,
-          slug: s.slug,
-          filePaths: s.filePaths,
-          toolPaths: s.toolPaths,
-          sourceFilePath: s.filePath,
-          sourceFileSize: s.fileSize,
-          sourceLineCount: s.lineCount,
-          workspacePath: s.workspacePath,
-          hasSqlite: s.hasSqlite,
-          deferRichCursorParse: s.provider === "cursor" && !!s.hasSqlite,
-          timestamp: s.timestamp,
-          title: s.title,
-          firstPrompt: s.firstPrompt,
-        }));
+        // Build scan inputs, then rank the catch-up order so new and UI-hinted
+        // sessions land in the scan cache before long-tail unchanged history.
+        const scanInputs: ScanInput[] = prioritizeScanInputs(
+          merged.map((s) => ({
+            sessionId: s.sessionId,
+            provider: s.provider,
+            project: s.project,
+            slug: s.slug,
+            filePaths: s.filePaths,
+            toolPaths: s.toolPaths,
+            sourceFilePath: s.filePath,
+            sourceFileSize: s.fileSize,
+            sourceLineCount: s.lineCount,
+            workspacePath: s.workspacePath,
+            hasSqlite: s.hasSqlite,
+            deferRichCursorParse: s.provider === "cursor" && !!s.hasSqlite,
+            timestamp: s.timestamp,
+            title: s.title,
+            firstPrompt: s.firstPrompt,
+          })),
+          previousResults,
+          hints,
+        );
 
         scanState.total = scanInputs.length;
 
@@ -1882,6 +2028,31 @@ export async function startServer(
     return c.json(sourcesEnrichmentStatus);
   });
 
+  app.post("/api/sources/enrich", async (c) => {
+    const hints = enrichmentHintsFromBody(await c.req.json().catch(() => undefined));
+    const cached = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
+    if (!cached?.data?.length) {
+      return c.json({ ok: false, message: "No sources cache available" }, 404);
+    }
+    const cursorProvider = getProvider("cursor");
+    if (!cursorProvider) return c.json({ ok: false, message: "Cursor provider unavailable" }, 404);
+
+    const cursorSessions = mergeSameSessions(await cursorProvider.discover());
+    const home = homedir();
+    for (const session of cursorSessions) {
+      if (session.project.startsWith(home)) {
+        session.project = `~${session.project.slice(home.length)}`;
+      }
+    }
+    const wasRunning = sourcesEnrichmentStatus.running;
+    enrichCursorStatsInBackground(cursorSessions, cached.data, hints);
+    return c.json({
+      ok: true,
+      running: sourcesEnrichmentStatus.running,
+      queued: wasRunning,
+    });
+  });
+
   app.get("/api/sources", async (c) => {
     try {
       const providers = getAllProviders();
@@ -2119,7 +2290,8 @@ export async function startServer(
   // --- Session scanner: background metadata extraction for insights ---
 
   app.post("/api/scan/start", async (c) => {
-    startBackgroundScan();
+    const hints = enrichmentHintsFromBody(await c.req.json().catch(() => undefined));
+    startBackgroundScan(hints);
     return c.json({ ok: true, message: "Background scan started" });
   });
 
@@ -3309,6 +3481,7 @@ export const __testables = {
   buildInsightsSyncBatches,
   countSessionStats,
   pickSourceRecordForSession,
+  prioritizeScanInputs,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
 };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -614,7 +614,10 @@ function mergeEnrichmentHints(
 }
 
 function uniqueStrings(values: string[]): string[] {
-  return [...new Set(values.filter((value) => typeof value === "string" && value.trim()))];
+  return [...new Set(values.filter((value) => typeof value === "string" && value.trim()))].slice(
+    0,
+    200,
+  );
 }
 
 function enrichmentHintsFromBody(value: unknown): EnrichmentHints {
@@ -634,6 +637,14 @@ function stringArrayFromUnknown(value: unknown): string[] | undefined {
     (item): item is string => typeof item === "string" && item.trim().length > 0,
   );
   return strings.length > 0 ? [...new Set(strings)] : undefined;
+}
+
+function normalizeSessionProjectsForHome(sessions: SessionInfo[], home: string): SessionInfo[] {
+  return sessions.map((session) =>
+    session.project.startsWith(home)
+      ? { ...session, project: `~${session.project.slice(home.length)}` }
+      : { ...session },
+  );
 }
 
 function countSessionStats(turns: ParsedTurn[]): {
@@ -1067,6 +1078,7 @@ export async function startServer(
     baseSources: SourceSummaryRecord[];
     hints: EnrichmentHints;
   } | null = null;
+  let lastDiscoveredMergedSessions: SessionInfo[] = [];
 
   const enrichCursorStatsInBackground = (
     merged: SessionInfo[],
@@ -1107,9 +1119,10 @@ export async function startServer(
       return;
     }
 
+    const enrichedSources = baseSources.map((s) => ({ ...s }));
+
     void (async () => {
       let changed = false;
-      const enrichedSources = baseSources.map((s) => ({ ...s }));
       const bySessionId = new Map<string, SourceSummaryRecord>();
       const byKey = new Map<string, SourceSummaryRecord>();
       for (const source of enrichedSources) {
@@ -1208,7 +1221,7 @@ export async function startServer(
       const pending = pendingSourcesEnrichment;
       pendingSourcesEnrichment = null;
       if (pending) {
-        enrichCursorStatsInBackground(pending.merged, pending.baseSources, pending.hints);
+        enrichCursorStatsInBackground(pending.merged, enrichedSources, pending.hints);
       }
     });
   };
@@ -1431,6 +1444,7 @@ export async function startServer(
             s.project = `~${s.project.slice(home.length)}`;
           }
         }
+        lastDiscoveredMergedSessions = merged.map((session) => ({ ...session }));
 
         // Build scan inputs, then rank the catch-up order so new and UI-hinted
         // sessions land in the scan cache before long-tail unchanged history.
@@ -2037,12 +2051,19 @@ export async function startServer(
     const cursorProvider = getProvider("cursor");
     if (!cursorProvider) return c.json({ ok: false, message: "Cursor provider unavailable" }, 404);
 
-    const cursorSessions = mergeSameSessions(await cursorProvider.discover());
     const home = homedir();
-    for (const session of cursorSessions) {
-      if (session.project.startsWith(home)) {
-        session.project = `~${session.project.slice(home.length)}`;
-      }
+    let cursorSessions = lastDiscoveredMergedSessions.filter(
+      (session) => session.provider === "cursor",
+    );
+    if (cursorSessions.length === 0) {
+      cursorSessions = normalizeSessionProjectsForHome(
+        mergeSameSessions(await cursorProvider.discover()),
+        home,
+      );
+      lastDiscoveredMergedSessions = [
+        ...lastDiscoveredMergedSessions.filter((session) => session.provider !== "cursor"),
+        ...cursorSessions,
+      ];
     }
     const wasRunning = sourcesEnrichmentStatus.running;
     enrichCursorStatsInBackground(cursorSessions, cached.data, hints);
@@ -2063,6 +2084,7 @@ export async function startServer(
       }
 
       const merged = mergeSameSessions(allSessions);
+      lastDiscoveredMergedSessions = normalizeSessionProjectsForHome(merged, homedir());
       const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
       const result = await buildSourcesResult(
         merged,
@@ -2104,6 +2126,7 @@ export async function startServer(
         }
 
         const merged = mergeSameSessions(allSessions);
+        lastDiscoveredMergedSessions = normalizeSessionProjectsForHome(merged, homedir());
         const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
         const result = await buildSourcesResult(
           merged,

--- a/packages/cli/src/session-query.ts
+++ b/packages/cli/src/session-query.ts
@@ -1,0 +1,260 @@
+import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
+import { scanSession, type ScanInput, type SessionScanResult } from "./scanner.js";
+import type { SessionInfo } from "./types.js";
+import { shortenPath } from "./utils.js";
+
+export interface SessionQueryOptions {
+  query?: string;
+  project?: string;
+  provider?: string;
+  limit?: number;
+  scan?: boolean;
+}
+
+export interface SessionQueryMatch {
+  provider: string;
+  sessionId: string;
+  slug: string;
+  title?: string;
+  project: string;
+  cwd: string;
+  timestamp: string;
+  gitBranch?: string;
+  model?: string;
+  firstPrompt: string;
+  prompts?: string[];
+  filePath: string;
+  filePaths: string[];
+  toolPaths?: string[];
+  promptCount?: number;
+  toolCallCount?: number;
+  editCount?: number;
+  durationMs?: number;
+  hasPR?: boolean;
+  scan?: SessionQueryScanSummary;
+}
+
+export interface SessionQueryScanSummary {
+  promptCount: number;
+  toolCallCount: number;
+  editCount: number;
+  filesModified: Array<{ file: string; count: number }>;
+  durationMs?: number;
+  costEstimate?: number;
+  apiErrorCount: number;
+  compactionCount: number;
+  subAgentCount: number;
+  toolCallsPerPrompt?: number;
+  editsPerPrompt?: number;
+  medianTurnDurationMs?: number;
+  dataQualityNotes?: string[];
+}
+
+export async function queryLocalSessions(
+  sessions: SessionInfo[],
+  options: SessionQueryOptions = {},
+): Promise<SessionQueryMatch[]> {
+  const limit = normalizeLimit(options.limit);
+  const filtered = filterSessionInfos(sessions, options).slice(0, limit);
+  const matches = filtered.map(sessionInfoToMatch);
+
+  if (!options.scan) return matches;
+
+  const scanned = await Promise.all(
+    filtered.map(async (session) => {
+      try {
+        return await scanSession(scanInputFromSession(session));
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+
+  return matches.map((match, index) => {
+    const scan = scanned[index];
+    return scan ? { ...match, scan: scanSummary(scan) } : match;
+  });
+}
+
+export function filterSessionInfos(
+  sessions: SessionInfo[],
+  options: Pick<SessionQueryOptions, "query" | "project" | "provider"> = {},
+): SessionInfo[] {
+  const terms = splitTerms(options.query);
+  const projectTerm = normalizeSearch(options.project);
+  const provider = normalizeSearch(options.provider);
+
+  return [...sessions]
+    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+    .filter((session) => {
+      if (provider && normalizeSearch(session.provider) !== provider) return false;
+      if (projectTerm && !sessionProjectHaystack(session).includes(projectTerm)) return false;
+      if (terms.length > 0) {
+        const haystack = sessionHaystack(session);
+        if (!terms.every((term) => haystack.includes(term))) return false;
+      }
+      return true;
+    });
+}
+
+export function scanInputFromSession(session: SessionInfo): ScanInput {
+  return {
+    sessionId: session.sessionId,
+    provider: session.provider,
+    project: shortenPath(session.project),
+    slug: session.slug,
+    filePaths: session.filePaths,
+    toolPaths: session.toolPaths,
+    sourceFilePath: session.filePath,
+    sourceFileSize: session.fileSize,
+    sourceLineCount: session.lineCount,
+    workspacePath: session.workspacePath,
+    hasSqlite: session.hasSqlite,
+    timestamp: session.timestamp,
+    title: session.title,
+    firstPrompt: session.firstPrompt,
+  };
+}
+
+export function formatSessionQueryText(matches: SessionQueryMatch[]): string {
+  if (matches.length === 0) return "No matching sessions found.";
+
+  return matches
+    .map((match, index) => {
+      const title = match.title || previewPrompt(match.firstPrompt) || match.slug;
+      const lines = [
+        `${index + 1}. ${title}`,
+        `   ${match.provider} | ${match.timestamp} | ${match.project}`,
+        `   session: ${match.sessionId}`,
+        `   file: ${match.filePath}`,
+      ];
+      if (match.gitBranch) lines.push(`   branch: ${match.gitBranch}`);
+      if (match.model) lines.push(`   model: ${match.model}`);
+      if (match.firstPrompt) lines.push(`   first prompt: ${previewPrompt(match.firstPrompt)}`);
+      if (match.scan) lines.push(`   efficiency: ${formatScanSummary(match.scan)}`);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+function sessionInfoToMatch(session: SessionInfo): SessionQueryMatch {
+  return {
+    provider: session.provider,
+    sessionId: session.sessionId,
+    slug: session.slug,
+    title: cleanPromptText(session.title || "") || undefined,
+    project: shortenPath(session.project),
+    cwd: shortenPath(session.cwd),
+    timestamp: session.timestamp,
+    gitBranch: session.gitBranch,
+    model: session.model,
+    firstPrompt: cleanPromptText(session.firstPrompt),
+    prompts: session.prompts?.map(cleanPromptText).filter(Boolean),
+    filePath: session.filePath,
+    filePaths: session.filePaths,
+    toolPaths: session.toolPaths,
+    promptCount: session.promptCount,
+    toolCallCount: session.toolCallCount,
+    editCount: session.editCountEst,
+    durationMs: session.durationMsEst,
+    hasPR: session.hasPR,
+  };
+}
+
+function scanSummary(scan: SessionScanResult): SessionQueryScanSummary {
+  const promptCount = scan.promptCount;
+  return {
+    promptCount,
+    toolCallCount: scan.toolCallCount,
+    editCount: scan.editCount,
+    filesModified: scan.filesModified.slice(0, 20),
+    durationMs: scan.durationMs,
+    costEstimate: scan.costEstimate,
+    apiErrorCount: scan.apiErrorCount,
+    compactionCount: scan.compactionCount,
+    subAgentCount: scan.subAgentCount,
+    toolCallsPerPrompt: ratio(scan.toolCallCount, promptCount),
+    editsPerPrompt: ratio(scan.editCount, promptCount),
+    medianTurnDurationMs: median(scan.turnDurations),
+    dataQualityNotes: scan.dataQualityNotes,
+  };
+}
+
+function formatScanSummary(scan: SessionQueryScanSummary): string {
+  const parts = [
+    `${scan.promptCount} prompts`,
+    `${scan.toolCallCount} tools`,
+    `${scan.editCount} edits`,
+  ];
+  if (scan.durationMs) parts.push(formatDuration(scan.durationMs));
+  if (scan.costEstimate) parts.push(`$${scan.costEstimate.toFixed(2)}`);
+  if (scan.toolCallsPerPrompt !== undefined) {
+    parts.push(`${scan.toolCallsPerPrompt.toFixed(1)} tools/prompt`);
+  }
+  if (scan.apiErrorCount > 0) parts.push(`${scan.apiErrorCount} API errors`);
+  if (scan.compactionCount > 0) parts.push(`${scan.compactionCount} compactions`);
+  return parts.join(", ");
+}
+
+function splitTerms(query: string | undefined): string[] {
+  return normalizeSearch(query)
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+function sessionHaystack(session: SessionInfo): string {
+  return normalizeSearch(
+    [
+      session.provider,
+      session.sessionId,
+      session.slug,
+      session.title,
+      session.project,
+      session.cwd,
+      session.gitBranch,
+      session.model,
+      session.firstPrompt,
+      ...(session.prompts || []),
+      ...(session.fsDetectedFiles || []),
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
+function sessionProjectHaystack(session: SessionInfo): string {
+  return normalizeSearch(
+    [session.project, session.cwd, session.workspacePath].filter(Boolean).join(" "),
+  );
+}
+
+function normalizeSearch(value: string | undefined): string {
+  return (value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit) || !limit || limit <= 0) return 10;
+  return Math.min(Math.floor(limit), 100);
+}
+
+function ratio(value: number, denominator: number): number | undefined {
+  if (denominator <= 0) return undefined;
+  return Math.round((value / denominator) * 10) / 10;
+}
+
+function median(values: number[] | undefined): number | undefined {
+  if (!values?.length) return undefined;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}
+
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+}

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -111,6 +111,84 @@ describe("sources enrichment helpers", () => {
     expect(candidates.map((s) => s.sessionId)).toEqual(["cursor-new", "cursor-old"]);
   });
 
+  it("prioritizes hinted cursor sessions before default recency", () => {
+    const merged = [
+      makeCursorSession({
+        sessionId: "cursor-old-visible",
+        slug: "visible0",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+      makeCursorSession({
+        sessionId: "cursor-new",
+        slug: "newnew00",
+        timestamp: "2026-01-03T00:00:00.000Z",
+      }),
+      makeCursorSession({
+        sessionId: "cursor-mid",
+        slug: "midmid00",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      }),
+    ];
+
+    const baseSources = merged.map((source) => ({
+      provider: "cursor",
+      sessionId: source.sessionId,
+      slug: source.slug,
+      project: source.project,
+      timestamp: source.timestamp,
+      filePaths: source.filePaths,
+      promptCount: undefined,
+      toolCallCount: undefined,
+    })) as any[];
+
+    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources, {
+      slugs: ["visible0"],
+      limit: 2,
+    });
+    expect(candidates.map((s) => s.sessionId)).toEqual(["cursor-old-visible", "cursor-new"]);
+  });
+
+  it("prioritizes unscanned and hinted sessions during scan catch-up", () => {
+    const inputs = [
+      {
+        sessionId: "already-new",
+        provider: "cursor",
+        project: "~/project-a",
+        slug: "new",
+        filePaths: ["/tmp/new.jsonl"],
+        timestamp: "2026-01-03T00:00:00.000Z",
+      },
+      {
+        sessionId: "unscanned-old",
+        provider: "cursor",
+        project: "~/project-a",
+        slug: "old",
+        filePaths: ["/tmp/old.jsonl"],
+        timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        sessionId: "hinted-mid",
+        provider: "cursor",
+        project: "~/project-a",
+        slug: "mid",
+        filePaths: ["/tmp/mid.jsonl"],
+        timestamp: "2026-01-02T00:00:00.000Z",
+      },
+    ] as any[];
+
+    const ordered = __testables.prioritizeScanInputs(
+      inputs,
+      [{ sessionId: "already-new" }, { sessionId: "hinted-mid" }] as any[],
+      { slugs: ["mid"] },
+    );
+
+    expect(ordered.map((input) => input.sessionId)).toEqual([
+      "hinted-mid",
+      "unscanned-old",
+      "already-new",
+    ]);
+  });
+
   it("does not cross-provider match by sessionId when picking cache records", () => {
     const current = makeCursorSession({ sessionId: "shared-id", slug: "aaaaaaaa" });
     const bySessionId = new Map<string, any>([

--- a/packages/cli/test/session-query.test.ts
+++ b/packages/cli/test/session-query.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterSessionInfos,
+  formatSessionQueryText,
+  queryLocalSessions,
+  scanInputFromSession,
+} from "../src/session-query.js";
+import type { SessionInfo } from "../src/types.js";
+
+function session(overrides: Partial<SessionInfo>): SessionInfo {
+  return {
+    provider: "cursor",
+    sessionId: "session-1",
+    slug: "fix-login",
+    title: "Fix login regression",
+    project: "/Users/test/Code/app",
+    cwd: "/Users/test/Code/app",
+    version: "1.0.0",
+    gitBranch: "main",
+    timestamp: "2026-05-01T10:00:00Z",
+    lineCount: 10,
+    fileSize: 1000,
+    filePath: "/tmp/session.jsonl",
+    filePaths: ["/tmp/session.jsonl"],
+    firstPrompt: "Please fix the login bug",
+    prompts: ["Please fix the login bug", "Run the tests"],
+    ...overrides,
+  };
+}
+
+describe("session query", () => {
+  const sessions = [
+    session({
+      sessionId: "older",
+      slug: "add-dashboard",
+      title: "Add dashboard filters",
+      project: "/Users/test/Code/vibe-replay",
+      timestamp: "2026-05-01T10:00:00Z",
+      firstPrompt: "Build project analytics filters",
+    }),
+    session({
+      sessionId: "newer",
+      slug: "codex-parser",
+      provider: "codex",
+      title: "Improve Codex replay parity",
+      project: "/Users/test/Code/vibe-replay",
+      gitBranch: "codex-replay-parity",
+      model: "gpt-5.4",
+      timestamp: "2026-05-02T10:00:00Z",
+      firstPrompt: "Handle Codex compaction and patch events",
+      fsDetectedFiles: ["packages/cli/src/providers/codex/parser.ts"],
+    }),
+    session({
+      sessionId: "other-project",
+      slug: "auth-flow",
+      title: "Fix auth flow",
+      project: "/Users/test/Code/api",
+      timestamp: "2026-05-03T10:00:00Z",
+      firstPrompt: "Debug login callback failures",
+    }),
+  ];
+
+  it("filters sessions by query terms across metadata", () => {
+    const result = filterSessionInfos(sessions, { query: "codex parser" });
+
+    expect(result.map((s) => s.sessionId)).toEqual(["newer"]);
+  });
+
+  it("filters by project and provider, sorted newest first", () => {
+    const result = filterSessionInfos(sessions, {
+      project: "vibe-replay",
+      provider: "cursor",
+    });
+
+    expect(result.map((s) => s.sessionId)).toEqual(["older"]);
+  });
+
+  it("limits query results and formats text output", async () => {
+    const result = await queryLocalSessions(sessions, { query: "login", limit: 1 });
+    const text = formatSessionQueryText(result);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.sessionId).toBe("other-project");
+    expect(text).toContain("Fix auth flow");
+    expect(text).toContain("first prompt: Debug login callback failures");
+  });
+
+  it("maps discovery sessions into scanner input", () => {
+    const input = scanInputFromSession(
+      session({
+        hasSqlite: true,
+        workspacePath: "/Users/test/Code/app",
+        toolPaths: ["/tmp/tool.txt"],
+      }),
+    );
+
+    expect(input).toMatchObject({
+      sessionId: "session-1",
+      provider: "cursor",
+      slug: "fix-login",
+      filePaths: ["/tmp/session.jsonl"],
+      toolPaths: ["/tmp/tool.txt"],
+      sourceFilePath: "/tmp/session.jsonl",
+      hasSqlite: true,
+      workspacePath: "/Users/test/Code/app",
+    });
+  });
+});

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -39,6 +39,16 @@ import {
   useScanInsightsContext,
 } from "./InsightsPanel";
 import ProjectsPanel from "./ProjectsPanel";
+import {
+  DataLevelBadge,
+  hasEnrichedSourceDetails,
+  hasPromptOrToolCounts,
+  hasRichScanMetrics,
+  ReadinessRow,
+  SessionDataPipeline,
+  SessionLoadingToast,
+  sessionDataState,
+} from "./SessionDataProgress";
 import { formatDuration } from "./StatsPanel";
 
 export type Tab = "home" | "sessions" | "replays" | "projects" | "insights";
@@ -341,6 +351,7 @@ export function SessionDetailPopup({
   isArchived: boolean;
 }) {
   const [scanData, setScanData] = useState<SessionScanData | null>(initialScanData);
+  const [scanLoading, setScanLoading] = useState(!initialScanData);
   const fallbackSuggested = sourceSuggestedTitle(s);
   const suggested = sourceDisplayTitle(s, scanData);
   const [titleValue, setTitleValue] = useState(s.replay?.title || suggested);
@@ -371,12 +382,17 @@ export function SessionDetailPopup({
 
   // Fetch scan results for richer data (cached at module level)
   useEffect(() => {
-    if (initialScanData) return;
+    if (initialScanData) {
+      setScanLoading(false);
+      return;
+    }
     let cancelled = false;
+    setScanLoading(true);
     fetchScanResults().then((results) => {
-      if (cancelled || !results) return;
-      const match = results.find((r) => r.slug === s.slug);
+      if (cancelled) return;
+      const match = results?.find((r) => r.slug === s.slug);
       if (match) setScanData(match);
+      setScanLoading(false);
     });
     return () => {
       cancelled = true;
@@ -406,6 +422,8 @@ export function SessionDetailPopup({
   const model = scanData?.model || s.model;
   const prompts = sessionPromptPreview(s, scanData, suggested);
   const dataQualityNotes = scanData?.dataQualityNotes || [];
+  const dataState = sessionDataState(s, scanData);
+  const dataPipelineActive = scanLoading && !hasRichScanMetrics(scanData);
 
   // Use scan data when available, fall back to discovery estimates
   const promptCount = scanData?.promptCount ?? s.promptCount;
@@ -450,6 +468,7 @@ export function SessionDetailPopup({
         <div className="flex items-center justify-between px-7 pt-5 pb-3">
           <div className="flex items-center gap-2">
             <ProviderBadge provider={s.provider} />
+            <DataLevelBadge state={dataState} compact />
             {model && (
               <span className="text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-terminal-surface-2 text-terminal-dimmer">
                 {shortModelName(model)}
@@ -623,6 +642,38 @@ export function SessionDetailPopup({
                   value={`#${pr.prNumber} (${pr.prRepository})`}
                 />
               ))}
+            </div>
+          </div>
+
+          <div className="bg-terminal-surface rounded-xl px-5 py-4">
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <div className="text-[10px] font-sans uppercase tracking-widest text-terminal-dimmer">
+                Data Readiness
+              </div>
+              <DataLevelBadge state={dataState} active={dataPipelineActive} />
+            </div>
+            <SessionDataPipeline state={dataState} active={dataPipelineActive} className="mb-3" />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-5 gap-y-2">
+              <ReadinessRow
+                ready
+                label="Basic discovery loaded"
+                pendingLabel="Waiting for discovery"
+              />
+              <ReadinessRow
+                ready={hasEnrichedSourceDetails(s)}
+                label="Title, prompt previews, or model enriched"
+                pendingLabel="Title and prompt previews not enriched yet"
+              />
+              <ReadinessRow
+                ready={hasPromptOrToolCounts(s, scanData)}
+                label="Prompt/tool counts loaded"
+                pendingLabel="Prompt/tool counts not loaded yet"
+              />
+              <ReadinessRow
+                ready={hasRichScanMetrics(scanData)}
+                label="Rich metrics loaded"
+                pendingLabel="Rich metrics deferred for this source"
+              />
             </div>
           </div>
 
@@ -1351,6 +1402,7 @@ function SessionsPanel() {
     return () => window.removeEventListener("vibe-open-session", handler);
   }, []);
   const wasEnrichingRef = useRef(false);
+  const requestedEnrichmentSignatureRef = useRef("");
   const [archivedSlugs, setArchivedSlugs] = useState<Set<string>>(new Set());
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const hasCursorSources = sources.some((source) => source.provider === "cursor");
@@ -1586,6 +1638,33 @@ function SessionsPanel() {
       )
     : projectSessions;
   const refreshAge = lastRefreshedAt ? formatCompactAge(lastRefreshedAt, refreshClockMs) : null;
+  const priorityEnrichmentSlugs = new Set(filtered.slice(0, 25).map((session) => session.slug));
+
+  useEffect(() => {
+    if (loading || filtered.length === 0) return;
+    const prioritySessions = filtered.slice(0, 25);
+    const slugs = prioritySessions.map((session) => session.slug);
+    const sessionIds = prioritySessions
+      .map((session) => session.sessionId)
+      .filter(
+        (sessionId): sessionId is string => typeof sessionId === "string" && sessionId.length > 0,
+      );
+    const projects = selectedProjectKey === ALL_PROJECTS ? [] : [selectedProjectKey];
+    const signature = JSON.stringify({ slugs, selectedProjectKey });
+    if (requestedEnrichmentSignatureRef.current === signature) return;
+    requestedEnrichmentSignatureRef.current = signature;
+
+    fetch("/api/sources/enrich", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slugs,
+        sessionIds,
+        projects,
+        limit: Math.max(30, prioritySessions.length),
+      }),
+    }).catch(() => {});
+  }, [filtered, loading, selectedProjectKey]);
 
   const showInitialLoading = loading && sources.length === 0;
 
@@ -1835,37 +1914,27 @@ function SessionsPanel() {
           </div>
         </div>
 
-        {(showInitialLoading || refreshing || staleCachedAt) && (
-          <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
-            {showInitialLoading ? (
-              <>
-                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
-                <span>FETCHING SESSIONS...</span>
-              </>
-            ) : refreshing ? (
-              <>
-                <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
-                <span>SCANNING LATEST SESSIONS...</span>
-                {staleCachedAt && (
-                  <span className="text-terminal-dim">
-                    Showing stale cache ({formatCacheAge(staleCachedAt)})
-                  </span>
-                )}
-              </>
-            ) : staleCachedAt ? (
-              <span>Showing stale cache ({formatCacheAge(staleCachedAt)})</span>
-            ) : null}
-          </div>
-        )}
-
-        {enrichmentStatus?.running && enrichmentStatus.total > 0 && (
-          <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg px-3 py-2.5 text-xs font-mono bg-terminal-blue-subtle text-terminal-blue shrink-0 shadow-layer-sm">
-            <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
-            <span>
-              BACKFILLING CURSOR STATS... {enrichmentStatus.processed}/{enrichmentStatus.total}
-            </span>
-          </div>
-        )}
+        {showInitialLoading ? (
+          <SessionLoadingToast
+            title="Fetching local sessions"
+            description="Reading cached session lists first, then refreshing local providers in the background."
+          />
+        ) : refreshing ? (
+          <SessionLoadingToast
+            title="Scanning latest sessions"
+            description={
+              staleCachedAt
+                ? `Showing stale cache (${formatCacheAge(staleCachedAt)}) while refreshing.`
+                : "Refreshing provider session lists and lightweight metadata."
+            }
+          />
+        ) : enrichmentStatus?.running && enrichmentStatus.total > 0 ? (
+          <SessionLoadingToast
+            status={enrichmentStatus}
+            title="Loading richer details for visible sessions"
+            description="Visible cards update in place as local data is enriched."
+          />
+        ) : null}
 
         {/* Error toast */}
         {refreshError && (
@@ -1979,12 +2048,19 @@ function SessionsPanel() {
                   scanData?.dataSource,
                   s.hasSdk,
                 );
+                const isPriorityEnriching =
+                  Boolean(enrichmentStatus?.running) &&
+                  priorityEnrichmentSlugs.has(s.slug) &&
+                  !hasRichScanMetrics(scanData);
+                const dataState = sessionDataState(s, scanData);
                 const isArchived = archivedSlugs.has(s.slug);
                 return (
                   <div
                     key={`${s.provider}-${s.slug}`}
                     onClick={() => setSelectedSlug(s.slug)}
-                    className={`bg-terminal-surface rounded-xl px-5 py-4 hover:bg-terminal-surface-hover transition-all duration-300 ease-material space-y-2.5 shadow-layer-sm cursor-pointer hover-lift ${isArchived ? "opacity-50" : ""}`}
+                    className={`bg-terminal-surface rounded-xl px-5 py-4 hover:bg-terminal-surface-hover transition-all duration-300 ease-material space-y-2.5 shadow-layer-sm cursor-pointer hover-lift ${
+                      isPriorityEnriching ? "ring-1 ring-terminal-blue/20" : ""
+                    } ${isArchived ? "opacity-50" : ""}`}
                   >
                     {/* Row 1: title + meta (left) / time + actions (right) */}
                     <div className="flex items-start justify-between gap-3">
@@ -1996,6 +2072,7 @@ function SessionsPanel() {
                           <div className="text-[11px] font-mono text-terminal-dimmer truncate">
                             slug: <span className="text-terminal-dim">{s.slug}</span>
                           </div>
+                          <DataLevelBadge state={dataState} compact active={isPriorityEnriching} />
                           {branch && (
                             <span className="text-[11px] font-mono px-1.5 py-0.5 rounded bg-terminal-surface-2 text-terminal-dim shrink-0 inline-flex items-center gap-0.5">
                               <svg

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1523,6 +1523,10 @@ function SessionsPanel() {
       } else if (wasEnrichingRef.current) {
         wasEnrichingRef.current = false;
         await refreshSourcesFromCache();
+        if (timer) {
+          window.clearInterval(timer);
+          timer = undefined;
+        }
       }
     };
     void poll();

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -20,6 +20,7 @@ import {
 } from "./dashboard-utils";
 import { ContributionHeatmap } from "./InsightsPage";
 import { useScanInsightsContext } from "./InsightsPanel";
+import { DataLevelBadge, SessionLoadingToast, sessionDataState } from "./SessionDataProgress";
 import { formatDuration } from "./StatsPanel";
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -54,7 +55,7 @@ function useDashboardData() {
   const [loadingReplays, setLoadingReplays] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [, setScanProgress] = useState<number | null>(null);
-  const [, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
+  const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const wasEnrichingRef = useRef(false);
   const lastSourcesCachedAtRef = useRef<string | undefined>(undefined);
   const hasCursorSources = useMemo(
@@ -228,6 +229,7 @@ function useDashboardData() {
     loading,
     loadingSources,
     loadingReplays,
+    enrichmentStatus,
     error,
   };
 }
@@ -339,6 +341,7 @@ function ProviderBadge({ provider }: { provider: string }) {
 function RecentSessionsList({
   sessions,
   isLoading,
+  enrichmentStatus,
   onViewAll,
   onGenerate,
   onViewReplay,
@@ -348,6 +351,7 @@ function RecentSessionsList({
 }: {
   sessions: SourceSession[];
   isLoading: boolean;
+  enrichmentStatus?: SourcesEnrichmentStatus | null;
   onViewAll: () => void;
   onGenerate: (source: SourceSession) => void;
   onViewReplay: (slug: string) => void;
@@ -369,6 +373,8 @@ function RecentSessionsList({
         const hasReplay = !!s.existingReplay;
         const isGenerating = generatingSlug === s.slug;
         const hasError = generateErrorSlug === s.slug;
+        const isEnriching = Boolean(enrichmentStatus?.running) && s.provider === "cursor";
+        const dataState = sessionDataState(s, null);
         return (
           <div
             key={`${s.provider}-${s.slug}`}
@@ -380,9 +386,12 @@ function RecentSessionsList({
               <p className="text-sm font-sans text-terminal-text truncate">
                 {sourceSuggestedTitle(s)}
               </p>
-              <p className="text-[11px] font-mono text-terminal-dimmer truncate">
-                {projectName(s.project)}
-              </p>
+              <div className="flex items-center gap-1.5 min-w-0">
+                <p className="text-[11px] font-mono text-terminal-dimmer truncate">
+                  {projectName(s.project)}
+                </p>
+                {isEnriching && <DataLevelBadge state={dataState} active compact />}
+              </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <span className="text-[11px] font-mono text-terminal-dimmer tabular-nums">
@@ -655,8 +664,16 @@ function SystemChecksSection() {
 // ─── Main Component ──────────────────────────────────────────────────
 
 export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
-  const { sources, setSources, replays, loading, loadingSources, loadingReplays, error } =
-    useDashboardData();
+  const {
+    sources,
+    setSources,
+    replays,
+    loading,
+    loadingSources,
+    loadingReplays,
+    enrichmentStatus,
+    error,
+  } = useDashboardData();
   const insights = useMemo(() => computeInsights(sources, replays), [sources, replays]);
   const { scanStatus, userInsights } = useScanInsightsContext();
   const [generatingSlug, setGeneratingSlug] = useState<string | null>(null);
@@ -668,6 +685,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   const [tick, setTick] = useState(0);
+  const requestedEnrichmentSignatureRef = useRef("");
   const syncPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const syncPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectedSession = selectedSlug
@@ -867,6 +885,36 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     };
   }, []);
 
+  useEffect(() => {
+    if (loadingSources || insights.recentSources.length === 0) return;
+    const prioritySessions = insights.recentSources
+      .filter((session) => session.provider === "cursor")
+      .slice(0, 10);
+    if (prioritySessions.length === 0) return;
+
+    const slugs = prioritySessions.map((session) => session.slug);
+    const sessionIds = prioritySessions
+      .map((session) => session.sessionId)
+      .filter(
+        (sessionId): sessionId is string => typeof sessionId === "string" && sessionId.length > 0,
+      );
+    const projects = [...new Set(prioritySessions.map((session) => session.project))].slice(0, 5);
+    const signature = JSON.stringify({ slugs });
+    if (requestedEnrichmentSignatureRef.current === signature) return;
+    requestedEnrichmentSignatureRef.current = signature;
+
+    fetch("/api/sources/enrich", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slugs,
+        sessionIds,
+        projects,
+        limit: Math.max(10, prioritySessions.length),
+      }),
+    }).catch(() => {});
+  }, [insights.recentSources, loadingSources]);
+
   // Tick every 30s to update "synced X ago" relative time
   useEffect(() => {
     if (!lastSyncedAt) return;
@@ -890,6 +938,10 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     return (
       <div className="flex-1 overflow-auto animate-in fade-in duration-500">
         <div className="max-w-6xl mx-auto px-4 md:px-6 py-6 space-y-6">
+          <SessionLoadingToast
+            title="Fetching local sessions"
+            description="Loading cached sessions first, then enriching recent Cursor details in place."
+          />
           {/* Overview + activity skeleton */}
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-4">
             <div className="grid grid-cols-4 gap-6">
@@ -1049,6 +1101,22 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           </div>
         </div>
 
+        {(loadingSources || (enrichmentStatus?.running && enrichmentStatus.total > 0)) && (
+          <SessionLoadingToast
+            status={enrichmentStatus?.running ? enrichmentStatus : null}
+            title={
+              loadingSources
+                ? "Refreshing local session list"
+                : "Loading more local session details"
+            }
+            description={
+              loadingSources
+                ? "Home is using cached data while local providers refresh in the background."
+                : "Recent sessions will update in place as titles, prompt previews, counts, and metrics become available."
+            }
+          />
+        )}
+
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-stretch">
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm flex flex-col">
             <div className="flex items-center justify-between mb-3">
@@ -1063,6 +1131,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
               <RecentSessionsList
                 sessions={insights.recentSources}
                 isLoading={loadingSources}
+                enrichmentStatus={enrichmentStatus}
                 onViewAll={() => onNavigate("sessions")}
                 onGenerate={handleGenerate}
                 onViewReplay={handleOpenReplay}

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -208,6 +208,10 @@ function useDashboardData() {
       } else if (wasEnrichingRef.current) {
         wasEnrichingRef.current = false;
         await maybeRefreshSourcesFromCache();
+        if (timer) {
+          window.clearInterval(timer);
+          timer = undefined;
+        }
       }
     };
 

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -1,0 +1,287 @@
+import type { SourceSession } from "../types";
+import type { SourcesEnrichmentStatus } from "./dashboard-utils";
+
+export type SessionDataLevel = "basic" | "loading" | "details" | "counts" | "metrics";
+
+export interface SessionDataState {
+  level: SessionDataLevel;
+  label: string;
+  description: string;
+  className: string;
+}
+
+interface SessionMetricSnapshot {
+  promptCount?: number;
+  toolCallCount?: number;
+  editCount?: number;
+  durationMs?: number;
+  costEstimate?: number;
+  tokenUsage?: unknown;
+  apiErrorCount?: number;
+  compactionCount?: number;
+  subAgentCount?: number;
+  filesModified?: Array<unknown>;
+  prLinks?: Array<unknown>;
+}
+
+const STAGES: Array<{ level: Exclude<SessionDataLevel, "loading">; label: string }> = [
+  { level: "basic", label: "basic" },
+  { level: "details", label: "details" },
+  { level: "counts", label: "counts" },
+  { level: "metrics", label: "metrics" },
+];
+
+export function hasEnrichedSourceDetails(session: SourceSession): boolean {
+  return Boolean(
+    session.title ||
+    (session.prompts && session.prompts.length > 1) ||
+    session.model ||
+    session.gitBranch ||
+    session.promptCount != null ||
+    session.toolCallCount != null ||
+    session.durationMsEst != null ||
+    session.editCountEst != null,
+  );
+}
+
+export function hasPromptOrToolCounts(
+  session: SourceSession,
+  scanData: SessionMetricSnapshot | null | undefined,
+): boolean {
+  return Boolean(
+    scanData?.promptCount != null ||
+    scanData?.toolCallCount != null ||
+    session.promptCount != null ||
+    session.toolCallCount != null,
+  );
+}
+
+export function hasRichScanMetrics(scanData: SessionMetricSnapshot | null | undefined): boolean {
+  return Boolean(
+    scanData &&
+    ((scanData.filesModified && scanData.filesModified.length > 0) ||
+      (scanData.editCount ?? 0) > 0 ||
+      Boolean(scanData.durationMs) ||
+      Boolean(scanData.costEstimate) ||
+      (scanData.apiErrorCount ?? 0) > 0 ||
+      (scanData.compactionCount ?? 0) > 0 ||
+      (scanData.subAgentCount ?? 0) > 0 ||
+      Boolean(scanData.tokenUsage) ||
+      Boolean(scanData.prLinks?.length)),
+  );
+}
+
+export function sessionDataState(
+  session: SourceSession,
+  scanData: SessionMetricSnapshot | null | undefined,
+): SessionDataState {
+  if (hasRichScanMetrics(scanData)) {
+    return {
+      level: "metrics",
+      label: "metrics ready",
+      description:
+        "Rich scan metrics are available: files, edits, duration, errors, cost, tokens, or PR links.",
+      className: "bg-terminal-green-subtle text-terminal-green",
+    };
+  }
+  if (scanData || hasPromptOrToolCounts(session, scanData)) {
+    return {
+      level: "counts",
+      label: "counts ready",
+      description: "Prompt/tool counts are available, but richer metrics may still be deferred.",
+      className: "bg-terminal-green-subtle text-terminal-green",
+    };
+  }
+  if (hasEnrichedSourceDetails(session)) {
+    return {
+      level: "details",
+      label: "details ready",
+      description:
+        "Discovery has richer title, prompt previews, model, or lightweight counts for this session.",
+      className: "bg-terminal-purple-subtle text-terminal-purple",
+    };
+  }
+  return {
+    level: "basic",
+    label: "basic",
+    description: "Only lightweight discovery data is available so far.",
+    className: "bg-terminal-surface-2 text-terminal-dimmer",
+  };
+}
+
+export function DataLevelBadge({
+  state,
+  compact = false,
+  active = false,
+}: {
+  state: SessionDataState;
+  compact?: boolean;
+  active?: boolean;
+}) {
+  return (
+    <span
+      className={`relative inline-flex items-center gap-1 overflow-hidden font-mono rounded-md ${
+        state.className
+      } ${active ? "ring-1 ring-terminal-blue/25" : ""} ${
+        compact ? "text-[10px] px-1.5 py-0.5" : "text-xs px-1.5 py-0.5"
+      }`}
+      title={state.description}
+    >
+      {active && (
+        <span className="absolute inset-y-0 left-0 w-0.5 bg-terminal-blue animate-pulse" />
+      )}
+      {active && <span className="w-1 h-1 rounded-full bg-current animate-pulse" />}
+      {state.label}
+    </span>
+  );
+}
+
+export function ReadinessRow({
+  ready,
+  label,
+  pendingLabel,
+}: {
+  ready: boolean;
+  label: string;
+  pendingLabel: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs font-mono">
+      <span className={ready ? "text-terminal-green" : "text-terminal-dimmer"}>
+        {ready ? "✓" : "○"}
+      </span>
+      <span className={ready ? "text-terminal-dim" : "text-terminal-dimmer"}>
+        {ready ? label : pendingLabel}
+      </span>
+    </div>
+  );
+}
+
+export function SessionDataPipeline({
+  state,
+  active = false,
+  compact = false,
+  className = "",
+}: {
+  state: SessionDataState;
+  active?: boolean;
+  compact?: boolean;
+  className?: string;
+}) {
+  const level = state.level === "loading" ? "details" : state.level;
+  const activeIndex = Math.max(
+    0,
+    STAGES.findIndex((stage) => stage.level === level),
+  );
+  const fillPct = Math.max(12, ((activeIndex + 1) / STAGES.length) * 100);
+
+  return (
+    <div className={className} title={state.description}>
+      <div className="flex items-center gap-1.5">
+        {STAGES.map((stage, index) => {
+          const reached = index <= activeIndex;
+          const current = index === activeIndex;
+          return (
+            <div key={stage.level} className="flex items-center gap-1 min-w-0">
+              <span
+                className={`h-1.5 w-1.5 rounded-full shrink-0 ${
+                  reached
+                    ? active && current
+                      ? "bg-terminal-blue animate-pulse"
+                      : "bg-terminal-green"
+                    : "bg-terminal-surface-2"
+                }`}
+              />
+              {!compact && (
+                <span
+                  className={`text-[10px] font-mono uppercase tracking-wide ${
+                    reached ? "text-terminal-dim" : "text-terminal-dimmer"
+                  }`}
+                >
+                  {stage.label}
+                </span>
+              )}
+              {index < STAGES.length - 1 && (
+                <span
+                  className={`h-px w-4 shrink-0 ${
+                    index < activeIndex ? "bg-terminal-green/50" : "bg-terminal-surface-2"
+                  }`}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div
+        className={`mt-1.5 h-1 overflow-hidden rounded-full bg-terminal-bg ${
+          compact ? "max-w-32" : "w-full"
+        }`}
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${
+            active ? "bg-terminal-blue animate-pulse" : "bg-terminal-green"
+          }`}
+          style={{ width: `${fillPct}%` }}
+        />
+      </div>
+      {!compact && (
+        <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+          {active ? "Fetching richer local session data..." : state.description}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SessionLoadingRibbon({
+  status,
+  title,
+  description,
+}: {
+  status?: SourcesEnrichmentStatus | null;
+  title: string;
+  description: string;
+}) {
+  const total = status?.total ?? 0;
+  const processed = status?.processed ?? 0;
+  const pct = total > 0 ? Math.max(4, Math.min(100, Math.round((processed / total) * 100))) : 35;
+
+  return (
+    <div className="rounded-lg border border-terminal-blue/20 bg-terminal-blue-subtle/95 px-3 py-2 text-terminal-blue shadow-layer-md backdrop-blur-sm">
+      <div className="flex items-start gap-2.5">
+        <div className="mt-1.5 h-1.5 w-1.5 rounded-full bg-terminal-blue animate-pulse shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-xs font-mono truncate">{title}</div>
+            {total > 0 && (
+              <div className="text-[10px] font-mono tabular-nums text-terminal-blue/75">
+                {processed}/{total}
+              </div>
+            )}
+          </div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-blue/70 leading-relaxed">
+            {description}
+          </div>
+          <div className="mt-2 h-1 overflow-hidden rounded-full bg-terminal-bg/60">
+            <div
+              className="h-full rounded-full bg-terminal-blue transition-all duration-500 animate-pulse"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SessionLoadingToast(props: {
+  status?: SourcesEnrichmentStatus | null;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="fixed right-4 top-16 z-50 w-[calc(100vw-2rem)] max-w-sm pointer-events-none animate-in fade-in slide-in-from-top-2 duration-300">
+      <SessionLoadingRibbon {...props} />
+    </div>
+  );
+}

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -1,7 +1,7 @@
 import type { SourceSession } from "../types";
 import type { SourcesEnrichmentStatus } from "./dashboard-utils";
 
-export type SessionDataLevel = "basic" | "loading" | "details" | "counts" | "metrics";
+export type SessionDataLevel = "basic" | "details" | "counts" | "metrics";
 
 export interface SessionDataState {
   level: SessionDataLevel;
@@ -24,7 +24,7 @@ interface SessionMetricSnapshot {
   prLinks?: Array<unknown>;
 }
 
-const STAGES: Array<{ level: Exclude<SessionDataLevel, "loading">; label: string }> = [
+const STAGES: Array<{ level: SessionDataLevel; label: string }> = [
   { level: "basic", label: "basic" },
   { level: "details", label: "details" },
   { level: "counts", label: "counts" },
@@ -168,10 +168,9 @@ export function SessionDataPipeline({
   compact?: boolean;
   className?: string;
 }) {
-  const level = state.level === "loading" ? "details" : state.level;
   const activeIndex = Math.max(
     0,
-    STAGES.findIndex((stage) => stage.level === level),
+    STAGES.findIndex((stage) => stage.level === state.level),
   );
   const fillPct = Math.max(12, ((activeIndex + 1) / STAGES.length) * 100);
 


### PR DESCRIPTION
## Summary
- Add an agent-facing `vibe-replay sessions` command for local session lookup and targeted retro scans.
- Add a project skill that teaches agents when and how to use local session search safely.
- Prioritize dashboard source enrichment for visible/recent sessions and show non-jittery loading cues in Home, Sessions, and detail views.

## Test plan
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm build`
- Browser-validated Home/Sessions/detail enrichment UI and fixed corner loading toast


Made with [Cursor](https://cursor.com)