### PR TITLE
Improve session search evidence and evals

### DIFF
--- a/.cursor/skills/local-session-search/SKILL.md
+++ b/.cursor/skills/local-session-search/SKILL.md
@@ -47,15 +47,19 @@ Useful filters:
 vibe-replay sessions --project "vibe-replay" --json
 vibe-replay sessions --provider cursor --query "auth bug" --json
 vibe-replay sessions --query "codex parser" --scan --json
+vibe-replay sessions --query "PR review CI" --any --brief --dedupe --json
 ```
 
 ## Workflow
 
 1. Start shallow: use `--query` or `--project`, `--limit 10`, and `--json`.
 2. Rank matches by timestamp, project, title/first prompt match quality, provider, and user intent.
-3. Only add `--scan` for the narrowed candidate set when the user asks about retro, efficiency, prompt quality, cost, tool usage, compactions, API errors, files modified, or session quality.
-4. Summarize the best matching sessions with provider, timestamp, project, title, first prompt preview, file path, and why each matched.
-5. For deep review of one session, use the returned `filePath` or `filePaths` with the replay skill or `vibe-replay --provider <provider> --session <path> --github`.
+3. If a remembered query has several loose terms and returns nothing, retry with `--any` for explicit broad recall.
+4. Add `--brief` when the user asks a fuzzy retrospective question; it runs a targeted scan and adds `matchQuality`, matched/unmatched terms, `whyMatched`, `brief`, `signals`, and `suggestedNextAction`.
+5. Add `--dedupe` when repeated long-prompt sessions from multiple workspaces clutter the result set.
+6. Only add plain `--scan` for a narrowed candidate set when the user asks about retro, efficiency, prompt quality, cost, tool usage, compactions, API errors, files modified, or session quality.
+7. Summarize the best matching sessions with provider, timestamp, project, title, first prompt preview, file path, and why each matched.
+8. For deep review of one session, use the returned `filePath` or `filePaths` with the replay skill or `vibe-replay --provider <provider> --session <path> --github`.
 
 Avoid broad `--scan` over many sessions. It is intentionally available, but expensive compared with metadata search.
 
@@ -77,6 +81,7 @@ For search results, return a short ranked list. Include:
 - Title or prompt preview.
 - Provider, project, timestamp, and slug/session id.
 - Why it matched.
+- Match quality, matched/unmatched terms, brief/signals/next action when using `--brief`.
 - Whether deeper scan/replay is recommended.
 
 For retros, include the key metrics from `--scan` and a concise prompt/process diagnosis.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,9 +85,11 @@ For agent-friendly lookup and retros:
 ```bash
 vibe-replay sessions --query "codex parser" --limit 10 --json
 vibe-replay sessions --project "vibe-replay" --scan --json
+vibe-replay sessions --query "PR review CI" --any --brief --dedupe --json
 ```
 
 Use `--scan` to include efficiency metrics such as prompt count, tool calls, edits, duration, compactions, and API errors.
+Use `--any` for explicit broad recall when you only remember loose keywords. Add `--brief` for scan-backed evidence (`matchQuality`, matched/unmatched terms, match reasons, brief, signals, and next action). Add `--dedupe` to collapse near-duplicate long-prompt sessions.
 
 ## Run from Source
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/index.ts",
+    "eval:sessions": "tsx scripts/eval-session-query.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/cli/scripts/eval-session-query.ts
+++ b/packages/cli/scripts/eval-session-query.ts
@@ -1,0 +1,369 @@
+import { deduplicateSessionsByProvider, getAllProviders } from "../src/providers/index.js";
+import { queryLocalSessions, type SessionQueryMatch } from "../src/session-query.js";
+import type { SessionInfo } from "../src/types.js";
+
+type QueryMode = "strict" | "any" | "brief";
+
+interface EvalCase {
+  query: string;
+  intent: string;
+  relevanceNote: string;
+  isRelevant: (text: string) => boolean;
+}
+
+interface ModeSummary {
+  mode: QueryMode;
+  count: number;
+  judgedRelevant: number;
+  top1Relevant: boolean;
+  top3Relevant: number;
+  qualityCounts: Record<string, number>;
+  topResults: Array<{
+    slug: string;
+    project: string;
+    quality?: string;
+    matchedTerms: string[];
+    unmatchedTerms: string[];
+    judgedRelevant: boolean;
+    title: string;
+  }>;
+}
+
+const EVAL_CASES: EvalCase[] = [
+  {
+    query: "PR review CI merge",
+    intent: "Find PR/review workflows, ideally with CI or merge context.",
+    relevanceNote: "PR/pull request plus review, or a GitHub PR URL.",
+    isRelevant: (text) =>
+      /pull\/\d+|pull request|\bpr\b/.test(text) && /review|reviewer|ci|merge/.test(text),
+  },
+  {
+    query: "latest main branch feature",
+    intent: "Recover sessions about switching/pulling latest main for feature work.",
+    relevanceNote: "latest/main/branch/feature context, not arbitrary 'main' mentions.",
+    isRelevant: (text) => /latest/.test(text) && /(main|branch|feature)/.test(text),
+  },
+  {
+    query: "skill devspaces canonical",
+    intent: "Find skill work that involved Devspaces or canonical skill migration.",
+    relevanceNote: "skill plus devspaces/dev space/canonical/ROS CLI skill.",
+    isRelevant: (text) =>
+      /skill/.test(text) && /(devspaces|dev space|canonical|ros-?cli)/.test(text),
+  },
+  {
+    query: "progressive loading metrics ready",
+    intent: "Find Vibe Replay progressive session-data loading / metrics-ready UI work.",
+    relevanceNote:
+      "progressive/enrichment/session data/readiness/metrics-ready UI, not generic loading or ready.",
+    isRelevant: (text) =>
+      /(vibe-replay|dashboard|session data|data readiness|metrics ready|enrichment|progressive)/.test(
+        text,
+      ) && /(loading|metrics|ready|toast)/.test(text),
+  },
+  {
+    query: "toast style",
+    intent: "Find UI polish around toast styling.",
+    relevanceNote: "toast styling/design/placement.",
+    isRelevant: (text) => /toast/.test(text) && /(style|design|placement|loading)/.test(text),
+  },
+  {
+    query: "codex parser compaction",
+    intent: "Find Codex parser/replay parity work involving compaction.",
+    relevanceNote: "Codex plus parser/compaction/patch/replay parity.",
+    isRelevant: (text) =>
+      /codex/.test(text) && /(parser|compaction|patch|replay parity)/.test(text),
+  },
+  {
+    query: "local session search retro",
+    intent: "Find the local session search / retrospective feature work.",
+    relevanceNote: "local session/session search/vibe-replay sessions/session-query/retro.",
+    isRelevant: (text) =>
+      /(local session|session search|vibe-replay sessions|session-query|retro)/.test(text),
+  },
+  {
+    query: "auth login callback",
+    intent: "Find auth/login callback debugging sessions.",
+    relevanceNote: "auth/login/oauth/callback.",
+    isRelevant: (text) => /(auth|oauth)/.test(text) && /(login|callback|status)/.test(text),
+  },
+  {
+    query: "model pricing cursor",
+    intent: "Find model pricing / Cursor model metadata sessions.",
+    relevanceNote: "model/pricing/cursor together enough to indicate the topic.",
+    isRelevant: (text) => /model/.test(text) && /(pricing|cursor)/.test(text),
+  },
+  {
+    query: "sourcegraph skill search",
+    intent: "Find Sourcegraph or skill-search research.",
+    relevanceNote: "sourcegraph, or skill plus search.",
+    isRelevant: (text) => /sourcegraph/.test(text) || (/skill/.test(text) && /search/.test(text)),
+  },
+  {
+    query: "tuo-lei github identity",
+    intent: "Find local GitHub identity / account preference sessions.",
+    relevanceNote: "tuo-lei plus GitHub/account/identity.",
+    isRelevant: (text) => /tuo-lei/.test(text) && /(github|account|identity)/.test(text),
+  },
+  {
+    query: "browser screenshot review",
+    intent: "Find browser/screenshot review tasks.",
+    relevanceNote: "browser or screenshot plus review/screenshot.",
+    isRelevant: (text) => /(browser|screenshot)/.test(text) && /(review|screenshot)/.test(text),
+  },
+  {
+    query: "D1 drizzle migration auth",
+    intent: "Find D1/Drizzle migration/auth database work.",
+    relevanceNote: "D1/drizzle/migration plus auth/db context.",
+    isRelevant: (text) =>
+      /(d1|drizzle|migration)/.test(text) && /(auth|db|database|schema)/.test(text),
+  },
+  {
+    query: "Cursor SDK agent transcript",
+    intent: "Find Cursor SDK agent transcript work.",
+    relevanceNote: "Cursor SDK/SDK plus agent/transcript.",
+    isRelevant: (text) => /(cursor sdk|sdk)/.test(text) && /(agent|transcript)/.test(text),
+  },
+  {
+    query: "ROS CLI QPS bursty usage",
+    intent: "Find ROS CLI capacity / bursty QPS investigation.",
+    relevanceNote: "ROS CLI plus QPS/bursty/usage/server capacity.",
+    isRelevant: (text) => /ros cli/.test(text) && /(qps|bursty|usage|server|capacity)/.test(text),
+  },
+  {
+    query: "gdrive confluence slack skills",
+    intent: "Find skill catalog work around GDrive/Confluence/Slack skills.",
+    relevanceNote: "Any of gdrive/confluence/slack plus skill.",
+    isRelevant: (text) => /(gdrive|google drive|confluence|slack)/.test(text) && /skill/.test(text),
+  },
+  {
+    query: "mobile landing main PR",
+    intent: "Find Mobile Landing in Main PR review context.",
+    relevanceNote: "mobile landing or mobile+main+PR/review.",
+    isRelevant: (text) =>
+      /mobile/.test(text) && /(landing|main)/.test(text) && /(\bpr\b|review|pull\/\d+)/.test(text),
+  },
+  {
+    query: "e2e generated html",
+    intent: "Find generated HTML / E2E test work.",
+    relevanceNote: "e2e or generated HTML/HTML output.",
+    isRelevant: (text) => /e2e/.test(text) || /generated html/.test(text),
+  },
+  {
+    query: "cache enrichment priority",
+    intent: "Find session-source cache/enrichment priority work.",
+    relevanceNote: "cache plus enrichment/priority/sources.",
+    isRelevant: (text) => /cache/.test(text) && /(enrichment|priority|sources|session)/.test(text),
+  },
+  {
+    query: "nonexistent zebra pineapple",
+    intent: "Negative control.",
+    relevanceNote: "Should return nothing.",
+    isRelevant: () => false,
+  },
+];
+
+async function main(): Promise<void> {
+  const sessions = mergeSameSessions(
+    deduplicateSessionsByProvider(
+      (
+        await Promise.all(
+          getAllProviders().map(async (provider) => {
+            try {
+              return await provider.discover();
+            } catch {
+              return [];
+            }
+          }),
+        )
+      ).flat(),
+    ),
+  );
+
+  const rows = [];
+  for (const evalCase of EVAL_CASES) {
+    const strict = summarizeMode(
+      "strict",
+      evalCase,
+      await queryLocalSessions(sessions, { query: evalCase.query, limit: 5 }),
+    );
+    const any = summarizeMode(
+      "any",
+      evalCase,
+      await queryLocalSessions(sessions, { query: evalCase.query, any: true, limit: 5 }),
+    );
+    const brief = summarizeMode(
+      "brief",
+      evalCase,
+      await queryLocalSessions(sessions, {
+        query: evalCase.query,
+        any: true,
+        brief: true,
+        dedupe: true,
+        limit: 5,
+      }),
+    );
+    rows.push({ evalCase, strict, any, brief });
+  }
+
+  printReport(sessions.length, rows);
+}
+
+function summarizeMode(
+  mode: QueryMode,
+  evalCase: EvalCase,
+  matches: SessionQueryMatch[],
+): ModeSummary {
+  const topResults = matches.map((match) => {
+    const text = normalizedResultText(match);
+    return {
+      slug: match.slug,
+      project: match.project,
+      quality: match.matchQuality,
+      matchedTerms: match.matchedTerms || [],
+      unmatchedTerms: match.unmatchedTerms || [],
+      judgedRelevant: evalCase.isRelevant(text),
+      title: previewTitle(match),
+    };
+  });
+
+  return {
+    mode,
+    count: matches.length,
+    judgedRelevant: topResults.filter((result) => result.judgedRelevant).length,
+    top1Relevant: Boolean(topResults[0]?.judgedRelevant),
+    top3Relevant: topResults.slice(0, 3).filter((result) => result.judgedRelevant).length,
+    qualityCounts: topResults.reduce<Record<string, number>>((counts, result) => {
+      const quality = result.quality || "none";
+      counts[quality] = (counts[quality] || 0) + 1;
+      return counts;
+    }, {}),
+    topResults,
+  };
+}
+
+function printReport(
+  sessionCount: number,
+  rows: Array<{
+    evalCase: EvalCase;
+    strict: ModeSummary;
+    any: ModeSummary;
+    brief: ModeSummary;
+  }>,
+): void {
+  console.log(`# Session Query Eval\n`);
+  console.log(`Sessions discovered: ${sessionCount}`);
+  console.log(`Eval cases: ${rows.length}`);
+  console.log(`Top K per mode: 5\n`);
+
+  console.log(`## Aggregate\n`);
+  console.log(
+    `| Mode | Queries With Results | Top1 Relevant | Judged Relevant / Returned | Precision@5 | Negative Returned |`,
+  );
+  console.log(`| --- | ---: | ---: | ---: | ---: | ---: |`);
+  for (const mode of ["strict", "any", "brief"] as const) {
+    const summary = aggregate(rows, mode);
+    console.log(
+      `| ${mode} | ${summary.queriesWithResults}/${summary.nonNegativeQueries} | ${summary.top1Relevant}/${summary.nonNegativeQueries} | ${summary.judgedRelevant}/${summary.returned} | ${formatPct(summary.precision)} | ${summary.negativeReturned} |`,
+    );
+  }
+
+  console.log(`\n## Case Results\n`);
+  for (const row of rows) {
+    console.log(`### ${row.evalCase.query}`);
+    console.log(`Intent: ${row.evalCase.intent}`);
+    console.log(`Judge: ${row.evalCase.relevanceNote}\n`);
+    for (const mode of ["strict", "any", "brief"] as const) {
+      const result = row[mode];
+      console.log(
+        `- ${mode}: count=${result.count}, judgedRelevant=${result.judgedRelevant}/${result.count}, top3Relevant=${result.top3Relevant}/3, quality=${JSON.stringify(result.qualityCounts)}`,
+      );
+      for (const [index, top] of result.topResults.slice(0, 3).entries()) {
+        const quality = top.quality ? ` ${top.quality}` : "";
+        const matched = top.matchedTerms.length ? ` matched=${top.matchedTerms.join(",")}` : "";
+        const unmatched = top.unmatchedTerms.length
+          ? ` unmatched=${top.unmatchedTerms.join(",")}`
+          : "";
+        console.log(
+          `  ${index + 1}. ${top.judgedRelevant ? "Y" : "N"} ${top.slug}${quality}${matched}${unmatched} - ${top.title}`,
+        );
+      }
+    }
+    console.log();
+  }
+
+  const weakOnly = rows
+    .filter((row) => row.brief.count > 0)
+    .filter((row) => (row.brief.qualityCounts.weak || 0) === row.brief.count);
+  console.log(`## Brief Weak-Only Cases\n`);
+  for (const row of weakOnly) {
+    const top = row.brief.topResults[0];
+    console.log(
+      `- ${row.evalCase.query}: top=${top?.slug || "none"} matched=${top?.matchedTerms.join(",") || ""} unmatched=${top?.unmatchedTerms.join(",") || ""}`,
+    );
+  }
+}
+
+function aggregate(
+  rows: Array<{
+    evalCase: EvalCase;
+    strict: ModeSummary;
+    any: ModeSummary;
+    brief: ModeSummary;
+  }>,
+  mode: "strict" | "any" | "brief",
+): {
+  nonNegativeQueries: number;
+  queriesWithResults: number;
+  top1Relevant: number;
+  judgedRelevant: number;
+  returned: number;
+  precision: number | undefined;
+  negativeReturned: number;
+} {
+  const nonNegative = rows.filter((row) => row.evalCase.intent !== "Negative control.");
+  const judgedRelevant = nonNegative.reduce((sum, row) => sum + row[mode].judgedRelevant, 0);
+  const returned = nonNegative.reduce((sum, row) => sum + row[mode].count, 0);
+  return {
+    nonNegativeQueries: nonNegative.length,
+    queriesWithResults: nonNegative.filter((row) => row[mode].count > 0).length,
+    top1Relevant: nonNegative.filter((row) => row[mode].top1Relevant).length,
+    judgedRelevant,
+    returned,
+    precision: returned > 0 ? judgedRelevant / returned : undefined,
+    negativeReturned:
+      rows.find((row) => row.evalCase.intent === "Negative control.")?.[mode].count || 0,
+  };
+}
+
+function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
+  const groups = new Map<string, SessionInfo[]>();
+  for (const session of sessions) {
+    const key = `${session.project}::${session.slug}`;
+    groups.set(key, [...(groups.get(key) || []), session]);
+  }
+
+  return [...groups.values()].map((group) => {
+    group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    return group[0];
+  });
+}
+
+function normalizedResultText(match: SessionQueryMatch): string {
+  return [match.title, match.firstPrompt, match.project, match.gitBranch]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function previewTitle(match: SessionQueryMatch): string {
+  return (match.title || match.firstPrompt || match.slug).replace(/\s+/g, " ").slice(0, 100);
+}
+
+function formatPct(value: number | undefined): string {
+  return value === undefined ? "-" : `${Math.round(value * 1000) / 10}%`;
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -742,6 +742,9 @@ interface SessionsCommandOptions {
   provider?: string;
   limit?: number;
   scan?: boolean;
+  any?: boolean;
+  brief?: boolean;
+  dedupe?: boolean;
   json?: boolean;
 }
 
@@ -753,6 +756,9 @@ program
   .option("-p, --provider <name>", "Filter by provider (claude-code, cursor, codex, ...)")
   .option("-l, --limit <number>", "Maximum sessions to return", (value) => Number(value), 10)
   .option("--scan", "Run richer per-session scan for efficiency metrics")
+  .option("--any", "Match any query term instead of requiring all terms")
+  .option("--brief", "Include scan-backed session briefs and match evidence")
+  .option("--dedupe", "Collapse near-duplicate sessions with the same long prompt/title")
   .option("--json", "Print machine-readable JSON")
   .action(async (opts: SessionsCommandOptions) => {
     const discoverSpinner = opts.json ? undefined : ora("Discovering local sessions...").start();

--- a/packages/cli/src/session-query.ts
+++ b/packages/cli/src/session-query.ts
@@ -66,19 +66,26 @@ export interface SessionQueryBrief {
   suggestedNextAction: string;
 }
 
+interface ScoredSessionInfo {
+  session: SessionInfo;
+  query: SessionQueryScore;
+}
+
+const HIGH_TOOL_DENSITY_THRESHOLD = 20;
+
 export async function queryLocalSessions(
   sessions: SessionInfo[],
   options: SessionQueryOptions = {},
 ): Promise<SessionQueryMatch[]> {
   const limit = normalizeLimit(options.limit);
   const terms = splitTerms(options.query);
-  const filtered = filterSessionInfos(sessions, options).slice(0, limit);
-  const matches = filtered.map((session) => sessionInfoToMatch(session, terms));
+  const filtered = filterScoredSessionInfos(sessions, options).slice(0, limit);
+  const matches = filtered.map(({ session, query }) => sessionInfoToMatch(session, terms, query));
 
   if (!options.scan && !options.brief) return matches;
 
   const scanned = await Promise.all(
-    filtered.map(async (session) => {
+    filtered.map(async ({ session }) => {
       try {
         return await scanSession(scanInputFromSession(session));
       } catch {
@@ -102,6 +109,13 @@ export function filterSessionInfos(
   sessions: SessionInfo[],
   options: Pick<SessionQueryOptions, "query" | "project" | "provider" | "any" | "dedupe"> = {},
 ): SessionInfo[] {
+  return filterScoredSessionInfos(sessions, options).map(({ session }) => session);
+}
+
+function filterScoredSessionInfos(
+  sessions: SessionInfo[],
+  options: Pick<SessionQueryOptions, "query" | "project" | "provider" | "any" | "dedupe"> = {},
+): ScoredSessionInfo[] {
   const terms = splitTerms(options.query);
   const projectTerm = normalizeSearch(options.project);
   const provider = normalizeSearch(options.provider);
@@ -127,10 +141,9 @@ export function filterSessionInfos(
         if (scoreDelta) return scoreDelta;
       }
       return b.session.timestamp.localeCompare(a.session.timestamp);
-    })
-    .map(({ session }) => session);
+    });
 
-  return options.dedupe ? dedupeSimilarSessions(filtered) : filtered;
+  return options.dedupe ? dedupeSimilarScoredSessions(filtered) : filtered;
 }
 
 export function scanInputFromSession(session: SessionInfo): ScanInput {
@@ -190,8 +203,12 @@ export function formatSessionQueryText(matches: SessionQueryMatch[]): string {
     .join("\n\n");
 }
 
-function sessionInfoToMatch(session: SessionInfo, terms: string[] = []): SessionQueryMatch {
-  const query = scoreSession(session, terms);
+function sessionInfoToMatch(
+  session: SessionInfo,
+  terms: string[] = [],
+  precomputedScore?: SessionQueryScore,
+): SessionQueryMatch {
+  const query = precomputedScore || scoreSession(session, terms);
   return {
     provider: session.provider,
     sessionId: session.sessionId,
@@ -298,7 +315,9 @@ function scoreSession(session: SessionInfo, terms: string[]): SessionQueryScore 
   }
 
   if (matchedTerms.length === terms.length && terms.length > 1) score += 5;
-  if (session.hasPR) score += 2;
+  if (session.hasPR && terms.some((term) => ["pr", "review", "pull", "merge"].includes(term))) {
+    score += 2;
+  }
   if (session.promptCount && session.promptCount > 10) score += 1;
 
   return {
@@ -343,7 +362,7 @@ function classifyTaskType(
   scan: SessionQueryScanSummary | undefined,
 ): string {
   if (/(review|pr|pull request|merge|ai review)/i.test(text) || match.hasPR) return "PR/review";
-  if (/(latest main|branch|current feature|what.*working|做什么feature)/i.test(text)) {
+  if (/(latest main|branch|current feature|what.*working)/i.test(text)) {
     return "context recovery";
   }
   if (/(skill|dev space|devspaces)/i.test(text)) return "skill workflow";
@@ -360,12 +379,10 @@ function sessionSignals(
   const signals: string[] = [];
   const promptCount = scan?.promptCount ?? match.promptCount ?? 0;
   const toolCount = scan?.toolCallCount ?? match.toolCallCount ?? 0;
-  const toolsPerPrompt = scan?.toolCallsPerPrompt;
+  const toolsPerPrompt = scan?.toolCallsPerPrompt ?? ratio(toolCount, promptCount);
 
-  if (toolsPerPrompt !== undefined && toolsPerPrompt >= 30) {
+  if (toolsPerPrompt !== undefined && toolsPerPrompt >= HIGH_TOOL_DENSITY_THRESHOLD) {
     signals.push(`high tool density (${toolsPerPrompt.toFixed(1)} tools/prompt)`);
-  } else if (promptCount > 0 && toolCount / promptCount >= 20) {
-    signals.push(`high tool density (${Math.round(toolCount / promptCount)} tools/prompt)`);
   }
   if (promptCount >= 40) signals.push(`long conversation (${promptCount} prompts)`);
   if ((scan?.editCount ?? match.editCount ?? 0) >= 50) {
@@ -431,14 +448,15 @@ function textMatchesTerm(text: string, term: string): boolean {
   return text.includes(term);
 }
 
-function dedupeSimilarSessions(sessions: SessionInfo[]): SessionInfo[] {
+function dedupeSimilarScoredSessions(scoredSessions: ScoredSessionInfo[]): ScoredSessionInfo[] {
   const seen = new Set<string>();
-  const deduped: SessionInfo[] = [];
-  for (const session of sessions) {
+  const deduped: ScoredSessionInfo[] = [];
+  for (const scored of scoredSessions) {
+    const { session } = scored;
     const key = duplicateSessionKey(session);
     if (key && seen.has(key)) continue;
     if (key) seen.add(key);
-    deduped.push(session);
+    deduped.push(scored);
   }
   return deduped;
 }
@@ -448,6 +466,7 @@ function duplicateSessionKey(session: SessionInfo): string | undefined {
   if (prompt.length >= 60) return `prompt:${prompt.slice(0, 240)}`;
   const title = normalizeSearch(cleanPromptText(session.title || ""));
   if (title.length >= 60) return `title:${title.slice(0, 240)}`;
+  // Short prompts/titles are too ambiguous to dedupe safely.
   return undefined;
 }
 

--- a/packages/cli/src/session-query.ts
+++ b/packages/cli/src/session-query.ts
@@ -9,6 +9,9 @@ export interface SessionQueryOptions {
   provider?: string;
   limit?: number;
   scan?: boolean;
+  any?: boolean;
+  brief?: boolean;
+  dedupe?: boolean;
 }
 
 export interface SessionQueryMatch {
@@ -31,7 +34,13 @@ export interface SessionQueryMatch {
   editCount?: number;
   durationMs?: number;
   hasPR?: boolean;
+  score?: number;
+  matchedTerms?: string[];
+  unmatchedTerms?: string[];
+  matchQuality?: "all-terms" | "strong" | "weak";
+  whyMatched?: string[];
   scan?: SessionQueryScanSummary;
+  brief?: SessionQueryBrief;
 }
 
 export interface SessionQueryScanSummary {
@@ -50,15 +59,23 @@ export interface SessionQueryScanSummary {
   dataQualityNotes?: string[];
 }
 
+export interface SessionQueryBrief {
+  taskType: string;
+  summary: string;
+  signals: string[];
+  suggestedNextAction: string;
+}
+
 export async function queryLocalSessions(
   sessions: SessionInfo[],
   options: SessionQueryOptions = {},
 ): Promise<SessionQueryMatch[]> {
   const limit = normalizeLimit(options.limit);
+  const terms = splitTerms(options.query);
   const filtered = filterSessionInfos(sessions, options).slice(0, limit);
-  const matches = filtered.map(sessionInfoToMatch);
+  const matches = filtered.map((session) => sessionInfoToMatch(session, terms));
 
-  if (!options.scan) return matches;
+  if (!options.scan && !options.brief) return matches;
 
   const scanned = await Promise.all(
     filtered.map(async (session) => {
@@ -72,29 +89,48 @@ export async function queryLocalSessions(
 
   return matches.map((match, index) => {
     const scan = scanned[index];
-    return scan ? { ...match, scan: scanSummary(scan) } : match;
+    const summary = scan ? scanSummary(scan) : undefined;
+    return {
+      ...match,
+      ...(summary ? { scan: summary } : {}),
+      ...(options.brief ? { brief: buildSessionBrief(match, summary) } : {}),
+    };
   });
 }
 
 export function filterSessionInfos(
   sessions: SessionInfo[],
-  options: Pick<SessionQueryOptions, "query" | "project" | "provider"> = {},
+  options: Pick<SessionQueryOptions, "query" | "project" | "provider" | "any" | "dedupe"> = {},
 ): SessionInfo[] {
   const terms = splitTerms(options.query);
   const projectTerm = normalizeSearch(options.project);
   const provider = normalizeSearch(options.provider);
+  const wideMatch = Boolean(options.any);
 
-  return [...sessions]
-    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
-    .filter((session) => {
+  const filtered = [...sessions]
+    .map((session) => ({
+      session,
+      query: scoreSession(session, terms),
+    }))
+    .filter(({ session, query }) => {
       if (provider && normalizeSearch(session.provider) !== provider) return false;
       if (projectTerm && !sessionProjectHaystack(session).includes(projectTerm)) return false;
       if (terms.length > 0) {
-        const haystack = sessionHaystack(session);
-        if (!terms.every((term) => haystack.includes(term))) return false;
+        if (wideMatch) return query.matchedTerms.length > 0;
+        if (query.matchedTerms.length !== terms.length) return false;
       }
       return true;
-    });
+    })
+    .sort((a, b) => {
+      if (wideMatch || terms.length > 0) {
+        const scoreDelta = b.query.score - a.query.score;
+        if (scoreDelta) return scoreDelta;
+      }
+      return b.session.timestamp.localeCompare(a.session.timestamp);
+    })
+    .map(({ session }) => session);
+
+  return options.dedupe ? dedupeSimilarSessions(filtered) : filtered;
 }
 
 export function scanInputFromSession(session: SessionInfo): ScanInput {
@@ -130,14 +166,32 @@ export function formatSessionQueryText(matches: SessionQueryMatch[]): string {
       ];
       if (match.gitBranch) lines.push(`   branch: ${match.gitBranch}`);
       if (match.model) lines.push(`   model: ${match.model}`);
+      if (match.matchedTerms?.length) {
+        const quality = match.matchQuality ? `${match.matchQuality}, ` : "";
+        lines.push(
+          `   matched: ${quality}${match.matchedTerms.length}/${(match.matchedTerms.length || 0) + (match.unmatchedTerms?.length || 0)} terms (${match.matchedTerms.join(", ")})`,
+        );
+      }
+      if (match.unmatchedTerms?.length) {
+        lines.push(`   unmatched: ${match.unmatchedTerms.join(", ")}`);
+      }
+      if (match.whyMatched?.length) lines.push(`   why: ${match.whyMatched.join("; ")}`);
       if (match.firstPrompt) lines.push(`   first prompt: ${previewPrompt(match.firstPrompt)}`);
       if (match.scan) lines.push(`   efficiency: ${formatScanSummary(match.scan)}`);
+      if (match.brief) {
+        lines.push(`   brief: ${match.brief.summary}`);
+        if (match.brief.signals.length > 0) {
+          lines.push(`   signals: ${match.brief.signals.join("; ")}`);
+        }
+        lines.push(`   next: ${match.brief.suggestedNextAction}`);
+      }
       return lines.join("\n");
     })
     .join("\n\n");
 }
 
-function sessionInfoToMatch(session: SessionInfo): SessionQueryMatch {
+function sessionInfoToMatch(session: SessionInfo, terms: string[] = []): SessionQueryMatch {
+  const query = scoreSession(session, terms);
   return {
     provider: session.provider,
     sessionId: session.sessionId,
@@ -158,6 +212,11 @@ function sessionInfoToMatch(session: SessionInfo): SessionQueryMatch {
     editCount: session.editCountEst,
     durationMs: session.durationMsEst,
     hasPR: session.hasPR,
+    score: query.score,
+    matchedTerms: query.matchedTerms,
+    unmatchedTerms: query.unmatchedTerms,
+    matchQuality: query.matchQuality,
+    whyMatched: query.whyMatched,
   };
 }
 
@@ -196,6 +255,164 @@ function formatScanSummary(scan: SessionQueryScanSummary): string {
   return parts.join(", ");
 }
 
+interface SessionQueryScore {
+  score: number;
+  matchedTerms: string[];
+  unmatchedTerms: string[];
+  matchQuality?: "all-terms" | "strong" | "weak";
+  whyMatched: string[];
+}
+
+function scoreSession(session: SessionInfo, terms: string[]): SessionQueryScore {
+  if (terms.length === 0) {
+    return { score: 0, matchedTerms: [], unmatchedTerms: [], whyMatched: [] };
+  }
+
+  const fields = [
+    { name: "title", value: session.title, weight: 8 },
+    { name: "first prompt", value: session.firstPrompt, weight: 7 },
+    { name: "prompts", value: (session.prompts || []).join(" "), weight: 5 },
+    { name: "project", value: session.project, weight: 4 },
+    { name: "branch", value: session.gitBranch, weight: 4 },
+    { name: "model", value: session.model, weight: 2 },
+    { name: "provider", value: session.provider, weight: 2 },
+    { name: "slug", value: session.slug, weight: 2 },
+    { name: "files", value: (session.fsDetectedFiles || []).join(" "), weight: 3 },
+  ].map((field) => ({ ...field, normalized: normalizeSearch(field.value) }));
+
+  const matchedTerms: string[] = [];
+  const unmatchedTerms: string[] = [];
+  const whyMatched: string[] = [];
+  let score = 0;
+
+  for (const term of terms) {
+    const hits = fields.filter((field) => textMatchesTerm(field.normalized, term));
+    if (hits.length === 0) {
+      unmatchedTerms.push(term);
+      continue;
+    }
+    matchedTerms.push(term);
+    const best = hits.sort((a, b) => b.weight - a.weight)[0];
+    score += best.weight;
+    whyMatched.push(`${term} in ${best.name}`);
+  }
+
+  if (matchedTerms.length === terms.length && terms.length > 1) score += 5;
+  if (session.hasPR) score += 2;
+  if (session.promptCount && session.promptCount > 10) score += 1;
+
+  return {
+    score,
+    matchedTerms,
+    unmatchedTerms,
+    matchQuality: matchQuality(matchedTerms.length, terms.length),
+    whyMatched,
+  };
+}
+
+function matchQuality(
+  matchedTermCount: number,
+  queryTermCount: number,
+): SessionQueryScore["matchQuality"] {
+  if (queryTermCount === 0 || matchedTermCount === 0) return undefined;
+  if (matchedTermCount === queryTermCount) return "all-terms";
+  if (matchedTermCount >= 2) return "strong";
+  return "weak";
+}
+
+function buildSessionBrief(
+  match: SessionQueryMatch,
+  scan: SessionQueryScanSummary | undefined,
+): SessionQueryBrief {
+  const text = normalizeSearch(
+    [match.title, match.firstPrompt, match.project, match.gitBranch].filter(Boolean).join(" "),
+  );
+  const taskType = classifyTaskType(text, match, scan);
+  const signals = sessionSignals(match, scan);
+  return {
+    taskType,
+    summary: briefSummary(taskType, match, scan),
+    signals,
+    suggestedNextAction: suggestedNextAction(taskType, signals, scan),
+  };
+}
+
+function classifyTaskType(
+  text: string,
+  match: SessionQueryMatch,
+  scan: SessionQueryScanSummary | undefined,
+): string {
+  if (/(review|pr|pull request|merge|ai review)/i.test(text) || match.hasPR) return "PR/review";
+  if (/(latest main|branch|current feature|what.*working|做什么feature)/i.test(text)) {
+    return "context recovery";
+  }
+  if (/(skill|dev space|devspaces)/i.test(text)) return "skill workflow";
+  if (/(auth|oauth|login)/i.test(text)) return "auth/debugging";
+  if (/(ci|test|lint|build|e2e)/i.test(text)) return "CI/test";
+  if ((scan?.editCount || 0) > 0 || (match.editCount || 0) > 0) return "implementation";
+  return "research";
+}
+
+function sessionSignals(
+  match: SessionQueryMatch,
+  scan: SessionQueryScanSummary | undefined,
+): string[] {
+  const signals: string[] = [];
+  const promptCount = scan?.promptCount ?? match.promptCount ?? 0;
+  const toolCount = scan?.toolCallCount ?? match.toolCallCount ?? 0;
+  const toolsPerPrompt = scan?.toolCallsPerPrompt;
+
+  if (toolsPerPrompt !== undefined && toolsPerPrompt >= 30) {
+    signals.push(`high tool density (${toolsPerPrompt.toFixed(1)} tools/prompt)`);
+  } else if (promptCount > 0 && toolCount / promptCount >= 20) {
+    signals.push(`high tool density (${Math.round(toolCount / promptCount)} tools/prompt)`);
+  }
+  if (promptCount >= 40) signals.push(`long conversation (${promptCount} prompts)`);
+  if ((scan?.editCount ?? match.editCount ?? 0) >= 50) {
+    signals.push(`heavy editing (${scan?.editCount ?? match.editCount} edits)`);
+  }
+  if ((scan?.filesModified?.length || 0) >= 10) {
+    signals.push(`broad file surface (${scan?.filesModified.length} files in scan summary)`);
+  }
+  if ((scan?.apiErrorCount || 0) > 0) signals.push(`${scan?.apiErrorCount} API errors`);
+  if ((scan?.compactionCount || 0) > 0) signals.push(`${scan?.compactionCount} compactions`);
+  if ((scan?.subAgentCount || 0) > 0) signals.push(`${scan?.subAgentCount} sub-agents`);
+  if (match.matchedTerms?.length) {
+    const quality = match.matchQuality ? `${match.matchQuality} match` : "matched";
+    signals.push(`${quality}: ${match.matchedTerms.join(", ")}`);
+  }
+  if (match.unmatchedTerms?.length) {
+    signals.push(`unmatched: ${match.unmatchedTerms.join(", ")}`);
+  }
+  return signals;
+}
+
+function briefSummary(
+  taskType: string,
+  match: SessionQueryMatch,
+  scan: SessionQueryScanSummary | undefined,
+): string {
+  const title = previewPrompt(match.title || match.firstPrompt || match.slug);
+  if (!scan) return `${taskType} session: ${title}`;
+  return `${taskType} session with ${plural(scan.promptCount, "prompt")}, ${plural(scan.toolCallCount, "tool")}, and ${plural(scan.editCount, "edit")}: ${title}`;
+}
+
+function suggestedNextAction(
+  taskType: string,
+  signals: string[],
+  scan: SessionQueryScanSummary | undefined,
+): string {
+  if (!scan) return "Run again with --scan or --brief before doing a retro.";
+  if (signals.some((signal) => signal.includes("high tool density") || signal.includes("long"))) {
+    return "Generate a replay or inspect chapters; raw metrics suggest a dense session.";
+  }
+  if (taskType === "PR/review")
+    return "Inspect PR links/review comments or generate a PR-focused replay.";
+  if (taskType === "context recovery")
+    return "Use this as evidence for a session-start snapshot feature.";
+  return "Use filePaths for deeper transcript/replay inspection if this is the right candidate.";
+}
+
 function splitTerms(query: string | undefined): string[] {
   return normalizeSearch(query)
     .split(/\s+/)
@@ -203,24 +420,35 @@ function splitTerms(query: string | undefined): string[] {
     .filter(Boolean);
 }
 
-function sessionHaystack(session: SessionInfo): string {
-  return normalizeSearch(
-    [
-      session.provider,
-      session.sessionId,
-      session.slug,
-      session.title,
-      session.project,
-      session.cwd,
-      session.gitBranch,
-      session.model,
-      session.firstPrompt,
-      ...(session.prompts || []),
-      ...(session.fsDetectedFiles || []),
-    ]
+function textMatchesTerm(text: string, term: string): boolean {
+  if (!term) return false;
+  if (/^[a-z0-9]{1,3}$/.test(term)) {
+    return text
+      .split(/[^a-z0-9]+/)
       .filter(Boolean)
-      .join(" "),
-  );
+      .includes(term);
+  }
+  return text.includes(term);
+}
+
+function dedupeSimilarSessions(sessions: SessionInfo[]): SessionInfo[] {
+  const seen = new Set<string>();
+  const deduped: SessionInfo[] = [];
+  for (const session of sessions) {
+    const key = duplicateSessionKey(session);
+    if (key && seen.has(key)) continue;
+    if (key) seen.add(key);
+    deduped.push(session);
+  }
+  return deduped;
+}
+
+function duplicateSessionKey(session: SessionInfo): string | undefined {
+  const prompt = normalizeSearch(cleanPromptText(session.firstPrompt));
+  if (prompt.length >= 60) return `prompt:${prompt.slice(0, 240)}`;
+  const title = normalizeSearch(cleanPromptText(session.title || ""));
+  if (title.length >= 60) return `title:${title.slice(0, 240)}`;
+  return undefined;
 }
 
 function sessionProjectHaystack(session: SessionInfo): string {
@@ -231,6 +459,10 @@ function sessionProjectHaystack(session: SessionInfo): string {
 
 function normalizeSearch(value: string | undefined): string {
   return (value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function plural(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
 }
 
 function normalizeLimit(limit: number | undefined): number {

--- a/packages/cli/test/session-query.test.ts
+++ b/packages/cli/test/session-query.test.ts
@@ -66,6 +66,36 @@ describe("session query", () => {
     expect(result.map((s) => s.sessionId)).toEqual(["newer"]);
   });
 
+  it("can broaden multi-term queries with any-term matching", () => {
+    expect(filterSessionInfos(sessions, { query: "codex auth" })).toHaveLength(0);
+
+    const result = filterSessionInfos(sessions, { query: "codex auth", any: true });
+
+    expect(result.map((s) => s.sessionId)).toEqual(["other-project", "newer"]);
+  });
+
+  it("does not match short acronym terms inside longer words", () => {
+    const result = filterSessionInfos(
+      [
+        session({
+          sessionId: "pricing",
+          slug: "pricing",
+          title: "Cursor model pricing",
+          firstPrompt: "Update model prices",
+        }),
+        session({
+          sessionId: "pr-review",
+          slug: "pr-review",
+          title: "PR review CI followup",
+          firstPrompt: "Review the PR and CI checks",
+        }),
+      ],
+      { query: "PR CI", any: true },
+    );
+
+    expect(result.map((s) => s.sessionId)).toEqual(["pr-review"]);
+  });
+
   it("filters by project and provider, sorted newest first", () => {
     const result = filterSessionInfos(sessions, {
       project: "vibe-replay",
@@ -83,6 +113,89 @@ describe("session query", () => {
     expect(result[0]?.sessionId).toBe("other-project");
     expect(text).toContain("Fix auth flow");
     expect(text).toContain("first prompt: Debug login callback failures");
+  });
+
+  it("adds scored match context and scan-backed briefs", async () => {
+    const result = await queryLocalSessions(sessions, {
+      query: "codex auth",
+      any: true,
+      brief: true,
+      limit: 2,
+    });
+
+    expect(result.map((s) => s.sessionId)).toEqual(["other-project", "newer"]);
+    expect(result[0]?.matchedTerms).toEqual(["auth"]);
+    expect(result[0]?.unmatchedTerms).toEqual(["codex"]);
+    expect(result[0]?.matchQuality).toBe("weak");
+    expect(result[0]?.whyMatched?.[0]).toContain("auth in title");
+    expect(result[0]?.brief?.taskType).toBe("auth/debugging");
+    expect(result[0]?.brief?.suggestedNextAction).toContain("filePaths");
+  });
+
+  it("keeps weak broad matches but makes match quality explicit", async () => {
+    const result = await queryLocalSessions(
+      [
+        session({
+          sessionId: "one-term",
+          title: "Toast fix",
+          firstPrompt: "Make the toast nicer",
+        }),
+        session({
+          sessionId: "two-terms",
+          title: "Toast style loading polish",
+          firstPrompt: "Improve loading toast style",
+        }),
+      ],
+      { query: "toast style loading metrics", any: true, brief: true },
+    );
+
+    expect(result.map((s) => s.sessionId)).toEqual(["two-terms", "one-term"]);
+    expect(result[0]?.matchQuality).toBe("strong");
+    expect(result[0]?.matchedTerms).toEqual(["toast", "style", "loading"]);
+    expect(result[0]?.unmatchedTerms).toEqual(["metrics"]);
+    expect(result[1]?.matchQuality).toBe("weak");
+    expect(result[1]?.matchedTerms).toEqual(["toast"]);
+    expect(result[1]?.unmatchedTerms).toEqual(["style", "loading", "metrics"]);
+  });
+
+  it("keeps explicit any-term matching broad", () => {
+    const result = filterSessionInfos(
+      [
+        session({
+          sessionId: "one-term",
+          title: "Toast style fix",
+          firstPrompt: "Make the toast nicer",
+        }),
+      ],
+      { query: "toast unknown metrics", any: true },
+    );
+
+    expect(result.map((s) => s.sessionId)).toEqual(["one-term"]);
+  });
+
+  it("deduplicates repeated long-prompt sessions when requested", () => {
+    const repeatedPrompt =
+      "https://github.rbx.com/Roblox/skills/pull/162 canonical skill migration decision and sync strategy";
+    const result = filterSessionInfos(
+      [
+        session({
+          sessionId: "newer-copy",
+          title: repeatedPrompt,
+          firstPrompt: repeatedPrompt,
+          timestamp: "2026-05-04T10:00:00Z",
+        }),
+        session({
+          sessionId: "older-copy",
+          title: repeatedPrompt,
+          firstPrompt: repeatedPrompt,
+          project: "/Users/test/Code/other-workspace",
+          timestamp: "2026-05-03T10:00:00Z",
+        }),
+      ],
+      { query: "canonical skill", dedupe: true },
+    );
+
+    expect(result.map((s) => s.sessionId)).toEqual(["newer-copy"]);
   });
 
   it("maps discovery sessions into scanner input", () => {


### PR DESCRIPTION
## Summary
- Splits fuzzy session lookup into explicit `--any`, `--brief`, and `--dedupe` controls instead of presenting it as opaque smart search.
- Adds match evidence (`matchQuality`, matched/unmatched terms, reasons) and scan-backed briefs for agent retros.
- Adds a repeatable local eval harness for session search quality over real local sessions.

## Test plan
- `pnpm --filter vibe-replay test -- session-query.test.ts`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm --filter vibe-replay build`
- `pnpm --filter vibe-replay eval:sessions`


Made with [Cursor](https://cursor.com)