### PR TITLE
Fix Cursor SQLite session path replay

### DIFF
--- a/.cursor/skills/local-session-search/SKILL.md
+++ b/.cursor/skills/local-session-search/SKILL.md
@@ -26,7 +26,7 @@ Do not use this for live dashboard enrichment behavior. Dashboard enrichment is 
 From this repo during development:
 
 ```bash
-pnpm --filter vibe-replay dev -- sessions --query "<terms>" --limit 10 --json
+pnpm --filter vibe-replay dev sessions --query "<terms>" --limit 10 --json
 ```
 
 After building from source:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -448,7 +448,12 @@ program
 
       const info = displayedSessions.find((s) => s.filePath === chosen);
       sessionInfo = info;
-      sessionPaths = info ? [...info.filePaths, ...(info.toolPaths || [])] : [chosen];
+      const sourcePaths = info
+        ? info.filePaths.length > 0
+          ? info.filePaths
+          : [info.filePath]
+        : [chosen];
+      sessionPaths = [...sourcePaths, ...(info?.toolPaths || [])];
       providerName = info?.provider || opts.provider;
     }
 

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -109,6 +109,22 @@ describe("parseCursorSession", () => {
     expect(mockedParseCursorSqlite).toHaveBeenCalledWith("", sessionId);
   });
 
+  it("surfaces sqlite errors for inferred store.db sessions without a transcript fallback", async () => {
+    const sessionId = "ee3500f9-cfc2-4396-a5f2-1b556f8ac573";
+    mockedParseCursorSqlite.mockRejectedValueOnce(new Error("no such table: ItemTable"));
+
+    await expect(
+      parseCursorSession([`/Users/test/.cursor/chats/workspace-hash/${sessionId}/store.db`]),
+    ).rejects.toThrow(/no such table: ItemTable/);
+  });
+
+  it("does not infer arbitrary parent directories as Cursor store.db session IDs", async () => {
+    await expect(parseCursorSession(["/tmp/store.db"])).rejects.toThrow(
+      /requires at least one transcript \.jsonl path/,
+    );
+    expect(mockedParseCursorSqlite).not.toHaveBeenCalled();
+  });
+
   it("falls back to JSONL when sqlite parsing throws", async () => {
     mockedParseCursorSqlite.mockRejectedValueOnce(new Error("no such table: meta"));
 

--- a/packages/cli/src/providers/cursor/parser.test.ts
+++ b/packages/cli/src/providers/cursor/parser.test.ts
@@ -63,6 +63,52 @@ describe("parseCursorSession", () => {
     expect(mockedParseCursorSqlite).toHaveBeenCalledWith("/repo", "sqlite-session");
   });
 
+  it("parses explicit Cursor store.db session paths without discovery metadata", async () => {
+    const sessionId = "ee3500f9-cfc2-4396-a5f2-1b556f8ac573";
+    mockedParseCursorSqlite.mockResolvedValueOnce({
+      sessionId,
+      slug: "ee3500f9",
+      cwd: "",
+      turns: [{ role: "user", blocks: [{ type: "text", text: "hello" }] }],
+      dataSource: "sqlite",
+      dataSourceInfo: {
+        primary: "sqlite",
+        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      },
+    });
+
+    const parsed = await parseCursorSession([
+      `/Users/test/.cursor/chats/workspace-hash/${sessionId}/store.db`,
+    ]);
+
+    expect(parsed.dataSource).toBe("sqlite");
+    expect(parsed.sessionId).toBe(sessionId);
+    expect(mockedParseCursorSqlite).toHaveBeenCalledWith("", sessionId);
+  });
+
+  it("parses explicit Cursor global-state session paths without discovery metadata", async () => {
+    const sessionId = "38bca9d6-9996-498d-b461-f9d8ae4b8cb4";
+    mockedParseCursorSqlite.mockResolvedValueOnce({
+      sessionId,
+      slug: "38bca9d6",
+      cwd: "",
+      turns: [{ role: "user", blocks: [{ type: "text", text: "hello" }] }],
+      dataSource: "global-state",
+      dataSourceInfo: {
+        primary: "global-state",
+        sources: ["cursor/user/globalStorage/state.vscdb"],
+      },
+    });
+
+    const parsed = await parseCursorSession([
+      `/Users/test/Library/Application Support/Cursor/User/globalStorage/state.vscdb#composerData:${sessionId}`,
+    ]);
+
+    expect(parsed.dataSource).toBe("global-state");
+    expect(parsed.sessionId).toBe(sessionId);
+    expect(mockedParseCursorSqlite).toHaveBeenCalledWith("", sessionId);
+  });
+
   it("falls back to JSONL when sqlite parsing throws", async () => {
     mockedParseCursorSqlite.mockRejectedValueOnce(new Error("no such table: meta"));
 

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -39,17 +39,23 @@ export async function parseCursorSession(
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
   const transcriptPaths = paths.filter((p) => p.endsWith(".jsonl"));
   const explicitToolPaths = paths.filter((p) => p.endsWith(".txt"));
+  const inferredSqliteSession = inferCursorSqliteSession(paths);
   let sqliteError: string | undefined;
   let sqliteFallbackNote: string | undefined;
   let sqliteAttempted = false;
 
   // Try SQLite first if session info is available
-  if (sessionInfo?.sessionId) {
+  const sqliteSessionId = sessionInfo?.sessionId || inferredSqliteSession?.sessionId;
+  if (sqliteSessionId) {
     sqliteAttempted = true;
     let sqliteResult: ProviderParseResult | null = null;
     try {
-      const preferredWorkspacePath = sessionInfo.workspacePath || sessionInfo.cwd || "";
-      sqliteResult = await parseCursorSqlite(preferredWorkspacePath, sessionInfo.sessionId);
+      const preferredWorkspacePath =
+        sessionInfo?.workspacePath ||
+        sessionInfo?.cwd ||
+        inferredSqliteSession?.workspacePath ||
+        "";
+      sqliteResult = await parseCursorSqlite(preferredWorkspacePath, sqliteSessionId);
     } catch (err) {
       // Cursor DB schemas can vary across versions/hosts; fall back to JSONL when available.
       sqliteError = compactErrorMessage(err);
@@ -148,6 +154,38 @@ export async function parseCursorSession(
     }
   }
   return jsonlResult;
+}
+
+interface InferredCursorSqliteSession {
+  sessionId: string;
+  workspacePath?: string;
+}
+
+function inferCursorSqliteSession(paths: string[]): InferredCursorSqliteSession | undefined {
+  for (const path of paths) {
+    const sessionId = sessionIdFromGlobalStatePath(path) || sessionIdFromStoreDbPath(path);
+    if (sessionId) return { sessionId };
+  }
+  return undefined;
+}
+
+function sessionIdFromGlobalStatePath(path: string): string | undefined {
+  const marker = "#composerData:";
+  const markerIndex = path.indexOf(marker);
+  if (markerIndex < 0) return undefined;
+  const rawSessionId = path
+    .slice(markerIndex + marker.length)
+    .split(/[/?#]/, 1)[0]
+    ?.trim();
+  return rawSessionId || undefined;
+}
+
+function sessionIdFromStoreDbPath(path: string): string | undefined {
+  const normalized = path.replaceAll("\\", "/");
+  const parts = normalized.split("/");
+  if (parts.at(-1) !== "store.db") return undefined;
+  const rawSessionId = parts.at(-2)?.trim();
+  return rawSessionId || undefined;
 }
 
 async function tryLoadSdkEnrichment(sessionId: string): Promise<SdkAgentEnrichment | null> {

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -21,6 +21,8 @@ import {
   parseCursorSqlite,
 } from "./sqlite-reader.js";
 
+const CURSOR_UUID_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function toErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
   return String(err);
@@ -50,11 +52,7 @@ export async function parseCursorSession(
     sqliteAttempted = true;
     let sqliteResult: ProviderParseResult | null = null;
     try {
-      const preferredWorkspacePath =
-        sessionInfo?.workspacePath ||
-        sessionInfo?.cwd ||
-        inferredSqliteSession?.workspacePath ||
-        "";
+      const preferredWorkspacePath = sessionInfo?.workspacePath || sessionInfo?.cwd || "";
       sqliteResult = await parseCursorSqlite(preferredWorkspacePath, sqliteSessionId);
     } catch (err) {
       // Cursor DB schemas can vary across versions/hosts; fall back to JSONL when available.
@@ -156,12 +154,7 @@ export async function parseCursorSession(
   return jsonlResult;
 }
 
-interface InferredCursorSqliteSession {
-  sessionId: string;
-  workspacePath?: string;
-}
-
-function inferCursorSqliteSession(paths: string[]): InferredCursorSqliteSession | undefined {
+function inferCursorSqliteSession(paths: string[]): { sessionId: string } | undefined {
   for (const path of paths) {
     const sessionId = sessionIdFromGlobalStatePath(path) || sessionIdFromStoreDbPath(path);
     if (sessionId) return { sessionId };
@@ -185,7 +178,8 @@ function sessionIdFromStoreDbPath(path: string): string | undefined {
   const parts = normalized.split("/");
   if (parts.at(-1) !== "store.db") return undefined;
   const rawSessionId = parts.at(-2)?.trim();
-  return rawSessionId || undefined;
+  if (!rawSessionId || !CURSOR_UUID_SESSION_ID_RE.test(rawSessionId)) return undefined;
+  return rawSessionId;
 }
 
 async function tryLoadSdkEnrichment(sessionId: string): Promise<SdkAgentEnrichment | null> {


### PR DESCRIPTION
## Summary
- Allow explicit Cursor `store.db` and `state.vscdb#composerData:<id>` session paths to replay without discovery metadata.
- Preserve SQLite/global-state representative file paths when selecting sessions from the CLI picker.
- Fix the local session-search skill's dev command so `sessions` receives its arguments.

## Test plan
- `pnpm --filter vibe-replay test src/providers/cursor/parser.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm --filter vibe-replay build`
- `pnpm lint:check`
- Smoke-tested a real old Cursor `store.db` export via `vibe-replay --provider cursor --session ... --github`

Made with [Cursor](https://cursor.com)