### PR TITLE
Improve Cursor live diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm db:migrate:remote    # Apply to production D1 (requires auth)
 - **`</` escaping**: JSON in `<script>` tags MUST escape `</` as `<\/` — browsers close the tag otherwise (see `generator.ts`)
 - **`lastIndexOf("</head>")`**: Use `lastIndexOf`, not `indexOf` — minified JS in the viewer bundle may contain the string `</head>`
 - **Shared types**: `Scene`, `Annotation`, `DataSourceInfo`, `ReplaySession` live in `packages/types` (`@vibe-replay/types`). CLI and viewer re-export from there. Provider-specific and viewer-specific types remain in their respective packages.
-- **Viewer size limit**: Keep under 1MB after build. This is why we use `marked` instead of `react-markdown`. Watch for size regressions when adding features.
+- **Viewer size limit**: Keep under 1MB after build (current build is ~825KB). This is why we use `marked` instead of `react-markdown`. Watch for size regressions when adding features.
 - **Self-contained HTML**: Output must make zero external requests. Everything inlined.
 - **Multi-file sessions**: Claude Code `/resume` creates new JSONL files. Parser accepts `string | string[]` and merges by slug+project.
 - **Cursor tri-source**: Sessions come from SQLite `store.db` (primary), `globalStorage/state.vscdb`, or JSONL (fallback). Discovery merges all sources. DB data is source of truth; JSONL supplements missing thinking/images.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pnpm db:migrate:remote    # Apply to production D1 (requires auth)
 - **`</` escaping**: JSON in `<script>` tags MUST escape `</` as `<\/` — browsers close the tag otherwise (see `generator.ts`)
 - **`lastIndexOf("</head>")`**: Use `lastIndexOf`, not `indexOf` — minified JS in the viewer bundle may contain the string `</head>`
 - **Shared types**: `Scene`, `Annotation`, `DataSourceInfo`, `ReplaySession` live in `packages/types` (`@vibe-replay/types`). CLI and viewer re-export from there. Provider-specific and viewer-specific types remain in their respective packages.
-- **Viewer size limit**: Keep under 800KB after build. This is why we use `marked` instead of `react-markdown`. Watch for size regressions when adding features.
+- **Viewer size limit**: Keep under 1MB after build. This is why we use `marked` instead of `react-markdown`. Watch for size regressions when adding features.
 - **Self-contained HTML**: Output must make zero external requests. Everything inlined.
 - **Multi-file sessions**: Claude Code `/resume` creates new JSONL files. Parser accepts `string | string[]` and merges by slug+project.
 - **Cursor tri-source**: Sessions come from SQLite `store.db` (primary), `globalStorage/state.vscdb`, or JSONL (fallback). Discovery merges all sources. DB data is source of truth; JSONL supplements missing thinking/images.

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -93,6 +93,43 @@ describe("cursor sqlite metrics helpers", () => {
     expect(calls).toBe(2);
   });
 
+  it("builds live diagnostics signatures from session rows, not WAL probe metadata", () => {
+    const base = {
+      source: "global-state" as const,
+      probedAt: "2026-01-01T00:00:00.000Z",
+      dbPath: "/tmp/state.vscdb",
+      dbMtimeMs: 1,
+      walMtimeMs: 2,
+      walSize: 3,
+      composerBytes: 100,
+      headerCount: 2,
+      latestBubbleId: "bubble-1",
+      latestBubbleCreatedAt: "2026-01-01T00:00:01.000Z",
+      bubbleCount: 2,
+      toolCallCount: 1,
+      toolResultCount: 0,
+      pendingToolCount: 1,
+      maxBubbleBytes: 80,
+      totalBubbleBytes: 120,
+    };
+
+    expect(
+      __testables.cursorLiveDiagnosticsSignature({
+        ...base,
+        probedAt: "2026-01-01T00:00:10.000Z",
+        walMtimeMs: 999,
+        walSize: 999,
+      }),
+    ).toBe(__testables.cursorLiveDiagnosticsSignature(base));
+    expect(
+      __testables.cursorLiveDiagnosticsSignature({
+        ...base,
+        toolResultCount: 1,
+        pendingToolCount: 0,
+      }),
+    ).not.toBe(__testables.cursorLiveDiagnosticsSignature(base));
+  });
+
   it("computes token increments from cumulative snapshots", () => {
     const first = __testables.estimateTokenIncrement(
       {

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -102,6 +102,7 @@ describe("cursor sqlite metrics helpers", () => {
       walMtimeMs: 2,
       walSize: 3,
       composerBytes: 100,
+      composerLastUpdatedAt: "2026-01-01T00:00:00.000Z",
       headerCount: 2,
       latestBubbleId: "bubble-1",
       latestBubbleCreatedAt: "2026-01-01T00:00:01.000Z",
@@ -126,6 +127,12 @@ describe("cursor sqlite metrics helpers", () => {
         ...base,
         toolResultCount: 1,
         pendingToolCount: 0,
+      }),
+    ).not.toBe(__testables.cursorLiveDiagnosticsSignature(base));
+    expect(
+      __testables.cursorLiveDiagnosticsSignature({
+        ...base,
+        composerLastUpdatedAt: "2026-01-01T00:00:02.000Z",
       }),
     ).not.toBe(__testables.cursorLiveDiagnosticsSignature(base));
   });

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -85,6 +85,7 @@ interface GlobalStateDiscoveryCache {
 }
 
 export interface CursorLiveDiagnostics {
+  // Keep in sync with LiveCursorDiagnostics in packages/viewer/src/hooks/useSessionLoader.ts.
   source: "global-state";
   signature: string;
   probedAt: string;
@@ -551,6 +552,7 @@ export async function readCursorLiveDiagnostics(
   const latest = latestBubbleId
     ? bubbleRowsByKey.get(`bubbleId:${sessionId}:${latestBubbleId}`) || {}
     : {};
+  const latestToolName = valueToString(latest.toolName).trim();
   let toolCallCount = 0;
   let toolResultCount = 0;
   let pendingToolCount = 0;
@@ -593,11 +595,9 @@ export async function readCursorLiveDiagnostics(
     ...(valueToString(latest.text).trim()
       ? { latestTextPreview: valueToString(latest.text).replace(/\s+/g, " ").trim().slice(0, 160) }
       : {}),
-    ...(valueToString(latest.toolName).trim()
-      ? { latestToolName: valueToString(latest.toolName) }
-      : {}),
-    ...(latest.toolHasResult !== undefined
-      ? { latestToolHasResult: Boolean(Number(latest.toolHasResult)) }
+    ...(latestToolName ? { latestToolName } : {}),
+    ...(latestToolName && latest.toolHasResult !== undefined
+      ? { latestToolHasResult: Number(latest.toolHasResult) !== 0 }
       : {}),
     ...(latest.toolResultLength !== null && latest.toolResultLength !== undefined
       ? { latestToolResultLength: toNonNegativeInt(latest.toolResultLength) }
@@ -624,6 +624,7 @@ function cursorLiveDiagnosticsSignature(
     diagnostics.toolResultCount,
     diagnostics.pendingToolCount,
     diagnostics.composerBytes,
+    diagnostics.composerLastUpdatedAt || "",
     diagnostics.latestBubbleId || "",
     diagnostics.latestBubbleCreatedAt || "",
     diagnostics.latestBubbleUpdatedAt || "",

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -84,6 +84,33 @@ interface GlobalStateDiscoveryCache {
   sessionIds: string[];
 }
 
+export interface CursorLiveDiagnostics {
+  source: "global-state";
+  signature: string;
+  probedAt: string;
+  dbPath: string;
+  dbMtimeMs: number;
+  walMtimeMs: number;
+  walSize: number;
+  composerBytes: number;
+  headerCount: number;
+  composerLastUpdatedAt?: string;
+  latestBubbleId?: string;
+  latestBubbleCreatedAt?: string;
+  latestBubbleUpdatedAt?: string;
+  latestBubbleType?: number;
+  latestTextPreview?: string;
+  latestToolName?: string;
+  latestToolHasResult?: boolean;
+  latestToolResultLength?: number;
+  bubbleCount: number;
+  toolCallCount: number;
+  toolResultCount: number;
+  pendingToolCount: number;
+  maxBubbleBytes: number;
+  totalBubbleBytes: number;
+}
+
 let cachedGlobalStateDb: CachedGlobalStateDb | null = null;
 
 // Releasing a sql.js Database can throw if the underlying memory was already
@@ -465,6 +492,146 @@ export async function resolveCursorLiveWatchPaths(sessionId: string): Promise<st
   }
 
   return [...paths];
+}
+
+export async function readCursorLiveDiagnostics(
+  sessionId: string,
+): Promise<CursorLiveDiagnostics | null> {
+  const globalStateDb = await openGlobalStateDb();
+  if (!globalStateDb || !(await hasGlobalStateSession(globalStateDb, sessionId))) return null;
+
+  const rawComposer = await queryGlobalStateTextValue(globalStateDb, `composerData:${sessionId}`);
+  const composer = parseJson<Record<string, any>>(rawComposer || "");
+  if (!composer) return null;
+
+  const headerBubbleIds = Array.isArray(composer.fullConversationHeadersOnly)
+    ? composer.fullConversationHeadersOnly
+        .map((header: any) =>
+          header && typeof header === "object" && typeof header.bubbleId === "string"
+            ? header.bubbleId
+            : "",
+        )
+        .filter(Boolean)
+    : Array.isArray(composer.conversation)
+      ? composer.conversation
+          .map((item: any) =>
+            item && typeof item === "object" && typeof item.bubbleId === "string"
+              ? item.bubbleId
+              : "",
+          )
+          .filter(Boolean)
+      : [];
+  const latestBubbleId = headerBubbleIds[headerBubbleIds.length - 1];
+
+  const bubbleRows: Record<string, any>[] = [];
+  const bubbleKeys = headerBubbleIds.map((bubbleId) => `bubbleId:${sessionId}:${bubbleId}`);
+  for (let i = 0; i < bubbleKeys.length; i += GLOBAL_STATE_BUBBLE_KEY_CHUNK_SIZE) {
+    const chunk = bubbleKeys.slice(i, i + GLOBAL_STATE_BUBBLE_KEY_CHUNK_SIZE);
+    bubbleRows.push(
+      ...(await queryGlobalStateRows(
+        globalStateDb,
+        [
+          "SELECT",
+          "key,",
+          "length(value) AS bytes,",
+          "json_extract(value,'$.type') AS type,",
+          "json_extract(value,'$.text') AS text,",
+          "json_extract(value,'$.createdAt') AS createdAt,",
+          "json_extract(value,'$.lastUpdatedAt') AS lastUpdatedAt,",
+          "json_extract(value,'$.toolFormerData.name') AS toolName,",
+          "json_extract(value,'$.toolFormerData.result') IS NOT NULL AS toolHasResult,",
+          "length(json_extract(value,'$.toolFormerData.result')) AS toolResultLength",
+          "FROM cursorDiskKV",
+          `WHERE key IN (${chunk.map(sqlString).join(",")}) AND json_valid(value)`,
+        ].join(" "),
+      )),
+    );
+  }
+  const bubbleRowsByKey = new Map(bubbleRows.map((row) => [valueToString(row.key), row]));
+  const latest = latestBubbleId
+    ? bubbleRowsByKey.get(`bubbleId:${sessionId}:${latestBubbleId}`) || {}
+    : {};
+  let toolCallCount = 0;
+  let toolResultCount = 0;
+  let pendingToolCount = 0;
+  let maxBubbleBytes = 0;
+  let totalBubbleBytes = 0;
+  for (const row of bubbleRows) {
+    const bytes = toNonNegativeInt(row.bytes);
+    maxBubbleBytes = Math.max(maxBubbleBytes, bytes);
+    totalBubbleBytes += bytes;
+    if (!valueToString(row.toolName)) continue;
+    toolCallCount++;
+    if (Number(row.toolHasResult)) {
+      toolResultCount++;
+    } else {
+      pendingToolCount++;
+    }
+  }
+  const wal = await globalStateWalFingerprint(globalStateDb.dbPath);
+
+  const diagnostics: CursorLiveDiagnostics = {
+    source: "global-state",
+    probedAt: new Date().toISOString(),
+    dbPath: globalStateDb.dbPath,
+    dbMtimeMs: Math.round(globalStateDb.mtimeMs),
+    walMtimeMs: Math.round(wal.walMtimeMs),
+    walSize: Math.round(wal.walSize),
+    composerBytes: rawComposer ? Buffer.byteLength(rawComposer, "utf-8") : 0,
+    headerCount: headerBubbleIds.length,
+    ...(toIsoTimestamp(composer.lastUpdatedAt)
+      ? { composerLastUpdatedAt: toIsoTimestamp(composer.lastUpdatedAt) }
+      : {}),
+    ...(latestBubbleId ? { latestBubbleId } : {}),
+    ...(toIsoTimestamp(latest.createdAt)
+      ? { latestBubbleCreatedAt: toIsoTimestamp(latest.createdAt) }
+      : {}),
+    ...(toIsoTimestamp(latest.lastUpdatedAt)
+      ? { latestBubbleUpdatedAt: toIsoTimestamp(latest.lastUpdatedAt) }
+      : {}),
+    ...(typeof latest.type === "number" ? { latestBubbleType: latest.type } : {}),
+    ...(valueToString(latest.text).trim()
+      ? { latestTextPreview: valueToString(latest.text).replace(/\s+/g, " ").trim().slice(0, 160) }
+      : {}),
+    ...(valueToString(latest.toolName).trim()
+      ? { latestToolName: valueToString(latest.toolName) }
+      : {}),
+    ...(latest.toolHasResult !== undefined
+      ? { latestToolHasResult: Boolean(Number(latest.toolHasResult)) }
+      : {}),
+    ...(latest.toolResultLength !== null && latest.toolResultLength !== undefined
+      ? { latestToolResultLength: toNonNegativeInt(latest.toolResultLength) }
+      : {}),
+    bubbleCount: bubbleRows.length,
+    toolCallCount,
+    toolResultCount,
+    pendingToolCount,
+    maxBubbleBytes,
+    totalBubbleBytes,
+    signature: "",
+  };
+  diagnostics.signature = cursorLiveDiagnosticsSignature(diagnostics);
+  return diagnostics;
+}
+
+function cursorLiveDiagnosticsSignature(
+  diagnostics: Omit<CursorLiveDiagnostics, "signature">,
+): string {
+  return [
+    diagnostics.headerCount,
+    diagnostics.bubbleCount,
+    diagnostics.toolCallCount,
+    diagnostics.toolResultCount,
+    diagnostics.pendingToolCount,
+    diagnostics.composerBytes,
+    diagnostics.latestBubbleId || "",
+    diagnostics.latestBubbleCreatedAt || "",
+    diagnostics.latestBubbleUpdatedAt || "",
+    diagnostics.latestToolName || "",
+    diagnostics.latestToolHasResult ? "1" : "0",
+    diagnostics.latestToolResultLength ?? "",
+    diagnostics.totalBubbleBytes,
+  ].join("|");
 }
 
 export async function listStoreDbSessionIds(forceRefresh = false): Promise<Set<string>> {
@@ -3133,5 +3300,6 @@ export const __testables = {
   parseUserContent,
   projectedCursorBubbleRowToBubble,
   projectedCursorBubbleSelectSql,
+  cursorLiveDiagnosticsSignature,
   sqlKeyPrefixRange,
 };

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -35,7 +35,10 @@ import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { parseCodexLines } from "./providers/codex/parser.js";
-import { resolveCursorLiveWatchPaths } from "./providers/cursor/sqlite-reader.js";
+import {
+  readCursorLiveDiagnostics,
+  resolveCursorLiveWatchPaths,
+} from "./providers/cursor/sqlite-reader.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   getApiUrl,
@@ -1609,6 +1612,7 @@ export async function startServer(
       let inFlight = false;
       let dirty = false;
       let lastSignature: string | null = null;
+      let lastCursorDiagnosticsSignature: string | null = null;
       // Live session state (busy / idle / stopped / unknown) — populated
       // from `~/.claude/sessions/<pid>.json` for Claude. Other providers
       // don't write that file, so they get "unknown" and the viewer keeps
@@ -1767,6 +1771,24 @@ export async function startServer(
           // silently go stale.
           ensureWatchersFor(paths);
           await ensureCursorDbWatchersFor(info);
+          const cursorDiagnostics =
+            isCursorProvider && info.hasSqlite
+              ? await readCursorLiveDiagnostics(info.sessionId).catch(() => null)
+              : null;
+          if (
+            cursorDiagnostics &&
+            lastCursorDiagnosticsSignature === cursorDiagnostics.signature &&
+            lastSignature !== null
+          ) {
+            await stream.writeSSE({
+              data: JSON.stringify({
+                type: "diagnostics",
+                cursorDiagnostics,
+                cursorRowsChanged: false,
+              }),
+            });
+            return;
+          }
           let parsed;
           if (isJsonlLiveProvider) {
             // Tail-based fast path. Concat already-cached lines from every
@@ -1811,6 +1833,9 @@ export async function startServer(
             lastLiveState = await readClaudeSessionState(sessionId);
           }
           const signature = JSON.stringify(replay.scenes);
+          if (cursorDiagnostics) {
+            lastCursorDiagnosticsSignature = cursorDiagnostics.signature;
+          }
           if (signature !== lastSignature) {
             lastSignature = signature;
             await stream.writeSSE({
@@ -1818,6 +1843,15 @@ export async function startServer(
                 type: "session",
                 session: replay,
                 state: lastLiveState,
+                ...(cursorDiagnostics ? { cursorDiagnostics, cursorRowsChanged: true } : {}),
+              }),
+            });
+          } else if (cursorDiagnostics) {
+            await stream.writeSSE({
+              data: JSON.stringify({
+                type: "diagnostics",
+                cursorDiagnostics,
+                cursorRowsChanged: true,
               }),
             });
           }

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -493,8 +493,12 @@ function LiveStateCard({
           {latestAge ? ` · durable ${latestAge}` : ""}
         </div>
         <div className="text-[9px] font-mono text-terminal-dimmer mt-1 tracking-wide">
-          {cursorDiagnostics.bubbleCount} bubbles · {cursorDiagnostics.toolResultCount}/
-          {cursorDiagnostics.toolCallCount} tool results · {rowState}
+          {cursorDiagnostics.bubbleCount} bubbles
+          {cursorDiagnostics.toolCallCount > 0
+            ? ` · ${cursorDiagnostics.toolResultCount}/${cursorDiagnostics.toolCallCount} tool results`
+            : ""}
+          {" · "}
+          {rowState}
           {probeAge ? ` · probed ${probeAge}` : ""}
         </div>
       </div>
@@ -561,7 +565,8 @@ function formatCompactAge(iso?: string): string {
   if (!Number.isFinite(ms) || ms < 0) return "";
   if (ms < 60_000) return `${Math.max(1, Math.round(ms / 1000))}s ago`;
   if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
-  return `${Math.round(ms / 3_600_000)}h ago`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h ago`;
+  return `${Math.round(ms / 86_400_000)}d ago`;
 }
 
 function TimeGapIndicator({ gapMs }: { gapMs: number }) {

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import type { OverlayActions } from "../hooks/useOverlays";
+import type { LiveCursorDiagnostics } from "../hooks/useSessionLoader";
 import type { EffectivePrefs } from "../hooks/useViewPrefs";
 import type { Scene, TurnStat } from "../types";
 import { displayToolName } from "../utils/toolName";
@@ -32,6 +33,9 @@ interface Props {
    *  - unknown: non-Claude provider, no metadata file → fall back to BUSY UX.
    *  Only consulted when `isLive` is true. */
   liveSessionState?: "busy" | "idle" | "stopped" | "unknown";
+  liveCursorDiagnostics?: LiveCursorDiagnostics;
+  liveCursorRowsChanged?: boolean;
+  liveCursorProbeAt?: number;
 }
 
 interface TurnGroup {
@@ -77,6 +81,9 @@ export default function ConversationView({
   turnStats,
   isLive,
   liveSessionState,
+  liveCursorDiagnostics,
+  liveCursorRowsChanged,
+  liveCursorProbeAt,
 }: Props & { onSeek?: (index: number) => void }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [activeStickyPrompt, setActiveStickyPrompt] = useState<StickyPromptSummary | null>(null);
@@ -397,7 +404,12 @@ export default function ConversationView({
         )}
 
         {visibleCount >= scenes.length && isLive && (
-          <LiveStateCard sessionState={liveSessionState} />
+          <LiveStateCard
+            cursorDiagnostics={liveCursorDiagnostics}
+            cursorRowsChanged={liveCursorRowsChanged}
+            cursorProbeAt={liveCursorProbeAt}
+            sessionState={liveSessionState}
+          />
         )}
       </div>
     </div>
@@ -440,11 +452,54 @@ function ActiveStickyPrompt({ prompt }: { prompt: StickyPromptSummary | null }) 
  *                         (Cursor / Codex etc.) where we can't tell.
  */
 function LiveStateCard({
+  cursorDiagnostics,
+  cursorRowsChanged,
+  cursorProbeAt,
   sessionState,
 }: {
+  cursorDiagnostics?: LiveCursorDiagnostics;
+  cursorRowsChanged?: boolean;
+  cursorProbeAt?: number;
   sessionState?: "busy" | "idle" | "stopped" | "unknown";
 }) {
   const effective = sessionState ?? "busy";
+
+  if (effective === "unknown" && cursorDiagnostics) {
+    const latestAt =
+      cursorDiagnostics.latestBubbleUpdatedAt ||
+      cursorDiagnostics.latestBubbleCreatedAt ||
+      cursorDiagnostics.composerLastUpdatedAt;
+    const latestAge = formatCompactAge(latestAt);
+    const probeAge = cursorProbeAt ? formatCompactAge(new Date(cursorProbeAt).toISOString()) : "";
+    const latestLabel = cursorDiagnostics.latestToolName
+      ? `${displayToolName(cursorDiagnostics.latestToolName)} ${
+          cursorDiagnostics.latestToolHasResult ? "result persisted" : "waiting for result"
+        }`
+      : cursorDiagnostics.latestTextPreview
+        ? "assistant text persisted"
+        : "session rows persisted";
+    const rowState = cursorRowsChanged === false ? "db event, rows unchanged" : "rows updated";
+    return (
+      <div className="pt-10 pb-24 flex flex-col items-center justify-center select-none">
+        <div className="h-px w-8 bg-terminal-border-subtle mb-5" />
+        <div className="flex items-center gap-2.5 px-3 py-1.5 rounded-full bg-terminal-blue-subtle/40 border border-terminal-blue/20">
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-terminal-blue" />
+          <span className="text-[10px] font-mono font-bold text-terminal-blue uppercase tracking-[0.25em]">
+            Cursor Live
+          </span>
+        </div>
+        <div className="text-[9px] font-mono text-terminal-dimmer mt-3 tracking-wide">
+          {latestLabel}
+          {latestAge ? ` · durable ${latestAge}` : ""}
+        </div>
+        <div className="text-[9px] font-mono text-terminal-dimmer mt-1 tracking-wide">
+          {cursorDiagnostics.bubbleCount} bubbles · {cursorDiagnostics.toolResultCount}/
+          {cursorDiagnostics.toolCallCount} tool results · {rowState}
+          {probeAge ? ` · probed ${probeAge}` : ""}
+        </div>
+      </div>
+    );
+  }
 
   if (effective === "stopped") {
     return (
@@ -498,6 +553,15 @@ function LiveStateCard({
       </div>
     </div>
   );
+}
+
+function formatCompactAge(iso?: string): string {
+  if (!iso) return "";
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 60_000) return `${Math.max(1, Math.round(ms / 1000))}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  return `${Math.round(ms / 3_600_000)}h ago`;
 }
 
 function TimeGapIndicator({ gapMs }: { gapMs: number }) {

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -804,6 +804,9 @@ export default function Player({
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
                     isLive={isLive}
+                    liveCursorDiagnostics={live?.cursorDiagnostics}
+                    liveCursorProbeAt={live?.lastCursorProbe}
+                    liveCursorRowsChanged={live?.cursorRowsChanged}
                     liveSessionState={live?.sessionState}
                     onComment={
                       isReadOnly

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -31,6 +31,39 @@ export interface LiveStatus {
    * the existing always-live UI rather than misreporting "stopped".
    */
   sessionState?: "busy" | "idle" | "stopped" | "unknown";
+  /** Cursor-specific row-level probe of the durable SQLite/global-state source. */
+  cursorDiagnostics?: LiveCursorDiagnostics;
+  /** True when the latest Cursor probe changed session rows; false when only a DB/WAL event fired. */
+  cursorRowsChanged?: boolean;
+  /** Time of the last Cursor diagnostics probe received by the viewer. */
+  lastCursorProbe?: number;
+}
+
+export interface LiveCursorDiagnostics {
+  source: "global-state";
+  signature: string;
+  probedAt: string;
+  dbPath: string;
+  dbMtimeMs: number;
+  walMtimeMs: number;
+  walSize: number;
+  composerBytes: number;
+  headerCount: number;
+  composerLastUpdatedAt?: string;
+  latestBubbleId?: string;
+  latestBubbleCreatedAt?: string;
+  latestBubbleUpdatedAt?: string;
+  latestBubbleType?: number;
+  latestTextPreview?: string;
+  latestToolName?: string;
+  latestToolHasResult?: boolean;
+  latestToolResultLength?: number;
+  bubbleCount: number;
+  toolCallCount: number;
+  toolResultCount: number;
+  pendingToolCount: number;
+  maxBubbleBytes: number;
+  totalBubbleBytes: number;
 }
 
 interface LoadResult {
@@ -176,6 +209,8 @@ function startLiveStream(
       session?: ReplaySession;
       message?: string;
       state?: LiveStatus["sessionState"];
+      cursorDiagnostics?: LiveCursorDiagnostics;
+      cursorRowsChanged?: boolean;
     };
     try {
       payload = JSON.parse(ev.data);
@@ -190,6 +225,18 @@ function startLiveStream(
         lastUpdate: Date.now(),
         error: undefined,
         sessionState: payload.state ?? liveStatus.sessionState,
+        cursorDiagnostics: payload.cursorDiagnostics ?? liveStatus.cursorDiagnostics,
+        cursorRowsChanged: payload.cursorRowsChanged ?? liveStatus.cursorRowsChanged,
+        lastCursorProbe: payload.cursorDiagnostics ? Date.now() : liveStatus.lastCursorProbe,
+      };
+      emit();
+    } else if (payload.type === "diagnostics" && payload.cursorDiagnostics) {
+      liveStatus = {
+        ...liveStatus,
+        state: "open",
+        cursorDiagnostics: payload.cursorDiagnostics,
+        cursorRowsChanged: payload.cursorRowsChanged,
+        lastCursorProbe: Date.now(),
       };
       emit();
     } else if (payload.type === "state" && payload.state) {

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -40,6 +40,7 @@ export interface LiveStatus {
 }
 
 export interface LiveCursorDiagnostics {
+  // Keep in sync with CursorLiveDiagnostics in packages/cli/src/providers/cursor/sqlite-reader.ts.
   source: "global-state";
   signature: string;
   probedAt: string;


### PR DESCRIPTION
## Summary
- Add Cursor live row diagnostics so WAL-only noise can skip full replay parsing.
- Surface Cursor durable row/tool status in the live trailing card.
- Raise the documented self-contained viewer size target to 1MB.

## Test plan
- pnpm --filter vibe-replay test src/providers/cursor/sqlite-reader.test.ts test/server-generate.test.ts
- pnpm exec tsc --noEmit --pretty false (packages/cli)
- pnpm lint:check
- pnpm build
- Live SSE smoke test against an active Cursor session


Made with [Cursor](https://cursor.com)