### PR TITLE
Add Windows support + harden dashboard against transient fetch failures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize line endings to LF on checkout for every platform.
+# Without this, Windows clones (core.autocrlf=true) get CRLF working trees,
+# which makes oxfmt --check fail on every file. eol=lf overrides autocrlf.
+* text=auto eol=lf
+
+# Explicitly mark binary assets so they are never line-ending normalized.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.wasm binary
+*.mp4 binary
+*.mov binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ pnpm db:migrate:remote    # Apply to production D1 (requires auth)
 - **Skip `progress` lines**: These are subagent streaming artifacts in JSONL.
 - **sql.js (WASM)**: Used instead of native SQLite bindings for portability — no C++ compiler needed.
 - **Session discovery cache**: CLI picker + local dashboard use file cache at `~/.vibe-replay/cache/*.json` (stale-while-refresh UX). Cache validity is tied to CLI release version (`CLI_VERSION`) plus envelope version, so caches auto-invalidate across releases. Keep cache writes best-effort and never block generation/parsing on cache failures.
+- **Windows support**: Cursor encodes workspace dirs as `C:\a\b` → `C-a-b` (drive colon dropped, separators → `-`); `decodeProjectDir` has a `win32` branch that resolves these against the real filesystem (POSIX uses `/` root, Windows uses the drive root). Cursor on Windows stores IDE chats only in the `globalStorage/state.vscdb` under `%APPDATA%\Cursor` (there is no `~/.cursor/chats` dir). Replay output normalizes file paths to `/` for cross-platform display via `redactFilePath` in `transform.ts` — never apply that to prose. Build scripts shell out to `scripts/copy-file.mjs` instead of `mkdir -p`/`cp` (not available in PowerShell). `.gitattributes` forces `eol=lf` so Windows clones don't trip `oxfmt --check` with CRLF.
 
 ## Rules
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/tuo-lei/vibe-replay"
   },
   "scripts": {
-    "build": "pnpm --filter @vibe-replay/viewer build && mkdir -p packages/cli/assets && cp packages/viewer/dist/index.html packages/cli/assets/viewer.html && pnpm --filter vibe-replay build",
-    "build:website": "pnpm --filter @vibe-replay/viewer build && mkdir -p website/public/view && cp packages/viewer/dist/index.html website/public/view/index.html && pnpm --filter @vibe-replay/website build",
+    "build": "pnpm --filter @vibe-replay/viewer build && node scripts/copy-file.mjs packages/viewer/dist/index.html packages/cli/assets/viewer.html && pnpm --filter vibe-replay build",
+    "build:website": "pnpm --filter @vibe-replay/viewer build && node scripts/copy-file.mjs packages/viewer/dist/index.html website/public/view/index.html && pnpm --filter @vibe-replay/website build",
     "start": "pnpm build && node packages/cli/dist/index.js",
     "dev": "node scripts/dev.mjs",
     "dev:menu": "node scripts/dev.mjs --menu",

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -9,9 +9,28 @@
  * Experimental feature — output quality depends on the model behind the CLI.
  */
 
-import { spawn } from "node:child_process";
+import { type ChildProcessByStdio, spawn, type SpawnOptions } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import type { Readable, Writable } from "node:stream";
 import type { Annotation, OverlaySource, ReplaySession, Scene, SceneOverlay } from "./types.js";
+
+const IS_WINDOWS = process.platform === "win32";
+
+type PipedChild = ChildProcessByStdio<Writable, Readable, Readable>;
+
+/**
+ * Spawn an external AI CLI cross-platform. On Windows these tools are installed
+ * as `.cmd`/`.ps1` shims that `spawn()` cannot exec directly, so route through
+ * the shell (quoting the command path, which may contain spaces). All callers
+ * use piped stdio, so the return is typed as a fully-piped child process.
+ */
+function spawnTool(command: string, args: string[], options: SpawnOptions): PipedChild {
+  if (IS_WINDOWS) {
+    const quoted = /\s/.test(command) ? `"${command}"` : command;
+    return spawn(quoted, args, { ...options, shell: true }) as PipedChild;
+  }
+  return spawn(command, args, options) as PipedChild;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,8 +100,8 @@ export async function detectFeedbackTools(): Promise<{
   const tools: FeedbackTool[] = [];
   for (const tool of candidates) {
     try {
-      const path = await shell(`which ${tool.cmd}`);
-      if (path.trim()) tools.push({ name: tool.name, command: path.trim() });
+      const located = await locateCommand(tool.cmd);
+      if (located) tools.push({ name: tool.name, command: located });
     } catch {
       /* not found */
     }
@@ -357,7 +376,7 @@ async function executeFeedback(prompt: string, tool: FeedbackTool): Promise<stri
 
 function runClaude(prompt: string, cmd: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, ["-p", "--output-format", "json"], {
+    const proc = spawnTool(cmd, ["-p", "--output-format", "json"], {
       env: { ...process.env, NO_COLOR: "1" },
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -391,7 +410,7 @@ function runClaude(prompt: string, cmd: string): Promise<string> {
 function runOpencode(prompt: string, cmd: string): Promise<string> {
   return new Promise((resolve, reject) => {
     // Use stdin pipe: opencode reads from stdin when run without message args
-    const proc = spawn(cmd, ["run"], {
+    const proc = spawnTool(cmd, ["run"], {
       env: { ...process.env, NO_COLOR: "1", TERM: "dumb" },
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -419,7 +438,7 @@ function runOpencode(prompt: string, cmd: string): Promise<string> {
 
 function runAgent(prompt: string, cmd: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, ["-p", "--output-format", "json", "--mode", "ask", "--trust"], {
+    const proc = spawnTool(cmd, ["-p", "--output-format", "json", "--mode", "ask", "--trust"], {
       env: { ...process.env, NO_COLOR: "1" },
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -1280,14 +1299,24 @@ export function stripAnsi(str: string): string {
   return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "").replace(/\x1B\][^\x07]*\x07/g, "");
 }
 
-function shell(cmd: string): Promise<string> {
+/**
+ * Resolve a command to its absolute path, cross-platform. Uses `where` on
+ * Windows and `which` elsewhere. Returns the first match, or `null` if not
+ * found. Both locators are real executables on PATH, so no shell is needed.
+ */
+function locateCommand(cmd: string): Promise<string | null> {
   return new Promise((resolve, reject) => {
-    const proc = spawn("sh", ["-c", cmd], { timeout: 5000 });
+    const locator = IS_WINDOWS ? "where" : "which";
+    const proc = spawn(locator, [cmd], { timeout: 5000 });
     let out = "";
     proc.stdout.on("data", (d) => (out += d.toString()));
     proc.on("close", (code) => {
-      if (code === 0) resolve(out);
-      else reject(new Error(`${cmd} failed`));
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const first = out.split(/\r?\n/).find((line) => line.trim());
+      resolve(first ? first.trim() : null);
     });
     proc.on("error", reject);
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -193,17 +193,6 @@ program
   .action(async (opts) => {
     console.log(chalk.bold.cyan("\n  vibe-replay") + chalk.dim(` v${CLI_VERSION}\n`));
 
-    // Windows is not supported yet (see https://github.com/tuo-lei/vibe-replay/issues/26)
-    if (process.platform === "win32") {
-      console.log(chalk.yellow("  ⚠ Windows is not supported yet.\n"));
-      console.log(chalk.dim("  We're working on it! Follow progress and updates:"));
-      console.log(
-        chalk.dim("  → ") + chalk.white("https://github.com/tuo-lei/vibe-replay/issues/26"),
-      );
-      console.log(chalk.dim("  → ") + chalk.white("https://vibe-replay.com\n"));
-      process.exit(1);
-    }
-
     const { join: pathJoin } = await import("node:path");
     const { homedir } = await import("node:os");
     const replayBaseDir = pathJoin(homedir(), ".vibe-replay");
@@ -1092,11 +1081,6 @@ program
   .option("-p, --provider <name>", "Provider name (default: auto-detect)")
   .option("-s, --session <sessionId>", "Specific session ID to watch")
   .action(async (opts: { provider?: string; session?: string }) => {
-    if (process.platform === "win32") {
-      console.log(chalk.yellow("\n  ⚠ Windows is not supported yet.\n"));
-      process.exit(1);
-    }
-
     const { join: pathJoin } = await import("node:path");
     const { homedir } = await import("node:os");
     const replayBaseDir = pathJoin(homedir(), ".vibe-replay");

--- a/packages/cli/src/providers/cursor/discover.test.ts
+++ b/packages/cli/src/providers/cursor/discover.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { __testables } from "./discover.js";
 
 const tempDirs: string[] = [];
+const IS_WINDOWS = process.platform === "win32";
 
 async function makeTempRoot(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-discover-"));
@@ -12,7 +13,13 @@ async function makeTempRoot(): Promise<string> {
   return root;
 }
 
+/**
+ * Mirror how Cursor encodes a workspace path into a `~/.cursor/projects`
+ * directory name. On Windows the drive colon is dropped and every `\` becomes
+ * `-`; on POSIX every `/` becomes `-`.
+ */
 function encodeCursorProjectPath(path: string): string {
+  if (IS_WINDOWS) return path.replace(":", "").replaceAll("\\", "-");
   return path.replaceAll("/", "-");
 }
 
@@ -52,9 +59,18 @@ describe("cursor project directory decoding", () => {
     ).resolves.toBe(slashPreferred);
   });
 
-  it("falls back to slash-decoded paths when no real path matches", async () => {
+  it.skipIf(IS_WINDOWS)("falls back to slash-decoded paths when no real path matches", async () => {
     await expect(__testables.decodeProjectDir("-definitely-missing-cursor-path")).resolves.toBe(
       "/definitely/missing/cursor/path",
     );
   });
+
+  it.runIf(IS_WINDOWS)(
+    "falls back to a backslash-decoded drive path when no real path matches",
+    async () => {
+      await expect(__testables.decodeProjectDir("Z-definitely-missing-cursor-path")).resolves.toBe(
+        "Z:\\definitely\\missing\\cursor\\path",
+      );
+    },
+  );
 });

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -157,11 +157,36 @@ async function decodeProjectDir(encoded: string): Promise<string> {
 }
 
 async function decodeProjectDirUncached(encoded: string): Promise<string> {
+  if (process.platform === "win32") return decodeWindowsProjectDir(encoded);
   const parts = encoded.split("-");
   const startIdx = parts[0] ? 0 : 1;
   const resolved = await resolveEncodedProjectParts(parts, startIdx, "/");
   const fallbackEncoded = encoded.startsWith("-") ? encoded.slice(1) : encoded;
   return `/${resolved ? resolved.slice(1) : fallbackEncoded.replace(/-/g, "/")}`;
+}
+
+/**
+ * Windows variant of {@link decodeProjectDir}. Cursor encodes `C:\a\b` as
+ * `C-a-b`, dropping the drive colon and turning every separator into `-`.
+ * The first segment is the drive letter; the rest are resolved against the
+ * real filesystem so directory names that legitimately contain `-`
+ * (e.g. `vibe-replay`) are not split apart.
+ */
+async function decodeWindowsProjectDir(encoded: string): Promise<string> {
+  const parts = encoded.split("-").filter((part, idx) => part !== "" || idx !== 0);
+  if (parts.length === 0) return encoded;
+
+  const drive = parts[0];
+  // Bail out for non-path project dirs (e.g. `empty-window`, numeric ids):
+  // a real Windows drive is a single ASCII letter.
+  if (!/^[a-zA-Z]$/.test(drive)) {
+    return parts.join("\\");
+  }
+
+  const root = `${drive.toUpperCase()}:\\`;
+  const resolved = await resolveEncodedProjectParts(parts, 1, root);
+  if (resolved) return resolved;
+  return parts.length === 1 ? root : `${root}${parts.slice(1).join("\\")}`;
 }
 
 async function resolveEncodedProjectParts(

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -434,7 +434,9 @@ function normalizeImagePlaceholderLines(text: string): string {
 }
 
 function resolveImagePath(pathValue: string): string {
-  if (pathValue.startsWith("~/")) return join(homedir(), pathValue.slice(2));
+  if (pathValue.startsWith("~/") || pathValue.startsWith("~\\")) {
+    return join(homedir(), pathValue.slice(2));
+  }
   return pathValue;
 }
 
@@ -452,7 +454,9 @@ function extractImageFilePathsFromText(text: string): { cleanedText: string; pat
   let match: RegExpExecArray | null;
   while ((match = blockPattern.exec(text)) !== null) {
     const blockContent = match[1];
-    const pathRegex = /(?:^|\n)\s*(?:\d+\.\s*)?((?:~\/|\/)[^\n]+\.(?:png|jpe?g|gif|webp))/gi;
+    // Match POSIX (`~/`, `/`) and Windows (`~\`, `\`, `C:\`) absolute image paths.
+    const pathRegex =
+      /(?:^|\n)\s*(?:\d+\.\s*)?((?:~[\\/]|[\\/]|[A-Za-z]:[\\/])[^\n]+\.(?:png|jpe?g|gif|webp))/gi;
     let pathMatch: RegExpExecArray | null;
     while ((pathMatch = pathRegex.exec(blockContent)) !== null) {
       const pathValue = pathMatch[1].trim();

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { promisify } from "node:util";
 import type { CursorSidecars, PrLink, TokenUsage, TurnStat } from "@vibe-replay/types";
 import { readFileCache, writeFileCache } from "../../cache.js";
@@ -1959,7 +1959,9 @@ function addContextFilesFromAttachedFolderResult(
           ? normalizeCursorContextFile((file as Record<string, any>).name)
           : normalizeCursorContextFile(file);
       if (directory && name) {
-        addUniqueContextFile(files, seen, join(directory, name));
+        // Workspace-relative context paths are always POSIX-style; never use the
+        // OS-specific separator here (it would emit `src\\utils.ts` on Windows).
+        addUniqueContextFile(files, seen, posix.join(directory, name));
         continue;
       }
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -729,7 +729,8 @@ async function buildSourcesResult(
   const projectExistsMap = new Map<string, boolean>();
   const projectIsGitMap = new Map<string, boolean>();
   for (const p of uniqueProjects) {
-    const resolved = p.startsWith("~/") ? join(home, p.slice(2)) : p === "~" ? home : p;
+    const resolved =
+      p === "~" ? home : p.startsWith("~/") || p.startsWith("~\\") ? join(home, p.slice(2)) : p;
     try {
       const s = await stat(resolved);
       projectExistsMap.set(p, s.isDirectory());
@@ -2896,7 +2897,9 @@ export async function startServer(
       versionArgs: string[] = ["--version"],
       extraCheck?: (run: RunCommand) => Promise<ExtraCheckResult>,
     ): Promise<ToolCheck> {
-      const whichResult = await runCommand("which", [cmd]);
+      // Windows has no `which`; `where` is the builtin equivalent.
+      const locator = process.platform === "win32" ? "where" : "which";
+      const whichResult = await runCommand(locator, [cmd]);
       if (!whichResult.ok) {
         if (whichResult.timedOut) {
           return { name, label, purpose, installed: false, detail: CHECK_TIMEOUT_DETAIL };

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -14,6 +14,18 @@ function redactPath(s: string): string {
   return s.replaceAll(HOME, "~");
 }
 
+/**
+ * Like {@link redactPath} but, on Windows only, also normalizes `\` separators
+ * to `/` so replays generated on Windows display POSIX-style paths consistently
+ * with macOS/Linux. Gated to win32 because on POSIX a backslash is a legal
+ * filename character and must be preserved. Used only for genuine file-path
+ * fields — never apply to free-form prose.
+ */
+function redactFilePath(s: string): string {
+  const redacted = redactPath(s);
+  return process.platform === "win32" ? redacted.replaceAll("\\", "/") : redacted;
+}
+
 export function transformToReplay(
   parsed: ProviderParseResult,
   provider: string,
@@ -157,7 +169,7 @@ export function transformToReplay(
       startTime: parsed.startTime || new Date().toISOString(),
       endTime: parsed.endTime,
       model: parsed.model,
-      cwd: redactPath(parsed.cwd),
+      cwd: redactFilePath(parsed.cwd),
       project,
       ...(options?.generator ? { generator: options.generator } : {}),
       stats: {
@@ -188,10 +200,10 @@ export function transformToReplay(
       ...(parsed.memoryMode ? { memoryMode: parsed.memoryMode } : {}),
       ...(parsed.apiErrors && parsed.apiErrors.length > 0 ? { apiErrors: parsed.apiErrors } : {}),
       ...(parsed.trackedFiles && parsed.trackedFiles.length > 0
-        ? { trackedFiles: parsed.trackedFiles.map(redactPath) }
+        ? { trackedFiles: parsed.trackedFiles.map(redactFilePath) }
         : {}),
       ...(parsed.contextFiles && parsed.contextFiles.length > 0
-        ? { contextFiles: parsed.contextFiles.map(redactPath) }
+        ? { contextFiles: parsed.contextFiles.map(redactFilePath) }
         : {}),
       ...(parsed.cursorSidecars ? { cursorSidecars: parsed.cursorSidecars } : {}),
       ...(parsed.serviceTier ? { serviceTier: parsed.serviceTier } : {}),
@@ -212,7 +224,7 @@ function buildFileDiff(
 ): ToolCallScene["diff"] | undefined {
   if (toolName === "Edit" && input.file_path) {
     return {
-      filePath: redactPath(input.file_path),
+      filePath: redactFilePath(input.file_path),
       oldContent: input.old_string ?? "",
       newContent: input.new_string ?? "",
     };
@@ -225,7 +237,7 @@ function buildFileDiff(
       // MultiEdit records independent replacements, not full before/after file
       // states. Show a synthetic chunk list so the replay still surfaces what changed.
       return {
-        filePath: redactPath(input.file_path),
+        filePath: redactFilePath(input.file_path),
         oldContent: edits.map((edit) => edit.old_string ?? "").join("\n\n"),
         newContent: edits.map((edit) => edit.new_string ?? "").join("\n\n"),
       };
@@ -233,14 +245,14 @@ function buildFileDiff(
   }
   if (toolName === "Write" && input.file_path) {
     return {
-      filePath: redactPath(input.file_path),
+      filePath: redactFilePath(input.file_path),
       oldContent: "",
       newContent: truncate(input.content || "", 3000),
     };
   }
   if (toolName === "Delete" && input.file_path) {
     return {
-      filePath: redactPath(input.file_path),
+      filePath: redactFilePath(input.file_path),
       oldContent: input.old_string ?? "(file deleted)",
       newContent: "",
     };

--- a/packages/cli/test/cursor-sqlite.test.ts
+++ b/packages/cli/test/cursor-sqlite.test.ts
@@ -29,9 +29,10 @@ describe("workspaceHash", () => {
 describe("storeDbPath", () => {
   it("constructs correct path", () => {
     const path = storeDbPath("/Users/me/project", "abc-123");
-    expect(path).toContain(".cursor/chats/");
+    // Use join() so the separator matches the host OS (\ on Windows, / elsewhere).
+    expect(path).toContain(join(".cursor", "chats"));
     expect(path).toContain(workspaceHash("/Users/me/project"));
-    expect(path).toContain("abc-123/store.db");
+    expect(path).toContain(join("abc-123", "store.db"));
   });
 });
 

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -12,7 +12,9 @@ import {
   formatDataSourceLabel,
   formatDate,
   formatSize,
+  fetchWithRetry,
   getErrorMessage,
+  getFriendlyErrorMessage,
   isCacheFresh,
   navigateTo,
   navigateToLive,
@@ -1293,14 +1295,14 @@ function RegenerateAllButton() {
     setError(null);
     setResult(null);
     try {
-      const res = await fetch("/api/regenerate-all", { method: "POST" });
+      const res = await fetchWithRetry("/api/regenerate-all", { method: "POST" });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed");
       setResult({ regenerated: data.regenerated, total: data.total });
       // Reload after short delay to show updated replays
       setTimeout(() => window.location.reload(), 1500);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to regenerate");
+      setError(getFriendlyErrorMessage(err));
     } finally {
       setLoading(false);
     }
@@ -1444,7 +1446,7 @@ function SessionsPanel() {
     }
 
     try {
-      const freshResp = await fetch("/api/sources");
+      const freshResp = await fetchWithRetry("/api/sources");
       if (!freshResp.ok) throw new Error("Failed to load sessions");
       const fresh = (await freshResp.json()) as {
         sessions: SourceSession[];
@@ -1456,7 +1458,7 @@ function SessionsPanel() {
       setStaleCachedAt(null);
     } catch (err) {
       if (!servedFromCache) {
-        setError(getErrorMessage(err) || "Failed to load sessions");
+        setError(getFriendlyErrorMessage(err) || "Failed to load sessions");
       } else {
         setRefreshError("Failed to refresh latest sessions. Showing cached data.");
       }
@@ -1567,7 +1569,10 @@ function SessionsPanel() {
     setGenerateError(null);
 
     try {
-      const resp = await fetch("/api/generate", {
+      // Retry transient network drops (the local server may be mid-restart):
+      // generation is keyed by session slug/project and overwrites in place, so
+      // re-issuing the request is safe.
+      const resp = await fetchWithRetry("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -1583,7 +1588,7 @@ function SessionsPanel() {
       if (!resp.ok) throw new Error(data.error || "Generation failed");
       navigateTo({ view: null, session: data.slug });
     } catch (err) {
-      setGenerateError(getErrorMessage(err));
+      setGenerateError(getFriendlyErrorMessage(err));
     } finally {
       setGeneratingSlug(null);
     }
@@ -2402,7 +2407,7 @@ function ReplaysPanel() {
       }
 
       try {
-        const resp = await fetch("/api/sessions");
+        const resp = await fetchWithRetry("/api/sessions");
         if (!resp.ok) throw new Error("Failed to load sessions");
         const data = (await resp.json()) as SessionSummary[];
         if (!mounted) return;
@@ -2473,7 +2478,7 @@ function ReplaysPanel() {
   const handleRegenerate = async (s: SessionSummary) => {
     setRegeneratingSlug(s.slug);
     try {
-      const resp = await fetch("/api/generate", {
+      const resp = await fetchWithRetry("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1295,6 +1295,8 @@ function RegenerateAllButton() {
     setError(null);
     setResult(null);
     try {
+      // Retry transient network drops: regeneration overwrites every replay in
+      // place (keyed by slug), so re-issuing the request is idempotent.
       const res = await fetchWithRetry("/api/regenerate-all", { method: "POST" });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Failed");

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -4,6 +4,7 @@ import type { SessionSummary, SourceSession } from "../types";
 import { localDayKey } from "../utils/date";
 import { SessionDetailPopup } from "./Dashboard";
 import {
+  fetchWithRetry,
   formatCompactDuration,
   isCacheFresh,
   navigateTo,
@@ -128,7 +129,7 @@ function useDashboardData() {
               // SSE failed — fall back to regular fetch
               es.close();
               setScanProgress(null);
-              fetch("/api/sources")
+              fetchWithRetry("/api/sources")
                 .then((r) => {
                   if (!r.ok) throw new Error("Failed to load sources");
                   return r.json();
@@ -147,7 +148,7 @@ function useDashboardData() {
 
       if (!replayFresh) {
         refreshPromises.push(
-          fetch("/api/sessions")
+          fetchWithRetry("/api/sessions")
             .then((r) => {
               if (!r.ok) throw new Error("Failed to load replays");
               return r.json();
@@ -718,7 +719,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     setGenerateErrorSlug(null);
     try {
       const title = sourceSuggestedTitle(source);
-      const resp = await fetch("/api/generate", {
+      const resp = await fetchWithRetry("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -747,7 +748,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     setGeneratingSlug(source.slug);
     setGenerateErrorSlug(null);
     try {
-      const resp = await fetch("/api/generate", {
+      const resp = await fetchWithRetry("/api/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -238,6 +238,10 @@ describe("isNetworkError", () => {
     expect(isNetworkError("some string")).toBe(false);
     expect(isNetworkError(undefined)).toBe(false);
   });
+
+  it("does not treat an unrelated TypeError (a real bug) as retryable", () => {
+    expect(isNetworkError(new TypeError("x is not a function"))).toBe(false);
+  });
 });
 
 describe("getFriendlyErrorMessage", () => {

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agentWorktreeParent,
+  fetchWithRetry,
   formatDataSourceLabel,
+  getFriendlyErrorMessage,
+  isNetworkError,
   providerBadgeClass,
   providerBadgeLabel,
   providerBarClass,
@@ -220,5 +223,84 @@ describe("provider display helpers", () => {
     expect(providerBadgeClass("codex")).toContain("terminal-purple");
     expect(providerBarClass("codex")).toBe("bg-terminal-purple");
     expect(providerFamily("codex")).toBe("purple");
+  });
+});
+
+describe("isNetworkError", () => {
+  it("treats fetch TypeErrors (failed/network/load) as network errors", () => {
+    expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isNetworkError(new Error("NetworkError when attempting to fetch resource."))).toBe(true);
+    expect(isNetworkError(new Error("Load failed"))).toBe(true);
+  });
+
+  it("does not treat application errors as network errors", () => {
+    expect(isNetworkError(new Error("Generation failed"))).toBe(false);
+    expect(isNetworkError("some string")).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("getFriendlyErrorMessage", () => {
+  it("rewrites raw network failures into an actionable message", () => {
+    expect(getFriendlyErrorMessage(new TypeError("Failed to fetch"))).toMatch(
+      /local vibe-replay server/i,
+    );
+  });
+
+  it("passes through real application error messages", () => {
+    expect(getFriendlyErrorMessage(new Error("Generation failed"))).toBe("Generation failed");
+  });
+});
+
+describe("fetchWithRetry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries a transient network rejection then succeeds", async () => {
+    const ok = new Response("{}", { status: 200 });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(ok);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("/api/sources", undefined, { baseDelayMs: 1 });
+    expect(resp.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries gateway statuses (503) from the dev proxy", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("", { status: 503 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("/api/sources", undefined, { baseDelayMs: 1 });
+    expect(resp.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a real application error response (500)", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('{"error":"boom"}', { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resp = await fetchWithRetry("/api/generate", { method: "POST" }, { baseDelayMs: 1 });
+    expect(resp.status).toBe(500);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after exhausting retries and rethrows the network error", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchWithRetry("/api/sources", undefined, { retries: 2, baseDelayMs: 1 }),
+    ).rejects.toThrow(/failed to fetch/i);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -506,6 +506,78 @@ export function getErrorMessage(err: unknown): string {
   return "Unknown error";
 }
 
+/**
+ * True when `fetch()` rejected at the network/transport layer (the request never
+ * got an HTTP response) rather than the server returning an error status.
+ *
+ * The dashboard talks to a *local* CLI server. In dev that server restarts on
+ * source changes (and on Windows the tsx cold-boot widens the restart window to
+ * a couple of seconds), so an in-flight request can land while the port is
+ * momentarily closed. The browser surfaces that as `TypeError: Failed to fetch`
+ * — which is meaningless to a user and looks like a hard failure even though the
+ * server comes right back. We use this to retry instead of erroring.
+ */
+export function isNetworkError(err: unknown): boolean {
+  // Browsers throw a TypeError for connection refused / reset / DNS failures.
+  // The message differs across engines ("Failed to fetch", "NetworkError when
+  // attempting to fetch resource", "Load failed"), so match the type plus a
+  // loose message check rather than an exact string.
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    return /failed to fetch|networkerror|load failed|fetch failed/i.test(err.message);
+  }
+  return false;
+}
+
+/** A user-facing message that explains a dropped local-server connection. */
+export function getFriendlyErrorMessage(err: unknown): string {
+  if (isNetworkError(err)) {
+    return "Couldn't reach the local vibe-replay server — it may be starting up or restarting. Try again in a moment.";
+  }
+  return getErrorMessage(err);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * `fetch` wrapper that retries transient failures against the local CLI server.
+ *
+ * Retries on (a) network-level rejections (server restarting / not yet listening)
+ * and (b) gateway statuses the Vite dev proxy returns while the upstream is down
+ * (502/503/504). Real application errors (4xx, 500 with a JSON body) are returned
+ * to the caller unchanged so existing error handling still works.
+ *
+ * Safe for idempotent GETs; do not use for non-idempotent mutations that may have
+ * partially applied before the connection dropped.
+ */
+export async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  opts?: { retries?: number; baseDelayMs?: number },
+): Promise<Response> {
+  const retries = opts?.retries ?? 4;
+  const baseDelayMs = opts?.baseDelayMs ?? 250;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const resp = await fetch(input, init);
+      if (
+        (resp.status === 502 || resp.status === 503 || resp.status === 504) &&
+        attempt < retries
+      ) {
+        await sleep(baseDelayMs * 2 ** attempt);
+        continue;
+      }
+      return resp;
+    } catch (err) {
+      lastErr = err;
+      if (!isNetworkError(err) || attempt === retries) throw err;
+      await sleep(baseDelayMs * 2 ** attempt);
+    }
+  }
+  throw lastErr;
+}
+
 /** Shorten a path to fit the sidebar, keeping first + last meaningful segments */
 export function shortenPath(path: string): string {
   const special = specialProjectLabel(path);

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -518,15 +518,13 @@ export function getErrorMessage(err: unknown): string {
  * server comes right back. We use this to retry instead of erroring.
  */
 export function isNetworkError(err: unknown): boolean {
-  // Browsers throw a TypeError for connection refused / reset / DNS failures.
-  // The message differs across engines ("Failed to fetch", "NetworkError when
-  // attempting to fetch resource", "Load failed"), so match the type plus a
-  // loose message check rather than an exact string.
-  if (err instanceof TypeError) return true;
-  if (err instanceof Error) {
-    return /failed to fetch|networkerror|load failed|fetch failed/i.test(err.message);
-  }
-  return false;
+  if (!(err instanceof Error)) return false;
+  // A failed fetch rejects with a TypeError (undici also uses TypeError), but the
+  // message differs across engines: "Failed to fetch" (Chromium), "NetworkError
+  // when attempting to fetch resource" (Firefox), "Load failed" (Safari), or
+  // "fetch failed" (undici). Match the message rather than the bare type so we
+  // don't classify unrelated TypeErrors (real programming bugs) as retryable.
+  return /failed to fetch|networkerror|load failed|fetch failed/i.test(err.message);
 }
 
 /** A user-facing message that explains a dropped local-server connection. */
@@ -547,8 +545,11 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
  * (502/503/504). Real application errors (4xx, 500 with a JSON body) are returned
  * to the caller unchanged so existing error handling still works.
  *
- * Safe for idempotent GETs; do not use for non-idempotent mutations that may have
- * partially applied before the connection dropped.
+ * Only retries when the connection itself failed (no HTTP response), so a request
+ * that reached the server is never silently re-sent. It is therefore safe for GETs
+ * and for *idempotent* mutations whose effect is keyed and overwritten in place
+ * (e.g. generate/regenerate, keyed by session slug). Do not use it for mutations
+ * that accumulate or are otherwise unsafe to repeat.
  */
 export async function fetchWithRetry(
   input: RequestInfo | URL,
@@ -575,7 +576,9 @@ export async function fetchWithRetry(
       await sleep(baseDelayMs * 2 ** attempt);
     }
   }
-  throw lastErr;
+  // Unreachable when retries >= 0 (the final iteration always returns or throws),
+  // but required to satisfy control-flow analysis and to handle a retries < 0 call.
+  throw lastErr ?? new Error("fetchWithRetry: no attempts were made");
 }
 
 /** Shorten a path to fit the sidebar, keeping first + last meaningful segments */

--- a/scripts/copy-file.mjs
+++ b/scripts/copy-file.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Cross-platform replacement for `mkdir -p <dir> && cp <src> <dest>`.
+// Windows shells lack `mkdir -p`/`cp`, so build scripts shell out here instead.
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const [src, dest] = process.argv.slice(2);
+if (!src || !dest) {
+  console.error("usage: copy-file.mjs <src> <dest>");
+  process.exit(1);
+}
+
+mkdirSync(dirname(dest), { recursive: true });
+copyFileSync(src, dest);

--- a/scripts/dev-utils.mjs
+++ b/scripts/dev-utils.mjs
@@ -1,7 +1,38 @@
 /**
  * Shared utilities for dev launcher scripts.
  */
+import { spawn } from "node:child_process";
 import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const IS_WINDOWS = process.platform === "win32";
+
+/**
+ * Spawn `pnpm` cross-platform. On Windows the pnpm binary is a `.cmd`/`.ps1`
+ * shim that `spawn()` cannot exec directly (it throws `ENOENT`), so route
+ * through the shell there. Args are simple identifiers, so shell quoting is
+ * not a concern.
+ */
+export function spawnPnpm(args, options = {}) {
+  return spawn("pnpm", args, { ...options, shell: IS_WINDOWS });
+}
+
+/**
+ * Spawn `tsx` to run a TypeScript entry cross-platform. Uses the current Node
+ * binary with tsx registered as a loader (`node --import tsx`) instead of the
+ * `node_modules/.bin/tsx` shim, which is a `.cmd` on Windows and cannot be
+ * exec'd directly. Spawning Node directly also keeps Ctrl+C / signal handling
+ * reliable (no wrapper process).
+ */
+export function spawnTsx(scriptArgs, options = {}) {
+  return spawn(process.execPath, ["--import", "tsx", ...scriptArgs], options);
+}
+
+/** Cross-platform temp log path for the backgrounded Vite viewer. */
+export function viewerLogPath(port) {
+  return join(tmpdir(), `vibe-replay-viewer-${port}.log`);
+}
 
 /**
  * Check if a port is free on BOTH IPv4 and IPv6 (macOS Vite listens on ::1).

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -8,8 +8,7 @@
  * Usage:
  *   node scripts/dev-website.mjs
  */
-import { spawn } from "node:child_process";
-import { findFreePort } from "./dev-utils.mjs";
+import { findFreePort, spawnPnpm, viewerLogPath } from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const ASTRO_PREFERRED = 4321;
@@ -30,13 +29,13 @@ console.log(`[vibe-replay] /view/  →     redirects to Vite viewer`);
 console.log();
 
 // Start Vite viewer dev (backgrounded, logs to file)
-const vite = spawn("pnpm", ["--filter", "@vibe-replay/viewer", "dev"], {
+const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
   env: { ...process.env, VITE_PORT: String(vitePort) },
 });
 
 const { createWriteStream } = await import("node:fs");
-const logPath = `/tmp/vibe-replay-viewer-${vitePort}.log`;
+const logPath = viewerLogPath(vitePort);
 const logStream = createWriteStream(logPath);
 vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
@@ -52,7 +51,7 @@ vite.on("exit", (code) => {
 });
 
 // Start Astro website dev (foreground, inherits stdio)
-const astro = spawn("pnpm", ["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
+const astro = spawnPnpm(["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
   stdio: "inherit",
   env: {
     ...process.env,

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -8,9 +8,8 @@
  *   node scripts/dev.mjs -d         # explicit dashboard mode (same as default)
  *   node scripts/dev.mjs --menu     # interactive CLI menu mode
  */
-import { spawn } from "node:child_process";
 import { watch } from "node:fs";
-import { findFreePort } from "./dev-utils.mjs";
+import { findFreePort, spawnPnpm, spawnTsx, viewerLogPath } from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const API_PREFERRED = 13456;
@@ -39,14 +38,14 @@ console.log();
 
 // Start Vite dev server (backgrounded) — port + strictPort via env vars in vite.config.ts
 const cloudApiUrl = process.env.VIBE_REPLAY_API_URL || "http://localhost:8787";
-const vite = spawn("pnpm", ["--filter", "@vibe-replay/viewer", "dev"], {
+const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
   env: { ...process.env, VITE_PORT: String(vitePort), VITE_API_PORT: String(apiPort), VITE_CLOUD_API_URL: cloudApiUrl },
 });
 
 // Pipe Vite output to a log file
 const { createWriteStream } = await import("node:fs");
-const logPath = `/tmp/vibe-replay-viewer-${vitePort}.log`;
+const logPath = viewerLogPath(vitePort);
 const logStream = createWriteStream(logPath);
 vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
@@ -74,14 +73,15 @@ let shuttingDown = false;
 let hasOpenedBrowser = false;
 
 function startCli() {
-  // Use node_modules/.bin/tsx directly instead of npx to avoid an extra
-  // wrapper process that swallows signals (making Ctrl+C unreliable).
+  // Run tsx via `node --import tsx` (see spawnTsx) instead of the
+  // node_modules/.bin/tsx shim — the shim is a .cmd on Windows that spawn()
+  // can't exec directly, and spawning Node directly keeps Ctrl+C reliable.
   const cliEnvForRun = {
     ...cliEnv,
     // Open browser only once per dev launcher process to avoid tab spam on restarts.
     VIBE_REPLAY_NO_AUTO_OPEN: hasOpenedBrowser ? "1" : "0",
   };
-  cli = spawn("node_modules/.bin/tsx", [cliScript, ...cliExtraArgs], {
+  cli = spawnTsx([cliScript, ...cliExtraArgs], {
     stdio: "inherit",
     env: cliEnvForRun,
   });


### PR DESCRIPTION
## Summary

Makes vibe-replay work on Windows (the CLI previously hard-exited with "Windows is not supported"), and hardens the dashboard against transient local-server hiccups that surfaced as a raw `Failed to fetch` banner.

### Windows support
- **Cursor session discovery**: decode Windows-encoded project dirs (drive letters / backslashes, e.g. `c-git-roblox-vibe-replay`) by resolving against the real filesystem; force POSIX joins for context files and normalize displayed paths to `/` in the transform so replays render consistently.
- **Image paths**: extend the image-path regex to match `C:\...` and `~\...`, and resolve `~\` like `~/`.
- **Build & dev tooling**: replace Unix-only `mkdir -p && cp` with a cross-platform `scripts/copy-file.mjs`; add `spawnPnpm`/`spawnTsx` helpers (fixes `spawn pnpm ENOENT`) and a cross-platform viewer-log path; use `where` vs `which` for tool detection in `server.ts` and `feedback.ts`.
- **Line endings**: add `.gitattributes` (`eol=lf`) so Windows clones (`core.autocrlf=true`) don't break `oxfmt --check`.
- Remove the hard Windows exit guards in the main and `live` commands.

### Dashboard fetch resilience
- In dev the local CLI server briefly restarts (a wider window on Windows where `tsx` cold-boot is slower), so in-flight requests reject with a raw `TypeError: Failed to fetch` shown as a scary error banner (e.g. when clicking **Generate**).
- Add `fetchWithRetry` / `isNetworkError` / `getFriendlyErrorMessage`: retry network-level rejections and proxy `502/503/504` with backoff, leave real `4xx/5xx` errors untouched, and show an actionable message on hard failure.
- Applied to the sources/sessions reads and the generate/regenerate POSTs (idempotent by session slug).

## Compatibility
All path/spawn changes are gated to `win32` or are no-ops on POSIX; no expected impact on macOS / Linux / WSL. The dashboard retry logic is pure client-side and cross-platform.

## Test plan
- [x] `pnpm --filter @vibe-replay/viewer test` — 141 passed (9 new tests for the retry/network helpers)
- [x] CLI test suite + typecheck pass on Windows
- [x] `pnpm lint:check` clean; `pnpm build` succeeds (viewer 825 kB, < 1 MB)
- [x] End-to-end on Windows: dashboard, session discovery, replay generation (HTML/SVG/GIF/MD), and viewer verified in-browser
- [x] Verified the retry fix by injecting a one-shot transient `/api/generate` failure — generation self-healed with no error banner
- [ ] Sanity check on macOS/Linux (no regressions expected)
