### PR TITLE
Handle Claude API error message flag

### DIFF
--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -270,6 +270,19 @@ export async function parseClaudeCodeLines(
 
     const { role, content: msgContent, id: msgId } = obj.message;
 
+    if (obj.isApiErrorMessage && obj.timestamp) {
+      const text = extractMessageText(msgContent);
+      const errorType = inferApiErrorMessageType(text);
+      if (
+        !apiErrors.some((err) => err.timestamp === obj.timestamp && err.errorType === errorType)
+      ) {
+        apiErrors.push({
+          timestamp: obj.timestamp,
+          ...(errorType ? { errorType } : {}),
+        });
+      }
+    }
+
     // Capture system-injected messages: extract skill names and emit meaningful ones as scenes
     if (obj.isMeta && role === "user") {
       const text = extractMessageText(msgContent);
@@ -617,6 +630,14 @@ function extractMessageText(content: string | ContentBlock[]): string {
       .join("\n");
   }
   return "";
+}
+
+function inferApiErrorMessageType(text: string): string | undefined {
+  const lower = text.toLowerCase();
+  if (lower.includes("rate limit")) return "rate_limit_error";
+  if (lower.includes("overloaded")) return "overloaded_error";
+  if (lower.includes("api error")) return "api_error_message";
+  return undefined;
 }
 
 function extractImages(block: ContentBlock): string[] {

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -273,14 +273,11 @@ export async function parseClaudeCodeLines(
     if (obj.isApiErrorMessage && obj.timestamp) {
       const text = extractMessageText(msgContent);
       const errorType = inferApiErrorMessageType(text);
-      if (
-        !apiErrors.some((err) => err.timestamp === obj.timestamp && err.errorType === errorType)
-      ) {
-        apiErrors.push({
-          timestamp: obj.timestamp,
-          ...(errorType ? { errorType } : {}),
-        });
-      }
+      apiErrors.push({
+        timestamp: obj.timestamp,
+        ...(errorType ? { errorType } : {}),
+      });
+      // Fall through so the synthetic assistant message still renders as text.
     }
 
     // Capture system-injected messages: extract skill names and emit meaningful ones as scenes
@@ -636,7 +633,7 @@ function inferApiErrorMessageType(text: string): string | undefined {
   const lower = text.toLowerCase();
   if (lower.includes("rate limit")) return "rate_limit_error";
   if (lower.includes("overloaded")) return "overloaded_error";
-  if (lower.includes("api error")) return "api_error_message";
+  if (lower.includes("api error")) return "api_error";
   return undefined;
 }
 

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -406,6 +406,10 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         continue;
       }
 
+      if (obj.type === "assistant" && obj.isApiErrorMessage) {
+        apiErrorCount++;
+      }
+
       // Extract skill/command names from isMeta messages
       if (obj.isMeta) {
         const text = extractMetaText(obj.message?.content);

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -110,6 +110,10 @@ export interface RawMessage {
     | "attachment";
   subtype?: string;
   timestamp?: string;
+  /** Optional provider URL attached to newer Claude Code system messages. */
+  url?: string;
+  /** True when Claude Code writes a synthetic assistant message describing an API failure. */
+  isApiErrorMessage?: boolean;
   message?: {
     role: "user" | "assistant";
     id?: string;

--- a/packages/cli/test/claude-code-real-world.test.ts
+++ b/packages/cli/test/claude-code-real-world.test.ts
@@ -356,6 +356,17 @@ describe("Claude Code parser — max_tokens truncation", () => {
 // Transform: synthetic messages produce text-response scenes
 // ---------------------------------------------------------------------------
 describe("Claude Code → transform — synthetic and edge scenes", () => {
+  it("counts synthetic API error messages in parsed metadata", async () => {
+    const result = await parseClaudeCodeSession(REAL);
+
+    expect(result.apiErrors).toEqual([
+      {
+        timestamp: "2025-01-30T10:00:15Z",
+        errorType: "api_error_message",
+      },
+    ]);
+  });
+
   it("produces text-response scene from API error synthetic message", async () => {
     const result = await parseClaudeCodeSession(REAL);
     const replay = transformToReplay(result, "claude-code", "~/test/realproject");

--- a/packages/cli/test/claude-code-real-world.test.ts
+++ b/packages/cli/test/claude-code-real-world.test.ts
@@ -362,7 +362,7 @@ describe("Claude Code → transform — synthetic and edge scenes", () => {
     expect(result.apiErrors).toEqual([
       {
         timestamp: "2025-01-30T10:00:15Z",
-        errorType: "api_error_message",
+        errorType: "api_error",
       },
     ]);
   });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -250,6 +250,46 @@ describe("scanSession", () => {
     expect(result.durationMs).toBe(9000);
   });
 
+  it("counts synthetic assistant API error messages", async () => {
+    const path = join(tmpDir, "api-error-message.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "assistant",
+          timestamp: "2025-03-20T10:00:00Z",
+          isApiErrorMessage: true,
+          message: {
+            role: "assistant",
+            id: "msg-api-error",
+            content: [{ type: "text", text: "API Error: Claude's response failed." }],
+          },
+        }),
+        makeLine({
+          type: "assistant",
+          timestamp: "2025-03-20T10:00:01Z",
+          isApiErrorMessage: false,
+          message: {
+            role: "assistant",
+            id: "msg-no-response",
+            content: [{ type: "text", text: "No response requested." }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "test-session-api-error-message",
+      provider: "claude-code",
+      project: "~/project",
+      slug: "api-error-message",
+      filePaths: [path],
+    });
+
+    expect(result.apiErrorCount).toBe(1);
+  });
+
   it("extracts token usage and cost", async () => {
     const result = await scanSession({
       sessionId: "test-session-1",


### PR DESCRIPTION
## Summary
- Treat Claude Code synthetic assistant messages marked `isApiErrorMessage` as API errors in parsed replay metadata.
- Count the same flag in scan-backed dashboard/session metrics.
- Add RawMessage coverage for newly observed Claude Code `url` and `isApiErrorMessage` fields.

Fixes #278.

## Test plan
- `pnpm --filter vibe-replay test test/claude-code-real-world.test.ts test/scanner.test.ts`
- `pnpm exec tsc --noEmit --pretty false` in `packages/cli`
- `pnpm lint:check`
- `pnpm build`


Made with [Cursor](https://cursor.com)