### PR TITLE
Add Windows CI smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
       - run: pnpm test
       - run: pnpm test:cloudflare
 
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter vibe-replay test
+      - run: pnpm --filter @vibe-replay/viewer test
+      - run: pnpm build
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -50,14 +64,12 @@ jobs:
 
       - name: Build CLI
         run: |
-          mkdir -p packages/cli/assets
-          cp packages/viewer/dist/index.html packages/cli/assets/viewer.html
+          node scripts/copy-file.mjs packages/viewer/dist/index.html packages/cli/assets/viewer.html
           pnpm --filter vibe-replay build
 
       - name: Build website
         run: |
-          mkdir -p website/public/view
-          cp packages/viewer/dist/index.html website/public/view/index.html
+          node scripts/copy-file.mjs packages/viewer/dist/index.html website/public/view/index.html
           pnpm --filter @vibe-replay/website build
 
       - name: Simulate npm install (catch broken releases before merge)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,14 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter vibe-replay test
-      - run: pnpm --filter @vibe-replay/viewer test
-      - run: pnpm build
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Test CLI
+        run: pnpm --filter vibe-replay test
+      - name: Test viewer
+        run: pnpm --filter @vibe-replay/viewer test
+      - name: Build
+        run: pnpm build
 
   build:
     runs-on: ubuntu-latest

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -212,8 +212,16 @@ async function resolveEncodedProjectParts(
   // names that are real child directories instead of stat-ing every split.
   for (let end = idx + 1; end <= parts.length; end++) {
     const candidate = parts.slice(idx, end).join("-");
-    if (!dirNames.has(candidate)) continue;
-    const resolved = await resolveEncodedProjectParts(parts, end, join(current, candidate));
+    const candidatePath = join(current, candidate);
+    if (!dirNames.has(candidate)) {
+      // Windows temp/profile paths can contain 8.3 short-name segments such as
+      // RUNNER~1. They are valid paths but do not appear in readdir(), so use a
+      // targeted stat fallback before giving up on this split.
+      if (process.platform !== "win32") continue;
+      const candidateStat = await stat(candidatePath).catch(() => null);
+      if (!candidateStat?.isDirectory()) continue;
+    }
+    const resolved = await resolveEncodedProjectParts(parts, end, candidatePath);
     if (resolved) return resolved;
   }
 


### PR DESCRIPTION
## Summary
- Add a `windows-latest` smoke job that runs CLI tests, viewer tests, and the full build on Windows.
- Replace remaining Unix-only copy commands in the build workflow with `scripts/copy-file.mjs`.

Refs #26.

## Test plan
- `pnpm lint:check`
- `pnpm test`
- `pnpm build`


Made with [Cursor](https://cursor.com)