### PR TITLE
Harden replay diff redaction

### DIFF
--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -247,10 +247,7 @@ function buildFileDiff(
     return {
       filePath: redactFilePath(input.file_path),
       oldContent: "",
-      newContent: truncate(
-        redactPath(typeof input.content === "string" ? input.content : ""),
-        3000,
-      ),
+      newContent: truncate(redactDiffContent(input.content), 3000),
     };
   }
   if (toolName === "Delete" && input.file_path) {

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -225,8 +225,8 @@ function buildFileDiff(
   if (toolName === "Edit" && input.file_path) {
     return {
       filePath: redactFilePath(input.file_path),
-      oldContent: input.old_string ?? "",
-      newContent: input.new_string ?? "",
+      oldContent: redactDiffContent(input.old_string),
+      newContent: redactDiffContent(input.new_string),
     };
   }
   if (toolName === "MultiEdit" && input.file_path && Array.isArray(input.edits)) {
@@ -238,8 +238,8 @@ function buildFileDiff(
       // states. Show a synthetic chunk list so the replay still surfaces what changed.
       return {
         filePath: redactFilePath(input.file_path),
-        oldContent: edits.map((edit) => edit.old_string ?? "").join("\n\n"),
-        newContent: edits.map((edit) => edit.new_string ?? "").join("\n\n"),
+        oldContent: edits.map((edit) => redactDiffContent(edit.old_string)).join("\n\n"),
+        newContent: edits.map((edit) => redactDiffContent(edit.new_string)).join("\n\n"),
       };
     }
   }
@@ -247,17 +247,27 @@ function buildFileDiff(
     return {
       filePath: redactFilePath(input.file_path),
       oldContent: "",
-      newContent: truncate(input.content || "", 3000),
+      newContent: truncate(
+        redactPath(typeof input.content === "string" ? input.content : ""),
+        3000,
+      ),
     };
   }
   if (toolName === "Delete" && input.file_path) {
     return {
       filePath: redactFilePath(input.file_path),
-      oldContent: input.old_string ?? "(file deleted)",
+      oldContent:
+        typeof input.old_string === "string"
+          ? redactDiffContent(input.old_string)
+          : "(file deleted)",
       newContent: "",
     };
   }
   return undefined;
+}
+
+function redactDiffContent(value: unknown): string {
+  return typeof value === "string" ? redactSecrets(redactPath(value)) : "";
 }
 
 function buildToolScene(

--- a/packages/cli/test/transform-security.test.ts
+++ b/packages/cli/test/transform-security.test.ts
@@ -421,6 +421,128 @@ describe("secret redaction in transform", () => {
     expect(JSON.stringify(scene.input)).not.toContain(token);
     expect(scene.input?.tokens[1]).toBe("safe-value");
   });
+
+  it("redacts secrets and home paths in Edit diff content", () => {
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Edit",
+            input: {
+              file_path: `${HOME}/project/auth.ts`,
+              old_string: `const token = "${EXAMPLE_GH_PAT}";\nconst path = "${HOME}/secret.env";`,
+              new_string: `const token = "${EXAMPLE_OPENAI_KEY}";\nconst path = "${HOME}/public.env";`,
+            },
+            _result: "ok",
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const scene = replay.scenes.find((s) => s.type === "tool-call")!;
+    expect(scene.diff?.oldContent).not.toContain(EXAMPLE_GH_PAT);
+    expect(scene.diff?.newContent).not.toContain(EXAMPLE_OPENAI_KEY);
+    expect(scene.diff?.oldContent).not.toContain(HOME);
+    expect(scene.diff?.newContent).not.toContain(HOME);
+    expect(scene.diff?.oldContent).toContain("[REDACTED]");
+    expect(scene.diff?.newContent).toContain("[REDACTED]");
+    expect(scene.diff?.oldContent).toContain("~/secret.env");
+    expect(scene.diff?.newContent).toContain("~/public.env");
+  });
+
+  it("redacts secrets and home paths in MultiEdit diff content", () => {
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "MultiEdit",
+            input: {
+              file_path: `${HOME}/project/auth.ts`,
+              edits: [
+                {
+                  old_string: `token=${EXAMPLE_GH_PAT}`,
+                  new_string: `token=${EXAMPLE_OPENAI_KEY}`,
+                },
+                {
+                  old_string: `path=${HOME}/before.env`,
+                  new_string: `path=${HOME}/after.env`,
+                },
+              ],
+            },
+            _result: "ok",
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const scene = replay.scenes.find((s) => s.type === "tool-call")!;
+    expect(scene.diff?.oldContent).not.toContain(EXAMPLE_GH_PAT);
+    expect(scene.diff?.newContent).not.toContain(EXAMPLE_OPENAI_KEY);
+    expect(scene.diff?.oldContent).not.toContain(HOME);
+    expect(scene.diff?.newContent).not.toContain(HOME);
+    expect(scene.diff?.oldContent).toContain("[REDACTED]");
+    expect(scene.diff?.newContent).toContain("[REDACTED]");
+    expect(scene.diff?.oldContent).toContain("~/before.env");
+    expect(scene.diff?.newContent).toContain("~/after.env");
+  });
+
+  it("redacts secrets and home paths in Delete diff content", () => {
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Delete",
+            input: {
+              file_path: `${HOME}/project/auth.ts`,
+              old_string: `token=${EXAMPLE_GH_PAT}\npath=${HOME}/deleted.env`,
+            },
+            _result: "ok",
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const scene = replay.scenes.find((s) => s.type === "tool-call")!;
+    expect(scene.diff?.oldContent).not.toContain(EXAMPLE_GH_PAT);
+    expect(scene.diff?.oldContent).not.toContain(HOME);
+    expect(scene.diff?.oldContent).toContain("[REDACTED]");
+    expect(scene.diff?.oldContent).toContain("~/deleted.env");
+  });
+
+  it("redacts secrets and home paths in Write diff content", () => {
+    const parsed = makeParsed([
+      {
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Write",
+            input: {
+              file_path: `${HOME}/project/auth.ts`,
+              content: `token=${EXAMPLE_GH_PAT}\npath=${HOME}/created.env`,
+            },
+            _result: "ok",
+          } as any,
+        ],
+      },
+    ]);
+    const replay = transform(parsed);
+    const scene = replay.scenes.find((s) => s.type === "tool-call")!;
+    expect(scene.diff?.newContent).not.toContain(EXAMPLE_GH_PAT);
+    expect(scene.diff?.newContent).not.toContain(HOME);
+    expect(scene.diff?.newContent).toContain("[REDACTED]");
+    expect(scene.diff?.newContent).toContain("~/created.env");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Redacts paths and secret-like values from Edit, MultiEdit, Delete, and Write diff payloads before embedding them in replay output.
- Adds transform security coverage so diff content follows the same privacy guarantees as prompts, tool inputs, and tool results.

## Test plan
- pnpm --filter vibe-replay test -- transform-security.test.ts
- pnpm --filter vibe-replay build
- pnpm lint:check


Made with [Cursor](https://cursor.com)