### PR TITLE
Harden website JSON-LD output

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "vitest run --config e2e/vitest.config.ts",
     "lint": "oxlint --fix packages/ website/src cloudflare/src && oxfmt packages/ website/src cloudflare/src",
     "lint:check": "oxlint packages/ website/src cloudflare/src && oxfmt --check packages/ website/src cloudflare/src",
-    "typecheck": "tsc --noEmit -p packages/types/tsconfig.json && tsc --noEmit -p packages/cli/tsconfig.json && tsc --noEmit -p packages/viewer/tsconfig.json && tsc --noEmit -p cloudflare/tsconfig.json",
+    "typecheck": "tsc --noEmit -p packages/types/tsconfig.json && tsc --noEmit -p packages/cli/tsconfig.json && tsc --noEmit -p packages/viewer/tsconfig.json && tsc --noEmit -p cloudflare/tsconfig.json && pnpm --filter @vibe-replay/website check",
     "fmt": "oxfmt packages/ website/src cloudflare/src",
     "prepare": "lefthook install"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "dev": "bash ./scripts/run-with-required-node.sh dev",
     "build": "bash ./scripts/run-with-required-node.sh build",
     "preview": "bash ./scripts/run-with-required-node.sh preview",
-    "check": "astro check"
+    "check": "bash ./scripts/run-with-required-node.sh check"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -33,6 +33,10 @@ const canonicalURL = canonicalPath
 const ogImage = ogImageProp
   ? new URL(ogImageProp, siteBase).href
   : new URL("/og.png", siteBase).href;
+
+function stringifyJsonLd(value: Record<string, unknown>): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
 ---
 
 <!doctype html>
@@ -93,7 +97,7 @@ const ogImage = ogImageProp
         ? (Array.isArray(jsonLdProp) ? jsonLdProp : [jsonLdProp])
         : [defaultJsonLd];
       return blocks.map((b) => (
-        <script type="application/ld+json" set:html={JSON.stringify(b)} />
+        <script is:inline type="application/ld+json" set:html={stringifyJsonLd(b)} />
       ));
     })()}
 


### PR DESCRIPTION
## Summary
- Escapes `<` in JSON-LD before injecting structured data into inline script tags, preventing `</script>` from prematurely closing the tag.
- Runs website Astro checking through the same Node-version wrapper used by other website scripts.
- Adds the website check to the root `typecheck` command so Astro regressions are covered by the standard verification path.

## Test plan
- pnpm --filter @vibe-replay/website check
- pnpm typecheck
- pnpm lint:check
- pnpm build:website


Made with [Cursor](https://cursor.com)