### PR TITLE
Harden viewer state edge cases

### DIFF
--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -8,6 +8,27 @@ interface Props {
   annotatedScenes?: Set<number>;
 }
 
+export function clampTimelineIndex(index: number, sceneCount: number): number {
+  if (sceneCount <= 0) return 0;
+  return Math.max(0, Math.min(sceneCount - 1, index));
+}
+
+export function timelineIndexFromPointer(
+  offsetX: number,
+  width: number,
+  sceneCount: number,
+): number {
+  if (sceneCount <= 0 || width <= 0) return 0;
+  const pct = Math.max(0, Math.min(1, offsetX / width));
+  return clampTimelineIndex(Math.floor(pct * sceneCount), sceneCount);
+}
+
+export function timelineProgressPct(currentIndex: number, sceneCount: number): number {
+  if (sceneCount <= 0) return 0;
+  const completedScenes = Math.max(0, Math.min(sceneCount, currentIndex + 1));
+  return (completedScenes / sceneCount) * 100;
+}
+
 function sceneColor(type: Scene["type"]): string {
   switch (type) {
     case "user-prompt":
@@ -65,7 +86,8 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
     return result;
   }, [scenes]);
 
-  const progressPct = scenes.length > 0 ? ((currentIndex + 1) / scenes.length) * 100 : 0;
+  const clampedCurrentIndex = clampTimelineIndex(currentIndex, scenes.length);
+  const progressPct = timelineProgressPct(currentIndex, scenes.length);
 
   const barRef = useRef<HTMLDivElement>(null);
 
@@ -75,9 +97,7 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
       if (!bar) return;
       const rect = bar.getBoundingClientRect();
       const x = e.clientX - rect.left;
-      const pct = Math.max(0, Math.min(1, x / rect.width));
-      const idx = Math.floor(pct * scenes.length);
-      onSeek(idx);
+      onSeek(timelineIndexFromPointer(x, rect.width, scenes.length));
     },
     [scenes.length, onSeek],
   );
@@ -135,7 +155,7 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
       aria-label="Scene timeline"
       aria-valuemin={0}
       aria-valuemax={scenes.length - 1}
-      aria-valuenow={currentIndex}
+      aria-valuenow={clampedCurrentIndex}
       tabIndex={0}
     >
       {/* Annotation + compaction dots above timeline */}

--- a/packages/viewer/src/components/Timeline.tsx
+++ b/packages/viewer/src/components/Timeline.tsx
@@ -194,7 +194,7 @@ export default function Timeline({ scenes, currentIndex, onSeek, annotatedScenes
             className="flex-1 transition-opacity duration-150"
             style={{
               backgroundColor: sceneColor(seg.type),
-              opacity: seg.startIndex <= currentIndex ? 1 : 0.15,
+              opacity: seg.startIndex <= clampedCurrentIndex ? 1 : 0.15,
             }}
           />
         ))}

--- a/packages/viewer/src/components/__tests__/timeline.test.ts
+++ b/packages/viewer/src/components/__tests__/timeline.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { clampTimelineIndex, timelineIndexFromPointer, timelineProgressPct } from "../Timeline";
+
+describe("timeline helpers", () => {
+  it("clamps current indices into the scene range for ARIA values", () => {
+    expect(clampTimelineIndex(-1, 5)).toBe(0);
+    expect(clampTimelineIndex(2, 5)).toBe(2);
+    expect(clampTimelineIndex(5, 5)).toBe(4);
+    expect(clampTimelineIndex(0, 0)).toBe(0);
+  });
+
+  it("maps pointer positions to valid scene indices", () => {
+    expect(timelineIndexFromPointer(-10, 100, 5)).toBe(0);
+    expect(timelineIndexFromPointer(0, 100, 5)).toBe(0);
+    expect(timelineIndexFromPointer(99, 100, 5)).toBe(4);
+    expect(timelineIndexFromPointer(100, 100, 5)).toBe(4);
+    expect(timelineIndexFromPointer(120, 100, 5)).toBe(4);
+    expect(timelineIndexFromPointer(50, 0, 5)).toBe(0);
+  });
+
+  it("keeps progress between empty and complete", () => {
+    expect(timelineProgressPct(-1, 5)).toBe(0);
+    expect(timelineProgressPct(1, 5)).toBe(40);
+    expect(timelineProgressPct(10, 5)).toBe(100);
+    expect(timelineProgressPct(0, 0)).toBe(0);
+  });
+});

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -1,4 +1,5 @@
 import type { SessionSummary, SourceSession } from "../types";
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from "../utils/safe-storage";
 
 // ─── Shared types ────────────────────────────────────────────────────
 
@@ -303,9 +304,9 @@ export function navigateTo(
       if (v) dashboardState[p] = v;
     });
     if (Object.keys(dashboardState).length > 0) {
-      sessionStorage.setItem("vibe_dashboard_state", JSON.stringify(dashboardState));
+      safeStorageSet(sessionStorage, "vibe_dashboard_state", JSON.stringify(dashboardState));
     } else {
-      sessionStorage.removeItem("vibe_dashboard_state");
+      safeStorageRemove(sessionStorage, "vibe_dashboard_state");
     }
   }
 
@@ -325,7 +326,7 @@ export function navigateTo(
   // 3. If we are going back to dashboard, restored saved state if URL is empty
   const goingToDashboard = params.view === "dashboard" || (params.session === null && !params.view);
   if (goingToDashboard) {
-    const saved = sessionStorage.getItem("vibe_dashboard_state");
+    const saved = safeStorageGet(sessionStorage, "vibe_dashboard_state");
     if (saved) {
       try {
         const state = JSON.parse(saved);

--- a/packages/viewer/src/hooks/useTheme.ts
+++ b/packages/viewer/src/hooks/useTheme.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { safeStorageGet, safeStorageSet } from "../utils/safe-storage";
 
 export type Theme = "dark" | "light";
 
@@ -8,7 +9,7 @@ export function useTheme() {
     const urlTheme = params.get("theme");
     if (urlTheme === "light" || urlTheme === "dark") return urlTheme;
 
-    const stored = localStorage.getItem("vibe-replay-theme");
+    const stored = safeStorageGet(localStorage, "vibe-replay-theme");
     if (stored === "light" || stored === "dark") return stored;
     return "dark";
   });
@@ -19,7 +20,7 @@ export function useTheme() {
     el.classList.add("theme-transition");
     el.classList.toggle("dark", theme === "dark");
     el.classList.toggle("light", theme === "light");
-    localStorage.setItem("vibe-replay-theme", theme);
+    safeStorageSet(localStorage, "vibe-replay-theme", theme);
     // Remove transition class after animation completes to avoid interfering
     const timer = setTimeout(() => el.classList.remove("theme-transition"), 300);
     return () => clearTimeout(timer);

--- a/packages/viewer/src/hooks/useViewPrefs.ts
+++ b/packages/viewer/src/hooks/useViewPrefs.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { safeStorageGet, safeStorageSet } from "../utils/safe-storage";
 
 export type DisplayMode = "all" | "compact" | "custom";
 
@@ -56,7 +57,7 @@ const defaultPrefs: ViewPrefs = {
 
 function loadPrefs(): ViewPrefs {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = safeStorageGet(localStorage, STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
       // Migration: old prefs without displayMode
@@ -75,7 +76,7 @@ export function useViewPrefs() {
   const updatePref = useCallback(<K extends keyof ViewPrefs>(key: K, value: ViewPrefs[K]) => {
     setPrefs((prev) => {
       const next = { ...prev, [key]: value };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      safeStorageSet(localStorage, STORAGE_KEY, JSON.stringify(next));
       return next;
     });
   }, []);
@@ -85,7 +86,7 @@ export function useViewPrefs() {
       const val = prev[key];
       if (typeof val !== "boolean") return prev;
       const next = { ...prev, [key]: !val };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      safeStorageSet(localStorage, STORAGE_KEY, JSON.stringify(next));
       return next;
     });
   }, []);

--- a/packages/viewer/src/utils/__tests__/safe-storage.test.ts
+++ b/packages/viewer/src/utils/__tests__/safe-storage.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import { safeStorageGet, safeStorageRemove, safeStorageSet } from "../safe-storage";
 
 describe("safe storage helpers", () => {
+  it("returns stored values when getItem succeeds", () => {
+    const storage = {
+      getItem: vi.fn(() => "hello"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    } as unknown as Storage;
+
+    expect(safeStorageGet(storage, "key")).toBe("hello");
+  });
+
   it("returns null when getItem throws", () => {
     const storage = {
       getItem: vi.fn(() => {

--- a/packages/viewer/src/utils/__tests__/safe-storage.test.ts
+++ b/packages/viewer/src/utils/__tests__/safe-storage.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { safeStorageGet, safeStorageRemove, safeStorageSet } from "../safe-storage";
+
+describe("safe storage helpers", () => {
+  it("returns null when getItem throws", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    } as unknown as Storage;
+
+    expect(safeStorageGet(storage, "key")).toBeNull();
+  });
+
+  it("ignores setItem and removeItem failures", () => {
+    const storage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(() => {
+        throw new Error("quota");
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+    } as unknown as Storage;
+
+    expect(() => safeStorageSet(storage, "key", "value")).not.toThrow();
+    expect(() => safeStorageRemove(storage, "key")).not.toThrow();
+  });
+});

--- a/packages/viewer/src/utils/safe-storage.ts
+++ b/packages/viewer/src/utils/safe-storage.ts
@@ -1,0 +1,25 @@
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function safeStorageGet(storage: StorageLike, key: string): string | null {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeStorageSet(storage: StorageLike, key: string, value: string): void {
+  try {
+    storage.setItem(key, value);
+  } catch {
+    /* blocked or quota-limited storage should not break playback */
+  }
+}
+
+export function safeStorageRemove(storage: StorageLike, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary
- Clamp timeline seek/progress/ARIA values so right-edge clicks and out-of-range indices stay within valid scene bounds.
- Add safe storage helpers and use them for theme, view preferences, and dashboard navigation state so blocked or quota-limited storage does not crash playback.
- Cover the new timeline and storage behavior with focused viewer unit tests.

## Test plan
- pnpm --filter @vibe-replay/viewer test
- pnpm typecheck
- pnpm lint:check
- pnpm build


Made with [Cursor](https://cursor.com)