### PR TITLE
Surface parser data-loss warnings

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,7 @@ import { scanForSecrets } from "./scan.js";
 import { startDashboard, startServer } from "./server.js";
 import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
 import { transformToReplay } from "./transform.js";
-import type { ReplaySession, SessionInfo } from "./types.js";
+import type { ParseWarning, ReplaySession, SessionInfo } from "./types.js";
 import { normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
@@ -159,6 +159,41 @@ function suggestedReplayTitle(
   if (firstPromptTitle) return firstPromptTitle;
 
   return replayCandidate || slug || replaySlug;
+}
+
+function formatParseWarningSummary(warnings?: ParseWarning[]): string[] {
+  if (!warnings?.length) return [];
+  return warnings.map((warning) => {
+    const label =
+      warning.kind === "malformed-json"
+        ? "malformed JSONL line"
+        : warning.kind === "missing-image"
+          ? "image file"
+          : warning.kind === "unreadable-source"
+            ? "unreadable source"
+            : "item";
+    const plural = warning.count === 1 ? label : `${label}s`;
+    const location = warning.firstLine ? ` first at line ${warning.firstLine}` : "";
+    const source = warning.source ? ` in ${warning.source}` : "";
+    const sample = warning.sample ? ` Sample: ${warning.sample}` : "";
+    return `${warning.count} ${plural} skipped${source}${location}. ${warning.message}.${sample}`;
+  });
+}
+
+function printParseWarnings(warnings?: ParseWarning[]): void {
+  const lines = formatParseWarningSummary(warnings);
+  if (lines.length === 0) return;
+  const total = warnings?.reduce((sum, warning) => sum + warning.count, 0) ?? 0;
+  process.stderr.write(
+    `${chalk.yellow(`  ⚠ ${total} parser warning${total === 1 ? "" : "s"} detected`)}\n`,
+  );
+  for (const line of lines.slice(0, 4)) {
+    process.stderr.write(`${chalk.dim("    - ")}${chalk.yellow(line)}\n`);
+  }
+  if (lines.length > 4) {
+    process.stderr.write(chalk.dim(`    ... ${lines.length - 4} more warning group(s)\n`));
+  }
+  process.stderr.write("\n");
 }
 
 async function discoverAllSessions(): Promise<SessionInfo[]> {
@@ -550,6 +585,8 @@ program
         console.log(chalk.dim("  Continuing — user confirmed findings are safe.\n"));
       }
     }
+
+    printParseWarnings(replay.meta.parseWarnings);
 
     // --open: auto-open in browser and exit (non-interactive mode)
     if (opts.open) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -176,7 +176,7 @@ function formatParseWarningSummary(warnings?: ParseWarning[]): string[] {
     const location = warning.firstLine ? ` first at line ${warning.firstLine}` : "";
     const source = warning.source ? ` in ${warning.source}` : "";
     const sample = warning.sample ? ` Sample: ${warning.sample}` : "";
-    return `${warning.count} ${plural} skipped${source}${location}. ${warning.message}.${sample}`;
+    return `${warning.count} ${plural} skipped${source}${location}.${sample}`;
   });
 }
 

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -5,6 +5,7 @@ import { isSystemGeneratedMessage } from "../../clean-prompt.js";
 import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, RawMessage } from "../../types.js";
 import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
+import { addParseWarning } from "../warnings.js";
 
 export async function parseClaudeCodeSession(
   filePaths: string | string[],
@@ -15,7 +16,7 @@ export async function parseClaudeCodeSession(
   const allLines: string[] = [];
   for (const fp of paths) {
     const content = await readFile(fp, "utf-8");
-    allLines.push(...content.split("\n").filter((l) => l.trim()));
+    allLines.push(...content.split("\n"));
   }
 
   return parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] });
@@ -124,12 +125,22 @@ export async function parseClaudeCodeLines(
 
   // All JSONL entry timestamps — used to estimate active duration when turn_duration events are missing
   const allTimestamps: string[] = [];
+  const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    if (!line.trim()) continue;
     let obj: RawMessage;
     try {
       obj = JSON.parse(line);
     } catch {
+      addParseWarning(parseWarnings, {
+        kind: "malformed-json",
+        source: "claude-code JSONL",
+        firstLine: lineIndex + 1,
+        message: "Skipped malformed JSONL line",
+        sample: line,
+      });
       continue;
     }
 
@@ -435,7 +446,7 @@ export async function parseClaudeCodeLines(
   // Read subagent JSONL files: extract full conversations + token usage.
   // Must happen before enrichment so subAgentData is available.
   const subAgentData = options.subagentsSourcePath
-    ? await readSubagents(options.subagentsSourcePath, usageByMsgId)
+    ? await readSubagents(options.subagentsSourcePath, usageByMsgId, parseWarnings)
     : new Map<string, SubAgentParsed>();
 
   // Build assistant turns with enriched blocks
@@ -615,6 +626,7 @@ export async function parseClaudeCodeLines(
     agentName,
     worktree,
     queueOperationStats,
+    parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
   };
 }
 
@@ -851,6 +863,7 @@ async function readSubagents(
       model?: string;
     }
   >,
+  parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]>,
 ): Promise<Map<string, SubAgentParsed>> {
   const result = new Map<string, SubAgentParsed>();
   const sessionDir = mainFilePath.replace(/\.jsonl$/, "");
@@ -907,12 +920,21 @@ async function readSubagents(
     const saAssistantOrder: string[] = [];
     const saAssistantTimestamps = new Map<string, string>();
 
+    let lineNumber = 0;
     for (const line of content.split("\n")) {
+      lineNumber++;
       if (!line.trim()) continue;
       let obj: any;
       try {
         obj = JSON.parse(line);
       } catch {
+        addParseWarning(parseWarnings, {
+          kind: "malformed-json",
+          source: "claude-code subagent JSONL",
+          firstLine: lineNumber,
+          message: "Skipped malformed subagent JSONL line",
+          sample: line,
+        });
         continue;
       }
 

--- a/packages/cli/src/providers/claude-cowork/parser.ts
+++ b/packages/cli/src/providers/claude-cowork/parser.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { parseClaudeCodeLines } from "../claude-code/parser.js";
 import type { ProviderParseResult } from "../types.js";
+import { addParseWarning } from "../warnings.js";
 import type { SessionInfo } from "../../types.js";
 
 /**
@@ -15,11 +16,12 @@ import type { SessionInfo } from "../../types.js";
  *   - Extra types like `rate_limit_event`, `tool_use_summary` — parser ignores them.
  *   - Missing `cwd` / `gitBranch` / `custom-title` — supplied by sibling metadata JSON.
  */
-export function normalizeCoworkLine(line: string): string | null {
+export function normalizeCoworkLine(line: string, onMalformedJson?: () => void): string | null {
   let obj: Record<string, unknown>;
   try {
     obj = JSON.parse(line);
   } catch {
+    onMalformedJson?.();
     return null;
   }
   if (!obj || typeof obj !== "object") return null;
@@ -50,12 +52,23 @@ export async function parseClaudeCoworkSession(
 ): Promise<ProviderParseResult> {
   const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
   const normalized: string[] = [];
+  const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
   for (const fp of paths) {
     const content = await readFile(fp, "utf-8");
-    for (const raw of content.split("\n")) {
+    const lines = content.split("\n");
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const raw = lines[lineIndex];
       const t = raw.trim();
       if (!t) continue;
-      const line = normalizeCoworkLine(t);
+      const line = normalizeCoworkLine(t, () => {
+        addParseWarning(parseWarnings, {
+          kind: "malformed-json",
+          source: "claude-cowork audit JSONL",
+          firstLine: lineIndex + 1,
+          message: "Skipped malformed JSONL line",
+          sample: t,
+        });
+      });
       if (line) normalized.push(line);
     }
   }
@@ -63,6 +76,9 @@ export async function parseClaudeCoworkSession(
   // Cowork transcripts are self-contained — no sibling `agents/` directory, so
   // subagentsSourcePath is intentionally omitted (parser will use an empty map).
   const result = await parseClaudeCodeLines(normalized);
+  if (parseWarnings.length > 0) {
+    result.parseWarnings = [...parseWarnings, ...(result.parseWarnings || [])];
+  }
 
   // Overlay metadata that audit.jsonl does not carry but the sibling JSON does.
   // Only fall back to the overlay — parsed values always win when present.

--- a/packages/cli/src/providers/codex/parser.ts
+++ b/packages/cli/src/providers/codex/parser.ts
@@ -4,6 +4,7 @@ import { extname } from "node:path";
 import { estimateActiveDuration } from "../../duration.js";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
 import type { Compaction, ProviderParseResult, TokenUsage } from "../types.js";
+import { addParseWarning } from "../warnings.js";
 import { codexStripTwoPass, isCodexToolCallType } from "./constants.js";
 
 interface PendingTool {
@@ -50,7 +51,7 @@ export async function parseCodexSession(
   const lines: string[] = [];
   for (const fp of paths) {
     const content = await readFile(fp, "utf-8");
-    lines.push(...content.split("\n").filter((l) => l.trim()));
+    lines.push(...content.split("\n"));
   }
   return parseCodexLines(lines, sessionInfo, paths);
 }
@@ -85,12 +86,22 @@ export function parseCodexLines(
   const gitBranches: string[] = [];
   const seenUserMessages = new Map<string, number[]>();
   const seenAssistantMessages = new Map<string, number[]>();
+  const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
 
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    if (!line.trim()) continue;
     let obj: any;
     try {
       obj = JSON.parse(line);
     } catch {
+      addParseWarning(parseWarnings, {
+        kind: "malformed-json",
+        source: "codex JSONL",
+        firstLine: lineIndex + 1,
+        message: "Skipped malformed JSONL line",
+        sample: line,
+      });
       continue;
     }
 
@@ -421,6 +432,7 @@ export function parseCodexLines(
       supplements: sourcePaths,
       notes: ["Discovered from Codex state and parsed from rollout JSONL (local beta)."],
     },
+    parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
   };
 }
 

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -216,9 +216,11 @@ function mergeParseWarnings(
   base: ProviderParseResult["parseWarnings"],
   extra: ProviderParseResult["parseWarnings"],
 ): ProviderParseResult["parseWarnings"] {
-  if (!base?.length) return extra;
-  if (!extra?.length) return base;
-  return [...base, ...extra];
+  const merged: NonNullable<ProviderParseResult["parseWarnings"]> = [];
+  for (const warning of [...(base || []), ...(extra || [])]) {
+    addParseWarning(merged, warning);
+  }
+  return merged.length > 0 ? merged : undefined;
 }
 
 interface ParseJsonlOptions {

--- a/packages/cli/src/providers/cursor/parser.ts
+++ b/packages/cli/src/providers/cursor/parser.ts
@@ -20,6 +20,7 @@ import {
   mapToolArgs,
   parseCursorSqlite,
 } from "./sqlite-reader.js";
+import { addParseWarning } from "../warnings.js";
 
 const CURSOR_UUID_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -69,6 +70,10 @@ export async function parseCursorSession(
         const jsonlThinking = await parseCursorJsonl(transcriptPaths, [], {
           inferToolPaths: false,
         });
+        sqliteResult.parseWarnings = mergeParseWarnings(
+          sqliteResult.parseWarnings,
+          jsonlThinking.parseWarnings,
+        );
         sqliteResult.turns = mergeJsonlSupplementsIntoCursorTurns(
           sqliteResult.turns,
           jsonlThinking.turns,
@@ -207,6 +212,15 @@ function deriveSessionIdFromTranscript(transcriptPaths: string[]): string | null
   return null;
 }
 
+function mergeParseWarnings(
+  base: ProviderParseResult["parseWarnings"],
+  extra: ProviderParseResult["parseWarnings"],
+): ProviderParseResult["parseWarnings"] {
+  if (!base?.length) return extra;
+  if (!extra?.length) return base;
+  return [...base, ...extra];
+}
+
 interface ParseJsonlOptions {
   inferToolPaths: boolean;
 }
@@ -253,18 +267,28 @@ async function parseCursorJsonl(
   const toolResults = new Map<string, CursorToolResult>();
   const toolErrors = new Map<string, boolean>();
   const toolImages = new Map<string, string[]>();
+  const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
   const sortedTranscriptPaths = await sortByMtime(transcriptPaths);
   const sessionId = basename(sortedTranscriptPaths[sortedTranscriptPaths.length - 1], ".jsonl");
 
   for (const filePath of sortedTranscriptPaths) {
     const content = await readFile(filePath, "utf-8");
-    const lines = content.split("\n").filter((l) => l.trim());
+    const lines = content.split("\n");
 
-    for (const line of lines) {
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
+      if (!line.trim()) continue;
       let obj: any;
       try {
         obj = JSON.parse(line);
       } catch {
+        addParseWarning(parseWarnings, {
+          kind: "malformed-json",
+          source: "cursor transcript JSONL",
+          firstLine: lineIndex + 1,
+          message: "Skipped malformed JSONL line",
+          sample: line,
+        });
         continue;
       }
 
@@ -304,7 +328,17 @@ async function parseCursorJsonl(
 
       for (const imagePath of imageFilePaths) {
         const dataUrl = await readImageFileAsDataUrl(imagePath);
-        if (dataUrl) userImages.push(dataUrl);
+        if (dataUrl) {
+          userImages.push(dataUrl);
+        } else {
+          addParseWarning(parseWarnings, {
+            kind: "missing-image",
+            source: "cursor transcript image reference",
+            firstLine: lineIndex + 1,
+            message: "Skipped image reference because the file could not be read",
+            sample: imagePath,
+          });
+        }
       }
 
       if (role === "user" && textParts.length === 0 && userImages.length === 0) continue;
@@ -416,6 +450,7 @@ async function parseCursorJsonl(
         ...(hasToolData ? ["cursor/projects/agent-tools/*.txt"] : []),
       ],
     },
+    parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
   };
 }
 

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,4 +1,10 @@
-import type { CursorSidecars, PrLink, TokenUsage, TurnStat } from "@vibe-replay/types";
+import type {
+  CursorSidecars,
+  ParseWarning,
+  PrLink,
+  TokenUsage,
+  TurnStat,
+} from "@vibe-replay/types";
 import type { DataSource, DataSourceInfo, ParsedTurn, SessionInfo } from "../types.js";
 
 export type { DataSource, DataSourceInfo, TokenUsage };
@@ -62,6 +68,8 @@ export interface ProviderParseResult {
   trackedFiles?: string[];
   contextFiles?: string[];
   cursorSidecars?: CursorSidecars;
+  /** Parser data-loss warnings collected while reading provider source data */
+  parseWarnings?: ParseWarning[];
   /** API service tier (e.g. "standard") from usage data */
   serviceTier?: string;
   /** Skills / slash commands used in the session (e.g. ["playwright-cli", "/insights"]) */

--- a/packages/cli/src/providers/warnings.ts
+++ b/packages/cli/src/providers/warnings.ts
@@ -1,0 +1,29 @@
+import type { ParseWarning } from "@vibe-replay/types";
+
+export function addParseWarning(
+  warnings: ParseWarning[],
+  warning: Omit<ParseWarning, "count"> & { count?: number },
+): void {
+  const existing = warnings.find(
+    (w) => w.kind === warning.kind && w.source === warning.source && w.message === warning.message,
+  );
+  if (existing) {
+    existing.count += warning.count ?? 1;
+    return;
+  }
+
+  warnings.push({
+    kind: warning.kind,
+    count: warning.count ?? 1,
+    message: warning.message,
+    source: warning.source,
+    firstLine: warning.firstLine,
+    sample: warning.kind === "malformed-json" ? undefined : warning.sample,
+  });
+}
+
+export function compactWarningSample(value: string, max = 160): string {
+  const compacted = value.replace(/\s+/g, " ").trim();
+  if (compacted.length <= max) return compacted;
+  return `${compacted.slice(0, max)}...`;
+}

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
 import type { ProviderParseResult } from "./providers/types.js";
+import { compactWarningSample } from "./providers/warnings.js";
 import type { ContentBlock, ReplaySession, Scene, SubAgent } from "./types.js";
 import { estimateTokens } from "./utils/tokenEstimate.js";
 
@@ -206,6 +207,19 @@ export function transformToReplay(
         ? { contextFiles: parsed.contextFiles.map(redactFilePath) }
         : {}),
       ...(parsed.cursorSidecars ? { cursorSidecars: parsed.cursorSidecars } : {}),
+      ...(parsed.parseWarnings && parsed.parseWarnings.length > 0
+        ? {
+            parseWarnings: parsed.parseWarnings.map((warning) => ({
+              ...warning,
+              message: redactWarningText(warning.message),
+              ...(warning.source ? { source: redactWarningText(warning.source) } : {}),
+              sample:
+                warning.kind !== "malformed-json" && warning.sample
+                  ? compactWarningSample(redactWarningText(warning.sample))
+                  : undefined,
+            })),
+          }
+        : {}),
       ...(parsed.serviceTier ? { serviceTier: parsed.serviceTier } : {}),
       ...(parsed.skillsUsed ? { skillsUsed: parsed.skillsUsed } : {}),
       ...(parsed.mcpServersUsed ? { mcpServersUsed: parsed.mcpServersUsed } : {}),
@@ -265,6 +279,27 @@ function buildFileDiff(
 
 function redactDiffContent(value: unknown): string {
   return typeof value === "string" ? redactSecrets(redactPath(value)) : "";
+}
+
+function redactWarningText(value: string): string {
+  return redactSecrets(redactWarningPaths(redactPath(value))).replace(
+    /[A-Za-z0-9_-]{4,}\.\.\.\[REDACTED\]/g,
+    "[REDACTED]",
+  );
+}
+
+function redactWarningPaths(value: string): string {
+  let result = value;
+  if (HOME) {
+    const slashEscapedHome = HOME.replaceAll("/", "\\/");
+    result = result.replaceAll(slashEscapedHome, "~");
+
+    const backslashEscapedHome = HOME.replaceAll("\\", "\\\\");
+    if (backslashEscapedHome !== HOME) {
+      result = result.replaceAll(backslashEscapedHome, "~");
+    }
+  }
+  return result.replace(/[A-Za-z]:(?:\\\\|\\)Users(?:\\\\|\\)[^\\/"\s]+/g, "~");
 }
 
 function buildToolScene(

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -282,6 +282,8 @@ function redactDiffContent(value: unknown): string {
 }
 
 function redactWarningText(value: string): string {
+  // Warning samples are user-visible diagnostics, so fully hide even the short
+  // secret prefix that redactSecrets keeps for normal replay content context.
   return redactSecrets(redactWarningPaths(redactPath(value))).replace(
     /[A-Za-z0-9_-]{4,}\.\.\.\[REDACTED\]/g,
     "[REDACTED]",
@@ -291,6 +293,8 @@ function redactWarningText(value: string): string {
 function redactWarningPaths(value: string): string {
   let result = value;
   if (HOME) {
+    // Raw JSON snippets can contain slash-escaped POSIX paths like
+    // "\/Users\/name" that the literal redactPath pass above will not see.
     const slashEscapedHome = HOME.replaceAll("/", "\\/");
     result = result.replaceAll(slashEscapedHome, "~");
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -9,6 +9,7 @@ export type {
   DataSourceInfo,
   InsightsStore,
   OverlaySource,
+  ParseWarning,
   PrLink,
   ReplaySession,
   Scene,

--- a/packages/cli/test/claude-code-parser.test.ts
+++ b/packages/cli/test/claude-code-parser.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ContentBlock } from "../src/types.js";
@@ -70,6 +72,35 @@ describe("Claude Code parser", () => {
       .map((b) => (b as TextBlock).text)
       .join(" ");
     expect(allText).not.toContain("streaming");
+  });
+
+  it("records malformed JSONL lines as parse warnings", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-claude-malformed-"));
+    const jsonlPath = join(tempDir, "session.jsonl");
+    const validLine = JSON.stringify({
+      type: "user",
+      sessionId: "warn-session",
+      slug: "warn-session",
+      cwd: "/tmp/project",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: { role: "user", content: "Fix malformed parser reporting" },
+    });
+    await writeFile(jsonlPath, `${validLine}\n{not-json\n`, "utf-8");
+
+    try {
+      const result = await parseClaudeCodeSession(jsonlPath);
+      expect(result.turns).toHaveLength(1);
+      expect(result.parseWarnings).toEqual([
+        expect.objectContaining({
+          kind: "malformed-json",
+          count: 1,
+          source: "claude-code JSONL",
+          firstLine: 2,
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/cli/test/claude-cowork-parser.test.ts
+++ b/packages/cli/test/claude-cowork-parser.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -54,6 +56,12 @@ describe("normalizeCoworkLine", () => {
   it("returns null for unparseable JSON", () => {
     expect(normalizeCoworkLine("not json")).toBeNull();
     expect(normalizeCoworkLine("")).toBeNull();
+  });
+
+  it("reports malformed JSON through the optional callback", () => {
+    let malformedCount = 0;
+    expect(normalizeCoworkLine("not json", () => malformedCount++)).toBeNull();
+    expect(malformedCount).toBe(1);
   });
 
   it("passes through unrelated fields unchanged", () => {
@@ -161,5 +169,33 @@ describe("parseClaudeCoworkSession", () => {
 
     // Audit has model claude-opus-4-6 on the assistant turn — parsed value must win.
     expect(result.model).toBe("claude-opus-4-6");
+  });
+
+  it("records malformed audit JSONL lines as parse warnings", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cowork-malformed-"));
+    const auditPath = join(tempDir, "audit.jsonl");
+    const validLine = JSON.stringify({
+      type: "user",
+      session_id: "cowork-warning-session",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: { role: "user", content: "Investigate malformed cowork data" },
+    });
+    await writeFile(auditPath, `${validLine}\n{not-json\n`, "utf-8");
+
+    try {
+      const result = await parseClaudeCoworkSession(auditPath);
+      expect(result.turns).toHaveLength(1);
+      expect(result.parseWarnings).toEqual([
+        expect.objectContaining({
+          kind: "malformed-json",
+          count: 1,
+          source: "claude-cowork audit JSONL",
+          firstLine: 2,
+          message: "Skipped malformed JSONL line",
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/codex-parser.test.ts
+++ b/packages/cli/test/codex-parser.test.ts
@@ -124,6 +124,21 @@ describe("Codex parser", () => {
     });
   });
 
+  it("records malformed JSONL lines as parse warnings", () => {
+    const result = parseCodexLines([...lines.slice(0, 2), "{not-json", ...lines.slice(2)]);
+
+    expect(result.turns.length).toBeGreaterThan(0);
+    expect(result.parseWarnings).toEqual([
+      expect.objectContaining({
+        kind: "malformed-json",
+        count: 1,
+        source: "codex JSONL",
+        firstLine: 3,
+        message: "Skipped malformed JSONL line",
+      }),
+    ]);
+  });
+
   it("transforms Codex tool calls into replay scenes", () => {
     const parsed = parseCodexLines(lines);
     const replay = transformToReplay(parsed, "codex", "~/project");

--- a/packages/cli/test/cursor-parser.test.ts
+++ b/packages/cli/test/cursor-parser.test.ts
@@ -136,6 +136,71 @@ describe("Cursor parser", () => {
     }
   });
 
+  it("records malformed JSONL lines as parse warnings", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-malformed-"));
+    const jsonlPath = join(tempDir, "malformed-session.jsonl");
+    const validLine = JSON.stringify({
+      role: "user",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: {
+        content: [{ type: "text", text: "<user_query>\nFix malformed data\n</user_query>" }],
+      },
+    });
+    await writeFile(jsonlPath, `${validLine}\n{not-json\n`, "utf-8");
+
+    try {
+      const result = await parseCursorSession(jsonlPath);
+      expect(result.turns).toHaveLength(1);
+      expect(result.parseWarnings).toEqual([
+        expect.objectContaining({
+          kind: "malformed-json",
+          count: 1,
+          source: "cursor transcript JSONL",
+          firstLine: 2,
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records unreadable image references as parse warnings", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-missing-image-"));
+    const missingImagePath = join(tempDir, "missing.png");
+    const jsonlPath = join(tempDir, "missing-image-session.jsonl");
+    await writeFile(
+      jsonlPath,
+      JSON.stringify({
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: `<user_query>\n[Image]\nPlease inspect this\n<image_files>\n1. ${missingImagePath}\n</image_files>\n</user_query>`,
+            },
+          ],
+        },
+      }),
+      "utf-8",
+    );
+
+    try {
+      const result = await parseCursorSession(jsonlPath);
+      expect(result.turns).toHaveLength(1);
+      expect(result.parseWarnings).toEqual([
+        expect.objectContaining({
+          kind: "missing-image",
+          count: 1,
+          source: "cursor transcript image reference",
+          firstLine: 1,
+          sample: missingImagePath,
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("handles prompts without <user_query> wrapper", async () => {
     const result = await parseCursorSession(FIXTURE);
     const userTurns = result.turns.filter((t) => t.role === "user");

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os";
 import { describe, expect, it } from "vitest";
 import type { ProviderParseResult, TokenUsage } from "../src/providers/types.js";
 import { transformToReplay } from "../src/transform.js";
@@ -165,6 +166,31 @@ describe("transform — scene generation", () => {
     expect(sample).not.toContain("alice");
     expect(sample).not.toContain("C:\\\\Users");
     expect(sample).toContain("~\\\\project");
+  });
+
+  it("redacts JSON slash-escaped home paths in parse warning samples", () => {
+    const home = homedir();
+    const escapedHome = home.replaceAll("/", "\\/");
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [userTurn("Hello world")],
+        parseWarnings: [
+          {
+            kind: "unreadable-source",
+            count: 1,
+            message: "Skipped unreadable source",
+            sample: `{"path":"${escapedHome}\\/secret.jsonl"}`,
+          },
+        ],
+      }),
+      "cursor",
+      "~/test",
+    );
+
+    const sample = replay.meta.parseWarnings?.[0]?.sample || "";
+    expect(sample).not.toContain(home);
+    expect(sample).not.toContain(escapedHome);
+    expect(sample).toContain("~\\/secret.jsonl");
   });
 
   it("creates text-response scene from assistant text", () => {

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -74,6 +74,99 @@ describe("transform — scene generation", () => {
     expect(replay.scenes[0].content).toBe("Hello world");
   });
 
+  it("propagates parse warnings into replay metadata", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [userTurn("Hello world")],
+        parseWarnings: [
+          {
+            kind: "malformed-json",
+            count: 2,
+            message: "Skipped malformed JSONL line",
+            source: "test JSONL",
+            firstLine: 3,
+          },
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+
+    expect(replay.meta.parseWarnings).toEqual([
+      expect.objectContaining({ kind: "malformed-json", count: 2, source: "test JSONL" }),
+    ]);
+  });
+
+  it("redacts parse warning messages and drops malformed JSON samples", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [userTurn("Hello world")],
+        parseWarnings: [
+          {
+            kind: "malformed-json",
+            count: 1,
+            message: "Skipped malformed JSONL line with sk-ant-1234567890abcdef1234567890",
+            sample: '{"token":"sk-ant-1234567890abcdef1234567890"}',
+          },
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+
+    const warning = replay.meta.parseWarnings?.[0];
+    expect(warning?.message).toContain("[REDACTED]");
+    expect(warning?.sample).toBeUndefined();
+    expect(JSON.stringify(warning)).not.toContain("sk-ant-1234567890abcdef1234567890");
+  });
+
+  it("redacts parse warning samples before truncating them", () => {
+    const crossingBoundaryToken = `sk-ant-${"a".repeat(40)}`;
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [userTurn("Hello world")],
+        parseWarnings: [
+          {
+            kind: "unreadable-source",
+            count: 1,
+            message: "Skipped unreadable source",
+            sample: `${"x".repeat(150)}${crossingBoundaryToken}`,
+          },
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+
+    const sample = replay.meta.parseWarnings?.[0]?.sample || "";
+    expect(sample).toContain("[REDACTED]");
+    expect(sample).not.toContain("sk-ant-");
+    expect(sample).not.toContain(crossingBoundaryToken);
+  });
+
+  it("redacts JSON-escaped Windows user paths in parse warning samples", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [userTurn("Hello world")],
+        parseWarnings: [
+          {
+            kind: "unreadable-source",
+            count: 1,
+            message: "Skipped unreadable source",
+            sample: '{"file":"C:\\\\Users\\\\alice\\\\project\\\\session.jsonl"}',
+          },
+        ],
+      }),
+      "cursor",
+      "~/test",
+    );
+
+    const sample = replay.meta.parseWarnings?.[0]?.sample || "";
+    expect(sample).not.toContain("alice");
+    expect(sample).not.toContain("C:\\\\Users");
+    expect(sample).toContain("~\\\\project");
+  });
+
   it("creates text-response scene from assistant text", () => {
     const replay = transformToReplay(
       buildParsed({ turns: [assistantTextTurn("The answer is 42.")] }),

--- a/packages/cli/test/warnings.test.ts
+++ b/packages/cli/test/warnings.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { addParseWarning, compactWarningSample } from "../src/providers/warnings.js";
+import type { ParseWarning } from "../src/types.js";
+
+describe("parse warning helpers", () => {
+  it("aggregates warnings by kind, source, and message", () => {
+    const warnings: ParseWarning[] = [];
+
+    addParseWarning(warnings, {
+      kind: "malformed-json",
+      source: "cursor transcript JSONL",
+      firstLine: 3,
+      message: "Skipped malformed JSONL line",
+      sample: "{not-json",
+    });
+    addParseWarning(warnings, {
+      kind: "malformed-json",
+      source: "cursor transcript JSONL",
+      firstLine: 8,
+      message: "Skipped malformed JSONL line",
+      sample: "{still-not-json",
+    });
+
+    expect(warnings).toEqual([
+      {
+        kind: "malformed-json",
+        source: "cursor transcript JSONL",
+        firstLine: 3,
+        count: 2,
+        message: "Skipped malformed JSONL line",
+        sample: undefined,
+      },
+    ]);
+  });
+
+  it("keeps non-malformed warning samples for later redaction", () => {
+    const warnings: ParseWarning[] = [];
+
+    addParseWarning(warnings, {
+      kind: "missing-image",
+      source: "cursor transcript image reference",
+      message: "Skipped image reference because the file could not be read",
+      sample: "/Users/alice/project/image.png",
+    });
+
+    expect(warnings[0]?.sample).toBe("/Users/alice/project/image.png");
+  });
+
+  it("compacts long samples after callers redact them", () => {
+    expect(compactWarningSample(`  ${"x".repeat(170)}  `)).toBe(`${"x".repeat(160)}...`);
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,7 +31,11 @@ export interface CursorSidecars {
   hasWorkspaceRules?: boolean;
 }
 
-export type ParseWarningKind = "malformed-json" | "missing-image" | "unreadable-source";
+export type ParseWarningKind =
+  | "malformed-json"
+  | "missing-image"
+  // Reserved for provider source-read failures, such as unreadable or corrupt sidecars.
+  | "unreadable-source";
 
 export interface ParseWarning {
   kind: ParseWarningKind;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,6 +31,17 @@ export interface CursorSidecars {
   hasWorkspaceRules?: boolean;
 }
 
+export type ParseWarningKind = "malformed-json" | "missing-image" | "unreadable-source";
+
+export interface ParseWarning {
+  kind: ParseWarningKind;
+  count: number;
+  message: string;
+  source?: string;
+  firstLine?: number;
+  sample?: string;
+}
+
 export interface SubAgent {
   agentId: string;
   agentType: string;
@@ -301,6 +312,8 @@ export interface ReplaySession {
     contextFiles?: string[];
     /** Cursor-only sidecar coverage from global-state session metadata */
     cursorSidecars?: CursorSidecars;
+    /** Parser data-loss warnings collected while reading provider source data */
+    parseWarnings?: ParseWarning[];
     /** API service tier observed (e.g. "standard") */
     serviceTier?: string;
     /** Skills / slash commands used (e.g. ["playwright-cli", "/insights"]) */

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -2,12 +2,27 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { ReplaySession } from "../types";
 
+function formatParseWarningNote(
+  warning: NonNullable<ReplaySession["meta"]["parseWarnings"]>[number],
+): string {
+  const label =
+    warning.kind === "malformed-json"
+      ? "malformed JSONL line"
+      : warning.kind === "missing-image"
+        ? "image file"
+        : warning.kind === "unreadable-source"
+          ? "unreadable source"
+          : "item";
+  const plural = warning.count === 1 ? label : `${label}s`;
+  const source = warning.source ? ` in ${warning.source}` : "";
+  const location = warning.firstLine ? ` first at line ${warning.firstLine}` : "";
+  return `${warning.count} ${plural} skipped${source}${location}.`;
+}
+
 export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[] {
   const notes = [...(meta.dataSourceInfo?.notes || [])];
   for (const warning of meta.parseWarnings || []) {
-    notes.push(
-      `${warning.count} parser warning${warning.count === 1 ? "" : "s"}: ${warning.message}`,
-    );
+    notes.push(formatParseWarningNote(warning));
   }
 
   if (

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -4,6 +4,11 @@ import type { ReplaySession } from "../types";
 
 export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[] {
   const notes = [...(meta.dataSourceInfo?.notes || [])];
+  for (const warning of meta.parseWarnings || []) {
+    notes.push(
+      `${warning.count} parser warning${warning.count === 1 ? "" : "s"}: ${warning.message}`,
+    );
+  }
 
   if (
     meta.provider === "cursor" &&

--- a/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
+++ b/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { ReplaySession } from "../../types";
+import { getSessionDataQualityNotes } from "../DataQualityIndicator";
+
+function metaWithWarnings(
+  parseWarnings: NonNullable<ReplaySession["meta"]["parseWarnings"]>,
+): ReplaySession["meta"] {
+  return {
+    sessionId: "test-session",
+    slug: "test-session",
+    provider: "cursor",
+    startTime: "2026-01-01T00:00:00.000Z",
+    cwd: "~/project",
+    project: "project",
+    stats: {
+      sceneCount: 1,
+      userPrompts: 1,
+      toolCalls: 0,
+      tokenUsage: {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+      },
+    },
+    parseWarnings,
+  };
+}
+
+describe("getSessionDataQualityNotes", () => {
+  it("formats parser warnings with kind, source, and line context", () => {
+    expect(
+      getSessionDataQualityNotes(
+        metaWithWarnings([
+          {
+            kind: "malformed-json",
+            count: 2,
+            source: "cursor transcript JSONL",
+            firstLine: 3,
+            message: "Skipped malformed JSONL line",
+          },
+          {
+            kind: "missing-image",
+            count: 1,
+            source: "cursor transcript image reference",
+            message: "Skipped image reference because the file could not be read",
+          },
+        ]),
+      ),
+    ).toEqual([
+      "2 malformed JSONL lines skipped in cursor transcript JSONL first at line 3.",
+      "1 image file skipped in cursor transcript image reference.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Surface malformed JSONL parser warnings across Claude Code, Claude Cowork, Cursor, and Codex providers, including Claude Code subagent JSONL.
- Surface Cursor unreadable image-reference warnings, then thread parser warnings into replay metadata, CLI output, and viewer data-quality notes.
- Redact warning text and non-JSON samples before display; malformed JSON samples are dropped to avoid leaking raw broken source lines.

## Test plan
- pnpm test
- pnpm lint:check
- pnpm typecheck