### PR TITLE
Surface server recoverable warnings

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -277,10 +277,19 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
       let annotationCount = 0;
       try {
         const annRaw = await readFile(annotationsPath, "utf-8");
-        const anns = JSON.parse(annRaw) as Annotation[];
-        annotationCount = Array.isArray(anns) ? anns.length : 0;
-      } catch {
-        /* no annotations */
+        const anns = JSON.parse(annRaw) as unknown;
+        if (Array.isArray(anns)) {
+          annotationCount = anns.length;
+        } else {
+          warnRecoverable(
+            `Ignoring annotation count at ${annotationsPath}`,
+            new Error("expected JSON array"),
+          );
+        }
+      } catch (err) {
+        if (!isMissingFileError(err)) {
+          warnRecoverable(`Unable to count annotations at ${annotationsPath}`, err);
+        }
       }
 
       let gist: SavedGistInfo | undefined;
@@ -3586,7 +3595,6 @@ export const __testables = {
   buildSourcesResult,
   buildInsightsSyncBatches,
   countSessionStats,
-  formatRecoverableWarning,
   loadAnnotations,
   pickSourceRecordForSession,
   prioritizeScanInputs,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -101,6 +101,24 @@ function getErrorMessage(err: unknown): string {
   return "Unknown error";
 }
 
+function getErrorCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null || !("code" in err)) return undefined;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function isMissingFileError(err: unknown): boolean {
+  return getErrorCode(err) === "ENOENT";
+}
+
+function formatRecoverableWarning(context: string, err: unknown): string {
+  return `${context}: ${getErrorMessage(err)}`;
+}
+
+function warnRecoverable(context: string, err: unknown): void {
+  console.warn(`Warning: ${formatRecoverableWarning(context, err)}`);
+}
+
 function normalizeProjectPath(project: string): string {
   const home = homedir();
   return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
@@ -334,7 +352,11 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
             }
           : undefined,
       });
-    } catch {}
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        warnRecoverable(`Skipping unreadable replay at ${replayPath}`, err);
+      }
+    }
   }
 
   return results;
@@ -949,11 +971,20 @@ function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
 async function loadAnnotations(baseDir: string, slug: string): Promise<Annotation[]> {
   const dirs = [join(baseDir, slug), resolve("./vibe-replay", slug)];
   for (const dir of dirs) {
+    const annotationsPath = join(dir, "annotations.json");
     try {
-      const raw = await readFile(join(dir, "annotations.json"), "utf-8");
-      const anns = JSON.parse(raw) as Annotation[];
-      if (Array.isArray(anns)) return anns;
-    } catch {}
+      const raw = await readFile(annotationsPath, "utf-8");
+      const anns = JSON.parse(raw) as unknown;
+      if (Array.isArray(anns)) return anns as Annotation[];
+      warnRecoverable(
+        `Ignoring annotations at ${annotationsPath}`,
+        new Error("expected JSON array"),
+      );
+    } catch (err) {
+      if (!isMissingFileError(err)) {
+        warnRecoverable(`Unable to load annotations at ${annotationsPath}`, err);
+      }
+    }
   }
   return [];
 }
@@ -1011,7 +1042,8 @@ export async function startServer(
       const sessions = await scanSessions(baseDir);
       await writeFileCache(replaysCacheKey, sessions);
       return sessions;
-    } catch {
+    } catch (err) {
+      warnRecoverable("Unable to refresh dashboard replay cache", err);
       // Best-effort cache refresh for dashboard listing.
       // Return null (not []) so callers can distinguish "scan failed" from "no replays".
       return null;
@@ -1067,7 +1099,8 @@ export async function startServer(
       if (changed) {
         await writeFileCache(sourcesCacheKey, updated);
       }
-    } catch {
+    } catch (err) {
+      warnRecoverable("Unable to sync sources cache with replay summaries", err);
       // Best-effort — never break core flows
     }
   };
@@ -1189,7 +1222,8 @@ export async function startServer(
               };
             }
           }
-        } catch {
+        } catch (err) {
+          warnRecoverable(`Unable to enrich Cursor stats for ${session.sessionId}`, err);
           // Best-effort enrichment only.
         } finally {
           sourcesEnrichmentStatus = {
@@ -1215,7 +1249,8 @@ export async function startServer(
       if (pending) {
         enrichCursorStatsInBackground(pending.merged, enrichedSources, pending.hints);
       }
-    })().catch(() => {
+    })().catch((err) => {
+      warnRecoverable("Cursor stat backfill failed", err);
       sourcesEnrichmentStatus = {
         ...sourcesEnrichmentStatus,
         running: false,
@@ -1373,7 +1408,9 @@ export async function startServer(
       const result = await syncInsightsToCloud();
       if (!result.error) lastAutoSyncDate = today;
     });
-    syncLock = job.catch(() => {});
+    syncLock = job.catch((err) => {
+      warnRecoverable("Auto-sync insights failed", err);
+    });
     return job;
   };
 
@@ -1502,11 +1539,16 @@ export async function startServer(
         // Persist insights to durable local store (survives source file deletion)
         persistInsightsFromScan(results)
           .then(() => autoSyncInsights()) // Auto-sync to cloud if logged in
-          .catch(() => {});
+          .catch((err) => {
+            warnRecoverable("Unable to persist or sync insights", err);
+          });
 
         // Pre-compute insights cache in background (non-blocking)
-        precomputeInsightsCache(results).catch(() => {});
-      } catch {
+        precomputeInsightsCache(results).catch((err) => {
+          warnRecoverable("Unable to precompute insights cache", err);
+        });
+      } catch (err) {
+        warnRecoverable("Background scan failed", err);
         scanState = {
           ...scanState,
           running: false,
@@ -2271,7 +2313,9 @@ export async function startServer(
       try {
         const sessions = mergeSameSessions(await provider.discover());
         allSessions.push(...sessions);
-      } catch {}
+      } catch (err) {
+        warnRecoverable(`Unable to discover ${provider.name} sessions for regeneration`, err);
+      }
     }
 
     let entries: string[];
@@ -2726,7 +2770,9 @@ export async function startServer(
               await saveAuthToken({ token: data.token, user: data.user }, cloudApiBaseUrl);
 
               // Auto-sync insights to cloud after login (fire-and-forget)
-              autoSyncInsights().catch(() => {});
+              autoSyncInsights().catch((err) => {
+                warnRecoverable("Unable to auto-sync insights after login", err);
+              });
             } catch {
               res.writeHead(400);
               res.end("Bad Request");
@@ -3540,8 +3586,11 @@ export const __testables = {
   buildSourcesResult,
   buildInsightsSyncBatches,
   countSessionStats,
+  formatRecoverableWarning,
+  loadAnnotations,
   pickSourceRecordForSession,
   prioritizeScanInputs,
+  scanSessionsFromDir,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
 };

--- a/packages/cli/test/server-observability.test.ts
+++ b/packages/cli/test/server-observability.test.ts
@@ -1,16 +1,46 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testables } from "../src/server.js";
 
 describe("server recoverable warnings", () => {
-  afterEach(() => {
+  const tempDirs: string[] = [];
+
+  async function createTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function makeReplayJson(slug: string): string {
+    return JSON.stringify({
+      meta: {
+        sessionId: slug,
+        slug,
+        title: slug,
+        provider: "claude-code",
+        startTime: "2026-01-01T00:00:00.000Z",
+        cwd: "/tmp/project",
+        project: "/tmp/project",
+        stats: {
+          sceneCount: 0,
+          userPrompts: 0,
+          toolCalls: 0,
+        },
+      },
+      scenes: [],
+    });
+  }
+
+  afterEach(async () => {
     vi.restoreAllMocks();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
   it("skips missing replay files without warning", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const baseDir = await createTempDir();
+    // Exercise the ENOENT suppression path with a non-replay subdirectory.
     await mkdir(join(baseDir, "cache"), { recursive: true });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -21,7 +51,7 @@ describe("server recoverable warnings", () => {
   });
 
   it("warns when a replay file exists but cannot be parsed", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const baseDir = await createTempDir();
     const replayDir = join(baseDir, "broken-session");
     await mkdir(replayDir, { recursive: true });
     await writeFile(join(replayDir, "replay.json"), "{", "utf-8");
@@ -35,8 +65,63 @@ describe("server recoverable warnings", () => {
     expect(warn.mock.calls[0]?.[0]).toContain("broken-session");
   });
 
+  it("warns when a replay file has an invalid shape", async () => {
+    const baseDir = await createTempDir();
+    const replayDir = join(baseDir, "invalid-shape-session");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(join(replayDir, "replay.json"), "{}", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sessions = await __testables.scanSessionsFromDir(baseDir);
+
+    expect(sessions).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Skipping unreadable replay");
+    expect(warn.mock.calls[0]?.[0]).toContain("invalid-shape-session");
+  });
+
+  it("warns when scan-time annotation counts cannot be parsed", async () => {
+    const baseDir = await createTempDir();
+    const replayDir = join(baseDir, "session-with-bad-annotation-count");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(
+      join(replayDir, "replay.json"),
+      makeReplayJson("session-with-bad-annotation-count"),
+    );
+    await writeFile(join(replayDir, "annotations.json"), "{", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sessions = await __testables.scanSessionsFromDir(baseDir);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.annotationCount).toBe(0);
+    expect(sessions[0]?.hasAnnotations).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Unable to count annotations");
+  });
+
+  it("warns when scan-time annotation counts have the wrong shape", async () => {
+    const baseDir = await createTempDir();
+    const replayDir = join(baseDir, "session-with-object-annotation-count");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(
+      join(replayDir, "replay.json"),
+      makeReplayJson("session-with-object-annotation-count"),
+    );
+    await writeFile(join(replayDir, "annotations.json"), "{}", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sessions = await __testables.scanSessionsFromDir(baseDir);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.annotationCount).toBe(0);
+    expect(sessions[0]?.hasAnnotations).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("expected JSON array");
+  });
+
   it("warns when annotations exist but cannot be parsed", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const baseDir = await createTempDir();
     const replayDir = join(baseDir, "session-with-bad-annotations");
     await mkdir(replayDir, { recursive: true });
     await writeFile(join(replayDir, "annotations.json"), "{", "utf-8");
@@ -50,7 +135,7 @@ describe("server recoverable warnings", () => {
   });
 
   it("warns when annotations JSON has the wrong shape", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const baseDir = await createTempDir();
     const replayDir = join(baseDir, "session-with-object-annotations");
     await mkdir(replayDir, { recursive: true });
     await writeFile(join(replayDir, "annotations.json"), "{}", "utf-8");

--- a/packages/cli/test/server-observability.test.ts
+++ b/packages/cli/test/server-observability.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testables } from "../src/server.js";
+
+describe("server recoverable warnings", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips missing replay files without warning", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    await mkdir(join(baseDir, "cache"), { recursive: true });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sessions = await __testables.scanSessionsFromDir(baseDir);
+
+    expect(sessions).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when a replay file exists but cannot be parsed", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const replayDir = join(baseDir, "broken-session");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(join(replayDir, "replay.json"), "{", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const sessions = await __testables.scanSessionsFromDir(baseDir);
+
+    expect(sessions).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Skipping unreadable replay");
+    expect(warn.mock.calls[0]?.[0]).toContain("broken-session");
+  });
+
+  it("warns when annotations exist but cannot be parsed", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const replayDir = join(baseDir, "session-with-bad-annotations");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(join(replayDir, "annotations.json"), "{", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const annotations = await __testables.loadAnnotations(baseDir, "session-with-bad-annotations");
+
+    expect(annotations).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("Unable to load annotations");
+  });
+
+  it("warns when annotations JSON has the wrong shape", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "vr-server-observability-"));
+    const replayDir = join(baseDir, "session-with-object-annotations");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(join(replayDir, "annotations.json"), "{}", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const annotations = await __testables.loadAnnotations(
+      baseDir,
+      "session-with-object-annotations",
+    );
+
+    expect(annotations).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("expected JSON array");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a small recoverable-warning helper for server-side best-effort flows.
- Surface warnings for malformed replay/annotation files and failed dashboard/background sync work while preserving fallback behavior.
- Cover malformed replay and annotation warning behavior with focused server tests.

## Test plan
- pnpm test
- pnpm lint:check
- pnpm typecheck


Made with [Cursor](https://cursor.com)