### PR TITLE
Add CLI guardrail tests

### DIFF
--- a/packages/cli/test/README.md
+++ b/packages/cli/test/README.md
@@ -39,6 +39,8 @@ These tests protect **parser compatibility** with real-world session data from C
 | `cursor-thinking-merge.test.ts` | Thinking block merge algorithm | Merge correctness |
 | `clean-prompt.test.ts` | Prompt cleaning | Text cleanup |
 | `scan.test.ts` | Secret scanning patterns | **Security (do not weaken)** |
+| `cache.test.ts` | File cache envelope versioning, key sanitization, disable flag | Cache compatibility |
+| `insights.test.ts` | Durable insight conversion, merge provenance, daily aggregation, stats | Insights persistence |
 | `pricing.test.ts` | Model pricing lookup + cost calculation | Per-model pricing |
 | `cost-estimation.test.ts` | Parser → transform cost integration | Multi-model cost accuracy |
 

--- a/packages/cli/test/cache.test.ts
+++ b/packages/cli/test/cache.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CLI_VERSION } from "../src/version.js";
+
+const homes: string[] = [];
+
+async function importCacheForHome(home: string) {
+  vi.resetModules();
+  vi.doMock("node:os", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:os")>();
+    return { ...actual, homedir: () => home };
+  });
+  return import("../src/cache.js");
+}
+
+function cachePath(home: string, key: string): string {
+  const safeKey = key.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return join(home, ".vibe-replay", "cache", `${safeKey}.json`);
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.doUnmock("node:os");
+  vi.resetModules();
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe("file cache", () => {
+  it("round-trips data through the versioned cache envelope", async () => {
+    const home = await mkdtemp(join(tmpdir(), "vibe-cache-test-"));
+    homes.push(home);
+    const { readFileCache, writeFileCache } = await importCacheForHome(home);
+
+    await writeFileCache("sources/project:one", { sessions: 3 });
+    const raw = JSON.parse(await readFile(cachePath(home, "sources/project:one"), "utf-8"));
+
+    expect(raw).toMatchObject({
+      envelopeVersion: 1,
+      appVersion: CLI_VERSION,
+      data: { sessions: 3 },
+    });
+    expect(typeof raw.updatedAt).toBe("string");
+    await expect(readFileCache<{ sessions: number }>("sources/project:one")).resolves.toMatchObject(
+      {
+        data: { sessions: 3 },
+      },
+    );
+  });
+
+  it("treats incompatible or malformed cache entries as misses", async () => {
+    const home = await mkdtemp(join(tmpdir(), "vibe-cache-test-"));
+    homes.push(home);
+    const { readFileCache } = await importCacheForHome(home);
+
+    await mkdir(join(home, ".vibe-replay", "cache"), { recursive: true });
+    await writeFile(cachePath(home, "bad-version"), JSON.stringify({ data: "stale" }), "utf-8");
+    await writeFile(cachePath(home, "bad-json"), "{", "utf-8");
+
+    await expect(readFileCache("bad-version")).resolves.toBeNull();
+    await expect(readFileCache("bad-json")).resolves.toBeNull();
+    await expect(readFileCache("missing")).resolves.toBeNull();
+  });
+
+  it("honors the disable flag for reads and writes", async () => {
+    const home = await mkdtemp(join(tmpdir(), "vibe-cache-test-"));
+    homes.push(home);
+    const { readFileCache, writeFileCache } = await importCacheForHome(home);
+
+    vi.stubEnv("VIBE_REPLAY_DISABLE_FILE_CACHE", "1");
+    await writeFileCache("disabled", { ok: true });
+
+    await expect(readFileCache("disabled")).resolves.toBeNull();
+    await expect(readFile(cachePath(home, "disabled"), "utf-8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/packages/cli/test/cache.test.ts
+++ b/packages/cli/test/cache.test.ts
@@ -56,9 +56,20 @@ describe("file cache", () => {
 
     await mkdir(join(home, ".vibe-replay", "cache"), { recursive: true });
     await writeFile(cachePath(home, "bad-version"), JSON.stringify({ data: "stale" }), "utf-8");
+    await writeFile(
+      cachePath(home, "stale-app-version"),
+      JSON.stringify({
+        envelopeVersion: 1,
+        appVersion: "0.0.0",
+        updatedAt: new Date().toISOString(),
+        data: "stale",
+      }),
+      "utf-8",
+    );
     await writeFile(cachePath(home, "bad-json"), "{", "utf-8");
 
     await expect(readFileCache("bad-version")).resolves.toBeNull();
+    await expect(readFileCache("stale-app-version")).resolves.toBeNull();
     await expect(readFileCache("bad-json")).resolves.toBeNull();
     await expect(readFileCache("missing")).resolves.toBeNull();
   });

--- a/packages/cli/test/insights.test.ts
+++ b/packages/cli/test/insights.test.ts
@@ -1,0 +1,214 @@
+import type { InsightsStore, SessionInsight } from "@vibe-replay/types";
+import { INSIGHTS_SCHEMA_VERSION } from "@vibe-replay/types";
+import { describe, expect, it } from "vitest";
+import {
+  aggregateDailyInsights,
+  getInsightsStats,
+  mergeInsights,
+  scanResultToInsight,
+} from "../src/insights.js";
+import type { SessionScanResult } from "../src/scanner.js";
+
+function makeScan(overrides: Partial<SessionScanResult> = {}): SessionScanResult {
+  return {
+    sessionId: "session-a",
+    provider: "claude-code",
+    project: "~/Code/app",
+    slug: "session-a",
+    startTime: "2026-05-01T10:00:00.000Z",
+    durationMs: 60_000,
+    model: "claude-sonnet-4-20250514",
+    promptCount: 2,
+    toolCallCount: 5,
+    editCount: 1,
+    filesModified: [{ file: "src/app.ts", count: 1 }],
+    tokenUsage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 40,
+    },
+    costEstimate: 0.25,
+    subAgentCount: 1,
+    apiErrorCount: 0,
+    compactionCount: 0,
+    dataSource: "jsonl",
+    ...overrides,
+  };
+}
+
+function makeInsight(overrides: Partial<SessionInsight> = {}): SessionInsight {
+  return {
+    sessionId: "session-a",
+    slug: "session-a",
+    provider: "claude-code",
+    project: "~/Code/app",
+    startTime: "2026-04-30T10:00:00.000Z",
+    promptCount: 1,
+    toolCallCount: 1,
+    editCount: 0,
+    hasPR: false,
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
+    capturedAt: "2026-04-30T11:00:00.000Z",
+    capturedByVersion: "0.0.0",
+    machineId: "machine-original",
+    machineName: "Original Machine",
+    ...overrides,
+  };
+}
+
+function makeStore(sessions: SessionInsight[]): InsightsStore {
+  return {
+    schemaVersion: INSIGHTS_SCHEMA_VERSION,
+    lastUpdated: "2026-05-01T00:00:00.000Z",
+    sessions,
+  };
+}
+
+describe("scanResultToInsight", () => {
+  it("maps scan metadata into durable insight records", () => {
+    const insight = scanResultToInsight(
+      makeScan({
+        prLinks: [
+          {
+            prNumber: 42,
+            prUrl: "https://github.com/tuo-lei/app/pull/42",
+            prRepository: "tuo-lei/app",
+          },
+        ],
+        skillsUsed: ["replay"],
+      }),
+    );
+
+    expect(insight).toMatchObject({
+      sessionId: "session-a",
+      provider: "claude-code",
+      project: "~/Code/app",
+      hasPR: true,
+      prLinks: [
+        {
+          prNumber: 42,
+          prUrl: "https://github.com/tuo-lei/app/pull/42",
+          prRepository: "tuo-lei/app",
+        },
+      ],
+      skillsUsed: ["replay"],
+      filesModified: [{ file: "src/app.ts", count: 1 }],
+      dataSource: "jsonl",
+    });
+    expect(typeof insight.capturedAt).toBe("string");
+    expect(typeof insight.capturedByVersion).toBe("string");
+  });
+
+  it("omits empty file lists and marks missing PRs as false", () => {
+    const insight = scanResultToInsight(makeScan({ filesModified: [], prLinks: [] }));
+
+    expect(insight.filesModified).toBeUndefined();
+    expect(insight.hasPR).toBe(false);
+  });
+});
+
+describe("mergeInsights", () => {
+  it("upserts fresh scans while preserving original capture provenance", () => {
+    const existing = makeInsight();
+    const stale = makeInsight({ sessionId: "deleted-source", slug: "deleted-source" });
+
+    const merged = mergeInsights(makeStore([existing, stale]), [
+      makeScan({ promptCount: 7, machineId: undefined } as Partial<SessionScanResult>),
+      makeScan({ sessionId: "session-b", slug: "session-b", promptCount: 3 }),
+    ]);
+
+    expect(merged.schemaVersion).toBe(INSIGHTS_SCHEMA_VERSION);
+    expect(merged.sessions.map((s) => s.sessionId)).toEqual([
+      "session-a",
+      "deleted-source",
+      "session-b",
+    ]);
+    const updated = merged.sessions.find((s) => s.sessionId === "session-a");
+    expect(updated).toMatchObject({
+      promptCount: 7,
+      capturedAt: "2026-04-30T11:00:00.000Z",
+      machineId: "machine-original",
+      machineName: "Original Machine",
+    });
+    expect(updated?.updatedAt).toBeDefined();
+  });
+});
+
+describe("aggregateDailyInsights", () => {
+  it("groups sessions by local day with JSON breakdowns", () => {
+    const aggregate = aggregateDailyInsights(
+      makeStore([
+        makeInsight({
+          sessionId: "session-a",
+          project: "~/Code/app",
+          provider: "claude-code",
+          model: "sonnet",
+          startTime: "2026-05-01T10:00:00.000Z",
+          promptCount: 2,
+          toolCallCount: 3,
+          editCount: 1,
+          durationMs: 10_000,
+          costEstimate: 0.1,
+        }),
+        makeInsight({
+          sessionId: "session-b",
+          project: "~/Code/app",
+          provider: "cursor",
+          model: "gpt-5.5",
+          startTime: "2026-05-01T12:00:00.000Z",
+          promptCount: 4,
+          toolCallCount: 5,
+          editCount: 2,
+          durationMs: 20_000,
+          costEstimate: 0.2,
+        }),
+        makeInsight({
+          sessionId: "session-c",
+          project: "~/Code/other",
+          provider: "claude-code",
+          startTime: "2026-05-02T10:00:00.000Z",
+          promptCount: 1,
+        }),
+        makeInsight({ sessionId: "missing-time", startTime: undefined }),
+      ]),
+    );
+
+    expect(aggregate.days.map((day) => day.date)).toEqual(["2026-05-01", "2026-05-02"]);
+    expect(aggregate.days[0]).toMatchObject({
+      sessions: 2,
+      prompts: 6,
+      toolCalls: 8,
+      edits: 3,
+      durationMs: 30_000,
+      cost: 0.30000000000000004,
+    });
+    expect(JSON.parse(aggregate.days[0].projects)).toMatchObject({
+      "~/Code/app": { sessions: 2, prompts: 6, toolCalls: 8, edits: 3, durationMs: 30_000 },
+    });
+    expect(JSON.parse(aggregate.days[0].providers)).toEqual({
+      "claude-code": { sessions: 1, cost: 0.1 },
+      cursor: { sessions: 1, cost: 0.2 },
+    });
+  });
+});
+
+describe("getInsightsStats", () => {
+  it("counts providers and unique projects", () => {
+    const stats = getInsightsStats(
+      makeStore([
+        makeInsight({ sessionId: "a", provider: "claude-code", project: "~/Code/app" }),
+        makeInsight({ sessionId: "b", provider: "cursor", project: "~/Code/app" }),
+        makeInsight({ sessionId: "c", provider: "cursor", project: "~/Code/other" }),
+      ]),
+    );
+
+    expect(stats).toEqual({
+      total: 3,
+      providers: { "claude-code": 1, cursor: 2 },
+      projects: 2,
+    });
+  });
+});

--- a/packages/cli/test/insights.test.ts
+++ b/packages/cli/test/insights.test.ts
@@ -116,7 +116,7 @@ describe("mergeInsights", () => {
     const stale = makeInsight({ sessionId: "deleted-source", slug: "deleted-source" });
 
     const merged = mergeInsights(makeStore([existing, stale]), [
-      makeScan({ promptCount: 7, machineId: undefined } as Partial<SessionScanResult>),
+      makeScan({ promptCount: 7 }),
       makeScan({ sessionId: "session-b", slug: "session-b", promptCount: 3 }),
     ]);
 
@@ -139,6 +139,9 @@ describe("mergeInsights", () => {
 
 describe("aggregateDailyInsights", () => {
   it("groups sessions by local day with JSON breakdowns", () => {
+    const may1Morning = new Date(2026, 4, 1, 10).toISOString();
+    const may1Noon = new Date(2026, 4, 1, 12).toISOString();
+    const may2Morning = new Date(2026, 4, 2, 10).toISOString();
     const aggregate = aggregateDailyInsights(
       makeStore([
         makeInsight({
@@ -146,7 +149,7 @@ describe("aggregateDailyInsights", () => {
           project: "~/Code/app",
           provider: "claude-code",
           model: "sonnet",
-          startTime: "2026-05-01T10:00:00.000Z",
+          startTime: may1Morning,
           promptCount: 2,
           toolCallCount: 3,
           editCount: 1,
@@ -158,7 +161,7 @@ describe("aggregateDailyInsights", () => {
           project: "~/Code/app",
           provider: "cursor",
           model: "gpt-5.5",
-          startTime: "2026-05-01T12:00:00.000Z",
+          startTime: may1Noon,
           promptCount: 4,
           toolCallCount: 5,
           editCount: 2,
@@ -169,7 +172,7 @@ describe("aggregateDailyInsights", () => {
           sessionId: "session-c",
           project: "~/Code/other",
           provider: "claude-code",
-          startTime: "2026-05-02T10:00:00.000Z",
+          startTime: may2Morning,
           promptCount: 1,
         }),
         makeInsight({ sessionId: "missing-time", startTime: undefined }),
@@ -183,10 +186,14 @@ describe("aggregateDailyInsights", () => {
       toolCalls: 8,
       edits: 3,
       durationMs: 30_000,
-      cost: 0.30000000000000004,
     });
+    expect(aggregate.days[0].cost).toBeCloseTo(0.3);
     expect(JSON.parse(aggregate.days[0].projects)).toMatchObject({
       "~/Code/app": { sessions: 2, prompts: 6, toolCalls: 8, edits: 3, durationMs: 30_000 },
+    });
+    expect(JSON.parse(aggregate.days[0].models)).toEqual({
+      sonnet: { sessions: 1, cost: 0.1 },
+      "gpt-5.5": { sessions: 1, cost: 0.2 },
     });
     expect(JSON.parse(aggregate.days[0].providers)).toEqual({
       "claude-code": { sessions: 1, cost: 0.1 },

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -666,4 +666,65 @@ describe("aggregateUserInsights", () => {
       "2/2 Cursor sessions do not include per-turn stats.",
     );
   });
+
+  it("aggregates token totals and turn duration histogram percentiles", () => {
+    const insights = aggregateUserInsights([
+      {
+        sessionId: "s1",
+        provider: "claude-code",
+        project: "~/Code/proj-a",
+        slug: "slug-1",
+        startTime: "2025-03-18T10:00:00Z",
+        durationMs: 60_000,
+        promptCount: 1,
+        toolCallCount: 2,
+        editCount: 0,
+        filesModified: [],
+        tokenUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 20,
+          cacheCreationTokens: 10,
+        },
+        turnDurations: [10_000, 45_000],
+        subAgentCount: 0,
+        apiErrorCount: 0,
+        compactionCount: 0,
+      },
+      {
+        sessionId: "s2",
+        provider: "claude-code",
+        project: "~/Code/proj-a",
+        slug: "slug-2",
+        startTime: "2025-03-18T11:00:00Z",
+        durationMs: 120_000,
+        promptCount: 1,
+        toolCallCount: 1,
+        editCount: 0,
+        filesModified: [],
+        tokenUsage: {
+          inputTokens: 300,
+          outputTokens: 75,
+          cacheReadTokens: 40,
+          cacheCreationTokens: 25,
+        },
+        turnDurations: [90_000, 720_000],
+        subAgentCount: 0,
+        apiErrorCount: 0,
+        compactionCount: 0,
+      },
+    ]);
+
+    expect(insights.tokenBreakdown).toEqual({
+      input: 400,
+      output: 125,
+      cacheRead: 60,
+      cacheCreation: 35,
+    });
+    expect(insights.medianTurnDurationMs).toBe(67500);
+    expect(insights.turnDurationHistogram?.totalTurns).toBe(4);
+    expect(insights.turnDurationHistogram?.buckets.map((bucket) => bucket.count)).toEqual([
+      1, 1, 1, 0, 0, 1,
+    ]);
+  });
 });

--- a/packages/cli/test/server-generate.test.ts
+++ b/packages/cli/test/server-generate.test.ts
@@ -127,6 +127,46 @@ describe("resolveGenerateInputs", () => {
     expect(resolved.value.sessionInfo?.sessionId).toBe("cursor-session-b");
   });
 
+  it("falls back to matching by sessionId when the replay slug differs", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "oldslug0",
+        sessionId: "cursor-session-from-db",
+      },
+      [
+        makeSession({
+          slug: "newslug0",
+          sessionId: "cursor-session-from-db",
+          filePaths: [],
+          toolPaths: [],
+        }),
+      ],
+    );
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.paths).toEqual([]);
+    expect(resolved.value.sessionInfo?.slug).toBe("newslug0");
+  });
+
+  it("uses explicit tool paths instead of discovered tool paths", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: ["/explicit/session.jsonl"],
+        toolPaths: ["/explicit/tool.txt"],
+        sessionSlug: "aaaaaaaa",
+      },
+      [makeSession()],
+    );
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.value.paths).toEqual(["/explicit/session.jsonl", "/explicit/tool.txt"]);
+  });
+
   it("still requires file paths for non-cursor providers", () => {
     const resolved = resolveGenerateInputs(
       {


### PR DESCRIPTION
## Summary
- Add cache envelope tests for versioning, malformed entries, safe key paths, and disabled cache behavior.
- Add durable insights tests for scan conversion, merge provenance, daily aggregation, and stats.
- Cover scanner token/turn-duration aggregation and server generate input fallback behavior before the refactor stack.

## Test plan
- pnpm --filter vibe-replay test -- test/cache.test.ts test/insights.test.ts test/scanner.test.ts test/server-generate.test.ts test/server-insights-sync.test.ts test/server-sources-enrichment.test.ts
- pnpm lint:check
- pnpm build
- pnpm test:e2e

Made with [Cursor](https://cursor.com)