### PR TITLE
Cover dashboard helper behavior

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -6,6 +6,7 @@ import DashboardHome from "./DashboardHome";
 import {
   cleanPrompt,
   computeProjectLabels,
+  dataSourceBadgeClass,
   formatCacheAge,
   formatCompactAge,
   formatCost,
@@ -18,6 +19,7 @@ import {
   isCacheFresh,
   navigateTo,
   navigateToLive,
+  nonDefaultBranch,
   normalizeTitleText,
   parseCachedList,
   projectName,
@@ -25,8 +27,10 @@ import {
   providerBadgeLabel,
   replaySuggestedTitle,
   rollupProject,
+  sessionPromptPreview,
   type SourcesEnrichmentStatus,
   shortModelName,
+  shortCoworkSpaceId,
   sourceDisplayTitle,
   sourceSuggestedTitle,
   TITLE_MAX_CHARS,
@@ -281,51 +285,6 @@ export interface SessionScanData {
   gitBranches?: string[];
   dataSource?: string;
   dataQualityNotes?: string[];
-}
-
-function sessionPromptPreview(
-  session: Pick<SourceSession, "prompts" | "firstPrompt">,
-  scanData?: Pick<SessionScanData, "firstPrompt"> | null,
-  displayTitle?: string,
-): string[] {
-  const prompts: string[] = [];
-  const seen = new Set<string>();
-  const candidates = [scanData?.firstPrompt, ...(session.prompts || [])];
-  if (!scanData?.firstPrompt) candidates.push(session.firstPrompt);
-  for (const candidate of candidates) {
-    const cleaned = cleanPrompt(candidate || "");
-    if (!cleaned || seen.has(cleaned)) continue;
-    seen.add(cleaned);
-    prompts.push(cleaned);
-  }
-  const normalizedTitle = cleanPrompt(displayTitle || "");
-  if (prompts.length > 1 && normalizedTitle && prompts[0] === normalizedTitle) {
-    prompts.shift();
-  }
-  if (prompts.length > 1 && /^(?:and|but|or|so|then)\b/i.test(prompts[0] || "")) {
-    prompts.shift();
-  }
-  return prompts;
-}
-
-function nonDefaultBranch(branch?: string): string | undefined {
-  return branch && branch !== "main" && branch !== "master" ? branch : undefined;
-}
-
-function shortCoworkSpaceId(spaceId: string): string {
-  const compact = spaceId.replace(/^space[_-]?/, "");
-  return compact.slice(0, 6) || spaceId.slice(0, 6);
-}
-
-function dataSourceBadgeClass(dataSource?: string, hasSqlite?: boolean, hasSdk?: boolean): string {
-  // SDK gets its own distinct purple badge so users can spot Cursor SDK sessions
-  // at a glance (they're functionally different from IDE chats — different store,
-  // different agent runtime, different lifecycle).
-  if (hasSdk) return "bg-terminal-purple-subtle text-terminal-purple";
-  if (dataSource === "jsonl") return "bg-terminal-orange-subtle text-terminal-orange";
-  if (dataSource === "global-state") return "bg-terminal-blue-subtle text-terminal-blue";
-  if (dataSource === "sqlite" || hasSqlite) return "bg-terminal-green-subtle text-terminal-green";
-  return "bg-terminal-surface-2 text-terminal-dimmer";
 }
 
 /** Session detail popup — shows full metadata, editable title, Generate CTA */

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -1,19 +1,30 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agentWorktreeParent,
+  cleanPrompt,
+  dataSourceBadgeClass,
   fetchWithRetry,
   formatDataSourceLabel,
   getFriendlyErrorMessage,
+  isCacheFresh,
   isNetworkError,
+  nonDefaultBranch,
+  parseCachedList,
   providerBadgeClass,
   providerBadgeLabel,
   providerBarClass,
   providerDisplayName,
   providerFamily,
+  replaySuggestedTitle,
   rollupProject,
   rollupTopProjects,
+  sessionPromptPreview,
+  shortCoworkSpaceId,
+  sourceDisplayTitle,
+  sourceSuggestedTitle,
   type TopProjectEntry,
 } from "../dashboard-utils";
+import type { SourceSession } from "../../types";
 
 function makeProject(overrides: Partial<TopProjectEntry> & { project: string }): TopProjectEntry {
   return {
@@ -31,6 +42,25 @@ function makeProject(overrides: Partial<TopProjectEntry> & { project: string }):
     ...overrides,
   };
 }
+
+function makeSource(overrides: Partial<SourceSession> = {}): SourceSession {
+  return {
+    provider: "cursor",
+    slug: "source-slug",
+    project: "~/Code/app",
+    timestamp: "2026-05-01T10:00:00.000Z",
+    fileSize: 1024,
+    lineCount: 10,
+    firstPrompt: "Build the dashboard",
+    filePaths: ["/tmp/session.jsonl"],
+    existingReplay: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("agentWorktreeParent", () => {
   it("returns the parent project for a Claude agent worktree path", () => {
@@ -196,6 +226,80 @@ describe("rollupTopProjects", () => {
   });
 });
 
+describe("cache response helpers", () => {
+  it("accepts cached list payloads and normalizes missing cachedAt", () => {
+    expect(parseCachedList<{ slug: string }>({ sessions: [{ slug: "a" }] })).toEqual({
+      sessions: [{ slug: "a" }],
+      cachedAt: undefined,
+    });
+    expect(parseCachedList({ sessions: [], cachedAt: "2026-05-01T00:00:00.000Z" })).toEqual({
+      sessions: [],
+      cachedAt: "2026-05-01T00:00:00.000Z",
+    });
+  });
+
+  it("rejects malformed cached list payloads", () => {
+    expect(parseCachedList(null)).toBeNull();
+    expect(parseCachedList({ sessions: "not-array" })).toBeNull();
+  });
+
+  it("treats only recent past timestamps as fresh", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T10:00:00.000Z"));
+
+    expect(isCacheFresh("2026-05-01T09:56:00.000Z")).toBe(true);
+    expect(isCacheFresh("2026-05-01T09:54:59.000Z")).toBe(false);
+    expect(isCacheFresh("2026-05-01T10:01:00.000Z")).toBe(false);
+    expect(isCacheFresh("not-a-date")).toBe(false);
+  });
+});
+
+describe("dashboard prompt and title helpers", () => {
+  it("cleans noisy prompt text before display", () => {
+    expect(cleanPrompt("<command-name>status</command-name>")).toBe("");
+    expect(cleanPrompt("1|Please refactor\n2|the dashboard")).toBe("Please refactor the dashboard");
+    expect(cleanPrompt("### AI Coding Session\n3 prompts, 4 tools, 10m\nShip it")).toBe("Ship it");
+  });
+
+  it("deduplicates prompt previews and hides a title duplicate", () => {
+    const prompts = sessionPromptPreview(
+      makeSource({
+        firstPrompt: "Build the dashboard",
+        prompts: ["Build the dashboard", "Then add tests", "Then add tests"],
+      }),
+      { firstPrompt: "Build the dashboard" },
+      "Build the dashboard",
+    );
+
+    expect(prompts).toEqual(["Then add tests"]);
+  });
+
+  it("falls back through source and replay titles predictably", () => {
+    const source = makeSource({
+      title: "<task-notification>hidden</task-notification>",
+      firstPrompt: "Implement search",
+      replay: {
+        slug: "source-slug",
+        title: "Replay title",
+        provider: "cursor",
+        project: "~/Code/app",
+        startTime: "2026-05-01T10:00:00.000Z",
+        endTime: "2026-05-01T10:10:00.000Z",
+        stats: { userPrompts: 1, toolCalls: 2 },
+        hasAnnotations: false,
+        annotationCount: 0,
+        messages: [],
+      },
+    });
+
+    expect(sourceSuggestedTitle(source)).toBe("Replay title");
+    expect(sourceDisplayTitle(source, { title: "Scan title" })).toBe("Scan title");
+    expect(replaySuggestedTitle({ ...source.replay!, firstMessage: "First replay prompt" })).toBe(
+      "Replay title",
+    );
+  });
+});
+
 describe("formatDataSourceLabel", () => {
   it("labels Cursor SDK sessions distinctly when hasSdk is true", () => {
     expect(formatDataSourceLabel(false, "jsonl+tools", true)).toBe(
@@ -213,6 +317,26 @@ describe("formatDataSourceLabel", () => {
     expect(formatDataSourceLabel(false, "global-state")).toBe("Cursor global state");
     expect(formatDataSourceLabel(true)).toBe("SQLite + JSONL");
     expect(formatDataSourceLabel()).toBe("JSONL");
+  });
+});
+
+describe("dashboard badge helpers", () => {
+  it("uses distinct data source badge classes", () => {
+    expect(dataSourceBadgeClass("jsonl")).toContain("terminal-orange");
+    expect(dataSourceBadgeClass("global-state")).toContain("terminal-blue");
+    expect(dataSourceBadgeClass("sqlite")).toContain("terminal-green");
+    expect(dataSourceBadgeClass(undefined, true)).toContain("terminal-green");
+    expect(dataSourceBadgeClass(undefined, false, true)).toContain("terminal-purple");
+    expect(dataSourceBadgeClass()).toContain("terminal-dimmer");
+  });
+
+  it("hides default branches and shortens Cowork space ids", () => {
+    expect(nonDefaultBranch("main")).toBeUndefined();
+    expect(nonDefaultBranch("master")).toBeUndefined();
+    expect(nonDefaultBranch("feature/dashboard")).toBe("feature/dashboard");
+    expect(shortCoworkSpaceId("space_abcdef123")).toBe("abcdef");
+    expect(shortCoworkSpaceId("space-xyz987")).toBe("xyz987");
+    expect(shortCoworkSpaceId("abc")).toBe("abc");
   });
 });
 

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -309,7 +309,7 @@ describe("dashboard prompt and title helpers", () => {
         project: "~/Code/app",
         startTime: "2026-05-01T10:00:00.000Z",
         endTime: "2026-05-01T10:10:00.000Z",
-        stats: { userPrompts: 1, toolCalls: 2 },
+        stats: { sceneCount: 3, userPrompts: 1, toolCalls: 2 },
         hasAnnotations: false,
         annotationCount: 0,
         messages: [],

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -274,6 +274,30 @@ describe("dashboard prompt and title helpers", () => {
     expect(prompts).toEqual(["Then add tests"]);
   });
 
+  it("keeps a single prompt even when it matches the title", () => {
+    const prompts = sessionPromptPreview(
+      makeSource({
+        firstPrompt: "Build the dashboard",
+        prompts: [],
+      }),
+      null,
+      "Build the dashboard",
+    );
+
+    expect(prompts).toEqual(["Build the dashboard"]);
+  });
+
+  it("drops leading continuation prompts when later context exists", () => {
+    const prompts = sessionPromptPreview(
+      makeSource({
+        firstPrompt: "",
+        prompts: ["Then add tests", "Ship docs"],
+      }),
+    );
+
+    expect(prompts).toEqual(["Ship docs"]);
+  });
+
   it("falls back through source and replay titles predictably", () => {
     const source = makeSource({
       title: "<task-notification>hidden</task-notification>",
@@ -323,6 +347,7 @@ describe("formatDataSourceLabel", () => {
 describe("dashboard badge helpers", () => {
   it("uses distinct data source badge classes", () => {
     expect(dataSourceBadgeClass("jsonl")).toContain("terminal-orange");
+    expect(dataSourceBadgeClass("jsonl+tools")).toContain("terminal-orange");
     expect(dataSourceBadgeClass("global-state")).toContain("terminal-blue");
     expect(dataSourceBadgeClass("sqlite")).toContain("terminal-green");
     expect(dataSourceBadgeClass(undefined, true)).toContain("terminal-green");

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -235,6 +235,40 @@ export function cleanPrompt(text: string): string {
   return cleaned;
 }
 
+export function sessionPromptPreview(
+  session: Pick<SourceSession, "prompts" | "firstPrompt">,
+  scanData?: { firstPrompt?: string } | null,
+  displayTitle?: string,
+): string[] {
+  const prompts: string[] = [];
+  const seen = new Set<string>();
+  const candidates = [scanData?.firstPrompt, ...(session.prompts || [])];
+  if (!scanData?.firstPrompt) candidates.push(session.firstPrompt);
+  for (const candidate of candidates) {
+    const cleaned = cleanPrompt(candidate || "");
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    prompts.push(cleaned);
+  }
+  const normalizedTitle = cleanPrompt(displayTitle || "");
+  if (prompts.length > 1 && normalizedTitle && prompts[0] === normalizedTitle) {
+    prompts.shift();
+  }
+  if (prompts.length > 1 && /^(?:and|but|or|so|then)\b/i.test(prompts[0] || "")) {
+    prompts.shift();
+  }
+  return prompts;
+}
+
+export function nonDefaultBranch(branch?: string): string | undefined {
+  return branch && branch !== "main" && branch !== "master" ? branch : undefined;
+}
+
+export function shortCoworkSpaceId(spaceId: string): string {
+  const compact = spaceId.replace(/^space[_-]?/, "");
+  return compact.slice(0, 6) || spaceId.slice(0, 6);
+}
+
 function sourcePromptTitle(
   s: Pick<SourceSession, "slug" | "title" | "prompts" | "firstPrompt">,
 ): string {
@@ -464,6 +498,21 @@ export function providerDisplayName(provider: string): string {
 
 export function providerBarClass(provider: string): string {
   return PROVIDER_BAR_COLORS[provider] || "bg-terminal-dim";
+}
+
+export function dataSourceBadgeClass(
+  dataSource?: string,
+  hasSqlite?: boolean,
+  hasSdk?: boolean,
+): string {
+  // SDK gets its own distinct purple badge so users can spot Cursor SDK sessions
+  // at a glance (they're functionally different from IDE chats — different store,
+  // different agent runtime, different lifecycle).
+  if (hasSdk) return "bg-terminal-purple-subtle text-terminal-purple";
+  if (dataSource === "jsonl") return "bg-terminal-orange-subtle text-terminal-orange";
+  if (dataSource === "global-state") return "bg-terminal-blue-subtle text-terminal-blue";
+  if (dataSource === "sqlite" || hasSqlite) return "bg-terminal-green-subtle text-terminal-green";
+  return "bg-terminal-surface-2 text-terminal-dimmer";
 }
 
 // ─── Archive helpers ────────────────────────────────────────────────

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -509,7 +509,9 @@ export function dataSourceBadgeClass(
   // at a glance (they're functionally different from IDE chats — different store,
   // different agent runtime, different lifecycle).
   if (hasSdk) return "bg-terminal-purple-subtle text-terminal-purple";
-  if (dataSource === "jsonl") return "bg-terminal-orange-subtle text-terminal-orange";
+  if (dataSource === "jsonl" || dataSource === "jsonl+tools") {
+    return "bg-terminal-orange-subtle text-terminal-orange";
+  }
   if (dataSource === "global-state") return "bg-terminal-blue-subtle text-terminal-blue";
   if (dataSource === "sqlite" || hasSqlite) return "bg-terminal-green-subtle text-terminal-green";
   return "bg-terminal-surface-2 text-terminal-dimmer";


### PR DESCRIPTION
## Summary
- Move pure dashboard prompt, branch, Cowork space, and data-source badge helpers into `dashboard-utils`.
- Add characterization tests for cached list parsing/freshness, prompt/title cleanup, data-source badges, and Cowork/default-branch display helpers.
- Keep `Dashboard.tsx` behavior unchanged while preparing the component split.

## Test plan
- pnpm --filter @vibe-replay/viewer test
- pnpm --filter @vibe-replay/viewer build
- pnpm lint:check
- pnpm build
- pnpm test:e2e

Stacked on #303.

Made with [Cursor](https://cursor.com)