### PR TITLE
Extract server core helpers

### DIFF
--- a/packages/cli/src/server-core.ts
+++ b/packages/cli/src/server-core.ts
@@ -31,7 +31,7 @@ function normalizeProjectPath(project: string): string {
 // Keep cloud sync requests comfortably below the current D1 bind / batch ceiling.
 export const MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST = 90;
 
-export function chunkItems<T>(items: T[], maxItems: number): T[][] {
+function chunkItems<T>(items: T[], maxItems: number): T[][] {
   if (maxItems <= 0) return [items.slice()];
   const chunks: T[][] = [];
   for (let i = 0; i < items.length; i += maxItems) {
@@ -61,7 +61,7 @@ export interface GenerateRequestBody {
   sessionId?: string;
 }
 
-interface ResolvedGenerateInputs {
+export interface ResolvedGenerateInputs {
   paths: string[];
   sessionInfo?: SessionInfo;
 }

--- a/packages/cli/src/server-core.ts
+++ b/packages/cli/src/server-core.ts
@@ -1,0 +1,136 @@
+import { homedir } from "node:os";
+import { basename } from "node:path";
+import type { SessionInfo } from "./types.js";
+
+/** Sanitize slug to prevent path traversal — rejects anything that isn't a simple name */
+export function safeSlug(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const clean = basename(raw);
+  if (!clean || clean !== raw || clean === "." || clean === "..") return null;
+  return clean;
+}
+
+/** Require a valid slug from query param, returning 400 if missing */
+export function requireSlug(raw: string | undefined): { slug: string } | { error: string } {
+  const slug = safeSlug(raw);
+  if (!slug) return { error: "slug parameter is required" };
+  return { slug };
+}
+
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown error";
+}
+
+function normalizeProjectPath(project: string): string {
+  const home = homedir();
+  return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
+}
+
+// Keep cloud sync requests comfortably below the current D1 bind / batch ceiling.
+export const MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST = 90;
+
+export function chunkItems<T>(items: T[], maxItems: number): T[][] {
+  if (maxItems <= 0) return [items.slice()];
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += maxItems) {
+    chunks.push(items.slice(i, i + maxItems));
+  }
+  return chunks;
+}
+
+export function buildInsightsSyncBatches<T extends { date: string }>(
+  days: T[],
+  existingDates: Iterable<string>,
+  today: string,
+  maxDaysPerBatch = MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST,
+): T[][] {
+  const existing = new Set(existingDates);
+  const pending = days.filter((day) => !existing.has(day.date) || day.date === today);
+  return chunkItems(pending, maxDaysPerBatch);
+}
+
+export interface GenerateRequestBody {
+  provider: string;
+  filePaths?: unknown;
+  toolPaths?: unknown;
+  title?: unknown;
+  sessionSlug?: string;
+  sessionProject?: string;
+  sessionId?: string;
+}
+
+interface ResolvedGenerateInputs {
+  paths: string[];
+  sessionInfo?: SessionInfo;
+}
+
+export type GenerateInputResolution =
+  | { ok: true; value: ResolvedGenerateInputs }
+  | { ok: false; error: string };
+
+function toStringArray(value: unknown): string[] | null {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return null;
+  if (value.some((item) => typeof item !== "string")) return null;
+  return value;
+}
+
+export function resolveGenerateInputs(
+  body: GenerateRequestBody,
+  discoveredSessions: SessionInfo[],
+): GenerateInputResolution {
+  const filePaths = toStringArray(body.filePaths);
+  if (!filePaths) {
+    return { ok: false, error: "filePaths must be an array of strings" };
+  }
+  const toolPaths = toStringArray(body.toolPaths);
+  if (!toolPaths) {
+    return { ok: false, error: "toolPaths must be an array of strings" };
+  }
+
+  const requestedSessionSlug =
+    typeof body.sessionSlug === "string" ? safeSlug(body.sessionSlug) : null;
+  const requestedSessionProject =
+    typeof body.sessionProject === "string" ? normalizeProjectPath(body.sessionProject) : undefined;
+
+  let sessionInfo: SessionInfo | undefined;
+  if (requestedSessionSlug) {
+    const slugMatches = discoveredSessions.filter((s) => s.slug === requestedSessionSlug);
+    if (requestedSessionProject) {
+      sessionInfo = slugMatches.find(
+        (s) => normalizeProjectPath(s.project) === requestedSessionProject,
+      );
+    }
+    sessionInfo = sessionInfo || slugMatches[0];
+  }
+  // Fallback: match by sessionId (covers old JSONL files where slug differs from replay slug)
+  if (!sessionInfo && typeof body.sessionId === "string" && body.sessionId) {
+    sessionInfo = discoveredSessions.find((s) => s.sessionId === body.sessionId);
+  }
+
+  const fallbackFilePaths = sessionInfo?.filePaths || [];
+  const fallbackToolPaths = sessionInfo?.toolPaths || [];
+  const paths = [
+    ...(filePaths.length > 0 ? filePaths : fallbackFilePaths),
+    ...(toolPaths.length > 0 ? toolPaths : fallbackToolPaths),
+  ];
+
+  const hasCursorSessionFallback = body.provider === "cursor" && Boolean(sessionInfo?.sessionId);
+  if (paths.length === 0 && !hasCursorSessionFallback) {
+    return {
+      ok: false,
+      error:
+        "filePaths is required (or provide a resolvable Cursor sessionSlug for SQLite/global-state sessions)",
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      paths,
+      sessionInfo,
+    },
+  };
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { serve } from "@hono/node-server";
 import chalk from "chalk";
@@ -59,6 +59,14 @@ import {
 } from "./publishers/gist.js";
 import { scanForSecrets } from "./scan.js";
 import {
+  buildInsightsSyncBatches,
+  getErrorMessage,
+  type GenerateRequestBody,
+  requireSlug,
+  resolveGenerateInputs,
+  safeSlug,
+} from "./server-core.js";
+import {
   aggregateProjectInsights,
   aggregateUserInsights,
   type BackgroundScanState,
@@ -80,138 +88,7 @@ import type {
 import { localDayKey, normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
-/** Sanitize slug to prevent path traversal — rejects anything that isn't a simple name */
-function safeSlug(raw: string | undefined): string | null {
-  if (!raw) return null;
-  const clean = basename(raw);
-  if (!clean || clean !== raw || clean === "." || clean === "..") return null;
-  return clean;
-}
-
-/** Require a valid slug from query param, returning 400 if missing */
-function requireSlug(raw: string | undefined): { slug: string } | { error: string } {
-  const slug = safeSlug(raw);
-  if (!slug) return { error: "slug parameter is required" };
-  return { slug };
-}
-
-function getErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
-  return "Unknown error";
-}
-
-function normalizeProjectPath(project: string): string {
-  const home = homedir();
-  return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
-}
-
-// Keep cloud sync requests comfortably below the current D1 bind / batch ceiling.
-const MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST = 90;
-
-function chunkItems<T>(items: T[], maxItems: number): T[][] {
-  if (maxItems <= 0) return [items.slice()];
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += maxItems) {
-    chunks.push(items.slice(i, i + maxItems));
-  }
-  return chunks;
-}
-
-function buildInsightsSyncBatches<T extends { date: string }>(
-  days: T[],
-  existingDates: Iterable<string>,
-  today: string,
-  maxDaysPerBatch = MAX_INSIGHTS_SYNC_DAYS_PER_REQUEST,
-): T[][] {
-  const existing = new Set(existingDates);
-  const pending = days.filter((day) => !existing.has(day.date) || day.date === today);
-  return chunkItems(pending, maxDaysPerBatch);
-}
-
-interface GenerateRequestBody {
-  provider: string;
-  filePaths?: unknown;
-  toolPaths?: unknown;
-  title?: unknown;
-  sessionSlug?: string;
-  sessionProject?: string;
-  sessionId?: string;
-}
-
-interface ResolvedGenerateInputs {
-  paths: string[];
-  sessionInfo?: SessionInfo;
-}
-
-type GenerateInputResolution =
-  | { ok: true; value: ResolvedGenerateInputs }
-  | { ok: false; error: string };
-
-function toStringArray(value: unknown): string[] | null {
-  if (value === undefined) return [];
-  if (!Array.isArray(value)) return null;
-  if (value.some((item) => typeof item !== "string")) return null;
-  return value;
-}
-
-export function resolveGenerateInputs(
-  body: GenerateRequestBody,
-  discoveredSessions: SessionInfo[],
-): GenerateInputResolution {
-  const filePaths = toStringArray(body.filePaths);
-  if (!filePaths) {
-    return { ok: false, error: "filePaths must be an array of strings" };
-  }
-  const toolPaths = toStringArray(body.toolPaths);
-  if (!toolPaths) {
-    return { ok: false, error: "toolPaths must be an array of strings" };
-  }
-
-  const requestedSessionSlug =
-    typeof body.sessionSlug === "string" ? safeSlug(body.sessionSlug) : null;
-  const requestedSessionProject =
-    typeof body.sessionProject === "string" ? normalizeProjectPath(body.sessionProject) : undefined;
-
-  let sessionInfo: SessionInfo | undefined;
-  if (requestedSessionSlug) {
-    const slugMatches = discoveredSessions.filter((s) => s.slug === requestedSessionSlug);
-    if (requestedSessionProject) {
-      sessionInfo = slugMatches.find(
-        (s) => normalizeProjectPath(s.project) === requestedSessionProject,
-      );
-    }
-    sessionInfo = sessionInfo || slugMatches[0];
-  }
-  // Fallback: match by sessionId (covers old JSONL files where slug differs from replay slug)
-  if (!sessionInfo && typeof body.sessionId === "string" && body.sessionId) {
-    sessionInfo = discoveredSessions.find((s) => s.sessionId === body.sessionId);
-  }
-
-  const fallbackFilePaths = sessionInfo?.filePaths || [];
-  const fallbackToolPaths = sessionInfo?.toolPaths || [];
-  const paths = [
-    ...(filePaths.length > 0 ? filePaths : fallbackFilePaths),
-    ...(toolPaths.length > 0 ? toolPaths : fallbackToolPaths),
-  ];
-
-  const hasCursorSessionFallback = body.provider === "cursor" && Boolean(sessionInfo?.sessionId);
-  if (paths.length === 0 && !hasCursorSessionFallback) {
-    return {
-      ok: false,
-      error:
-        "filePaths is required (or provide a resolvable Cursor sessionSlug for SQLite/global-state sessions)",
-    };
-  }
-
-  return {
-    ok: true,
-    value: {
-      paths,
-      sessionInfo,
-    },
-  };
-}
+export { resolveGenerateInputs } from "./server-core.js";
 
 // ─── Archive helpers (directory-based, one marker file per slug) ────
 

--- a/packages/cli/test/README.md
+++ b/packages/cli/test/README.md
@@ -41,6 +41,7 @@ These tests protect **parser compatibility** with real-world session data from C
 | `scan.test.ts` | Secret scanning patterns | **Security (do not weaken)** |
 | `cache.test.ts` | File cache envelope versioning, key sanitization, disable flag | Cache compatibility |
 | `insights.test.ts` | Durable insight conversion, merge provenance, daily aggregation, stats | Insights persistence |
+| `server-core.test.ts` | Server slug validation and error message helpers | Server helper contracts |
 | `pricing.test.ts` | Model pricing lookup + cost calculation | Per-model pricing |
 | `cost-estimation.test.ts` | Parser → transform cost integration | Multi-model cost accuracy |
 

--- a/packages/cli/test/server-core.test.ts
+++ b/packages/cli/test/server-core.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage, requireSlug, safeSlug } from "../src/server-core.js";
+
+describe("server core helpers", () => {
+  it("accepts simple slugs and rejects path traversal", () => {
+    expect(safeSlug("session-2026_05.json")).toBe("session-2026_05.json");
+    expect(safeSlug("nested/session.json")).toBeNull();
+    expect(safeSlug("../session.json")).toBeNull();
+    expect(safeSlug(".")).toBeNull();
+    expect(safeSlug("..")).toBeNull();
+    expect(safeSlug(undefined)).toBeNull();
+  });
+
+  it("returns the shared 400 error shape for invalid slugs", () => {
+    expect(requireSlug("abc123")).toEqual({ slug: "abc123" });
+    expect(requireSlug("../../abc123")).toEqual({ error: "slug parameter is required" });
+  });
+
+  it("normalizes thrown values into response messages", () => {
+    expect(getErrorMessage(new Error("disk failed"))).toBe("disk failed");
+    expect(getErrorMessage("plain failure")).toBe("plain failure");
+    expect(getErrorMessage({ message: "not an Error" })).toBe("Unknown error");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract server slug validation, error formatting, insights batching, and generate input resolution into `server-core`.
- Preserve the existing `server.ts` `resolveGenerateInputs` export and `__testables` surface.
- Keep route behavior untouched while preparing route-group extraction.
- Address review feedback by keeping `chunkItems` private, exporting `ResolvedGenerateInputs`, and adding direct server-core helper tests.

## Test plan
- pnpm --filter vibe-replay test -- test/server-core.test.ts test/server-generate.test.ts test/server-insights-sync.test.ts
- pnpm typecheck
- pnpm lint:check
- pnpm build
- pnpm test:e2e

Stacked on #305.

Made with [Cursor](https://cursor.com)