### PR TITLE
Split session asset routes

### DIFF
--- a/packages/cli/src/server-persistence.ts
+++ b/packages/cli/src/server-persistence.ts
@@ -1,0 +1,35 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type { Annotation, SessionOverlays } from "./types.js";
+
+/** Load annotations from disk for a given slug */
+export async function loadAnnotations(baseDir: string, slug: string): Promise<Annotation[]> {
+  const dirs = [join(baseDir, slug), resolve("./vibe-replay", slug)];
+  for (const dir of dirs) {
+    try {
+      const raw = await readFile(join(dir, "annotations.json"), "utf-8");
+      const anns = JSON.parse(raw) as Annotation[];
+      if (Array.isArray(anns)) return anns;
+    } catch {}
+  }
+  return [];
+}
+
+/** Save annotations to disk for a given slug */
+export async function saveAnnotations(
+  baseDir: string,
+  slug: string,
+  annotations: Annotation[],
+): Promise<void> {
+  const annPath = join(baseDir, slug, "annotations.json");
+  await writeFile(annPath, JSON.stringify(annotations, null, 2), "utf-8");
+}
+
+export async function saveOverlays(
+  baseDir: string,
+  slug: string,
+  overlays: SessionOverlays,
+): Promise<void> {
+  const overlayPath = join(baseDir, slug, "overlays.json");
+  await writeFile(overlayPath, JSON.stringify(overlays, null, 2), "utf-8");
+}

--- a/packages/cli/src/server-persistence.ts
+++ b/packages/cli/src/server-persistence.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { Annotation, SessionOverlays } from "./types.js";
 
@@ -21,15 +21,18 @@ export async function saveAnnotations(
   slug: string,
   annotations: Annotation[],
 ): Promise<void> {
+  await mkdir(join(baseDir, slug), { recursive: true });
   const annPath = join(baseDir, slug, "annotations.json");
   await writeFile(annPath, JSON.stringify(annotations, null, 2), "utf-8");
 }
 
+/** Save scene overlays to disk for a given slug */
 export async function saveOverlays(
   baseDir: string,
   slug: string,
   overlays: SessionOverlays,
 ): Promise<void> {
+  await mkdir(join(baseDir, slug), { recursive: true });
   const overlayPath = join(baseDir, slug, "overlays.json");
   await writeFile(overlayPath, JSON.stringify(overlays, null, 2), "utf-8");
 }

--- a/packages/cli/src/server-routes/session-assets.ts
+++ b/packages/cli/src/server-routes/session-assets.ts
@@ -1,0 +1,62 @@
+import type { Hono } from "hono";
+import { loadOverlays } from "../overlays.js";
+import { getErrorMessage, requireSlug } from "../server-core.js";
+import { loadAnnotations, saveAnnotations, saveOverlays } from "../server-persistence.js";
+import type { Annotation, SessionOverlays } from "../types.js";
+
+export function registerSessionAssetRoutes(app: Hono, deps: { baseDir: string }): void {
+  const { baseDir } = deps;
+
+  // --- Annotations (requires slug) ---
+  app.get("/api/annotations", async (c) => {
+    const result = requireSlug(c.req.query("slug"));
+    if ("error" in result) return c.json({ error: result.error }, 400);
+    const anns = await loadAnnotations(baseDir, result.slug);
+    return c.json(anns);
+  });
+
+  app.post("/api/annotations", async (c) => {
+    const result = requireSlug(c.req.query("slug"));
+    if ("error" in result) return c.json({ error: result.error }, 400);
+    let body: Annotation[];
+    try {
+      body = await c.req.json<Annotation[]>();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+    try {
+      await saveAnnotations(baseDir, result.slug, body);
+    } catch (err) {
+      return c.json({ error: `Failed to save annotations: ${getErrorMessage(err)}` }, 500);
+    }
+    return c.json({ ok: true });
+  });
+
+  // --- Overlays (requires slug) ---
+  app.get("/api/overlays", async (c) => {
+    const result = requireSlug(c.req.query("slug"));
+    if ("error" in result) return c.json({ error: result.error }, 400);
+    const overlays = await loadOverlays(baseDir, result.slug);
+    return c.json(overlays);
+  });
+
+  app.post("/api/overlays", async (c) => {
+    const result = requireSlug(c.req.query("slug"));
+    if ("error" in result) return c.json({ error: result.error }, 400);
+    let body: SessionOverlays;
+    try {
+      body = await c.req.json<SessionOverlays>();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+    if (!body || !Array.isArray(body.overlays)) {
+      return c.json({ error: "invalid overlays shape" }, 400);
+    }
+    try {
+      await saveOverlays(baseDir, result.slug, body);
+    } catch (err) {
+      return c.json({ error: `Failed to save overlays: ${getErrorMessage(err)}` }, 500);
+    }
+    return c.json({ ok: true });
+  });
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -11,7 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { serve } from "@hono/node-server";
 import chalk from "chalk";
@@ -58,7 +58,7 @@ import {
   type SavedGistInfo,
 } from "./publishers/gist.js";
 import { scanForSecrets } from "./scan.js";
-import { saveAnnotations, saveOverlays } from "./server-persistence.js";
+import { loadAnnotations, saveAnnotations, saveOverlays } from "./server-persistence.js";
 import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
   buildInsightsSyncBatches,
@@ -80,13 +80,7 @@ import {
   type UserInsights,
 } from "./scanner.js";
 import { transformToReplay } from "./transform.js";
-import type {
-  Annotation,
-  ParsedTurn,
-  ReplaySession,
-  SessionInfo,
-  SessionOverlays,
-} from "./types.js";
+import type { ParsedTurn, ReplaySession, SessionInfo, SessionOverlays } from "./types.js";
 import { localDayKey, normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
@@ -134,15 +128,7 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
     try {
       const raw = await readFile(replayPath, "utf-8");
       const session = JSON.parse(raw) as ReplaySession;
-      const annotationsPath = join(baseDir, entry, "annotations.json");
-      let annotationCount = 0;
-      try {
-        const annRaw = await readFile(annotationsPath, "utf-8");
-        const anns = JSON.parse(annRaw) as Annotation[];
-        annotationCount = Array.isArray(anns) ? anns.length : 0;
-      } catch {
-        /* no annotations */
-      }
+      const annotationCount = (await loadAnnotations(baseDir, entry)).length;
 
       let gist: SavedGistInfo | undefined;
       try {
@@ -258,16 +244,9 @@ async function loadSessionFromDisk(baseDir: string, slug: string): Promise<Repla
   const raw = await readFile(replayPath, "utf-8");
   const session = JSON.parse(raw) as ReplaySession;
 
-  const sessionDir = dirname(replayPath);
-  const annotationsPath = join(sessionDir, "annotations.json");
-  try {
-    const annRaw = await readFile(annotationsPath, "utf-8");
-    const anns = JSON.parse(annRaw) as Annotation[];
-    if (Array.isArray(anns) && anns.length > 0) {
-      session.annotations = anns;
-    }
-  } catch {
-    /* no annotations */
+  const annotations = await loadAnnotations(baseDir, slug);
+  if (annotations.length > 0) {
+    session.annotations = annotations;
   }
 
   return session;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -58,6 +58,8 @@ import {
   type SavedGistInfo,
 } from "./publishers/gist.js";
 import { scanForSecrets } from "./scan.js";
+import { saveAnnotations, saveOverlays } from "./server-persistence.js";
+import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
   buildInsightsSyncBatches,
   getErrorMessage,
@@ -820,40 +822,6 @@ function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
 
   result.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return result;
-}
-
-/** Load annotations from disk for a given slug */
-async function loadAnnotations(baseDir: string, slug: string): Promise<Annotation[]> {
-  const dirs = [join(baseDir, slug), resolve("./vibe-replay", slug)];
-  for (const dir of dirs) {
-    try {
-      const raw = await readFile(join(dir, "annotations.json"), "utf-8");
-      const anns = JSON.parse(raw) as Annotation[];
-      if (Array.isArray(anns)) return anns;
-    } catch {}
-  }
-  return [];
-}
-
-/** Save annotations to disk for a given slug */
-async function saveAnnotations(
-  baseDir: string,
-  slug: string,
-  annotations: Annotation[],
-): Promise<void> {
-  const annPath = join(baseDir, slug, "annotations.json");
-  await writeFile(annPath, JSON.stringify(annotations, null, 2), "utf-8");
-}
-
-// ─── Overlay persistence ────────────────────────────────────────────────────
-
-async function saveOverlays(
-  baseDir: string,
-  slug: string,
-  overlays: SessionOverlays,
-): Promise<void> {
-  const overlayPath = join(baseDir, slug, "overlays.json");
-  await writeFile(overlayPath, JSON.stringify(overlays, null, 2), "utf-8");
 }
 
 export async function startServer(
@@ -2333,30 +2301,7 @@ export async function startServer(
     return c.json(memory);
   });
 
-  // --- Annotations (requires slug) ---
-  app.get("/api/annotations", async (c) => {
-    const result = requireSlug(c.req.query("slug"));
-    if ("error" in result) return c.json({ error: result.error }, 400);
-    const anns = await loadAnnotations(baseDir, result.slug);
-    return c.json(anns);
-  });
-
-  app.post("/api/annotations", async (c) => {
-    const result = requireSlug(c.req.query("slug"));
-    if ("error" in result) return c.json({ error: result.error }, 400);
-    let body: Annotation[];
-    try {
-      body = await c.req.json<Annotation[]>();
-    } catch {
-      return c.json({ error: "invalid JSON body" }, 400);
-    }
-    try {
-      await saveAnnotations(baseDir, result.slug, body);
-    } catch (err) {
-      return c.json({ error: `Failed to save annotations: ${getErrorMessage(err)}` }, 500);
-    }
-    return c.json({ ok: true });
-  });
+  registerSessionAssetRoutes(app, { baseDir });
 
   // GitHub CLI status
   app.get("/api/gh-status", (c) => {
@@ -3185,34 +3130,6 @@ export async function startServer(
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
     }
-  });
-
-  // --- Overlays (requires slug) ---
-  app.get("/api/overlays", async (c) => {
-    const result = requireSlug(c.req.query("slug"));
-    if ("error" in result) return c.json({ error: result.error }, 400);
-    const overlays = await loadOverlays(baseDir, result.slug);
-    return c.json(overlays);
-  });
-
-  app.post("/api/overlays", async (c) => {
-    const result = requireSlug(c.req.query("slug"));
-    if ("error" in result) return c.json({ error: result.error }, 400);
-    let body: SessionOverlays;
-    try {
-      body = await c.req.json<SessionOverlays>();
-    } catch {
-      return c.json({ error: "invalid JSON body" }, 400);
-    }
-    if (!body || !Array.isArray(body.overlays)) {
-      return c.json({ error: "invalid overlays shape" }, 400);
-    }
-    try {
-      await saveOverlays(baseDir, result.slug, body);
-    } catch (err) {
-      return c.json({ error: `Failed to save overlays: ${getErrorMessage(err)}` }, 500);
-    }
-    return c.json({ ok: true });
   });
 
   // After generation, fix originalValue to be the TRUE original from the unmodified session

--- a/packages/cli/test/README.md
+++ b/packages/cli/test/README.md
@@ -42,6 +42,7 @@ These tests protect **parser compatibility** with real-world session data from C
 | `cache.test.ts` | File cache envelope versioning, key sanitization, disable flag | Cache compatibility |
 | `insights.test.ts` | Durable insight conversion, merge provenance, daily aggregation, stats | Insights persistence |
 | `server-core.test.ts` | Server slug validation and error message helpers | Server helper contracts |
+| `server-persistence.test.ts` | Annotation and overlay persistence read/write behavior | Server persistence |
 | `pricing.test.ts` | Model pricing lookup + cost calculation | Per-model pricing |
 | `cost-estimation.test.ts` | Parser → transform cost integration | Multi-model cost accuracy |
 

--- a/packages/cli/test/server-persistence.test.ts
+++ b/packages/cli/test/server-persistence.test.ts
@@ -1,0 +1,91 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadAnnotations, saveAnnotations, saveOverlays } from "../src/server-persistence.js";
+import type { Annotation, SessionOverlays } from "../src/types.js";
+
+const originalCwd = process.cwd();
+const roots: string[] = [];
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: "ann-1",
+    sceneIndex: 1,
+    body: "Needs follow-up",
+    author: "vibe-replay",
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    resolved: false,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("server persistence", () => {
+  it("loads annotations from primary, fallback, and malformed stores", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-server-persistence-"));
+    roots.push(root);
+    process.chdir(root);
+    const baseDir = join(root, "primary");
+
+    await expect(loadAnnotations(baseDir, "missing")).resolves.toEqual([]);
+
+    await mkdir(join(baseDir, "bad"), { recursive: true });
+    await writeFile(join(baseDir, "bad", "annotations.json"), JSON.stringify({ nope: true }));
+    await expect(loadAnnotations(baseDir, "bad")).resolves.toEqual([]);
+
+    const fallbackAnnotation = makeAnnotation({ id: "fallback" });
+    await mkdir(join(root, "vibe-replay", "fallback"), { recursive: true });
+    await writeFile(
+      join(root, "vibe-replay", "fallback", "annotations.json"),
+      JSON.stringify([fallbackAnnotation]),
+    );
+
+    await expect(loadAnnotations(baseDir, "fallback")).resolves.toEqual([fallbackAnnotation]);
+  });
+
+  it("creates the slug directory before saving annotations", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-server-persistence-"));
+    roots.push(root);
+    const baseDir = join(root, "primary");
+    const annotation = makeAnnotation();
+
+    await saveAnnotations(baseDir, "session-a", [annotation]);
+
+    await expect(
+      readFile(join(baseDir, "session-a", "annotations.json"), "utf-8").then(JSON.parse),
+    ).resolves.toEqual([annotation]);
+  });
+
+  it("creates the slug directory before saving overlays", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-server-persistence-"));
+    roots.push(root);
+    const baseDir = join(root, "primary");
+    const overlays: SessionOverlays = {
+      version: 1,
+      overlays: [
+        {
+          id: "overlay-1",
+          sceneIndex: 2,
+          field: "content",
+          originalValue: "Hello",
+          modifiedValue: "Bonjour",
+          source: { type: "translate", params: { from: "en", to: "fr" } },
+          createdAt: "2026-05-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        },
+      ],
+    };
+
+    await saveOverlays(baseDir, "session-a", overlays);
+
+    await expect(
+      readFile(join(baseDir, "session-a", "overlays.json"), "utf-8").then(JSON.parse),
+    ).resolves.toEqual(overlays);
+  });
+});

--- a/packages/cli/test/server-persistence.test.ts
+++ b/packages/cli/test/server-persistence.test.ts
@@ -39,6 +39,14 @@ describe("server persistence", () => {
     await writeFile(join(baseDir, "bad", "annotations.json"), JSON.stringify({ nope: true }));
     await expect(loadAnnotations(baseDir, "bad")).resolves.toEqual([]);
 
+    const primaryAnnotation = makeAnnotation({ id: "primary" });
+    await mkdir(join(baseDir, "primary"), { recursive: true });
+    await writeFile(
+      join(baseDir, "primary", "annotations.json"),
+      JSON.stringify([primaryAnnotation]),
+    );
+    await expect(loadAnnotations(baseDir, "primary")).resolves.toEqual([primaryAnnotation]);
+
     const fallbackAnnotation = makeAnnotation({ id: "fallback" });
     await mkdir(join(root, "vibe-replay", "fallback"), { recursive: true });
     await writeFile(


### PR DESCRIPTION
## Summary
- Move annotations and overlays API route registration into `server-routes/session-assets`.
- Move annotation/overlay persistence into `server-persistence` and reuse the shared annotation loader from session listing/detail flows.
- Create slug directories before writing annotations or overlays and cover persistence behavior directly.
- Keep the rest of `startServer` route state untouched while starting the route split.

## Test plan
- pnpm --filter vibe-replay test -- test/server-persistence.test.ts test/server-core.test.ts test/server-generate.test.ts
- pnpm typecheck
- pnpm lint:check
- pnpm build
- pnpm test:e2e

Stacked on #306.

Made with [Cursor](https://cursor.com)