### PR TITLE
chore(tests): replace as any with proper types in transform-comprehensive test

### DIFF
--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -49,13 +49,13 @@ function assistantToolTurn(
     role: "assistant",
     blocks: [
       {
-        type: "tool_use",
+        type: "tool_use" as const,
         id: `tool_${Math.random().toString(36).slice(2, 8)}`,
         name,
         input,
         _result: result,
-        ...(opts.images ? { _images: opts.images } : {}),
-      } as any,
+        _images: opts.images,
+      },
     ],
   };
 }
@@ -263,14 +263,16 @@ describe("transform — scene generation", () => {
       role: "user",
       blocks: [
         { type: "text", text: "Check this screenshot" },
-        { type: "_user_images", images: ["data:image/png;base64,abc123"] } as any,
+        { type: "_user_images", images: ["data:image/png;base64,abc123"] },
       ],
     };
     const replay = transformToReplay(buildParsed({ turns: [turn] }), "claude-code", "~/test");
     expect(replay.scenes).toHaveLength(1);
     expect(replay.scenes[0].type).toBe("user-prompt");
     expect(replay.scenes[0].content).toBe("Check this screenshot");
-    expect((replay.scenes[0] as any).images).toEqual(["data:image/png;base64,abc123"]);
+    expect((replay.scenes[0] as { images?: string[] }).images).toEqual([
+      "data:image/png;base64,abc123",
+    ]);
   });
 
   it("creates '(image)' content for image-only user prompt", () => {
@@ -278,13 +280,13 @@ describe("transform — scene generation", () => {
       role: "user",
       blocks: [
         { type: "text", text: "" },
-        { type: "_user_images", images: ["data:image/png;base64,abc123"] } as any,
+        { type: "_user_images", images: ["data:image/png;base64,abc123"] },
       ],
     };
     const replay = transformToReplay(buildParsed({ turns: [turn] }), "claude-code", "~/test");
     expect(replay.scenes).toHaveLength(1);
     expect(replay.scenes[0].content).toBe("(image)");
-    expect((replay.scenes[0] as any).images).toHaveLength(1);
+    expect((replay.scenes[0] as { images?: string[] }).images).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove 5 `as any` casts from `packages/cli/test/transform-comprehensive.test.ts`
- Net change: -7 +9 lines

## Motivation

All 5 casts were unnecessary — the underlying types already support the shapes used:
- `{ type: "_user_images"; images: string[] }` is a member of the `ContentBlock` union; the two `as any` on those object literals add nothing
- `(scene as any).images` → `(scene as { images?: string[] }).images`: `Scene` carries `images?` on its `user-prompt` and `tool-call` variants; narrowing via a structural cast is safer than erasing the type entirely
- `assistantToolTurn` helper: replaced conditional spread `...(opts.images ? { _images: opts.images } : {})` + `as any` with a direct `_images: opts.images` assignment — `_images?: string[]` accepts `undefined`, so the semantics are identical, and `type: "tool_use" as const` lets TypeScript narrow to the correct `ContentBlock` variant without a cast

## Test plan

- [x] `pnpm test` 全绿 (44 CLI + 9 viewer test files, 943 tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] E2E: 未跑（纯 type-level 改动，无运行时行为变化）

> 🤖 Daily auto-quality routine. Self-merged after AI review.