### PR TITLE
chore(tests): drop redundant as any from mapToolArgs return values

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -1107,7 +1107,7 @@ describe("cursor sqlite metrics helpers", () => {
     const mapped = __testables.mapToolArgs(
       "ApplyPatch",
       "*** Begin Patch\n*** Update File: /tmp/demo.ts\n@@\n-old line\n+new line\n*** End Patch",
-    ) as any;
+    );
     expect(mapped.file_path).toBe("/tmp/demo.ts");
     expect(mapped.old_string).toContain("old line");
     expect(mapped.new_string).toContain("new line");
@@ -1122,7 +1122,7 @@ describe("cursor sqlite metrics helpers", () => {
           chunks: [{ diffString: "@@\n-old c\n+new c" }],
         },
       }),
-    ) as any;
+    );
     expect(mapped.file_path).toBe("src/c.ts");
     expect(mapped.old_string).toContain("old c");
     expect(mapped.new_string).toContain("new c");
@@ -1132,7 +1132,7 @@ describe("cursor sqlite metrics helpers", () => {
     const mapped = __testables.mapToolArgs(
       "ApplyPatch",
       "*** Begin Patch\n*** Update File: /tmp/ctx.ts\n@@\n shared before\n-old value\n+new value\n shared after\n*** End Patch",
-    ) as any;
+    );
     expect(mapped.old_string).toContain("shared before");
     expect(mapped.old_string).toContain("shared after");
     expect(mapped.new_string).toContain("shared before");
@@ -1165,7 +1165,7 @@ describe("cursor sqlite metrics helpers", () => {
       description: "Search auth patterns",
       prompt: "Search auth patterns in the repo",
       subagentType: "Explore",
-    }) as any;
+    });
     expect(mapped).toEqual({
       description: "Search auth patterns",
       prompt: "Search auth patterns in the repo",
@@ -1177,12 +1177,12 @@ describe("cursor sqlite metrics helpers", () => {
     const run = __testables.mapToolArgs("run_terminal_cmd", {
       command: "git status",
       requireUserApproval: true,
-    }) as any;
+    });
     expect(run).toMatchObject({ command: "git status", requireUserApproval: true });
 
     const read = __testables.mapToolArgs("read_file", {
       targetFile: "/tmp/a.ts",
-    }) as any;
+    });
     expect(read).toEqual({ file_path: "/tmp/a.ts" });
   });
 
@@ -1195,7 +1195,7 @@ describe("cursor sqlite metrics helpers", () => {
           chunks: [{ diffString: "@@\n-const a = 1;\n+const a = 2;" }],
         },
       }),
-    ) as any;
+    );
     expect(mapped.file_path).toBe("/tmp/a.ts");
     expect(mapped.old_string).toContain("const a = 1;");
     expect(mapped.new_string).toContain("const a = 2;");
@@ -1210,7 +1210,7 @@ describe("cursor sqlite metrics helpers", () => {
           chunks: [{ diffString: "@@\n-old value\n+new value" }],
         },
       }),
-    ) as any;
+    );
     expect(mapped.file_path).toBe("src/a.ts");
     expect(mapped.old_string).toContain("old value");
     expect(mapped.new_string).toContain("new value");
@@ -1221,7 +1221,7 @@ describe("cursor sqlite metrics helpers", () => {
       relativeWorkspacePath: "src/b.ts",
       oldStr: "a",
       newStr: "b",
-    }) as any;
+    });
     expect(mapped).toEqual({ file_path: "src/b.ts", old_string: "a", new_string: "b" });
   });
 
@@ -1229,12 +1229,12 @@ describe("cursor sqlite metrics helpers", () => {
     const write = __testables.mapToolArgs("write", {
       relativeWorkspacePath: "/tmp/doc.md",
       code: { code: "# title" },
-    }) as any;
+    });
     expect(write).toEqual({ file_path: "/tmp/doc.md", content: "# title" });
 
     const ls = __testables.mapToolArgs("list_dir", {
       targetDirectory: "/tmp",
-    }) as any;
+    });
     expect(ls).toEqual({ path: "/tmp" });
   });
 
@@ -1242,24 +1242,24 @@ describe("cursor sqlite metrics helpers", () => {
     const mapped = __testables.mapToolArgs("Write", {
       relativeWorkspacePath: "docs/readme.md",
       code: { code: "hello" },
-    }) as any;
+    });
     expect(mapped).toEqual({ file_path: "docs/readme.md", content: "hello" });
   });
 
   it("maps Delete args across Cursor variants", () => {
     const canonical = __testables.mapToolArgs("Delete", {
       path: "docs/old.md",
-    }) as any;
+    });
     expect(canonical).toEqual({ file_path: "docs/old.md" });
 
     const legacy = __testables.mapToolArgs("delete_file", {
       relativeWorkspacePath: "src/obsolete.ts",
-    }) as any;
+    });
     expect(legacy).toEqual({ file_path: "src/obsolete.ts" });
   });
 
   it("keeps string tool args as raw text for unknown tools", () => {
-    const mapped = __testables.mapToolArgs("CustomTool", "plain text payload") as any;
+    const mapped = __testables.mapToolArgs("CustomTool", "plain text payload");
     expect(mapped).toEqual({ raw: "plain text payload" });
   });
 });


### PR DESCRIPTION
## Summary

- Remove 15 redundant `as any` casts on `mapToolArgs` return values in `sqlite-reader.test.ts`
- Net change: -15 `as any` casts, 0 behaviour change

## Motivation

`mapToolArgs` is declared as returning `Record<string, any>`, which already allows arbitrary property access (`.file_path`, `.old_string`, etc.) without any cast. The `as any` casts were no-ops that obscured the actual return type.

## Test plan

- [x] `pnpm test` 全绿 (812 CLI + 159 viewer tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 825KB)
- [x] E2E: 未运行（纯类型层面等价，无运行时行为变化）

> 🤖 Daily auto-quality routine. Self-merged after AI review.