### PR TITLE
chore(tests): drop remaining as any casts in sqlite-reader test

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -754,7 +754,7 @@ describe("cursor sqlite metrics helpers", () => {
           },
         },
       },
-    ] as any);
+    ]);
 
     expect(apiErrors).toEqual([
       {
@@ -1071,19 +1071,17 @@ describe("cursor sqlite metrics helpers", () => {
       { type: "text", text: "<system_reminder>\ninternal only\n</system_reminder>" },
       { type: "image_url" },
       { type: "text", text: "<user_query>\nSplit sqlite-reader.ts\n</user_query>" },
-    ]) as any[];
+    ]);
 
     expect(blocks).toHaveLength(1);
     expect(blocks[0]).toEqual({ type: "text", text: "Split sqlite-reader.ts" });
   });
 
   it("keeps normal user_query content from sqlite user content", () => {
-    const blocks = __testables.parseUserContent(
-      "<user_query>\nShip this fix\n</user_query>",
-    ) as any[];
+    const blocks = __testables.parseUserContent("<user_query>\nShip this fix\n</user_query>");
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("text");
-    expect(blocks[0].text).toBe("Ship this fix");
+    expect((blocks[0] as { text: string }).text).toBe("Ship this fix");
   });
 
   it("normalizes turn text and drops wrapped system context", () => {


### PR DESCRIPTION
## Summary

- Remove 3 remaining `as any` / `as any[]` casts in `sqlite-reader.test.ts`
- Net change: -6 +4 lines

## Motivation

Three `as any` casts remained after PR #315:
1. `extractCursorApiErrors([...] as any)` — argument literal is already compatible with `GlobalStateBubbleEntry[]` (bubble is `Record<string, any>`), cast was redundant
2. `parseUserContent([...]) as any[]` — return type is `ContentBlock[]`, `.toEqual()` check doesn't require narrowing
3. `parseUserContent("...") as any[]` — replaced with the inferred `ContentBlock[]` return; `.text` access narrowed to `(blocks[0] as { text: string }).text` instead

All three changes are type-level only; runtime behaviour is identical.

## Test plan

- [x] `pnpm test` 全绿 (813 CLI + 159 viewer tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 825KB)
- [x] E2E: 未运行（纯类型层面等价，无运行时行为变化）

> 🤖 Daily auto-quality routine. Self-merged after AI review.