### PR TITLE
Add Pi session provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/vibe-replay)](https://www.npmjs.com/package/vibe-replay)
 [![license](https://img.shields.io/npm/l/vibe-replay)](./LICENSE)
 
-Turn Claude Code, Cursor, and Codex sessions into shareable, interactive replays.
+Turn Claude Code, Cursor, Codex, and Pi sessions into shareable, interactive replays.
 
 ### The problem
 
@@ -124,7 +124,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 
 - **Zero config** — one command, no setup, no account. Works instantly with existing sessions
 - **Single HTML file** — self-contained, works offline, zero external requests. Drop it in Slack, email it, open it anywhere
-- **Claude Code, Cursor, and Codex** — all providers auto-discovered, including multi-file and resumed sessions
+- **Claude Code, Cursor, Codex, and Pi** — all providers auto-discovered, including multi-file and resumed sessions
 - **Share & export** — GitHub Gist, animated SVG, GIF, markdown summary, or cloud upload. Secret redaction built in
 - **Sub-agent visualization** — see delegated tool calls and sub-agent trees rendered inline
 - **Comments** — leave notes on any scene. Comments persist in the HTML and travel with the replay
@@ -139,6 +139,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 | Claude Cowork | Supported (agent-mode sessions) |
 | Codex | Supported (web search, GPT-5.x models, task timings, memory mode) |
 | Cursor | Supported (SQLite + JSONL + SDK store, auto-discovered) |
+| Pi | Supported (JSONL tree sessions, branching, compaction summaries) |
 | More coming soon | — |
 
 ## How It Works

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/vibe-replay)](https://www.npmjs.com/package/vibe-replay)
 [![license](https://img.shields.io/npm/l/vibe-replay)](https://github.com/tuo-lei/vibe-replay/blob/main/LICENSE)
 
-Turn AI coding sessions into animated, interactive web replays.
+Turn AI coding sessions from Claude Code, Cursor, Codex, and Pi into animated, interactive web replays.
 
 One command. One HTML file. Share anywhere.
 
@@ -63,6 +63,7 @@ https://your-host/viewer.html?url=https://example.com/replay.json
 | Claude Code | Supported |
 | Cursor | Supported |
 | Codex | Supported |
+| Pi | Supported |
 | Gemini CLI | Planned |
 
 ## Options
@@ -72,7 +73,7 @@ Usage: vibe-replay [options]
 
 Options:
   -s, --session <path>    Path to a specific JSONL session file
-  -p, --provider <name>   Provider name (default: claude-code)
+  -p, --provider <name>   Provider name (default: claude-code; supports pi)
   --dev                   Write demo.json for HMR development
   -V, --version           Output the version number
   -h, --help              Display help

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import http from "node:http";
 import { Separator, select } from "@inquirer/prompts";
 import chalk from "chalk";
-import { program } from "commander";
+import { Command, program } from "commander";
 import ora from "ora";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText } from "./clean-prompt.js";
@@ -319,7 +319,9 @@ program
                         ? chalk.hex("#0096FF")("cursor")
                         : provider === "codex"
                           ? chalk.hex("#B392F0")("codex")
-                          : chalk.yellow(provider);
+                          : provider === "pi"
+                            ? chalk.hex("#14B8A6")("pi")
+                            : chalk.yellow(provider);
               replayEntries.push({
                 name: `${providerBadge} ${chalk.dim(`[${time}]`)} ${chalk.white(title)} ${chalk.dim(`(${scenes} scenes)`)}`,
                 value: slug,
@@ -771,6 +773,7 @@ interface SessionsCommandOptions {
   query?: string;
   project?: string;
   provider?: string;
+  providerFilter?: string;
   limit?: number;
   scan?: boolean;
   any?: boolean;
@@ -784,22 +787,26 @@ program
   .description("Search local AI coding sessions (agent-friendly)")
   .option("-q, --query <text>", "Search title, prompt, project, branch, model, or slug")
   .option("--project <text>", "Filter by project path substring")
-  .option("-p, --provider <name>", "Filter by provider (claude-code, cursor, codex, ...)")
+  .option(
+    "-P, --provider-filter <name>",
+    "Filter by provider (claude-code, cursor, codex, pi, ...)",
+  )
   .option("-l, --limit <number>", "Maximum sessions to return", (value) => Number(value), 10)
   .option("--scan", "Run richer per-session scan for efficiency metrics")
   .option("--any", "Match any query term instead of requiring all terms")
   .option("--brief", "Include scan-backed session briefs and match evidence")
   .option("--dedupe", "Collapse near-duplicate sessions with the same long prompt/title")
   .option("--json", "Print machine-readable JSON")
-  .action(async (opts: SessionsCommandOptions) => {
+  .action(async (opts: SessionsCommandOptions, command: Command) => {
     const discoverSpinner = opts.json ? undefined : ora("Discovering local sessions...").start();
     try {
+      const queryOptions = normalizeSessionsCommandOptions(opts, command);
       const sessions = mergeSameSessions(await discoverAllSessions());
       discoverSpinner?.succeed(`Found ${sessions.length} sessions`);
 
       const scanSpinner =
         opts.scan && !opts.json ? ora("Scanning matching sessions...").start() : undefined;
-      const matches = await queryLocalSessions(sessions, opts);
+      const matches = await queryLocalSessions(sessions, queryOptions);
       scanSpinner?.succeed(`Prepared ${matches.length} session result(s)`);
 
       if (opts.json) {
@@ -1117,7 +1124,7 @@ program
   .description("Watch a running AI coding session live in the browser")
   .option("-p, --provider <name>", "Provider name (default: auto-detect)")
   .option("-s, --session <sessionId>", "Specific session ID to watch")
-  .action(async (opts: { provider?: string; session?: string }) => {
+  .action(async (opts: { provider?: string; session?: string }, command: Command) => {
     const { join: pathJoin } = await import("node:path");
     const { homedir } = await import("node:os");
     const replayBaseDir = pathJoin(homedir(), ".vibe-replay");
@@ -1128,7 +1135,7 @@ program
 
     if (opts.session) {
       // Explicit session id — find which provider owns it
-      const providerHint = opts.provider;
+      const providerHint = normalizeCommandProviderOption(opts.provider, command);
       const providers = providerHint
         ? [getProvider(providerHint)].filter((p): p is NonNullable<typeof p> => !!p)
         : getAllProviders();
@@ -1153,8 +1160,9 @@ program
       const ora = (await import("ora")).default;
       const spinner = ora("Finding the most recent session...").start();
       const all: SessionInfo[] = [];
-      const providers = opts.provider
-        ? [getProvider(opts.provider)].filter((p): p is NonNullable<typeof p> => !!p)
+      const providerHint = normalizeCommandProviderOption(opts.provider, command);
+      const providers = providerHint
+        ? [getProvider(providerHint)].filter((p): p is NonNullable<typeof p> => !!p)
         : getAllProviders();
       for (const provider of providers) {
         try {
@@ -1209,6 +1217,34 @@ program
 
 program.parse();
 
+function normalizeSessionsCommandOptions(
+  opts: SessionsCommandOptions,
+  command: Command,
+): SessionsCommandOptions {
+  const provider = opts.providerFilter || normalizeCommandProviderOption(opts.provider, command);
+  return {
+    ...opts,
+    ...(provider ? { provider } : {}),
+  };
+}
+
+function normalizeCommandProviderOption(
+  provider: string | undefined,
+  command: Command,
+): string | undefined {
+  if (command.getOptionValueSource("provider") === "cli") {
+    return provider;
+  }
+
+  const parent = command.parent;
+  if (parent?.getOptionValueSource("provider") === "cli") {
+    const parentProvider = parent.opts<{ provider?: string }>().provider;
+    return parentProvider;
+  }
+
+  return undefined;
+}
+
 function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: number) {
   // Merge sessions with the same slug under the same project
   const merged = mergeSameSessions(sessions);
@@ -1244,7 +1280,7 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
       const prompt = s.firstPrompt.replace(/\n/g, " ").slice(0, 50);
 
       // Claude: orange-brown (#D97706), Desktop: purple (#C084FC),
-      // Cowork: pink (#F472B6), Cursor: blue (#0096FF), Codex: purple (#B392F0)
+      // Cowork: pink (#F472B6), Cursor: blue (#0096FF), Codex: purple (#B392F0), Pi: teal (#14B8A6)
       const providerBadge =
         s.provider === "claude-code"
           ? chalk.hex("#D97706")("claude")
@@ -1256,7 +1292,9 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
                 ? chalk.hex("#0096FF")("cursor")
                 : s.provider === "codex"
                   ? chalk.hex("#B392F0")("codex")
-                  : chalk.yellow(s.provider);
+                  : s.provider === "pi"
+                    ? chalk.hex("#14B8A6")("pi")
+                    : chalk.yellow(s.provider);
 
       const titleStr = s.title ? chalk.white(` "${s.title}"`) : "";
 

--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -3,6 +3,7 @@ import { claudeCoworkProvider } from "./claude-cowork/index.js";
 import { claudeDesktopProvider } from "./claude-desktop/index.js";
 import { codexProvider } from "./codex/index.js";
 import { cursorProvider } from "./cursor/index.js";
+import { piProvider } from "./pi/index.js";
 import type { Provider } from "./types.js";
 import type { SessionInfo } from "../types.js";
 
@@ -12,13 +13,21 @@ const providers: Provider[] = [
   claudeCodeProvider,
   codexProvider,
   cursorProvider,
+  piProvider,
 ];
 
 // Priority order for deduplication — lower index = higher priority.
 // Cowork ranks first because its audit.jsonl is self-contained and the only
 // source of truth for agent-mode sessions (no other provider can discover them).
 // Codex uses distinct rollout UUIDs, so it does not collide with the Claude family.
-const PROVIDER_PRIORITY = ["claude-cowork", "claude-desktop", "claude-code", "codex", "cursor"];
+const PROVIDER_PRIORITY = [
+  "claude-cowork",
+  "claude-desktop",
+  "claude-code",
+  "codex",
+  "cursor",
+  "pi",
+];
 
 export function getAllProviders(): Provider[] {
   return providers;

--- a/packages/cli/src/providers/pi/config.ts
+++ b/packages/cli/src/providers/pi/config.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function getPiAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+export function getPiSessionsDir(): string {
+  return process.env.PI_CODING_AGENT_SESSION_DIR || join(getPiAgentDir(), "sessions");
+}
+
+export async function readPiModelContextWindows(): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  let raw: string;
+  try {
+    raw = await readFile(join(getPiAgentDir(), "models.json"), "utf-8");
+  } catch {
+    return result;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return result;
+  }
+
+  collectModelContextWindows(parsed, result);
+  return result;
+}
+
+function collectModelContextWindows(value: unknown, result: Map<string, number>): void {
+  if (!value || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectModelContextWindows(item, result);
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.id === "string" && typeof obj.contextWindow === "number") {
+    result.set(obj.id, obj.contextWindow);
+  }
+  for (const nested of Object.values(obj)) collectModelContextWindows(nested, result);
+}

--- a/packages/cli/src/providers/pi/discover.ts
+++ b/packages/cli/src/providers/pi/discover.ts
@@ -1,0 +1,184 @@
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+import { cleanPromptText } from "../../clean-prompt.js";
+import type { SessionInfo } from "../../types.js";
+import { getPiSessionsDir } from "./config.js";
+const PROMPT_SCAN_LIMIT = 2;
+
+interface PiSessionHeader {
+  type: "session";
+  version?: number;
+  id: string;
+  timestamp: string;
+  cwd?: string;
+}
+
+export async function discoverPiSessions(): Promise<SessionInfo[]> {
+  const sessionsRoot = getPiSessionsDir();
+  const sessions: SessionInfo[] = [];
+
+  let projectDirs: string[];
+  try {
+    projectDirs = await readdir(sessionsRoot);
+  } catch {
+    return sessions;
+  }
+
+  for (const projectDir of projectDirs) {
+    const projectPath = join(sessionsRoot, projectDir);
+    const projectStat = await stat(projectPath).catch(() => null);
+    if (!projectStat?.isDirectory()) continue;
+
+    let files: string[];
+    try {
+      files = await readdir(projectPath);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      if (!file.endsWith(".jsonl")) continue;
+      const filePath = join(projectPath, file);
+      const fileStat = await stat(filePath).catch(() => null);
+      if (!fileStat) continue;
+
+      const info = await extractPiSessionInfo(filePath, fileStat.size, projectDir);
+      if (info) sessions.push(info);
+    }
+  }
+
+  sessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return sessions;
+}
+
+async function extractPiSessionInfo(
+  filePath: string,
+  fileSize: number,
+  encodedProjectDir: string,
+): Promise<SessionInfo | null> {
+  let header: PiSessionHeader | undefined;
+  let timestamp = "";
+  let lineCount = 0;
+  let promptCount = 0;
+  let toolCallCount = 0;
+  let editCountEst = 0;
+  let model: string | undefined;
+  let title: string | undefined;
+  const prompts: string[] = [];
+
+  const input = createReadStream(filePath, { encoding: "utf-8" });
+  const rl = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
+
+  try {
+    for await (const rawLine of rl) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      lineCount++;
+
+      let entry: any;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      if (typeof entry.timestamp === "string" && entry.timestamp) {
+        timestamp = entry.timestamp;
+      }
+
+      if (!header) {
+        if (entry.type !== "session" || typeof entry.id !== "string") return null;
+        header = entry;
+        if (typeof entry.timestamp === "string" && entry.timestamp) timestamp = entry.timestamp;
+        continue;
+      }
+
+      if (entry.type === "session_info") {
+        const name = typeof entry.name === "string" ? entry.name.trim() : "";
+        title = name || undefined;
+        continue;
+      }
+
+      if (entry.type === "model_change" && typeof entry.modelId === "string") {
+        model = entry.modelId;
+        continue;
+      }
+
+      if (entry.type !== "message") continue;
+      const message = entry.message;
+      if (!message || typeof message !== "object") continue;
+
+      if (message.role === "user") {
+        const text = extractText(message.content).trim();
+        if (text) {
+          promptCount++;
+          if (prompts.length < PROMPT_SCAN_LIMIT) {
+            prompts.push(cleanPromptText(text).slice(0, 200));
+          }
+        }
+      } else if (message.role === "assistant") {
+        if (!model && typeof message.model === "string") model = message.model;
+        if (Array.isArray(message.content)) {
+          for (const block of message.content) {
+            if (block?.type !== "toolCall") continue;
+            toolCallCount++;
+            if (isEditTool(block.name)) editCountEst++;
+          }
+        }
+      }
+    }
+  } catch {
+    return null;
+  } finally {
+    rl.close();
+  }
+
+  if (!header || prompts.length === 0) return null;
+
+  const cwd = header.cwd || decodeProjectDir(encodedProjectDir);
+  const slug = basename(filePath, ".jsonl").replace(/^\d{4}-\d{2}-\d{2}T[^_]+_/, "");
+  const fallbackTimestamp = timestamp || header.timestamp || new Date().toISOString();
+
+  return {
+    provider: "pi",
+    sessionId: header.id,
+    slug,
+    title,
+    project: cwd,
+    cwd,
+    version: String(header.version || 1),
+    timestamp: fallbackTimestamp,
+    lineCount,
+    fileSize,
+    filePath,
+    filePaths: [filePath],
+    firstPrompt: prompts[0] || "(pi session)",
+    prompts,
+    promptCount,
+    toolCallCount,
+    model,
+    editCountEst,
+  };
+}
+
+function decodeProjectDir(encoded: string): string {
+  if (encoded.startsWith("--") && encoded.endsWith("--")) {
+    return `/${encoded.slice(2, -2).replace(/-/g, "/")}`;
+  }
+  return encoded;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is { type: string; text?: string } => block?.type === "text")
+    .map((block) => block.text || "")
+    .join("\n");
+}
+
+function isEditTool(name: unknown): boolean {
+  return name === "edit" || name === "write" || name === "Edit" || name === "Write";
+}

--- a/packages/cli/src/providers/pi/index.ts
+++ b/packages/cli/src/providers/pi/index.ts
@@ -1,0 +1,10 @@
+import type { Provider } from "../types.js";
+import { discoverPiSessions } from "./discover.js";
+import { parsePiSession } from "./parser.js";
+
+export const piProvider: Provider = {
+  name: "pi",
+  displayName: "Pi",
+  discover: discoverPiSessions,
+  parse: parsePiSession,
+};

--- a/packages/cli/src/providers/pi/parser.ts
+++ b/packages/cli/src/providers/pi/parser.ts
@@ -1,9 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { shortenPath } from "../../utils.js";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
 import type { ProviderParseResult, TokenUsage } from "../types.js";
 import { addParseWarning } from "../warnings.js";
-import { readPiModelContextWindows } from "./config.js";
+import { getPiSessionsDir, readPiModelContextWindows } from "./config.js";
 
 interface PiHeader {
   type: "session";
@@ -106,6 +107,7 @@ export async function parsePiSession(
   return parsePiLines(allLines, {
     sourcePath: paths[0],
     sessionInfo,
+    sessionsDir: getPiSessionsDir(),
     modelContextWindows: await readPiModelContextWindows(),
   });
 }
@@ -113,6 +115,7 @@ export async function parsePiSession(
 interface ParsePiLinesOptions {
   sourcePath?: string;
   sessionInfo?: SessionInfo;
+  sessionsDir?: string;
   modelContextWindows?: ReadonlyMap<string, number>;
 }
 
@@ -179,10 +182,8 @@ export function parsePiLines(
     }
 
     if (entry.type === "session_info") {
-      const name =
-        typeof (entry as { name?: unknown }).name === "string"
-          ? (entry as { name: string }).name.trim()
-          : "";
+      const sessionInfoEntry = entry as PiEntryBase & { name?: unknown };
+      const name = typeof sessionInfoEntry.name === "string" ? sessionInfoEntry.name.trim() : "";
       title = name || title;
       continue;
     }
@@ -322,7 +323,7 @@ export function parsePiLines(
     dataSource: "jsonl",
     dataSourceInfo: {
       primary: "jsonl",
-      sources: ["~/.pi/agent/sessions"],
+      sources: [shortenPath(options.sessionsDir || getPiSessionsDir())],
       ...(branchSelection.abandonedEntries > 0
         ? { notes: [`${branchSelection.abandonedEntries} off-branch Pi entries were omitted.`] }
         : {}),
@@ -366,7 +367,7 @@ function selectActiveBranch(
     if (!current.id || seen.has(current.id)) break;
     seen.add(current.id);
     branch.unshift(current);
-    const parentId = current.parentId;
+    const parentId: string | null | undefined = current.parentId;
     current = typeof parentId === "string" ? byId.get(parentId) : undefined;
   }
   return branch.length > 0
@@ -450,7 +451,7 @@ function buildBashExecutionBlock(
     name: "Bash",
     input: { command: message.command || "" },
     _result: outputParts.join(""),
-    ...(message.exitCode && message.exitCode !== 0 ? { _isError: true } : {}),
+    ...(message.exitCode !== undefined && message.exitCode !== 0 ? { _isError: true } : {}),
   };
 }
 

--- a/packages/cli/src/providers/pi/parser.ts
+++ b/packages/cli/src/providers/pi/parser.ts
@@ -360,19 +360,31 @@ function selectActiveBranch(
   const leaf = entries.toReversed().find((entry) => entry.id && byId.has(entry.id));
   if (!leaf?.id) return { entries, abandonedEntries: 0 };
 
+  const branchIds = new Set<string>();
   const branch: PiEntryBase[] = [];
   const seen = new Set<string>();
   let current: PiEntryBase | undefined = leaf;
   while (current) {
     if (!current.id || seen.has(current.id)) break;
     seen.add(current.id);
+    branchIds.add(current.id);
     branch.unshift(current);
     const parentId: string | null | undefined = current.parentId;
     current = typeof parentId === "string" ? byId.get(parentId) : undefined;
   }
-  return branch.length > 0
-    ? { entries: branch, abandonedEntries: Math.max(0, entries.length - branch.length) }
-    : { entries, abandonedEntries: 0 };
+  if (branch.length === 0) return { entries, abandonedEntries: 0 };
+
+  const idlessEntries = entries.filter((entry) => !entry.id);
+  if (idlessEntries.length === 0) {
+    return { entries: branch, abandonedEntries: Math.max(0, entries.length - branch.length) };
+  }
+
+  const selected = new Set<PiEntryBase>(branch);
+  const branchWithIdless = entries.filter((entry) => selected.has(entry) || !entry.id);
+  return {
+    entries: branchWithIdless,
+    abandonedEntries: entries.filter((entry) => entry.id && !branchIds.has(entry.id)).length,
+  };
 }
 
 function collectToolResults(entries: PiEntryBase[]): Map<string, ToolResultData> {
@@ -496,6 +508,8 @@ function normalizeToolInput(name: string, input: Record<string, unknown>): Recor
     };
   }
   if (normalized === "edit") {
+    // Pi's edit tool can carry multiple replacements, but the viewer renders
+    // one diff per tool call, so map the first edit as the representative diff.
     const firstEdit = Array.isArray(input.edits) ? input.edits[0] : undefined;
     const edit =
       firstEdit && typeof firstEdit === "object" ? (firstEdit as Record<string, unknown>) : input;

--- a/packages/cli/src/providers/pi/parser.ts
+++ b/packages/cli/src/providers/pi/parser.ts
@@ -1,0 +1,607 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import type { ContentBlock, ParsedTurn, SessionInfo } from "../../types.js";
+import type { ProviderParseResult, TokenUsage } from "../types.js";
+import { addParseWarning } from "../warnings.js";
+import { readPiModelContextWindows } from "./config.js";
+
+interface PiHeader {
+  type: "session";
+  version?: number;
+  id: string;
+  timestamp: string;
+  cwd: string;
+}
+
+interface PiEntryBase {
+  type: string;
+  id?: string;
+  parentId?: string | null;
+  timestamp?: string;
+}
+
+interface PiMessageEntry extends PiEntryBase {
+  type: "message";
+  message?: PiMessage;
+}
+
+interface PiMessage {
+  role: string;
+  content?: unknown;
+  timestamp?: number;
+  provider?: string;
+  model?: string;
+  usage?: PiUsage;
+  stopReason?: string;
+  errorMessage?: string;
+  toolCallId?: string;
+  toolName?: string;
+  isError?: boolean;
+  command?: string;
+  output?: string;
+  exitCode?: number;
+  cancelled?: boolean;
+  truncated?: boolean;
+  fullOutputPath?: string;
+  excludeFromContext?: boolean;
+  customType?: string;
+  display?: boolean;
+  details?: unknown;
+}
+
+interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+interface PiToolCallBlock {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+interface PiTextBlock {
+  type: "text";
+  text?: string;
+}
+
+interface PiImageBlock {
+  type: "image";
+  data?: string;
+  mimeType?: string;
+}
+
+interface PiThinkingBlock {
+  type: "thinking";
+  thinking?: string;
+}
+
+type PiContentBlock = PiTextBlock | PiImageBlock | PiThinkingBlock | PiToolCallBlock;
+
+interface ToolResultData {
+  text: string;
+  images: string[];
+  isError?: boolean;
+  timestamp?: string;
+}
+
+interface BranchSelection {
+  entries: PiEntryBase[];
+  abandonedEntries: number;
+}
+
+export async function parsePiSession(
+  filePaths: string | string[],
+  sessionInfo?: SessionInfo,
+): Promise<ProviderParseResult> {
+  const paths = Array.isArray(filePaths) ? filePaths : [filePaths];
+  const allLines: string[] = [];
+  for (const fp of paths) {
+    const content = await readFile(fp, "utf-8");
+    allLines.push(...content.split("\n"));
+  }
+  return parsePiLines(allLines, {
+    sourcePath: paths[0],
+    sessionInfo,
+    modelContextWindows: await readPiModelContextWindows(),
+  });
+}
+
+interface ParsePiLinesOptions {
+  sourcePath?: string;
+  sessionInfo?: SessionInfo;
+  modelContextWindows?: ReadonlyMap<string, number>;
+}
+
+export function parsePiLines(
+  lines: string[],
+  options: ParsePiLinesOptions = {},
+): ProviderParseResult {
+  let header: PiHeader | undefined;
+  const entries: PiEntryBase[] = [];
+  const byId = new Map<string, PiEntryBase>();
+  const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex];
+    if (!line.trim()) continue;
+
+    let entry: PiEntryBase | PiHeader;
+    try {
+      entry = JSON.parse(line) as PiEntryBase | PiHeader;
+    } catch {
+      addParseWarning(parseWarnings, {
+        kind: "malformed-json",
+        source: "pi JSONL",
+        firstLine: lineIndex + 1,
+        message: "Skipped malformed JSONL line",
+        sample: line,
+      });
+      continue;
+    }
+
+    if (entry.type === "session") {
+      if (!header && typeof (entry as PiHeader).id === "string") {
+        header = entry as PiHeader;
+      }
+      continue;
+    }
+
+    entries.push(entry);
+    if (entry.id) byId.set(entry.id, entry);
+  }
+
+  const branchSelection = selectActiveBranch(entries, byId);
+  const branchEntries = branchSelection.entries;
+  const toolResults = collectToolResults(branchEntries);
+  const turns: ParsedTurn[] = [];
+  const usageByMessageId = new Map<
+    string,
+    { usage: TokenUsage; model?: string; contextTokens?: number }
+  >();
+  const allTimestamps: string[] = [];
+  const compactions: NonNullable<ProviderParseResult["compactions"]> = [];
+  const apiErrors: NonNullable<ProviderParseResult["apiErrors"]> = [];
+  let title = options.sessionInfo?.title;
+  let model: string | undefined = options.sessionInfo?.model;
+  let currentModel: string | undefined = model;
+  let firstTimestamp: string | undefined;
+  let lastTimestamp: string | undefined;
+
+  for (const entry of branchEntries) {
+    if (entry.timestamp) {
+      allTimestamps.push(entry.timestamp);
+      if (!firstTimestamp || entry.timestamp < firstTimestamp) firstTimestamp = entry.timestamp;
+      if (!lastTimestamp || entry.timestamp > lastTimestamp) lastTimestamp = entry.timestamp;
+    }
+
+    if (entry.type === "session_info") {
+      const name =
+        typeof (entry as { name?: unknown }).name === "string"
+          ? (entry as { name: string }).name.trim()
+          : "";
+      title = name || title;
+      continue;
+    }
+
+    if (entry.type === "model_change") {
+      const nextModel = (entry as { modelId?: unknown }).modelId;
+      if (typeof nextModel === "string" && nextModel) {
+        currentModel = nextModel;
+        model = model || nextModel;
+      }
+      continue;
+    }
+
+    if (entry.type === "compaction") {
+      const compaction = entry as { summary?: unknown; tokensBefore?: unknown; timestamp?: string };
+      const summary = typeof compaction.summary === "string" ? compaction.summary : "";
+      if (summary) {
+        turns.push({
+          role: "user",
+          subtype: "compaction-summary",
+          timestamp: entry.timestamp,
+          blocks: [{ type: "text", text: summary }],
+        });
+      }
+      compactions.push({
+        timestamp: entry.timestamp || lastTimestamp || new Date().toISOString(),
+        trigger: "pi",
+        ...(typeof compaction.tokensBefore === "number"
+          ? { preTokens: compaction.tokensBefore }
+          : {}),
+      });
+      continue;
+    }
+
+    if (entry.type === "branch_summary") {
+      const summary = (entry as { summary?: unknown }).summary;
+      if (typeof summary === "string" && summary.trim()) {
+        turns.push({
+          role: "user",
+          subtype: "context-injection",
+          timestamp: entry.timestamp,
+          blocks: [{ type: "text", text: `Branch summary:\n${summary}` }],
+        });
+      }
+      continue;
+    }
+
+    if (entry.type === "custom_message") {
+      const custom = entry as { customType?: unknown; content?: unknown; display?: unknown };
+      const text = extractText(custom.content).trim();
+      if (text && custom.display !== false) {
+        const customType = typeof custom.customType === "string" ? custom.customType : "custom";
+        turns.push({
+          role: "user",
+          subtype: "context-injection",
+          timestamp: entry.timestamp,
+          blocks: [{ type: "text", text: `[${customType}]\n${text}` }],
+        });
+      }
+      continue;
+    }
+
+    if (entry.type !== "message") continue;
+    const messageEntry = entry as PiMessageEntry;
+    const message = messageEntry.message;
+    if (!message) continue;
+
+    if (message.role === "user") {
+      const blocks = buildUserBlocks(message.content);
+      if (blocks.length > 0) {
+        turns.push({ role: "user", timestamp: entry.timestamp, blocks });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const blocks = buildAssistantBlocks(message.content, toolResults, entry.timestamp);
+      if (message.errorMessage) {
+        blocks.push({ type: "text", text: message.errorMessage });
+        apiErrors.push({
+          timestamp: entry.timestamp || new Date().toISOString(),
+          ...parseApiErrorMessage(message.errorMessage),
+        });
+      }
+      if (blocks.length > 0) {
+        const msgModel = message.model || currentModel;
+        if (msgModel) model = model || msgModel;
+        if (message.usage && entry.id) {
+          const usage = normalizeUsage(message.usage);
+          usageByMessageId.set(entry.id, {
+            usage,
+            model: msgModel,
+            contextTokens: usage.inputTokens + usage.cacheCreationTokens + usage.cacheReadTokens,
+          });
+        }
+        turns.push({
+          role: "assistant",
+          messageId: entry.id,
+          model: msgModel,
+          timestamp: entry.timestamp,
+          blocks,
+          ...(message.stopReason === "length" ? { stopReason: "max_tokens" as const } : {}),
+        });
+      }
+      continue;
+    }
+
+    if (message.role === "bashExecution") {
+      const block = buildBashExecutionBlock(message, entry.id || `bash-${turns.length}`);
+      turns.push({ role: "assistant", timestamp: entry.timestamp, blocks: [block] });
+    }
+  }
+
+  const tokenUsage = aggregateUsage([...usageByMessageId.values()].map((value) => value.usage));
+  const tokenUsageByModel = aggregateUsageByModel(usageByMessageId);
+  const turnStats = buildTurnStats(turns, usageByMessageId);
+  const sessionId = header?.id || options.sessionInfo?.sessionId || "pi-session";
+  const sourcePath = options.sourcePath || options.sessionInfo?.filePath || "";
+  const slug = options.sessionInfo?.slug || basename(sourcePath || sessionId, ".jsonl");
+  const cwd = header?.cwd || options.sessionInfo?.cwd || options.sessionInfo?.project || "";
+
+  return {
+    sessionId,
+    slug,
+    title,
+    cwd,
+    model,
+    startTime: firstTimestamp || header?.timestamp,
+    endTime: lastTimestamp,
+    totalDurationMs: estimateActiveDuration(allTimestamps),
+    turns,
+    tokenUsage,
+    ...(tokenUsageByModel ? { tokenUsageByModel } : {}),
+    ...(turnStats.length > 0 ? { turnStats } : {}),
+    ...(compactions.length > 0 ? { compactions } : {}),
+    ...(apiErrors.length > 0 ? { apiErrors } : {}),
+    dataSource: "jsonl",
+    dataSourceInfo: {
+      primary: "jsonl",
+      sources: ["~/.pi/agent/sessions"],
+      ...(branchSelection.abandonedEntries > 0
+        ? { notes: [`${branchSelection.abandonedEntries} off-branch Pi entries were omitted.`] }
+        : {}),
+    },
+    ...(model ? contextLimitForModel(model, options.modelContextWindows) : {}),
+    ...(parseWarnings.length > 0 ? { parseWarnings } : {}),
+  };
+}
+
+function parseApiErrorMessage(message: string): { statusCode?: number; errorType?: string } {
+  const status = message.match(/\b(\d{3})\b/);
+  const errorType = message.match(/"([a-z][a-z0-9_]*error[a-z0-9_]*)"/i);
+  return {
+    ...(status ? { statusCode: Number(status[1]) } : {}),
+    ...(errorType ? { errorType: errorType[1] } : {}),
+  };
+}
+
+function contextLimitForModel(
+  model: string,
+  modelContextWindows?: ReadonlyMap<string, number>,
+): { contextLimit?: number } {
+  const contextLimit = modelContextWindows?.get(model);
+  return contextLimit ? { contextLimit } : {};
+}
+
+function selectActiveBranch(
+  entries: PiEntryBase[],
+  byId: Map<string, PiEntryBase>,
+): BranchSelection {
+  if (entries.length === 0) return { entries: [], abandonedEntries: 0 };
+  if (byId.size === 0) return { entries, abandonedEntries: 0 };
+
+  const leaf = entries.toReversed().find((entry) => entry.id && byId.has(entry.id));
+  if (!leaf?.id) return { entries, abandonedEntries: 0 };
+
+  const branch: PiEntryBase[] = [];
+  const seen = new Set<string>();
+  let current: PiEntryBase | undefined = leaf;
+  while (current) {
+    if (!current.id || seen.has(current.id)) break;
+    seen.add(current.id);
+    branch.unshift(current);
+    const parentId = current.parentId;
+    current = typeof parentId === "string" ? byId.get(parentId) : undefined;
+  }
+  return branch.length > 0
+    ? { entries: branch, abandonedEntries: Math.max(0, entries.length - branch.length) }
+    : { entries, abandonedEntries: 0 };
+}
+
+function collectToolResults(entries: PiEntryBase[]): Map<string, ToolResultData> {
+  const results = new Map<string, ToolResultData>();
+  for (const entry of entries) {
+    if (entry.type !== "message") continue;
+    const message = (entry as PiMessageEntry).message;
+    if (message?.role !== "toolResult" || typeof message.toolCallId !== "string") continue;
+    const { text, images } = extractTextAndImages(message.content);
+    results.set(message.toolCallId, {
+      text,
+      images,
+      isError: message.isError,
+      timestamp: entry.timestamp,
+    });
+  }
+  return results;
+}
+
+function buildUserBlocks(content: unknown): ContentBlock[] {
+  const { text, images } = extractTextAndImages(content);
+  const blocks: ContentBlock[] = [];
+  if (text.trim()) blocks.push({ type: "text", text });
+  if (images.length > 0) blocks.push({ type: "_user_images", images });
+  return blocks;
+}
+
+function buildAssistantBlocks(
+  content: unknown,
+  toolResults: Map<string, ToolResultData>,
+  assistantTimestamp?: string,
+): ContentBlock[] {
+  if (!Array.isArray(content)) return [];
+  const blocks: ContentBlock[] = [];
+  for (const block of content as PiContentBlock[]) {
+    if (block.type === "thinking" && block.thinking?.trim()) {
+      blocks.push({ type: "thinking", thinking: block.thinking });
+    } else if (block.type === "text" && block.text?.trim()) {
+      blocks.push({ type: "text", text: block.text });
+    } else if (block.type === "toolCall") {
+      const result = toolResults.get(block.id);
+      blocks.push({
+        type: "tool_use",
+        id: block.id,
+        name: mapToolName(block.name),
+        input: normalizeToolInput(block.name, block.arguments || {}),
+        _result: result?.text || "",
+        ...(result?.images.length ? { _images: result.images } : {}),
+        ...(result?.isError ? { _isError: true } : {}),
+        ...(assistantTimestamp && result?.timestamp
+          ? { _durationMs: toolDurationMs(assistantTimestamp, result.timestamp) }
+          : {}),
+      });
+    }
+  }
+  return blocks;
+}
+
+function toolDurationMs(start: string, end: string): number | undefined {
+  const duration = Date.parse(end) - Date.parse(start);
+  return duration > 0 && duration < 60 * 60_000 ? duration : undefined;
+}
+
+function buildBashExecutionBlock(
+  message: PiMessage,
+  fallbackId: string,
+): Extract<ContentBlock, { type: "tool_use" }> {
+  const outputParts = [message.output || ""];
+  if (message.cancelled) outputParts.push("\n(command cancelled)");
+  if (message.truncated && message.fullOutputPath) {
+    outputParts.push(`\n[Output truncated. Full output: ${message.fullOutputPath}]`);
+  }
+  return {
+    type: "tool_use",
+    id: fallbackId,
+    name: "Bash",
+    input: { command: message.command || "" },
+    _result: outputParts.join(""),
+    ...(message.exitCode && message.exitCode !== 0 ? { _isError: true } : {}),
+  };
+}
+
+function extractTextAndImages(content: unknown): { text: string; images: string[] } {
+  if (typeof content === "string") return { text: content, images: [] };
+  if (!Array.isArray(content)) return { text: "", images: [] };
+
+  const text: string[] = [];
+  const images: string[] = [];
+  for (const block of content as PiContentBlock[]) {
+    if (block.type === "text") {
+      text.push(block.text || "");
+    } else if (block.type === "image" && block.data) {
+      images.push(`data:${block.mimeType || "image/png"};base64,${block.data}`);
+    }
+  }
+  return { text: text.join("\n"), images };
+}
+
+function extractText(content: unknown): string {
+  return extractTextAndImages(content).text;
+}
+
+function mapToolName(name: string): string {
+  const normalized = name.toLowerCase();
+  if (normalized === "bash") return "Bash";
+  if (normalized === "read") return "Read";
+  if (normalized === "write") return "Write";
+  if (normalized === "edit") return "Edit";
+  if (normalized === "grep") return "Grep";
+  if (normalized === "find") return "Find";
+  if (normalized === "ls") return "LS";
+  return name;
+}
+
+function normalizeToolInput(name: string, input: Record<string, unknown>): Record<string, unknown> {
+  const normalized = name.toLowerCase();
+  if (normalized === "write") {
+    return {
+      ...input,
+      ...(typeof input.path === "string" ? { file_path: input.path } : {}),
+    };
+  }
+  if (normalized === "edit") {
+    const firstEdit = Array.isArray(input.edits) ? input.edits[0] : undefined;
+    const edit =
+      firstEdit && typeof firstEdit === "object" ? (firstEdit as Record<string, unknown>) : input;
+    return {
+      ...input,
+      ...(typeof input.path === "string" ? { file_path: input.path } : {}),
+      ...(typeof edit.oldText === "string" ? { old_string: edit.oldText } : {}),
+      ...(typeof edit.newText === "string" ? { new_string: edit.newText } : {}),
+    };
+  }
+  return input;
+}
+
+function normalizeUsage(usage: PiUsage): TokenUsage {
+  return {
+    inputTokens: usage.input || 0,
+    outputTokens: usage.output || 0,
+    cacheCreationTokens: usage.cacheWrite || 0,
+    cacheReadTokens: usage.cacheRead || 0,
+  };
+}
+
+function aggregateUsage(usages: TokenUsage[]): TokenUsage | undefined {
+  if (usages.length === 0) return undefined;
+  return usages.reduce<TokenUsage>(
+    (total, usage) => ({
+      inputTokens: total.inputTokens + usage.inputTokens,
+      outputTokens: total.outputTokens + usage.outputTokens,
+      cacheCreationTokens: total.cacheCreationTokens + usage.cacheCreationTokens,
+      cacheReadTokens: total.cacheReadTokens + usage.cacheReadTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 },
+  );
+}
+
+function aggregateUsageByModel(
+  usageByMessageId: Map<string, { usage: TokenUsage; model?: string; contextTokens?: number }>,
+): Record<string, TokenUsage> | undefined {
+  if (usageByMessageId.size === 0) return undefined;
+  const result: Record<string, TokenUsage> = {};
+  for (const { usage, model } of usageByMessageId.values()) {
+    const key = model || "unknown";
+    result[key] = aggregateUsage(
+      [result[key], usage].filter((value): value is TokenUsage => !!value),
+    )!;
+  }
+  return result;
+}
+
+function buildTurnStats(
+  turns: ParsedTurn[],
+  usageByMessageId: Map<string, { usage: TokenUsage; model?: string; contextTokens?: number }>,
+): NonNullable<ProviderParseResult["turnStats"]> {
+  const stats: NonNullable<ProviderParseResult["turnStats"]> = [];
+  let current: { turnIndex: number; messageIds: string[] } | undefined;
+  let turnIndex = -1;
+
+  for (const turn of turns) {
+    if (turn.role === "user" && !turn.subtype) {
+      if (current && current.messageIds.length > 0)
+        stats.push(buildTurnStat(current, usageByMessageId));
+      turnIndex++;
+      current = { turnIndex, messageIds: [] };
+    } else if (turn.role === "assistant" && turn.messageId && current) {
+      current.messageIds.push(turn.messageId);
+    }
+  }
+
+  if (current && current.messageIds.length > 0)
+    stats.push(buildTurnStat(current, usageByMessageId));
+  return stats;
+}
+
+function buildTurnStat(
+  turn: { turnIndex: number; messageIds: string[] },
+  usageByMessageId: Map<string, { usage: TokenUsage; model?: string; contextTokens?: number }>,
+): NonNullable<ProviderParseResult["turnStats"]>[number] {
+  const usages: TokenUsage[] = [];
+  let model: string | undefined;
+  let contextTokens = 0;
+  for (const messageId of turn.messageIds) {
+    const item = usageByMessageId.get(messageId);
+    if (!item) continue;
+    usages.push(item.usage);
+    model = model || item.model;
+    contextTokens = Math.max(contextTokens, item.contextTokens || 0);
+  }
+  const tokenUsage = aggregateUsage(usages);
+  return {
+    turnIndex: turn.turnIndex,
+    ...(model ? { model } : {}),
+    ...(tokenUsage ? { tokenUsage } : {}),
+    ...(contextTokens ? { contextTokens } : {}),
+  };
+}
+
+function estimateActiveDuration(timestamps: string[]): number | undefined {
+  if (timestamps.length < 2) return undefined;
+  const sorted = timestamps
+    .map((timestamp) => Date.parse(timestamp))
+    .filter((timestamp) => !Number.isNaN(timestamp))
+    .sort((a, b) => a - b);
+  if (sorted.length < 2) return undefined;
+  let total = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = sorted[i] - sorted[i - 1];
+    if (gap > 0 && gap < 30 * 60_000) total += gap;
+  }
+  return total || undefined;
+}

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -18,6 +18,7 @@ import { estimateActiveDuration } from "./duration.js";
 import { estimateCost, estimateCostSimple } from "./pricing.js";
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
+import { parsePiSession } from "./providers/pi/parser.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 import {
@@ -295,6 +296,14 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     } catch {
       // Fall through to the lightweight scanner so a partial Codex rollout
       // still appears in insights if the richer parser hits an unknown event.
+    }
+  }
+  if (input.provider === "pi") {
+    try {
+      return await scanPiSession(input);
+    } catch {
+      // Fall through to the lightweight scanner so Pi sessions still show up
+      // if the richer parser hits an unknown entry shape.
     }
   }
 
@@ -634,6 +643,27 @@ async function scanCodexSession(input: ScanInput): Promise<SessionScanResult> {
   };
 
   const parsed = await parseCodexSession(input.filePaths, sessionInfo);
+  return buildScanResultFromParsed(input, parsed);
+}
+
+async function scanPiSession(input: ScanInput): Promise<SessionScanResult> {
+  const sessionInfo: SessionInfo = {
+    provider: "pi",
+    sessionId: input.sessionId,
+    slug: input.slug,
+    title: input.title,
+    project: input.project,
+    cwd: input.workspacePath || input.project,
+    version: "",
+    timestamp: input.timestamp || new Date().toISOString(),
+    lineCount: 0,
+    fileSize: 0,
+    filePath: input.filePaths[0] || "",
+    filePaths: input.filePaths,
+    firstPrompt: input.firstPrompt || input.title || "(pi session)",
+  };
+
+  const parsed = await parsePiSession(input.filePaths, sessionInfo);
   return buildScanResultFromParsed(input, parsed);
 }
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -35,6 +35,7 @@ import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { parseCodexLines } from "./providers/codex/parser.js";
+import { parsePiLines } from "./providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
   resolveCursorLiveWatchPaths,
@@ -1445,7 +1446,8 @@ export async function startServer(
       const isClaudeProvider = providerName === "claude-code";
       const isCursorProvider = providerName === "cursor";
       const isCodexProvider = providerName === "codex";
-      const isJsonlLiveProvider = isClaudeProvider || isCodexProvider;
+      const isPiProvider = providerName === "pi";
+      const isJsonlLiveProvider = isClaudeProvider || isCodexProvider || isPiProvider;
       let lastLiveState: LiveSessionState = isClaudeProvider ? "busy" : "unknown";
       let cursorDbWatchAttached = false;
       const cursorDbWatchedSessionIds = new Set<string>();
@@ -1628,7 +1630,9 @@ export async function startServer(
             }
             parsed = isClaudeProvider
               ? await parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] })
-              : parseCodexLines(allLines, info, paths);
+              : isCodexProvider
+                ? parseCodexLines(allLines, info, paths)
+                : parsePiLines(allLines, { sourcePath: paths[0], sessionInfo: info });
           } else {
             parsed = await provider.parse(paths, info);
           }

--- a/packages/cli/test/pi-parser.test.ts
+++ b/packages/cli/test/pi-parser.test.ts
@@ -187,7 +187,9 @@ describe("Pi parser", () => {
         cacheCreationTokens: 7,
         cacheReadTokens: 15,
       });
-      expect(parsed.dataSourceInfo?.sources).toContain("~/.pi/agent/sessions");
+      expect(
+        parsed.dataSourceInfo?.sources.map((source) => source.replaceAll("\\", "/")),
+      ).toContain("~/.pi/agent/sessions");
       expect(parsed.turnStats?.map((stat) => stat.contextTokens)).toEqual([300]);
 
       const replay = transformToReplay(parsed, "pi", "~/project");

--- a/packages/cli/test/pi-parser.test.ts
+++ b/packages/cli/test/pi-parser.test.ts
@@ -1,0 +1,281 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parsePiSession } from "../src/providers/pi/parser.js";
+import { transformToReplay } from "../src/transform.js";
+
+async function withPiFixture(lines: unknown[], fn: (path: string) => Promise<void>) {
+  const dir = await mkdtemp(join(tmpdir(), "vibe-replay-pi-parser-"));
+  const path = join(dir, "2026-01-01T00-00-00-000Z_pi-session.jsonl");
+  await writeFile(path, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf-8");
+  try {
+    await fn(path);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("Pi parser", () => {
+  it("parses Pi JSONL tree sessions and enriches tools", async () => {
+    const lines = [
+      {
+        type: "session",
+        version: 3,
+        id: "pi-session-1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd: "/Users/test/project",
+      },
+      {
+        type: "model_change",
+        id: "model1",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        provider: "openai",
+        modelId: "gpt-5.5",
+      },
+      {
+        type: "message",
+        id: "user1",
+        parentId: "model1",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Fix auth.ts" }],
+          timestamp: 1767225602000,
+        },
+      },
+      {
+        type: "message",
+        id: "assistant1",
+        parentId: "user1",
+        timestamp: "2026-01-01T00:00:03.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I should inspect the file." },
+            { type: "text", text: "I'll inspect and patch it." },
+            {
+              type: "toolCall",
+              id: "call-read",
+              name: "read",
+              arguments: { path: "/Users/test/project/auth.ts" },
+            },
+          ],
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 100,
+            output: 20,
+            cacheRead: 5,
+            cacheWrite: 7,
+          },
+          stopReason: "toolUse",
+          timestamp: 1767225603000,
+        },
+      },
+      {
+        type: "message",
+        id: "result1",
+        parentId: "assistant1",
+        timestamp: "2026-01-01T00:00:04.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-read",
+          toolName: "read",
+          content: [{ type: "text", text: "export function login() { return null; }" }],
+          isError: false,
+          timestamp: 1767225604000,
+        },
+      },
+      {
+        type: "message",
+        id: "assistant2",
+        parentId: "result1",
+        timestamp: "2026-01-01T00:00:05.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-edit",
+              name: "edit",
+              arguments: {
+                path: "/Users/test/project/auth.ts",
+                edits: [{ oldText: "return null", newText: "return token" }],
+              },
+            },
+            {
+              type: "toolCall",
+              id: "call-bash",
+              name: "bash",
+              arguments: { command: "pnpm test" },
+            },
+          ],
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 200,
+            output: 30,
+            cacheRead: 10,
+            cacheWrite: 0,
+          },
+          stopReason: "toolUse",
+          timestamp: 1767225605000,
+        },
+      },
+      {
+        type: "message",
+        id: "result2",
+        parentId: "assistant2",
+        timestamp: "2026-01-01T00:00:06.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-edit",
+          toolName: "edit",
+          content: [{ type: "text", text: "Successfully replaced text" }],
+          isError: false,
+          timestamp: 1767225606000,
+        },
+      },
+      {
+        type: "message",
+        id: "result3",
+        parentId: "result2",
+        timestamp: "2026-01-01T00:00:07.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-bash",
+          toolName: "bash",
+          content: [{ type: "text", text: "tests passed" }],
+          isError: false,
+          timestamp: 1767225607000,
+        },
+      },
+      {
+        type: "message",
+        id: "assistant3",
+        parentId: "result3",
+        timestamp: "2026-01-01T00:00:08.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done." }],
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 300,
+            output: 10,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+          stopReason: "stop",
+          timestamp: 1767225608000,
+        },
+      },
+    ];
+
+    await withPiFixture(lines, async (path) => {
+      const parsed = await parsePiSession(path);
+      expect(parsed.sessionId).toBe("pi-session-1");
+      expect(parsed.cwd).toBe("/Users/test/project");
+      expect(parsed.model).toBe("gpt-5.5");
+      expect(parsed.turns.filter((turn) => turn.role === "user")).toHaveLength(1);
+      expect(parsed.turns.filter((turn) => turn.role === "assistant")).toHaveLength(3);
+      expect(parsed.tokenUsage).toEqual({
+        inputTokens: 600,
+        outputTokens: 60,
+        cacheCreationTokens: 7,
+        cacheReadTokens: 15,
+      });
+
+      const replay = transformToReplay(parsed, "pi", "~/project");
+      expect(replay.meta.provider).toBe("pi");
+      expect(replay.meta.stats.userPrompts).toBe(1);
+      expect(replay.meta.stats.toolCalls).toBe(3);
+
+      const editScene = replay.scenes.find(
+        (scene) => scene.type === "tool-call" && scene.toolName === "Edit",
+      );
+      expect(editScene?.type).toBe("tool-call");
+      expect(editScene?.type === "tool-call" && editScene.diff?.filePath).toBe(
+        "/Users/test/project/auth.ts",
+      );
+      expect(editScene?.type === "tool-call" && editScene.diff?.oldContent).toBe("return null");
+      expect(editScene?.type === "tool-call" && editScene.diff?.newContent).toBe("return token");
+
+      const bashScene = replay.scenes.find(
+        (scene) => scene.type === "tool-call" && scene.toolName === "Bash",
+      );
+      expect(bashScene?.type).toBe("tool-call");
+      expect(bashScene?.type === "tool-call" && bashScene.bashOutput?.command).toBe("pnpm test");
+      expect(bashScene?.type === "tool-call" && bashScene.bashOutput?.stdout).toContain(
+        "tests passed",
+      );
+    });
+  });
+
+  it("uses the active leaf branch and omits abandoned branches", async () => {
+    const lines = [
+      {
+        type: "session",
+        version: 3,
+        id: "pi-branch-session",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd: "/Users/test/project",
+      },
+      {
+        type: "message",
+        id: "root-user",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        message: { role: "user", content: [{ type: "text", text: "Root prompt" }] },
+      },
+      {
+        type: "message",
+        id: "main-answer",
+        parentId: "root-user",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Old branch answer" }],
+          model: "gpt-5.5",
+          usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+        },
+      },
+      {
+        type: "message",
+        id: "branch-user",
+        parentId: "root-user",
+        timestamp: "2026-01-01T00:00:03.000Z",
+        message: { role: "user", content: [{ type: "text", text: "New branch prompt" }] },
+      },
+      {
+        type: "message",
+        id: "branch-answer",
+        parentId: "branch-user",
+        timestamp: "2026-01-01T00:00:04.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "New branch answer" }],
+          model: "gpt-5.5",
+          usage: { input: 2, output: 2, cacheRead: 0, cacheWrite: 0 },
+        },
+      },
+    ];
+
+    await withPiFixture(lines, async (path) => {
+      const parsed = await parsePiSession(path);
+      const text = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .map((block) => {
+          if (block.type === "text") return block.text;
+          return "";
+        })
+        .join("\n");
+      expect(text).toContain("Root prompt");
+      expect(text).toContain("New branch prompt");
+      expect(text).toContain("New branch answer");
+      expect(text).not.toContain("Old branch answer");
+    });
+  });
+});

--- a/packages/cli/test/pi-parser.test.ts
+++ b/packages/cli/test/pi-parser.test.ts
@@ -187,6 +187,8 @@ describe("Pi parser", () => {
         cacheCreationTokens: 7,
         cacheReadTokens: 15,
       });
+      expect(parsed.dataSourceInfo?.sources).toContain("~/.pi/agent/sessions");
+      expect(parsed.turnStats?.map((stat) => stat.contextTokens)).toEqual([300]);
 
       const replay = transformToReplay(parsed, "pi", "~/project");
       expect(replay.meta.provider).toBe("pi");
@@ -276,6 +278,7 @@ describe("Pi parser", () => {
       expect(text).toContain("New branch prompt");
       expect(text).toContain("New branch answer");
       expect(text).not.toContain("Old branch answer");
+      expect(parsed.dataSourceInfo?.notes).toEqual(["1 off-branch Pi entries were omitted."]);
     });
   });
 });

--- a/packages/cli/test/pi-parser.test.ts
+++ b/packages/cli/test/pi-parser.test.ts
@@ -254,6 +254,12 @@ describe("Pi parser", () => {
         message: { role: "user", content: [{ type: "text", text: "New branch prompt" }] },
       },
       {
+        type: "session_info",
+        parentId: "branch-user",
+        timestamp: "2026-01-01T00:00:03.500Z",
+        name: "ID-less branch title",
+      },
+      {
         type: "message",
         id: "branch-answer",
         parentId: "branch-user",
@@ -280,6 +286,7 @@ describe("Pi parser", () => {
       expect(text).toContain("New branch prompt");
       expect(text).toContain("New branch answer");
       expect(text).not.toContain("Old branch answer");
+      expect(parsed.title).toBe("ID-less branch title");
       expect(parsed.dataSourceInfo?.notes).toEqual(["1 off-branch Pi entries were omitted."]);
     });
   });


### PR DESCRIPTION
## Summary

- add a Pi provider that discovers `~/.pi/agent/sessions` JSONL files
- parse Pi tree sessions into replay turns, including active-branch traversal, tool results, edit diffs, bash output, images, token/cost/context stats, API errors, and compaction/context injection entries
- include Pi in session search/scans, live JSONL tailing, provider badges, and docs

## Validation

- `pnpm lint:check`
- `pnpm --filter vibe-replay test -- pi-parser.test.ts`
- `pnpm --filter vibe-replay build`
- smoke-tested local Pi session generation:
  - `node packages/cli/dist/index.js --session ~/.pi/agent/sessions/--Users-tlei-git-roblox-vibe-replay--/2026-06-05T02-37-19-252Z_019e95a4-6414-75dc-adfe-07a8bf321a4a.jsonl --provider pi --open --title "Pi session smoke"`
