### PR TITLE
Handle Claude Code schema drift

### DIFF
--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -99,10 +99,10 @@ export async function parseClaudeCodeLines(
   // Service tier (from API usage data, e.g. "standard")
   let serviceTier: string | undefined;
 
-  // Skills used in the session (extracted from isMeta skill injection messages)
+  // Skills used in the session (extracted from isMeta skill injection messages and attribution fields)
   const skillsUsed = new Set<string>();
 
-  // MCP servers used (extracted from mcp__server__tool naming convention)
+  // MCP servers used (extracted from mcp__server__tool naming convention and attribution fields)
   const mcpServersUsed = new Set<string>();
 
   // Group assistant messages by message.id
@@ -281,11 +281,13 @@ export async function parseClaudeCodeLines(
 
     const { role, content: msgContent, id: msgId } = obj.message;
 
-    if (obj.isApiErrorMessage && obj.timestamp) {
+    if ((obj.isApiErrorMessage || obj.apiErrorStatus !== undefined) && obj.timestamp) {
       const text = extractMessageText(msgContent);
-      const errorType = inferApiErrorMessageType(text);
+      const statusCode = apiErrorStatusCode(obj.apiErrorStatus);
+      const errorType = errorTypeFromStatus(obj.apiErrorStatus) || inferApiErrorMessageType(text);
       apiErrors.push({
         timestamp: obj.timestamp,
+        ...(statusCode ? { statusCode } : {}),
         ...(errorType ? { errorType } : {}),
       });
       // Fall through so the synthetic assistant message still renders as text.
@@ -345,9 +347,11 @@ export async function parseClaudeCodeLines(
 
     // User message with array content (may contain text + images, or tool_results)
     if (role === "user" && Array.isArray(msgContent)) {
-      // ToolSearch automated responses have sourceToolAssistantUUID on the raw object.
-      // Process tool_result blocks for result matching, but skip emitting a user turn.
-      const isToolSearchResponse = !!obj.sourceToolAssistantUUID;
+      // ToolSearch/tool-originated automated responses have sourceToolAssistantUUID
+      // or newer sourceToolUseID/origin fields on the raw object. Process
+      // tool_result blocks for result matching, but skip emitting a user turn.
+      const isToolSearchResponse =
+        !!obj.sourceToolAssistantUUID || !!obj.sourceToolUseID || obj.origin === "tool_result";
 
       const textParts: string[] = [];
       const userImages: string[] = [];
@@ -397,6 +401,8 @@ export async function parseClaudeCodeLines(
     // Assistant message — group by message.id
     if (role === "assistant" && msgId && Array.isArray(msgContent)) {
       if (!model && obj.message.model) model = obj.message.model;
+      if (obj.attributionMcpServer) mcpServersUsed.add(obj.attributionMcpServer);
+      if (obj.attributionSkill) skillsUsed.add(obj.attributionSkill);
 
       // Track usage per message ID — overwrite so we keep the last (final) value
       const usage = obj.message.usage;
@@ -646,6 +652,22 @@ function inferApiErrorMessageType(text: string): string | undefined {
   if (lower.includes("rate limit")) return "rate_limit_error";
   if (lower.includes("overloaded")) return "overloaded_error";
   if (lower.includes("api error")) return "api_error";
+  return undefined;
+}
+
+function apiErrorStatusCode(status: unknown): number | undefined {
+  if (typeof status === "number" && Number.isFinite(status)) return status;
+  if (typeof status !== "string") return undefined;
+  const match = status.match(/\b(\d{3})\b/);
+  return match ? Number(match[1]) : undefined;
+}
+
+function errorTypeFromStatus(status: unknown): string | undefined {
+  if (typeof status !== "string") return undefined;
+  const lower = status.toLowerCase();
+  if (lower.includes("rate")) return "rate_limit_error";
+  if (lower.includes("overload")) return "overloaded_error";
+  if (lower.includes("error")) return lower.replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
   return undefined;
 }
 

--- a/packages/cli/src/providers/claude-code/parser.ts
+++ b/packages/cli/src/providers/claude-code/parser.ts
@@ -403,6 +403,9 @@ export async function parseClaudeCodeLines(
       if (!model && obj.message.model) model = obj.message.model;
       if (obj.attributionMcpServer) mcpServersUsed.add(obj.attributionMcpServer);
       if (obj.attributionSkill) skillsUsed.add(obj.attributionSkill);
+      // attributionMcpTool is tool-level detail; the replay metadata currently
+      // summarizes MCP usage by server only, so keep the typed field for
+      // forward compatibility without surfacing another aggregate today.
 
       // Track usage per message ID — overwrite so we keep the last (final) value
       const usage = obj.message.usage;
@@ -667,7 +670,12 @@ function errorTypeFromStatus(status: unknown): string | undefined {
   const lower = status.toLowerCase();
   if (lower.includes("rate")) return "rate_limit_error";
   if (lower.includes("overload")) return "overloaded_error";
-  if (lower.includes("error")) return lower.replace(/[^a-z0-9_]+/g, "_").replace(/^_+|_+$/g, "");
+  if (lower.includes("error")) {
+    return lower
+      .replace(/[^a-z0-9_]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .replace(/_\d+$/, "");
+  }
   return undefined;
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -180,6 +180,7 @@ export interface RawMessage {
   hookInfos?: unknown[];
   hasOutput?: boolean;
   preventedContinuation?: boolean;
+  /** Top-level hook stop reason; distinct from message.stop_reason on assistant messages. */
   stopReason?: string;
   toolUseID?: string;
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -83,9 +83,13 @@ export interface RawMessage {
   sessionId: string;
   version: string;
   gitBranch?: string;
-  slug: string;
+  slug?: string;
   /** UUID of the assistant message that triggered the tool whose result this message carries */
   sourceToolAssistantUUID?: string;
+  /** Newer Claude Code field for tool-originated user messages. */
+  sourceToolUseID?: string;
+  /** Source classification for user messages (for example, tool-originated messages). */
+  origin?: string;
   type:
     | "user"
     | "assistant"
@@ -115,6 +119,12 @@ export interface RawMessage {
   url?: string;
   /** True when Claude Code writes a synthetic assistant message describing an API failure. */
   isApiErrorMessage?: boolean;
+  /** Newer Claude Code API error status field on assistant entries. */
+  apiErrorStatus?: number | string;
+  /** Claude Code attribution for assistant output/tool calls that came from MCP or skills. */
+  attributionMcpServer?: string;
+  attributionMcpTool?: string;
+  attributionSkill?: string;
   message?: {
     role: "user" | "assistant";
     id?: string;
@@ -164,6 +174,14 @@ export interface RawMessage {
   };
   statusCode?: number;
   retryAttempt?: number;
+  /** Hook summary fields on newer system messages. Parsed leniently as metadata-only. */
+  hookCount?: number;
+  hookErrors?: unknown[];
+  hookInfos?: unknown[];
+  hasOutput?: boolean;
+  preventedContinuation?: boolean;
+  stopReason?: string;
+  toolUseID?: string;
 }
 
 export type ContentBlock =

--- a/packages/cli/test/claude-code-parser.test.ts
+++ b/packages/cli/test/claude-code-parser.test.ts
@@ -131,7 +131,7 @@ describe("Claude Code parser", () => {
         cwd: "/tmp/project",
         timestamp: "2026-06-02T00:00:04.000Z",
         isApiErrorMessage: true,
-        apiErrorStatus: "overloaded_error 529",
+        apiErrorStatus: "authentication_error 401",
         message: {
           role: "assistant",
           id: "msg_api",
@@ -154,7 +154,7 @@ describe("Claude Code parser", () => {
       expect(result.mcpServersUsed).toEqual(["sourcegraph"]);
       expect(result.skillsUsed).toEqual(["schema-watch"]);
       expect(result.apiErrors).toEqual([
-        expect.objectContaining({ statusCode: 529, errorType: "overloaded_error" }),
+        expect.objectContaining({ statusCode: 401, errorType: "authentication_error" }),
       ]);
       const toolUse = result.turns
         .flatMap((turn) => turn.blocks)

--- a/packages/cli/test/claude-code-parser.test.ts
+++ b/packages/cli/test/claude-code-parser.test.ts
@@ -74,6 +74,97 @@ describe("Claude Code parser", () => {
     expect(allText).not.toContain("streaming");
   });
 
+  it("handles newer Claude Code schema-drift fields", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-claude-schema-"));
+    const jsonlPath = join(tempDir, "session.jsonl");
+    const lines = [
+      {
+        type: "system",
+        subtype: "init",
+        sessionId: "schema-session",
+        cwd: "/tmp/project",
+        timestamp: "2026-06-02T00:00:00.000Z",
+        hookCount: 1,
+        hookInfos: [{ command: "echo ok" }],
+        hookErrors: [],
+        preventedContinuation: false,
+        toolUseID: "tool_1",
+      },
+      {
+        type: "user",
+        sessionId: "schema-session",
+        cwd: "/tmp/project",
+        timestamp: "2026-06-02T00:00:01.000Z",
+        message: { role: "user", content: "Check schema drift" },
+      },
+      {
+        type: "assistant",
+        sessionId: "schema-session",
+        cwd: "/tmp/project",
+        timestamp: "2026-06-02T00:00:02.000Z",
+        attributionMcpServer: "sourcegraph",
+        attributionMcpTool: "search",
+        attributionSkill: "schema-watch",
+        message: {
+          role: "assistant",
+          id: "msg_schema",
+          model: "claude-sonnet-4-20250514",
+          content: [{ type: "tool_use", id: "tool_1", name: "Read", input: { file_path: "a.ts" } }],
+          usage: { input_tokens: 10, output_tokens: 2 },
+        },
+      },
+      {
+        type: "user",
+        sessionId: "schema-session",
+        cwd: "/tmp/project",
+        timestamp: "2026-06-02T00:00:03.000Z",
+        sourceToolUseID: "tool_1",
+        origin: "tool_result",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tool_1", content: "file content" }],
+        },
+      },
+      {
+        type: "assistant",
+        sessionId: "schema-session",
+        cwd: "/tmp/project",
+        timestamp: "2026-06-02T00:00:04.000Z",
+        isApiErrorMessage: true,
+        apiErrorStatus: "overloaded_error 529",
+        message: {
+          role: "assistant",
+          id: "msg_api",
+          model: "<synthetic>",
+          content: [{ type: "text", text: "Claude API error" }],
+        },
+      },
+    ];
+    await writeFile(
+      jsonlPath,
+      `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+      "utf-8",
+    );
+
+    try {
+      const result = await parseClaudeCodeSession(jsonlPath);
+      const userTurns = result.turns.filter((turn) => turn.role === "user");
+      expect(userTurns).toHaveLength(1);
+      expect(result.slug).toBe("");
+      expect(result.mcpServersUsed).toEqual(["sourcegraph"]);
+      expect(result.skillsUsed).toEqual(["schema-watch"]);
+      expect(result.apiErrors).toEqual([
+        expect.objectContaining({ statusCode: 529, errorType: "overloaded_error" }),
+      ]);
+      const toolUse = result.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block): block is ToolUseBlock => block.type === "tool_use" && block.id === "tool_1");
+      expect(toolUse?._result).toBe("file content");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("records malformed JSONL lines as parse warnings", async () => {
     const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-claude-malformed-"));
     const jsonlPath = join(tempDir, "session.jsonl");


### PR DESCRIPTION
## Summary
- tolerate Claude Code sessions without the legacy top-level slug field
- record new apiErrorStatus metadata on synthetic API error assistant messages
- use new attributionMcpServer/attributionSkill fields for session metadata
- treat newer sourceToolUseID/origin tool-result user messages as automated tool responses
- document newer hook-related system fields in RawMessage

Closes #311

## Validation
- pnpm typecheck
- pnpm lint:check
- pnpm --filter vibe-replay test -- claude-code-parser.test.ts