### PR TITLE
Handle Cursor composer schema drift

### DIFF
--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -325,6 +325,16 @@ describe("cursor sqlite metrics helpers", () => {
     });
   });
 
+  it("preserves false Cursor mode-switching metadata", () => {
+    expect(
+      __testables.cursorComposerSidecarMetadata({ restrictAgentModeSwitching: false }),
+    ).toEqual({ restrictAgentModeSwitching: false });
+  });
+
+  it("omits empty Cursor composerData sidecar metadata", () => {
+    expect(__testables.cursorComposerSidecarMetadata({})).toBeUndefined();
+  });
+
   it("extracts Cursor branch metadata from composer payload", () => {
     const branchMeta = __testables.extractCursorBranchMetadata({
       createdOnBranch: "feature/start",

--- a/packages/cli/src/providers/cursor/sqlite-reader.test.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.test.ts
@@ -311,6 +311,20 @@ describe("cursor sqlite metrics helpers", () => {
     ).toBe("2026-04-28T20:25:48.085Z");
   });
 
+  it("extracts new Cursor composerData sidecar metadata", () => {
+    expect(
+      __testables.cursorComposerSidecarMetadata({
+        conversationCheckpointLastUpdatedAt: 1_780_000_000_000,
+        restrictAgentModeSwitching: true,
+        glassMetaParentAgent: "agent-parent-1",
+      }),
+    ).toEqual({
+      conversationCheckpointLastUpdatedAt: "2026-05-28T20:26:40.000Z",
+      restrictAgentModeSwitching: true,
+      glassMetaParentAgent: "agent-parent-1",
+    });
+  });
+
   it("extracts Cursor branch metadata from composer payload", () => {
     const branchMeta = __testables.extractCursorBranchMetadata({
       createdOnBranch: "feature/start",

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -760,6 +760,24 @@ function toIsoTimestamp(value: unknown): string | undefined {
   return undefined;
 }
 
+function cursorComposerSidecarMetadata(composer: Record<string, any>): CursorSidecars | undefined {
+  const conversationCheckpointLastUpdatedAt = toIsoTimestamp(
+    composer.conversationCheckpointLastUpdatedAt,
+  );
+  const restrictAgentModeSwitching =
+    typeof composer.restrictAgentModeSwitching === "boolean"
+      ? composer.restrictAgentModeSwitching
+      : undefined;
+  const glassMetaParentAgent = valueToString(composer.glassMetaParentAgent);
+
+  const metadata: CursorSidecars = {
+    ...(conversationCheckpointLastUpdatedAt ? { conversationCheckpointLastUpdatedAt } : {}),
+    ...(restrictAgentModeSwitching !== undefined ? { restrictAgentModeSwitching } : {}),
+    ...(glassMetaParentAgent ? { glassMetaParentAgent } : {}),
+  };
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 function maxIsoTimestamp(values: Array<unknown>): string | undefined {
   let maxMs: number | undefined;
   for (const value of values) {
@@ -2306,17 +2324,34 @@ function mergeCursorSidecars(
 ): CursorSidecars | undefined {
   if (!primary && !enrichment) return undefined;
 
-  const merged: CursorSidecars = {
-    ...((primary?.requestContextCount ?? enrichment?.requestContextCount)
-      ? { requestContextCount: primary?.requestContextCount ?? enrichment?.requestContextCount }
-      : {}),
-    ...((primary?.checkpointCount ?? enrichment?.checkpointCount)
-      ? { checkpointCount: primary?.checkpointCount ?? enrichment?.checkpointCount }
-      : {}),
-    ...((primary?.hasWorkspaceRules ?? enrichment?.hasWorkspaceRules) !== undefined
-      ? { hasWorkspaceRules: primary?.hasWorkspaceRules ?? enrichment?.hasWorkspaceRules }
-      : {}),
-  };
+  const merged: CursorSidecars = {};
+  if (primary?.requestContextCount ?? enrichment?.requestContextCount) {
+    merged.requestContextCount = primary?.requestContextCount ?? enrichment?.requestContextCount;
+  }
+  if (primary?.checkpointCount ?? enrichment?.checkpointCount) {
+    merged.checkpointCount = primary?.checkpointCount ?? enrichment?.checkpointCount;
+  }
+  if ((primary?.hasWorkspaceRules ?? enrichment?.hasWorkspaceRules) !== undefined) {
+    merged.hasWorkspaceRules = primary?.hasWorkspaceRules ?? enrichment?.hasWorkspaceRules;
+  }
+  if (
+    primary?.conversationCheckpointLastUpdatedAt ||
+    enrichment?.conversationCheckpointLastUpdatedAt
+  ) {
+    merged.conversationCheckpointLastUpdatedAt =
+      primary?.conversationCheckpointLastUpdatedAt ??
+      enrichment?.conversationCheckpointLastUpdatedAt;
+  }
+  if (
+    primary?.restrictAgentModeSwitching !== undefined ||
+    enrichment?.restrictAgentModeSwitching !== undefined
+  ) {
+    merged.restrictAgentModeSwitching =
+      primary?.restrictAgentModeSwitching ?? enrichment?.restrictAgentModeSwitching;
+  }
+  if (primary?.glassMetaParentAgent || enrichment?.glassMetaParentAgent) {
+    merged.glassMetaParentAgent = primary?.glassMetaParentAgent ?? enrichment?.glassMetaParentAgent;
+  }
 
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
@@ -2741,6 +2776,7 @@ async function parseCursorGlobalStateDb(
     const startTime = toIsoTimestamp(composer.createdAt);
     const endTime = maxIsoTimestamp([
       composer.lastUpdatedAt,
+      composer.conversationCheckpointLastUpdatedAt,
       ...turns.map((turn) => turn.timestamp).filter(Boolean),
     ]);
     const sessionTokenUsage = tokenUsageFromCursorTokenCount(composer.tokenCount);
@@ -2785,14 +2821,28 @@ async function parseCursorGlobalStateDb(
         "Context files are inferred from Cursor relevantFiles and request-context sidecars.",
       );
     }
+    const composerSidecarMetadata = cursorComposerSidecarMetadata(composer);
+    if (composerSidecarMetadata?.conversationCheckpointLastUpdatedAt) {
+      notes.push("Cursor composerData reports a conversation checkpoint timestamp.");
+    }
+    if (composerSidecarMetadata?.restrictAgentModeSwitching !== undefined) {
+      notes.push("Cursor composerData reports agent mode switching restrictions.");
+    }
+    if (composerSidecarMetadata?.glassMetaParentAgent) {
+      notes.push("Cursor composerData links this session to a Glass parent agent.");
+    }
     const cursorSidecars =
-      contextSummary.requestContextCount || checkpointCount > 0 || contextSummary.hasCursorRules
+      contextSummary.requestContextCount ||
+      checkpointCount > 0 ||
+      contextSummary.hasCursorRules ||
+      composerSidecarMetadata
         ? {
             ...(contextSummary.requestContextCount
               ? { requestContextCount: contextSummary.requestContextCount }
               : {}),
             ...(checkpointCount > 0 ? { checkpointCount } : {}),
             ...(contextSummary.hasCursorRules ? { hasWorkspaceRules: true } : {}),
+            ...composerSidecarMetadata,
           }
         : undefined;
 
@@ -3004,6 +3054,7 @@ export const __testables = {
   createRetryableInit,
   estimateTokenIncrement,
   extractCursorApiErrors,
+  cursorComposerSidecarMetadata,
   extractCursorBranchMetadata,
   extractCursorContextSummary,
   extractCursorPrLinks,

--- a/packages/cli/test/transform-comprehensive.test.ts
+++ b/packages/cli/test/transform-comprehensive.test.ts
@@ -699,6 +699,9 @@ describe("transform — metadata", () => {
           requestContextCount: 2,
           checkpointCount: 6,
           hasWorkspaceRules: true,
+          conversationCheckpointLastUpdatedAt: "2026-06-02T09:00:00.000Z",
+          restrictAgentModeSwitching: true,
+          glassMetaParentAgent: "agent-parent-1",
         },
       }),
       "cursor",
@@ -709,6 +712,9 @@ describe("transform — metadata", () => {
       requestContextCount: 2,
       checkpointCount: 6,
       hasWorkspaceRules: true,
+      conversationCheckpointLastUpdatedAt: "2026-06-02T09:00:00.000Z",
+      restrictAgentModeSwitching: true,
+      glassMetaParentAgent: "agent-parent-1",
     });
   });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,6 +29,12 @@ export interface CursorSidecars {
   checkpointCount?: number;
   /** Whether Cursor request context included workspace rules */
   hasWorkspaceRules?: boolean;
+  /** Cursor composerData conversationCheckpointLastUpdatedAt timestamp, if reported */
+  conversationCheckpointLastUpdatedAt?: string;
+  /** Cursor composerData flag limiting agent mode switches */
+  restrictAgentModeSwitching?: boolean;
+  /** Cursor Background Agent / Glass parent-agent reference, if reported */
+  glassMetaParentAgent?: string;
 }
 
 export type ParseWarningKind =

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -394,7 +394,10 @@ export default function SummaryView({ session }: Props) {
           meta.cursorSidecars &&
           (meta.cursorSidecars.requestContextCount ||
             meta.cursorSidecars.checkpointCount ||
-            meta.cursorSidecars.hasWorkspaceRules) && (
+            meta.cursorSidecars.hasWorkspaceRules ||
+            meta.cursorSidecars.conversationCheckpointLastUpdatedAt ||
+            meta.cursorSidecars.restrictAgentModeSwitching !== undefined ||
+            meta.cursorSidecars.glassMetaParentAgent) && (
             <div className="rounded border border-terminal-border-subtle bg-terminal-surface/40 px-3 py-2">
               <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
                 Cursor Sidecars
@@ -417,6 +420,26 @@ export default function SummaryView({ session }: Props) {
                     <span className="text-terminal-orange">checkpoint state:</span>{" "}
                     {meta.cursorSidecars.checkpointCount} entr
                     {meta.cursorSidecars.checkpointCount === 1 ? "y" : "ies"}
+                  </div>
+                ) : null}
+                {meta.cursorSidecars.conversationCheckpointLastUpdatedAt ? (
+                  <div>
+                    <span className="text-terminal-orange">checkpoint updated:</span>{" "}
+                    {new Date(
+                      meta.cursorSidecars.conversationCheckpointLastUpdatedAt,
+                    ).toLocaleString()}
+                  </div>
+                ) : null}
+                {meta.cursorSidecars.restrictAgentModeSwitching !== undefined ? (
+                  <div>
+                    <span className="text-terminal-blue">mode switching:</span>{" "}
+                    {meta.cursorSidecars.restrictAgentModeSwitching ? "restricted" : "allowed"}
+                  </div>
+                ) : null}
+                {meta.cursorSidecars.glassMetaParentAgent ? (
+                  <div>
+                    <span className="text-terminal-purple">glass parent:</span>{" "}
+                    {meta.cursorSidecars.glassMetaParentAgent}
                   </div>
                 ) : null}
               </div>


### PR DESCRIPTION
## Summary
- preserve new Cursor composerData metadata in cursorSidecars: conversationCheckpointLastUpdatedAt, restrictAgentModeSwitching, and glassMetaParentAgent
- include conversationCheckpointLastUpdatedAt as an end-time fallback for global-state sessions
- surface these Cursor sidecar fields in the viewer summary
- add regression coverage for parser metadata extraction and transform pass-through

Closes #312

## Validation
- pnpm typecheck
- pnpm lint:check
- pnpm --filter vibe-replay test -- cursor/sqlite-reader.test.ts transform-comprehensive.test.ts