### PR TITLE
chore: bump CLI version to 0.2.3

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary\n- Bump the CLI package version to 0.2.3 for the next patch release\n\n## Validation\n- pnpm --filter vibe-replay build\n- node packages/cli/dist/index.js --version