### PR TITLE
chore(cli): drop dead exports from overlays and pi/config

### DIFF
--- a/packages/cli/src/overlays.ts
+++ b/packages/cli/src/overlays.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import type { ReplaySession, SessionOverlays } from "./types.js";
 
-export const EMPTY_OVERLAYS: SessionOverlays = { version: 1, overlays: [] };
+const EMPTY_OVERLAYS: SessionOverlays = { version: 1, overlays: [] };
 
 /**
  * Load overlays.json for a session, falling back to ./vibe-replay/<slug> for

--- a/packages/cli/src/providers/pi/config.ts
+++ b/packages/cli/src/providers/pi/config.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export function getPiAgentDir(): string {
+function getPiAgentDir(): string {
   return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 }
 


### PR DESCRIPTION
## Summary

- Remove `export` from `EMPTY_OVERLAYS` in `overlays.ts` (only used inside same file as return value of `loadOverlays`)
- Remove `export` from `getPiAgentDir` in `providers/pi/config.ts` (only used inside same file by `getPiSessionsDir` and `readPiModelContextWindows`)

## Motivation

Both symbols are exported but have zero external importers — `grep` across the entire repo confirms no other file imports them. Making them module-private removes unnecessary public API surface. Runtime behavior is identical.

## Test plan

- [x] `pnpm test` 全绿 (49 CLI test files / 823 tests, 9 viewer test files / 160 tests)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 840KB < 1MB limit)
- [x] E2E: 跳过 — 改动是纯 export-visibility 变更，无行为变化，type-level 可证明等价

> 🤖 Daily auto-quality routine. Self-merged after AI review.