### PR TITLE
feat: add gitRepo to session discovery and dashboard

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1263,9 +1263,11 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
   for (let pi = 0; pi < projectEntries.length; pi++) {
     const [project, projectSessions] = projectEntries[pi];
 
-    // Prominent separator between projects
+    // Prominent separator between projects — show gitRepo when available
+    const gitRepo = projectSessions[0]?.gitRepo;
+    const heading = gitRepo ? `${project} ${chalk.dim(`(${gitRepo})`)}` : project;
     if (pi > 0) choices.push(new Separator(""));
-    choices.push(new Separator(chalk.bold.white(`  ─── ${project} ───`)));
+    choices.push(new Separator(chalk.bold.white(`  ─── ${heading} ───`)));
 
     for (const s of projectSessions) {
       const date = new Date(s.timestamp);

--- a/packages/cli/src/providers/claude-code/discover.ts
+++ b/packages/cli/src/providers/claude-code/discover.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { cleanPromptText, isSystemGeneratedMessage } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
-import { shortenPath } from "../../utils.js";
+import { readGitRepo, shortenPath } from "../../utils.js";
 
 const CLAUDE_DIR = join(homedir(), ".claude", "projects");
 
@@ -33,6 +33,11 @@ export async function discoverClaudeCodeSessions(): Promise<SessionInfo[]> {
       continue;
     }
 
+    // Resolve gitRepo once per project dir using the first session's cwd
+    // (decodeProjectDir is lossy for paths with hyphens, but session cwd is accurate)
+    let gitRepo: string | undefined;
+    let gitRepoResolved = false;
+
     for (const file of files) {
       if (!file.endsWith(".jsonl")) continue;
 
@@ -41,7 +46,14 @@ export async function discoverClaudeCodeSessions(): Promise<SessionInfo[]> {
       if (!fileStat) continue;
 
       const info = await extractSessionInfo(filePath, fileStat.size, project);
-      if (info) sessions.push(info);
+      if (info) {
+        if (!gitRepoResolved && info.cwd) {
+          gitRepo = await readGitRepo(info.cwd);
+          gitRepoResolved = true;
+        }
+        info.gitRepo = gitRepo;
+        sessions.push(info);
+      }
     }
   }
 

--- a/packages/cli/src/providers/claude-cowork/discover.ts
+++ b/packages/cli/src/providers/claude-cowork/discover.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { isSystemGeneratedMessage, previewPrompt } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
+import { readGitRepo } from "../../utils.js";
 
 /**
  * Claude Desktop stores Cowork (autonomous agent mode) sessions separately from
@@ -192,6 +193,7 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
   // real cwd is noise in the picker. Group all Cowork sessions under a single
   // "Cowork" heading — the session title is enough to tell them apart.
   const project = "Cowork";
+  const gitRepo = meta.cwd ? await readGitRepo(meta.cwd) : undefined;
 
   return {
     provider: "claude-cowork",
@@ -201,6 +203,7 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
     project,
     cwd: meta.cwd || "",
     version: "",
+    gitRepo,
     timestamp,
     lineCount,
     fileSize,

--- a/packages/cli/src/providers/claude-desktop/discover.ts
+++ b/packages/cli/src/providers/claude-desktop/discover.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { extractSessionInfo } from "../claude-code/discover.js";
 import type { SessionInfo } from "../../types.js";
+import { readGitRepo } from "../../utils.js";
 
 const DESKTOP_DIR = join(
   homedir(),
@@ -113,12 +114,15 @@ export async function extractDesktopSessionInfo(
     const info = await extractSessionInfo(jsonlPath, jsonlStat.size, desktop.cwd);
     if (!info) return null;
 
+    const gitRepo = info.gitRepo || (await readGitRepo(desktop.cwd));
+
     return {
       ...info,
       provider: "claude-desktop",
       title: desktop.title || info.title,
       model: desktop.model || info.model,
       timestamp: new Date(desktop.lastActivityAt).toISOString(),
+      gitRepo,
     };
   } catch {
     return null;

--- a/packages/cli/src/providers/claude-desktop/discover.ts
+++ b/packages/cli/src/providers/claude-desktop/discover.ts
@@ -114,7 +114,7 @@ export async function extractDesktopSessionInfo(
     const info = await extractSessionInfo(jsonlPath, jsonlStat.size, desktop.cwd);
     if (!info) return null;
 
-    const gitRepo = info.gitRepo || (await readGitRepo(desktop.cwd));
+    const gitRepo = await readGitRepo(desktop.cwd);
 
     return {
       ...info,

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -5,7 +5,7 @@ import { basename, join } from "node:path";
 import { createInterface } from "node:readline";
 import { cleanPromptText } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
-import { shortenPath } from "../../utils.js";
+import { readGitRepo, shortenPath } from "../../utils.js";
 import { CODEX_CONTEXT_TAGS, codexStripTwoPass, isCodexToolCallType } from "./constants.js";
 
 const STATE_DB_FILENAME = "state_5.sqlite";
@@ -59,15 +59,19 @@ async function sessionInfoFromThreadRow(row: CodexThreadRow): Promise<SessionInf
   const firstPrompt = rowFirstPrompt || extracted?.firstPrompt || "";
   if (!firstPrompt) return extracted;
 
+  const cwd = row.cwd || extracted?.cwd || "";
+  const gitRepo = await readGitRepo(cwd);
+
   return {
     provider: "codex",
     sessionId: row.id,
     slug: row.id.slice(0, 8),
     title: row.title || extracted?.title,
-    project: shortenPath(row.cwd || extracted?.cwd || ""),
-    cwd: row.cwd || extracted?.cwd || "",
+    project: shortenPath(cwd),
+    cwd,
     version: row.cli_version || extracted?.version || "",
     gitBranch: row.git_branch || extracted?.gitBranch,
+    gitRepo,
     timestamp:
       toIsoFlexible(row.updated_at_ms || row.updated_at) ||
       extracted?.timestamp ||

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -41,7 +41,10 @@ export async function discoverCodexSessions(): Promise<SessionInfo[]> {
     const fileStat = await stat(filePath).catch(() => null);
     if (!fileStat?.isFile()) continue;
     const info = await extractCodexSessionInfo(filePath, fileStat.size);
-    if (info && !byId.has(info.sessionId)) byId.set(info.sessionId, info);
+    if (info && !byId.has(info.sessionId)) {
+      if (info.cwd) info.gitRepo = await readGitRepo(info.cwd);
+      byId.set(info.sessionId, info);
+    }
   }
 
   return [...byId.values()].sort((a, b) => b.timestamp.localeCompare(a.timestamp));

--- a/packages/cli/src/providers/cursor/discover.ts
+++ b/packages/cli/src/providers/cursor/discover.ts
@@ -2,7 +2,7 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { SessionInfo } from "../../types.js";
-import { shortenPath } from "../../utils.js";
+import { readGitRepo, shortenPath } from "../../utils.js";
 import {
   discoverGlobalStateOnlySessions,
   discoverSqliteOnlySessions,
@@ -68,6 +68,7 @@ async function discoverProjectSessions(projDir: string): Promise<SessionInfo[]> 
   if (!dirStat?.isDirectory()) return [];
 
   const project = await decodeProjectDir(projDir);
+  const gitRepo = await readGitRepo(project);
   const transcriptEntries = await collectTranscriptEntries(transcriptsDir);
   if (transcriptEntries.length === 0) return [];
   transcriptEntries.sort((a, b) => a.mtimeMs - b.mtimeMs);
@@ -104,6 +105,7 @@ async function discoverProjectSessions(projDir: string): Promise<SessionInfo[]> 
     if (!info) return null;
     info.workspacePath = project;
     info.hasSqlite = false;
+    info.gitRepo = gitRepo;
     return info;
   });
 

--- a/packages/cli/src/providers/pi/discover.ts
+++ b/packages/cli/src/providers/pi/discover.ts
@@ -4,6 +4,7 @@ import { basename, join } from "node:path";
 import { createInterface } from "node:readline";
 import { cleanPromptText } from "../../clean-prompt.js";
 import type { SessionInfo } from "../../types.js";
+import { readGitRepo } from "../../utils.js";
 import { getPiSessionsDir } from "./config.js";
 const PROMPT_SCAN_LIMIT = 2;
 
@@ -138,6 +139,7 @@ async function extractPiSessionInfo(
   if (!header || prompts.length === 0) return null;
 
   const cwd = header.cwd || decodeProjectDir(encodedProjectDir);
+  const gitRepo = await readGitRepo(cwd);
   const slug = basename(filePath, ".jsonl").replace(/^\d{4}-\d{2}-\d{2}T[^_]+_/, "");
   const fallbackTimestamp = timestamp || header.timestamp || new Date().toISOString();
 
@@ -149,6 +151,7 @@ async function extractPiSessionInfo(
     project: cwd,
     cwd,
     version: String(header.version || 1),
+    gitRepo,
     timestamp: fallbackTimestamp,
     lineCount,
     fileSize,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -645,6 +645,7 @@ async function buildSourcesResult(
       hasSqlite: s.hasSqlite,
       hasSdk: s.hasSdk,
       gitBranch: s.gitBranch,
+      gitRepo: s.gitRepo,
       model: s.model,
       durationMsEst: s.durationMsEst,
       editCountEst: s.editCountEst,

--- a/packages/cli/src/session-query.ts
+++ b/packages/cli/src/session-query.ts
@@ -23,6 +23,7 @@ export interface SessionQueryMatch {
   cwd: string;
   timestamp: string;
   gitBranch?: string;
+  gitRepo?: string;
   model?: string;
   firstPrompt: string;
   prompts?: string[];
@@ -218,6 +219,7 @@ function sessionInfoToMatch(
     cwd: shortenPath(session.cwd),
     timestamp: session.timestamp,
     gitBranch: session.gitBranch,
+    gitRepo: session.gitRepo,
     model: session.model,
     firstPrompt: cleanPromptText(session.firstPrompt),
     prompts: session.prompts?.map(cleanPromptText).filter(Boolean),

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -34,6 +34,7 @@ export interface SessionInfo {
   cwd: string;
   version: string;
   gitBranch?: string;
+  gitRepo?: string; // normalized remote origin (e.g. "tuo-lei/vibe-replay")
   timestamp: string; // ISO string of last activity (most recent record / lastActivityAt / file mtime depending on provider)
   lineCount: number;
   fileSize: number;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -71,6 +71,7 @@ export function localDayKey(input: string | Date | number | undefined | null): s
  *   ssh://git@github.com/org/repo   → org/repo
  */
 export async function readGitRepo(projectDir: string): Promise<string | undefined> {
+  if (!projectDir.trim()) return undefined;
   try {
     const resolved = projectDir.startsWith("~") ? join(homedir(), projectDir.slice(1)) : projectDir;
     const config = await readFile(join(resolved, ".git", "config"), "utf-8");

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,4 +1,6 @@
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 /** Replace $HOME prefix with `~` for display. */
 export function shortenPath(path: string): string {
@@ -56,4 +58,51 @@ export function localDayKey(input: string | Date | number | undefined | null): s
   const m = String(d.getMonth() + 1).padStart(2, "0");
   const day = String(d.getDate()).padStart(2, "0");
   return `${y}-${m}-${day}`;
+}
+
+/**
+ * Read the git remote origin URL from a project directory's .git/config
+ * and normalize it to "owner/repo" format. Returns undefined if the directory
+ * is not a git repo or has no origin remote.
+ *
+ * Supports:
+ *   https://github.com/org/repo.git → org/repo
+ *   git@github.com:org/repo.git     → org/repo
+ *   ssh://git@github.com/org/repo   → org/repo
+ */
+export async function readGitRepo(projectDir: string): Promise<string | undefined> {
+  try {
+    const resolved = projectDir.startsWith("~") ? join(homedir(), projectDir.slice(1)) : projectDir;
+    const config = await readFile(join(resolved, ".git", "config"), "utf-8");
+    const match = config.match(/\[remote "origin"\][^[]*?url\s*=\s*(.+)/);
+    if (!match) return undefined;
+    return normalizeGitUrl(match[1].trim());
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize a git remote URL to "owner/repo" format. */
+export function normalizeGitUrl(url: string): string | undefined {
+  // SCP-style ssh: git@github.com:org/repo.git
+  const scpMatch = url.match(/:([^/][^:]+?)(?:\.git)?\s*$/);
+  if (!url.startsWith("http") && !url.startsWith("ssh://") && scpMatch) {
+    const path = scpMatch[1];
+    const parts = path.split("/");
+    if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+  }
+  // https/ssh-protocol: https://github.com/org/repo.git or ssh://git@github.com/org/repo
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname
+      .replace(/^\//, "")
+      .replace(/\.git$/, "")
+      .split("/");
+    if (parts.length >= 2) {
+      return `${parts[0]}/${parts[1]}`;
+    }
+  } catch {
+    // not a valid URL
+  }
+  return undefined;
 }

--- a/packages/cli/test/normalize-git-url.test.ts
+++ b/packages/cli/test/normalize-git-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeGitUrl } from "../src/utils.js";
+import { normalizeGitUrl, readGitRepo } from "../src/utils.js";
 
 describe("normalizeGitUrl", () => {
   it("normalizes SCP-style SSH remotes", () => {
@@ -26,5 +26,12 @@ describe("normalizeGitUrl", () => {
     expect(normalizeGitUrl("not-a-git-remote")).toBeUndefined();
     expect(normalizeGitUrl("https://github.com/org")).toBeUndefined();
     expect(normalizeGitUrl("git@github.com:org")).toBeUndefined();
+  });
+});
+
+describe("readGitRepo", () => {
+  it("returns undefined for empty project dirs instead of reading the current repo", async () => {
+    await expect(readGitRepo("")).resolves.toBeUndefined();
+    await expect(readGitRepo("   ")).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/test/normalize-git-url.test.ts
+++ b/packages/cli/test/normalize-git-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGitUrl } from "../src/utils.js";
+
+describe("normalizeGitUrl", () => {
+  it("normalizes SCP-style SSH remotes", () => {
+    expect(normalizeGitUrl("git@github.com:org/repo.git")).toBe("org/repo");
+    expect(normalizeGitUrl("git@github.com:org/repo")).toBe("org/repo");
+  });
+
+  it("normalizes HTTPS remotes", () => {
+    expect(normalizeGitUrl("https://github.com/org/repo.git")).toBe("org/repo");
+    expect(normalizeGitUrl("https://github.com/org/repo")).toBe("org/repo");
+  });
+
+  it("normalizes ssh:// remotes", () => {
+    expect(normalizeGitUrl("ssh://git@github.com/org/repo.git")).toBe("org/repo");
+    expect(normalizeGitUrl("ssh://git@github.com/org/repo")).toBe("org/repo");
+  });
+
+  it("ignores trailing whitespace", () => {
+    expect(normalizeGitUrl("git@github.com:org/repo.git   ")).toBe("org/repo");
+    expect(normalizeGitUrl("https://github.com/org/repo.git   ")).toBe("org/repo");
+  });
+
+  it("returns undefined for malformed URLs", () => {
+    expect(normalizeGitUrl("not-a-git-remote")).toBeUndefined();
+    expect(normalizeGitUrl("https://github.com/org")).toBeUndefined();
+    expect(normalizeGitUrl("git@github.com:org")).toBeUndefined();
+  });
+});

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -372,6 +372,7 @@ export function SessionDetailPopup({
                 Session Info
               </div>
               <InfoRow label="Project" value={projectName(s.project)} title={s.project} />
+              {s.gitRepo && <InfoRow label="Repo" value={s.gitRepo} />}
               {branch && <InfoRow label="Branch" value={branch} />}
               {scanData?.gitBranches && scanData.gitBranches.length > 1 && (
                 <InfoRow label="Branches" value={scanData.gitBranches.join(", ")} />

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -924,7 +924,6 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     (total, source) => total + (source.toolCallCount ?? source.replay?.stats.toolCalls ?? 0),
     0,
   );
-  const latestActivityTimestamp = insights.recentSources[0]?.timestamp;
   const activityWindowLabel = activityWindow === "today" ? "Today" : "This week";
   const activityDateLabel =
     activityWindow === "today"

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -581,7 +581,7 @@ function RecentSessionsList({
               {sourceSuggestedTitle(primary)}
             </p>
             <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-mono text-terminal-dimmer">
-              <span className="truncate">{projectName(primary.project)}</span>
+              <span className="truncate">{primary.gitRepo || projectName(primary.project)}</span>
               {primaryPromptCount > 0 && <span>{primaryPromptCount} prompts</span>}
               {primaryToolCount > 0 && <span>{primaryToolCount} tools</span>}
               <span className={primaryHasReplay ? "text-terminal-green" : "text-terminal-blue"}>
@@ -610,7 +610,7 @@ function RecentSessionsList({
                 </p>
                 <div className="flex items-center gap-1.5 min-w-0">
                   <p className="text-[11px] font-mono text-terminal-dimmer truncate">
-                    {projectName(s.project)}
+                    {s.gitRepo || projectName(s.project)}
                   </p>
                   {isEnriching && <DataLevelBadge state={dataState} active compact />}
                 </div>
@@ -1236,6 +1236,9 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                 <h2 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
                   {activityWindowLabel}
                 </h2>
+                <span className="text-[10px] font-mono text-terminal-dimmer">
+                  {activityDateLabel}
+                </span>
                 <InfoTooltip>
                   Short-term local activity for the selected window. Use this to see whether recent
                   AI work is still actively flowing before jumping into sessions.
@@ -1258,7 +1261,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-4 gap-2 lg:grid-cols-2">
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-green tabular-nums">
                   <AnimatedValue value={activeSessions} />
@@ -1291,15 +1294,6 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                   tools
                 </div>
               </div>
-            </div>
-
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-[10px] font-mono text-terminal-dimmer">
-              <span>{activityDateLabel}</span>
-              <span>
-                {latestActivityTimestamp
-                  ? `latest ${timeAgo(latestActivityTimestamp)}`
-                  : "No activity yet"}
-              </span>
             </div>
           </div>
 

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -71,6 +71,7 @@ export interface SourceSession {
   hasSqlite?: boolean;
   hasSdk?: boolean;
   gitBranch?: string;
+  gitRepo?: string;
   existingReplay: string | null;
   projectExists?: boolean;
   isGitRepo?: boolean;


### PR DESCRIPTION
## Summary
- Read git remote origin URL from .git/config during session discovery, normalize to owner/repo format
- Display gitRepo in CLI picker headings, Dashboard home list, and session detail popup
- Compact TODAY activity card: single row when stacked, date inline with header

## Test plan
- [x] `pnpm test` — 984 tests pass
- [x] `pnpm lint:check` — clean
- [x] `pnpm build` — success
- [ ] Visual check: Dashboard shows owner/repo in session list
- [ ] Visual check: TODAY card compact in narrow viewport