### PR TITLE
Fix source session cache freshness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,34 @@ Session files (JSONL / SQLite)
   → output                   vibe-replay/<slug>/index.html + replay.json
 ```
 
+### Dashboard terminology and caches
+
+The dashboard uses product terminology that distinguishes original AI sessions from generated replays:
+
+- **Sessions** in the UI are **Source Sessions**: raw/discovered AI coding sessions from providers such as Claude, Cursor, Codex, and Pi. They may or may not have a generated replay yet.
+- **Raw transcript/provider data** is provider-owned local storage, such as Claude JSONL, Codex JSONL, Pi JSONL under `~/.pi/agent/sessions`, or Cursor SQLite/globalStorage data.
+- **Replays** are generated Vibe Replay artifacts under `vibe-replay/<slug>/`, including `index.html` and `replay.json`.
+- **Replay Summaries** are lightweight listings of generated replay artifacts.
+- **Source Session Catalog Cache** is the dashboard's materialized cache of source-session summaries plus derived UI/linkage fields such as replay links. It is not raw transcript data.
+- **Enrichment** is optional background work, such as detailed Cursor parsing, that improves cached source-session summaries. Enrichment must not imply that provider discovery ran.
+
+Some localhost API names are legacy and must remain backward-compatible:
+
+| Clear term | Preferred route | Legacy route | Meaning |
+|------------|-----------------|--------------|---------|
+| Source Sessions | `/api/source-sessions*` | `/api/sources*` | Discovered provider sessions / UI Sessions |
+| Replays | `/api/replays*` | `/api/sessions*` | Generated replay summaries/artifacts |
+
+Do not change the existing semantics of the legacy routes. New response fields should be additive so older viewers, scripts, and skills can keep reading fields such as `sessions` and `cachedAt`.
+
+The source-session catalog has explicit discovery freshness metadata:
+
+- `discoveredAt` means the last successful provider discovery time.
+- Cache envelope `updatedAt` and API `cachedAt` mean the cache file was written. They may be updated by enrichment or replay-linkage sync and must not be used as a proxy for discovery freshness.
+- `providerStates` can store provider-specific discovery state and fingerprints. For Pi, `/api/source-sessions/cached` and `/api/sources/cached` cheaply stat JSONL files under `~/.pi/agent/sessions` and return `stale: true` with `staleProviders: ["pi"]` when provider files changed after discovery.
+
+Dashboard code should render cached source sessions immediately, then refresh discovery when `stale` is true or `discoveredAt` is outside the freshness window. When talking to an older server that lacks these fields, fall back to the legacy `cachedAt` TTL behavior.
+
 ### CLI structure
 
 ```

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -19,7 +19,7 @@ import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
-import { readFileCache, writeFileCache } from "./cache.js";
+import { readFileCache, writeFileCache, type FileCacheEntry } from "./cache.js";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
 import { computeDaysUntilCleanup, getClaudeCodeCleanupPeriod } from "./cleanup-warning.js";
 import {
@@ -35,6 +35,7 @@ import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { parseCodexLines } from "./providers/codex/parser.js";
+import { getPiSessionsDir } from "./providers/pi/config.js";
 import { parsePiLines } from "./providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
@@ -313,6 +314,40 @@ interface CachedSourceRecord extends SourceSummaryRecord {
   replay?: Omit<ReplaySummary, "baseDir" | "generatorVersion" | "replayOutdated">;
 }
 
+interface ProviderDiscoveryState {
+  provider: string;
+  discoveredAt: string;
+  sessionCount: number;
+  newestSourceMtimeMs?: number;
+  newestSourcePath?: string;
+  fingerprint?: string;
+}
+
+interface SourceSessionCatalogCache {
+  schemaVersion: 1;
+  discoveredAt: string;
+  updatedAt?: string;
+  providerStates?: Record<string, ProviderDiscoveryState>;
+  sessions: CachedSourceRecord[];
+}
+
+interface NormalizedSourceSessionCatalogCache {
+  sessions: CachedSourceRecord[];
+  cachedAt?: string;
+  discoveredAt?: string;
+  updatedAt?: string;
+  providerStates?: Record<string, ProviderDiscoveryState>;
+  legacy?: boolean;
+}
+
+interface SourceProviderFreshnessProbe {
+  provider: string;
+  sessionsRoot: string;
+  fileCount: number;
+  newestSourceMtimeMs?: number;
+  newestSourcePath?: string;
+}
+
 interface SourcesEnrichmentStatus {
   running: boolean;
   processed: number;
@@ -334,6 +369,173 @@ interface EnrichmentHints {
   slugs?: string[];
   projects?: string[];
   limit?: number;
+}
+
+function isSourceSessionCatalogCache(value: unknown): value is SourceSessionCatalogCache {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
+    typeof (value as { discoveredAt?: unknown }).discoveredAt === "string" &&
+    Array.isArray((value as { sessions?: unknown }).sessions)
+  );
+}
+
+function normalizeSourceSessionCatalogCache(
+  cached: FileCacheEntry<SourceSessionCatalogCache | CachedSourceRecord[]> | null,
+): NormalizedSourceSessionCatalogCache | null {
+  if (!cached) return null;
+  if (Array.isArray(cached.data)) {
+    return {
+      sessions: cached.data,
+      cachedAt: cached.updatedAt,
+      discoveredAt: cached.updatedAt,
+      updatedAt: cached.updatedAt,
+      legacy: true,
+    };
+  }
+  if (isSourceSessionCatalogCache(cached.data)) {
+    return {
+      sessions: cached.data.sessions,
+      cachedAt: cached.updatedAt,
+      discoveredAt: cached.data.discoveredAt || cached.updatedAt,
+      updatedAt: cached.data.updatedAt || cached.updatedAt,
+      providerStates: cached.data.providerStates,
+      legacy: false,
+    };
+  }
+  return null;
+}
+
+function buildProviderDiscoveryStates(
+  sources: SourceSummaryRecord[],
+  discoveredAt: string,
+): Record<string, ProviderDiscoveryState> {
+  const byProvider = new Map<string, SourceSummaryRecord[]>();
+  for (const source of sources) {
+    const bucket = byProvider.get(source.provider) || [];
+    bucket.push(source);
+    byProvider.set(source.provider, bucket);
+  }
+
+  const states: Record<string, ProviderDiscoveryState> = {};
+  for (const [provider, providerSources] of byProvider) {
+    states[provider] = {
+      provider,
+      discoveredAt,
+      sessionCount: providerSources.length,
+    };
+  }
+  return states;
+}
+
+function buildSourceSessionCatalogCache(
+  sessions: SourceSummaryRecord[],
+  discoveredAt: string,
+  previous?: NormalizedSourceSessionCatalogCache | null,
+): SourceSessionCatalogCache {
+  const providerStates = {
+    ...previous?.providerStates,
+    ...buildProviderDiscoveryStates(sessions, discoveredAt),
+  };
+  return {
+    schemaVersion: 1,
+    discoveredAt,
+    updatedAt: discoveredAt,
+    providerStates,
+    sessions: sessions as CachedSourceRecord[],
+  };
+}
+
+function updateSourceSessionCatalogSessions(
+  catalog: NormalizedSourceSessionCatalogCache,
+  sessions: CachedSourceRecord[],
+  updatedAt = new Date().toISOString(),
+): SourceSessionCatalogCache {
+  return {
+    schemaVersion: 1,
+    discoveredAt: catalog.discoveredAt || catalog.cachedAt || updatedAt,
+    updatedAt,
+    providerStates: catalog.providerStates,
+    sessions,
+  };
+}
+
+async function walkJsonlFreshness(
+  root: string,
+  provider: string,
+): Promise<SourceProviderFreshnessProbe> {
+  const probe: SourceProviderFreshnessProbe = {
+    provider,
+    sessionsRoot: root,
+    fileCount: 0,
+  };
+
+  async function walk(dir: string): Promise<void> {
+    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(entryPath);
+          return;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".jsonl")) return;
+        const fileStat = await stat(entryPath).catch(() => null);
+        if (!fileStat) return;
+        probe.fileCount += 1;
+        if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
+          probe.newestSourceMtimeMs = fileStat.mtimeMs;
+          probe.newestSourcePath = entryPath;
+        }
+      }),
+    );
+  }
+
+  await walk(root);
+  return probe;
+}
+
+async function probePiSourceFreshness(): Promise<SourceProviderFreshnessProbe> {
+  return walkJsonlFreshness(getPiSessionsDir(), "pi");
+}
+
+function sourceProviderFingerprint(probe: SourceProviderFreshnessProbe): string {
+  return `${probe.fileCount}:${probe.newestSourcePath || ""}`;
+}
+
+async function getStaleSourceProviders(
+  catalog: NormalizedSourceSessionCatalogCache | null,
+): Promise<string[]> {
+  if (!catalog) return [];
+  const staleProviders: string[] = [];
+  const piProbe = await probePiSourceFreshness();
+  const piFingerprint = sourceProviderFingerprint(piProbe);
+  const previousPiFingerprint = catalog.providerStates?.pi?.fingerprint;
+  if (previousPiFingerprint) {
+    if (piFingerprint !== previousPiFingerprint) staleProviders.push("pi");
+    return staleProviders;
+  }
+
+  const piDiscoveredAt =
+    catalog.providerStates?.pi?.discoveredAt || catalog.discoveredAt || catalog.cachedAt;
+  const piDiscoveredMs = piDiscoveredAt ? Date.parse(piDiscoveredAt) : Number.NaN;
+  if (
+    piProbe.fileCount > 0 &&
+    piProbe.newestSourceMtimeMs != null &&
+    (catalog.legacy ||
+      !Number.isFinite(piDiscoveredMs) ||
+      piProbe.newestSourceMtimeMs > piDiscoveredMs)
+  ) {
+    staleProviders.push("pi");
+  }
+  return staleProviders;
 }
 
 function sourceSessionKey(provider: string, project: string, slug: string): string {
@@ -832,6 +1034,43 @@ export async function startServer(
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
   const scanResultsCacheKey = `dashboard-scan-results-v1-${cacheKeySuffix}`;
   const insightsCacheKey = `dashboard-insights-v1-${cacheKeySuffix}`;
+  const readSourcesCatalogCache = async (): Promise<NormalizedSourceSessionCatalogCache | null> =>
+    normalizeSourceSessionCatalogCache(
+      await readFileCache<SourceSessionCatalogCache | CachedSourceRecord[]>(sourcesCacheKey),
+    );
+  const writeDiscoveredSourcesCatalog = async (
+    sessions: SourceSummaryRecord[],
+    previous?: NormalizedSourceSessionCatalogCache | null,
+  ): Promise<SourceSessionCatalogCache> => {
+    const discoveredAt = new Date().toISOString();
+    const catalog = buildSourceSessionCatalogCache(sessions, discoveredAt, previous);
+    try {
+      const piProbe = await probePiSourceFreshness();
+      catalog.providerStates = {
+        ...catalog.providerStates,
+        pi: {
+          ...(catalog.providerStates?.pi || {
+            provider: "pi",
+            discoveredAt,
+            sessionCount: 0,
+          }),
+          newestSourceMtimeMs: piProbe.newestSourceMtimeMs,
+          newestSourcePath: piProbe.newestSourcePath,
+          fingerprint: sourceProviderFingerprint(piProbe),
+        },
+      };
+    } catch {
+      // Freshness metadata is best-effort; discovery results are still valid.
+    }
+    await writeFileCache(sourcesCacheKey, catalog);
+    return catalog;
+  };
+  const writeUpdatedSourcesCatalog = async (
+    previous: NormalizedSourceSessionCatalogCache,
+    sessions: CachedSourceRecord[],
+  ): Promise<void> => {
+    await writeFileCache(sourcesCacheKey, updateSourceSessionCatalogSessions(previous, sessions));
+  };
   const refreshReplaysCache = async (): Promise<any[] | null> => {
     try {
       const sessions = await scanSessions(baseDir);
@@ -847,13 +1086,13 @@ export async function startServer(
   /** After replays change, sync the sources cache so existingReplay / replay stay consistent */
   const syncSourcesCacheWithReplays = async (replays: ReplaySummary[]): Promise<void> => {
     try {
-      const cached = await readFileCache<CachedSourceRecord[]>(sourcesCacheKey);
-      if (!cached?.data?.length) return;
+      const cached = await readSourcesCatalogCache();
+      if (!cached?.sessions.length) return;
 
       const { bySlug, bySessionId } = buildReplayMaps(replays);
 
       let changed = false;
-      const updated = cached.data.map((s) => {
+      const updated = cached.sessions.map((s) => {
         const replay =
           bySlug.get(s.slug) || (s.sessionId ? bySessionId.get(s.sessionId) : undefined);
         const hadReplay = !!s.existingReplay;
@@ -891,7 +1130,7 @@ export async function startServer(
       });
 
       if (changed) {
-        await writeFileCache(sourcesCacheKey, updated);
+        await writeUpdatedSourcesCatalog(cached, updated);
       }
     } catch {
       // Best-effort — never break core flows
@@ -1023,13 +1262,29 @@ export async function startServer(
             processed: sourcesEnrichmentStatus.processed + 1,
           };
           if (changed && sourcesEnrichmentStatus.processed % 5 === 0) {
-            await writeFileCache(sourcesCacheKey, enrichedSources);
+            const cached = await readSourcesCatalogCache();
+            await writeUpdatedSourcesCatalog(
+              cached || {
+                sessions: baseSources as CachedSourceRecord[],
+                discoveredAt: sourcesEnrichmentStatus.startedAt,
+                cachedAt: sourcesEnrichmentStatus.startedAt,
+              },
+              enrichedSources as CachedSourceRecord[],
+            );
           }
         }
       }
 
       if (changed) {
-        await writeFileCache(sourcesCacheKey, enrichedSources);
+        const cached = await readSourcesCatalogCache();
+        await writeUpdatedSourcesCatalog(
+          cached || {
+            sessions: baseSources as CachedSourceRecord[],
+            discoveredAt: sourcesEnrichmentStatus.startedAt,
+            cachedAt: sourcesEnrichmentStatus.startedAt,
+          },
+          enrichedSources as CachedSourceRecord[],
+        );
       }
       sourcesEnrichmentStatus = {
         ...sourcesEnrichmentStatus,
@@ -1812,23 +2067,29 @@ export async function startServer(
     });
   });
 
-  // --- Dashboard: list all sessions ---
-  app.get("/api/sessions/cached", async (c) => {
+  // --- Dashboard: list generated replays (legacy /api/sessions routes) ---
+  const getCachedReplays = async (c: Context) => {
     const cached = await readFileCache<any[]>(replaysCacheKey);
     return c.json({
       sessions: cached?.data || [],
       cachedAt: cached?.updatedAt,
     });
-  });
+  };
 
-  app.get("/api/sessions", async (c) => {
+  app.get("/api/sessions/cached", getCachedReplays);
+  app.get("/api/replays/cached", getCachedReplays);
+
+  const getReplays = async (c: Context) => {
     const sessions = await scanSessions(baseDir);
     await writeFileCache(replaysCacheKey, sessions);
     return c.json(sessions);
-  });
+  };
+
+  app.get("/api/sessions", getReplays);
+  app.get("/api/replays", getReplays);
 
   // --- Dashboard: update title ---
-  app.patch("/api/sessions/:slug", async (c) => {
+  const patchReplay = async (c: Context) => {
     const slug = safeSlug(c.req.param("slug"));
     if (!slug) return c.json({ error: "invalid slug" }, 400);
 
@@ -1856,10 +2117,13 @@ export async function startServer(
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
     }
-  });
+  };
+
+  app.patch("/api/sessions/:slug", patchReplay);
+  app.patch("/api/replays/:slug", patchReplay);
 
   // --- Dashboard: delete session ---
-  app.delete("/api/sessions/:slug", async (c) => {
+  const deleteReplay = async (c: Context) => {
     const slug = safeSlug(c.req.param("slug"));
     if (!slug) return c.json({ error: "invalid slug" }, 400);
     try {
@@ -1871,7 +2135,10 @@ export async function startServer(
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
     }
-  });
+  };
+
+  app.delete("/api/sessions/:slug", deleteReplay);
+  app.delete("/api/replays/:slug", deleteReplay);
 
   // --- Archive: directory-based, one marker file per slug ---
   app.get("/api/archived", async (c) => {
@@ -1893,23 +2160,33 @@ export async function startServer(
     return c.json({ ok: true });
   });
 
-  // --- Sources: discover AI coding sessions from all providers ---
-  app.get("/api/sources/cached", async (c) => {
-    const cached = await readFileCache<any[]>(sourcesCacheKey);
+  // --- Source sessions: discover raw AI coding sessions from all providers ---
+  const getCachedSourceSessions = async (c: Context) => {
+    const cached = await readSourcesCatalogCache();
+    const staleProviders = await getStaleSourceProviders(cached);
     return c.json({
-      sessions: cached?.data || [],
-      cachedAt: cached?.updatedAt,
+      sessions: cached?.sessions || [],
+      cachedAt: cached?.cachedAt,
+      discoveredAt: cached?.discoveredAt,
+      stale: staleProviders.length > 0,
+      staleProviders,
     });
-  });
+  };
 
-  app.get("/api/sources/enrichment-status", async (c) => {
+  app.get("/api/sources/cached", getCachedSourceSessions);
+  app.get("/api/source-sessions/cached", getCachedSourceSessions);
+
+  const getSourceSessionsEnrichmentStatus = async (c: Context) => {
     return c.json(sourcesEnrichmentStatus);
-  });
+  };
 
-  app.post("/api/sources/enrich", async (c) => {
+  app.get("/api/sources/enrichment-status", getSourceSessionsEnrichmentStatus);
+  app.get("/api/source-sessions/enrichment-status", getSourceSessionsEnrichmentStatus);
+
+  const postSourceSessionsEnrich = async (c: Context) => {
     const hints = enrichmentHintsFromBody(await c.req.json().catch(() => undefined));
-    const cached = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
-    if (!cached?.data?.length) {
+    const cached = await readSourcesCatalogCache();
+    if (!cached?.sessions.length) {
       return c.json({ ok: false, message: "No sources cache available" }, 404);
     }
     const cursorProvider = getProvider("cursor");
@@ -1930,15 +2207,18 @@ export async function startServer(
       ];
     }
     const wasRunning = sourcesEnrichmentStatus.running;
-    enrichCursorStatsInBackground(cursorSessions, cached.data, hints);
+    enrichCursorStatsInBackground(cursorSessions, cached.sessions, hints);
     return c.json({
       ok: true,
       running: sourcesEnrichmentStatus.running,
       queued: wasRunning,
     });
-  });
+  };
 
-  app.get("/api/sources", async (c) => {
+  app.post("/api/sources/enrich", postSourceSessionsEnrich);
+  app.post("/api/source-sessions/enrich", postSourceSessionsEnrich);
+
+  const getSourceSessions = async (c: Context) => {
     try {
       const providers = getAllProviders();
       const allSessions: SessionInfo[] = [];
@@ -1949,25 +2229,34 @@ export async function startServer(
 
       const merged = mergeSameSessions(allSessions);
       lastDiscoveredMergedSessions = normalizeSessionProjectsForHome(merged, homedir());
-      const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
+      const previous = await readSourcesCatalogCache();
       const result = await buildSourcesResult(
         merged,
         baseDir,
         homedir(),
-        previous?.data || [],
+        previous?.sessions || [],
         cleanupPeriodDays,
       );
 
-      await writeFileCache(sourcesCacheKey, result);
+      const catalog = await writeDiscoveredSourcesCatalog(result, previous);
       enrichCursorStatsInBackground(merged, result);
-      return c.json({ sessions: result, cleanupPeriodDays });
+      return c.json({
+        sessions: result,
+        cleanupPeriodDays,
+        discoveredAt: catalog.discoveredAt,
+        stale: false,
+        staleProviders: [],
+      });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
     }
-  });
+  };
 
-  // --- Sources SSE: stream discovery progress to the dashboard ---
-  app.get("/api/sources/stream", (c) => {
+  app.get("/api/sources", getSourceSessions);
+  app.get("/api/source-sessions", getSourceSessions);
+
+  // --- Source sessions SSE: stream discovery progress to the dashboard ---
+  const streamSourceSessions = (c: Context) => {
     return streamSSE(c, async (stream) => {
       try {
         const providers = getAllProviders();
@@ -1991,19 +2280,26 @@ export async function startServer(
 
         const merged = mergeSameSessions(allSessions);
         lastDiscoveredMergedSessions = normalizeSessionProjectsForHome(merged, homedir());
-        const previous = await readFileCache<SourceSummaryRecord[]>(sourcesCacheKey);
+        const previous = await readSourcesCatalogCache();
         const result = await buildSourcesResult(
           merged,
           baseDir,
           homedir(),
-          previous?.data || [],
+          previous?.sessions || [],
           cleanupPeriodDays,
         );
 
-        await writeFileCache(sourcesCacheKey, result);
+        const catalog = await writeDiscoveredSourcesCatalog(result, previous);
         enrichCursorStatsInBackground(merged, result);
         await stream.writeSSE({
-          data: JSON.stringify({ type: "complete", sessions: result, cleanupPeriodDays }),
+          data: JSON.stringify({
+            type: "complete",
+            sessions: result,
+            cleanupPeriodDays,
+            discoveredAt: catalog.discoveredAt,
+            stale: false,
+            staleProviders: [],
+          }),
         });
       } catch (err) {
         await stream.writeSSE({
@@ -2011,7 +2307,10 @@ export async function startServer(
         });
       }
     });
-  });
+  };
+
+  app.get("/api/sources/stream", streamSourceSessions);
+  app.get("/api/source-sessions/stream", streamSourceSessions);
 
   // --- Generate: parse a source session into a replay ---
   app.post("/api/generate", async (c) => {
@@ -3316,10 +3615,16 @@ export async function startDashboard(
 
 export const __testables = {
   buildSourcesResult,
+  buildSourceSessionCatalogCache,
   buildInsightsSyncBatches,
   countSessionStats,
+  getStaleSourceProviders,
+  normalizeSourceSessionCatalogCache,
   pickSourceRecordForSession,
+  probePiSourceFreshness,
   prioritizeScanInputs,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
+  sourceProviderFingerprint,
+  updateSourceSessionCatalogSessions,
 };

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -1,11 +1,21 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { ScanInput } from "../src/scanner.js";
 import type { SourceSummaryRecord } from "../src/server.js";
 import { __testables } from "../src/server.js";
 import type { SessionInfo } from "../src/types.js";
+
+const originalPiSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
+
+afterEach(() => {
+  if (originalPiSessionDir === undefined) {
+    delete process.env.PI_CODING_AGENT_SESSION_DIR;
+  } else {
+    process.env.PI_CODING_AGENT_SESSION_DIR = originalPiSessionDir;
+  }
+});
 
 function makeCursorSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -27,6 +37,160 @@ function makeCursorSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 describe("sources enrichment helpers", () => {
+  it("normalizes legacy and structured source-session catalog caches", () => {
+    const legacy = __testables.normalizeSourceSessionCatalogCache({
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      data: [
+        {
+          provider: "pi",
+          slug: "pi-a",
+          project: "~/project-a",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          filePaths: ["/tmp/pi-a.jsonl"],
+        },
+      ],
+    });
+    expect(legacy?.discoveredAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(legacy?.legacy).toBe(true);
+    expect(legacy?.sessions).toHaveLength(1);
+
+    const structured = __testables.normalizeSourceSessionCatalogCache({
+      updatedAt: "2026-01-01T00:10:00.000Z",
+      data: {
+        schemaVersion: 1,
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:05:00.000Z",
+        providerStates: {
+          pi: { provider: "pi", discoveredAt: "2026-01-01T00:00:00.000Z", sessionCount: 1 },
+        },
+        sessions: legacy!.sessions,
+      },
+    });
+    expect(structured?.cachedAt).toBe("2026-01-01T00:10:00.000Z");
+    expect(structured?.discoveredAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(structured?.legacy).toBe(false);
+    expect(structured?.providerStates?.pi?.sessionCount).toBe(1);
+  });
+
+  it("preserves discoveredAt across non-discovery source catalog updates", () => {
+    const updated = __testables.updateSourceSessionCatalogSessions(
+      {
+        sessions: [],
+        cachedAt: "2026-01-01T00:00:00.000Z",
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+        providerStates: {
+          pi: { provider: "pi", discoveredAt: "2026-01-01T00:00:00.000Z", sessionCount: 1 },
+        },
+      },
+      [
+        {
+          provider: "pi",
+          slug: "pi-a",
+          project: "~/project-a",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          filePaths: ["/tmp/pi-a.jsonl"],
+          existingReplay: "pi-a",
+        },
+      ],
+      "2026-01-01T00:10:00.000Z",
+    );
+
+    expect(updated.discoveredAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(updated.updatedAt).toBe("2026-01-01T00:10:00.000Z");
+    expect(updated.sessions[0]?.existingReplay).toBe("pi-a");
+  });
+
+  it("marks Pi source sessions stale when a JSONL mtime is newer than discovery", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-pi-freshness-"));
+    process.env.PI_CODING_AGENT_SESSION_DIR = root;
+    const projectDir = join(root, "--tmp-project--");
+    await mkdir(projectDir, { recursive: true });
+    const sessionPath = join(projectDir, "2026-01-01T00-10-00-000Z_session.jsonl");
+    await writeFile(sessionPath, "{}\n", "utf-8");
+    const newer = new Date("2026-01-01T00:10:00.000Z");
+    await utimes(sessionPath, newer, newer);
+
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [],
+        cachedAt: "2026-01-01T00:00:00.000Z",
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).resolves.toEqual(["pi"]);
+
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [],
+        cachedAt: "2026-01-01T00:20:00.000Z",
+        discoveredAt: "2026-01-01T00:20:00.000Z",
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not mark Pi stale just because an active JSONL mtime advances", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-pi-active-freshness-"));
+    process.env.PI_CODING_AGENT_SESSION_DIR = root;
+    const projectDir = join(root, "--tmp-project--");
+    await mkdir(projectDir, { recursive: true });
+    const sessionPath = join(projectDir, "2026-01-01T00-00-00-000Z_session.jsonl");
+    await writeFile(sessionPath, "{}\n", "utf-8");
+    const discovered = new Date("2026-01-01T00:00:00.000Z");
+    await utimes(sessionPath, discovered, discovered);
+    const discoveredProbe = await __testables.probePiSourceFreshness();
+
+    const newer = new Date("2026-01-01T00:10:00.000Z");
+    await utimes(sessionPath, newer, newer);
+
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [],
+        cachedAt: "2026-01-01T00:00:00.000Z",
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+        providerStates: {
+          pi: {
+            provider: "pi",
+            discoveredAt: "2026-01-01T00:00:00.000Z",
+            sessionCount: 1,
+            newestSourceMtimeMs: discoveredProbe.newestSourceMtimeMs,
+            newestSourcePath: discoveredProbe.newestSourcePath,
+            fingerprint: __testables.sourceProviderFingerprint(discoveredProbe),
+          },
+        },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("does not mark Pi stale when the sessions directory is missing", async () => {
+    process.env.PI_CODING_AGENT_SESSION_DIR = join(tmpdir(), "vr-missing-pi-sessions");
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [],
+        cachedAt: "2026-01-01T00:00:00.000Z",
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("marks legacy source-session catalog caches stale when Pi files exist", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-pi-legacy-freshness-"));
+    process.env.PI_CODING_AGENT_SESSION_DIR = root;
+    const projectDir = join(root, "--tmp-project--");
+    await mkdir(projectDir, { recursive: true });
+    const sessionPath = join(projectDir, "2026-01-01T00-00-00-000Z_session.jsonl");
+    await writeFile(sessionPath, "{}\n", "utf-8");
+    const older = new Date("2026-01-01T00:00:00.000Z");
+    await utimes(sessionPath, older, older);
+
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [],
+        cachedAt: "2026-01-01T01:00:00.000Z",
+        discoveredAt: "2026-01-01T01:00:00.000Z",
+        legacy: true,
+      }),
+    ).resolves.toEqual(["pi"]);
+  });
+
   it("skips candidate sessions already enriched in cached sources", () => {
     const merged = [
       makeCursorSession({

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -26,6 +26,7 @@ import {
   replaySuggestedTitle,
   rollupProject,
   sessionPromptPreview,
+  shouldRefreshCachedList,
   type SourcesEnrichmentStatus,
   shortModelName,
   shortCoworkSpaceId,
@@ -1166,7 +1167,7 @@ function SessionsPanel() {
       .then((r) => (r.ok ? r.json() : null))
       .catch(() => null);
     const cachedData = parseCachedList<SourceSession>(cached);
-    const shouldSkipRefresh = !opts?.forceRefresh && isCacheFresh(cachedData?.cachedAt);
+    const shouldSkipRefresh = !opts?.forceRefresh && !shouldRefreshCachedList(cachedData);
     if (cachedData && cachedData.sessions.length > 0) {
       servedFromCache = true;
       setSources(cachedData.sessions);

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -14,6 +14,7 @@ import {
   projectName,
   replaySuggestedTitle,
   rollupTopProjects,
+  shouldRefreshCachedList,
   type SourcesEnrichmentStatus,
   type TopProjectEntry,
   sourceSuggestedTitle,
@@ -90,7 +91,7 @@ function useDashboardData() {
         setLoading(false);
       }
 
-      const sourceFresh = isCacheFresh(cachedSources?.cachedAt);
+      const sourceFresh = !shouldRefreshCachedList(cachedSources);
       const replayFresh = isCacheFresh(cachedReplays?.cachedAt);
       const refreshPromises: Promise<void>[] = [];
 

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -19,6 +19,7 @@ import {
   rollupProject,
   rollupTopProjects,
   sessionPromptPreview,
+  shouldRefreshCachedList,
   shortCoworkSpaceId,
   sourceDisplayTitle,
   sourceSuggestedTitle,
@@ -231,10 +232,24 @@ describe("cache response helpers", () => {
     expect(parseCachedList<{ slug: string }>({ sessions: [{ slug: "a" }] })).toEqual({
       sessions: [{ slug: "a" }],
       cachedAt: undefined,
+      discoveredAt: undefined,
+      stale: undefined,
+      staleProviders: undefined,
     });
-    expect(parseCachedList({ sessions: [], cachedAt: "2026-05-01T00:00:00.000Z" })).toEqual({
+    expect(
+      parseCachedList({
+        sessions: [],
+        cachedAt: "2026-05-01T00:00:00.000Z",
+        discoveredAt: "2026-05-01T00:00:01.000Z",
+        stale: true,
+        staleProviders: ["pi", 42],
+      }),
+    ).toEqual({
       sessions: [],
       cachedAt: "2026-05-01T00:00:00.000Z",
+      discoveredAt: "2026-05-01T00:00:01.000Z",
+      stale: true,
+      staleProviders: ["pi"],
     });
   });
 
@@ -251,6 +266,34 @@ describe("cache response helpers", () => {
     expect(isCacheFresh("2026-05-01T09:54:59.000Z")).toBe(false);
     expect(isCacheFresh("2026-05-01T10:01:00.000Z")).toBe(false);
     expect(isCacheFresh("not-a-date")).toBe(false);
+  });
+
+  it("refreshes stale cached source-session responses even when cachedAt is fresh", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T10:00:00.000Z"));
+
+    expect(
+      shouldRefreshCachedList({
+        sessions: [],
+        cachedAt: "2026-05-01T09:59:00.000Z",
+        discoveredAt: "2026-05-01T09:59:00.000Z",
+        stale: true,
+        staleProviders: ["pi"],
+      }),
+    ).toBe(true);
+    expect(
+      shouldRefreshCachedList({
+        sessions: [],
+        cachedAt: "2026-05-01T09:59:00.000Z",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRefreshCachedList({
+        sessions: [],
+        cachedAt: "2026-05-01T09:59:00.000Z",
+        discoveredAt: "2026-05-01T09:54:00.000Z",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -6,6 +6,9 @@ import { safeStorageGet, safeStorageRemove, safeStorageSet } from "../utils/safe
 export type CachedListResponse<T> = {
   sessions: T[];
   cachedAt?: string;
+  discoveredAt?: string;
+  stale?: boolean;
+  staleProviders?: string[];
 };
 
 export interface SourcesEnrichmentStatus {
@@ -24,11 +27,22 @@ export const CACHE_REFRESH_TTL_MS = 5 * 60 * 1000;
 
 export function parseCachedList<T>(payload: unknown): CachedListResponse<T> | null {
   if (!payload || typeof payload !== "object") return null;
-  const obj = payload as { sessions?: unknown; cachedAt?: unknown };
+  const obj = payload as {
+    sessions?: unknown;
+    cachedAt?: unknown;
+    discoveredAt?: unknown;
+    stale?: unknown;
+    staleProviders?: unknown;
+  };
   if (!Array.isArray(obj.sessions)) return null;
   return {
     sessions: obj.sessions as T[],
     cachedAt: typeof obj.cachedAt === "string" ? obj.cachedAt : undefined,
+    discoveredAt: typeof obj.discoveredAt === "string" ? obj.discoveredAt : undefined,
+    stale: typeof obj.stale === "boolean" ? obj.stale : undefined,
+    staleProviders: Array.isArray(obj.staleProviders)
+      ? obj.staleProviders.filter((provider): provider is string => typeof provider === "string")
+      : undefined,
   };
 }
 
@@ -36,6 +50,15 @@ export function isCacheFresh(iso?: string, ttlMs = CACHE_REFRESH_TTL_MS): boolea
   if (!iso) return false;
   const ageMs = Date.now() - new Date(iso).getTime();
   return Number.isFinite(ageMs) && ageMs >= 0 && ageMs < ttlMs;
+}
+
+export function shouldRefreshCachedList<T>(
+  cached: CachedListResponse<T> | null | undefined,
+  ttlMs = CACHE_REFRESH_TTL_MS,
+): boolean {
+  // `stale` is the authoritative server-computed signal; `staleProviders` is diagnostic.
+  if (cached?.stale === true) return true;
+  return !isCacheFresh(cached?.discoveredAt || cached?.cachedAt, ttlMs);
 }
 
 // ─── Formatting helpers ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add explicit source-session catalog discovery metadata and legacy cache normalization
- preserve `discoveredAt` across enrichment/replay-linkage cache writes while adding Pi JSONL freshness probing
- make Dashboard refresh source sessions when cached responses report stale providers
- add non-breaking `/api/source-sessions*` and `/api/replays*` aliases while preserving legacy routes
- document Sessions vs Source Sessions vs Replays and cache freshness semantics

## Validation
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm build`
- Browser smoke via `pnpm dev:dashboard` + cmux browser: Dashboard home loaded, Recent Sessions rendered, and API smoke showed `/api/sources/cached` reported Pi stale before refresh and stale false after `/api/source-sessions/stream`.

## Compatibility
- Legacy `/api/sources*` and `/api/sessions*` semantics are unchanged.
- Response shape changes are additive (`discoveredAt`, `stale`, `staleProviders`).
- CLI flags used by replay skill remain available (`--session`, `--github`).
