### PR TITLE
Fix source session cache race

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -447,6 +447,62 @@ function buildSourceSessionCatalogCache(
   };
 }
 
+async function probeSourceRecordsFreshness(
+  sources: SourceSummaryRecord[],
+  provider: string,
+): Promise<SourceProviderFreshnessProbe> {
+  const probe: SourceProviderFreshnessProbe = {
+    provider,
+    sessionsRoot: provider,
+    fileCount: 0,
+  };
+
+  const paths = new Set(
+    sources
+      .filter((source) => source.provider === provider)
+      .flatMap((source) => source.filePaths || [])
+      .filter(
+        (filePath): filePath is string => typeof filePath === "string" && filePath.length > 0,
+      ),
+  );
+
+  for (const filePath of paths) {
+    const fileStat = await stat(filePath).catch(() => null);
+    if (!fileStat) continue;
+    probe.fileCount += 1;
+    if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
+      probe.newestSourceMtimeMs = fileStat.mtimeMs;
+      probe.newestSourcePath = filePath;
+    }
+  }
+
+  return probe;
+}
+
+function mergeSourceCatalogSessionUpdates(
+  current: CachedSourceRecord[],
+  updates: CachedSourceRecord[],
+): CachedSourceRecord[] {
+  if (current.length === 0) return updates;
+
+  const bySessionId = new Map<string, CachedSourceRecord>();
+  const byKey = new Map<string, CachedSourceRecord>();
+  for (const update of updates) {
+    byKey.set(sourceSessionKey(update.provider, update.project, update.slug), update);
+    if (typeof update.sessionId === "string" && update.sessionId) {
+      bySessionId.set(update.sessionId, update);
+    }
+  }
+
+  return current.map((session) => {
+    const byId = session.sessionId ? bySessionId.get(session.sessionId) : undefined;
+    const update =
+      (byId?.provider === session.provider ? byId : undefined) ??
+      byKey.get(sourceSessionKey(session.provider, session.project, session.slug));
+    return update ? { ...session, ...update } : session;
+  });
+}
+
 function updateSourceSessionCatalogSessions(
   catalog: NormalizedSourceSessionCatalogCache,
   sessions: CachedSourceRecord[],
@@ -518,9 +574,20 @@ async function getStaleSourceProviders(
   const piProbe = await probePiSourceFreshness();
   const piFingerprint = sourceProviderFingerprint(piProbe);
   const previousPiFingerprint = catalog.providerStates?.pi?.fingerprint;
+  const previousPiSessionCount = catalog.providerStates?.pi?.sessionCount;
+  const cachedPiSessionCount = catalog.sessions.filter(
+    (session) => session.provider === "pi",
+  ).length;
+  if (
+    cachedPiSessionCount > 0 &&
+    typeof previousPiSessionCount === "number" &&
+    previousPiSessionCount !== cachedPiSessionCount
+  ) {
+    staleProviders.push("pi");
+  }
   if (previousPiFingerprint) {
     if (piFingerprint !== previousPiFingerprint) staleProviders.push("pi");
-    return staleProviders;
+    return [...new Set(staleProviders)];
   }
 
   const piDiscoveredAt =
@@ -535,7 +602,7 @@ async function getStaleSourceProviders(
   ) {
     staleProviders.push("pi");
   }
-  return staleProviders;
+  return [...new Set(staleProviders)];
 }
 
 function sourceSessionKey(provider: string, project: string, slug: string): string {
@@ -1045,15 +1112,18 @@ export async function startServer(
     const discoveredAt = new Date().toISOString();
     const catalog = buildSourceSessionCatalogCache(sessions, discoveredAt, previous);
     try {
-      const piProbe = await probePiSourceFreshness();
+      const piProbe = await probeSourceRecordsFreshness(sessions, "pi");
+      const piSessionCount = sessions.filter((session) => session.provider === "pi").length;
       catalog.providerStates = {
         ...catalog.providerStates,
         pi: {
           ...(catalog.providerStates?.pi || {
             provider: "pi",
             discoveredAt,
-            sessionCount: 0,
           }),
+          provider: "pi",
+          discoveredAt,
+          sessionCount: piSessionCount,
           newestSourceMtimeMs: piProbe.newestSourceMtimeMs,
           newestSourcePath: piProbe.newestSourcePath,
           fingerprint: sourceProviderFingerprint(piProbe),
@@ -1069,7 +1139,13 @@ export async function startServer(
     previous: NormalizedSourceSessionCatalogCache,
     sessions: CachedSourceRecord[],
   ): Promise<void> => {
-    await writeFileCache(sourcesCacheKey, updateSourceSessionCatalogSessions(previous, sessions));
+    await writeFileCache(
+      sourcesCacheKey,
+      updateSourceSessionCatalogSessions(
+        previous,
+        mergeSourceCatalogSessionUpdates(previous.sessions, sessions),
+      ),
+    );
   };
   const refreshReplaysCache = async (): Promise<any[] | null> => {
     try {
@@ -3619,9 +3695,11 @@ export const __testables = {
   buildInsightsSyncBatches,
   countSessionStats,
   getStaleSourceProviders,
+  mergeSourceCatalogSessionUpdates,
   normalizeSourceSessionCatalogCache,
   pickSourceRecordForSession,
   probePiSourceFreshness,
+  probeSourceRecordsFreshness,
   prioritizeScanInputs,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -100,6 +100,47 @@ describe("sources enrichment helpers", () => {
     expect(updated.sessions[0]?.existingReplay).toBe("pi-a");
   });
 
+  it("merges non-discovery source catalog updates without dropping newer sessions", () => {
+    const current: Parameters<typeof __testables.mergeSourceCatalogSessionUpdates>[0] = [
+      {
+        provider: "pi",
+        sessionId: "pi-old-id",
+        slug: "pi-old",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/pi-old.jsonl"],
+        promptCount: 1,
+      },
+      {
+        provider: "pi",
+        sessionId: "pi-new-id",
+        slug: "pi-new",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:10:00.000Z",
+        filePaths: ["/tmp/pi-new.jsonl"],
+        promptCount: 1,
+      },
+    ];
+    const staleEnrichmentUpdate: Parameters<
+      typeof __testables.mergeSourceCatalogSessionUpdates
+    >[1] = [
+      {
+        provider: "pi",
+        sessionId: "pi-old-id",
+        slug: "pi-old",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/pi-old.jsonl"],
+        promptCount: 5,
+      },
+    ];
+
+    const merged = __testables.mergeSourceCatalogSessionUpdates(current, staleEnrichmentUpdate);
+    expect(merged).toHaveLength(2);
+    expect(merged.find((session) => session.slug === "pi-old")?.promptCount).toBe(5);
+    expect(merged.find((session) => session.slug === "pi-new")?.promptCount).toBe(1);
+  });
+
   it("marks Pi source sessions stale when a JSONL mtime is newer than discovery", async () => {
     const root = await mkdtemp(join(tmpdir(), "vr-pi-freshness-"));
     process.env.PI_CODING_AGENT_SESSION_DIR = root;
@@ -158,6 +199,74 @@ describe("sources enrichment helpers", () => {
         },
       }),
     ).resolves.toEqual([]);
+  });
+
+  it("marks Pi stale when cached provider state and cached sessions disagree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-pi-count-mismatch-"));
+    process.env.PI_CODING_AGENT_SESSION_DIR = root;
+    const projectDir = join(root, "--tmp-project--");
+    await mkdir(projectDir, { recursive: true });
+    const sessionPath = join(projectDir, "2026-01-01T00-00-00-000Z_session.jsonl");
+    await writeFile(sessionPath, "{}\n", "utf-8");
+    const discovered = new Date("2026-01-01T00:00:00.000Z");
+    await utimes(sessionPath, discovered, discovered);
+    const discoveredProbe = await __testables.probePiSourceFreshness();
+
+    await expect(
+      __testables.getStaleSourceProviders({
+        sessions: [
+          {
+            provider: "pi",
+            slug: "session",
+            project: "~/project-a",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            filePaths: [sessionPath],
+          },
+        ],
+        cachedAt: "2026-01-01T00:00:00.000Z",
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+        providerStates: {
+          pi: {
+            provider: "pi",
+            discoveredAt: "2026-01-01T00:00:00.000Z",
+            sessionCount: 2,
+            newestSourceMtimeMs: discoveredProbe.newestSourceMtimeMs,
+            newestSourcePath: discoveredProbe.newestSourcePath,
+            fingerprint: __testables.sourceProviderFingerprint(discoveredProbe),
+          },
+        },
+      }),
+    ).resolves.toEqual(["pi"]);
+  });
+
+  it("builds Pi freshness metadata from discovered source records only", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vr-pi-discovered-freshness-"));
+    const projectDir = join(root, "--tmp-project--");
+    await mkdir(projectDir, { recursive: true });
+    const discoveredPath = join(projectDir, "2026-01-01T00-00-00-000Z_discovered.jsonl");
+    const unseenPath = join(projectDir, "2026-01-01T00-10-00-000Z_unseen.jsonl");
+    await writeFile(discoveredPath, "{}\n", "utf-8");
+    await writeFile(unseenPath, "{}\n", "utf-8");
+    const older = new Date("2026-01-01T00:00:00.000Z");
+    const newer = new Date("2026-01-01T00:10:00.000Z");
+    await utimes(discoveredPath, older, older);
+    await utimes(unseenPath, newer, newer);
+
+    const probe = await __testables.probeSourceRecordsFreshness(
+      [
+        {
+          provider: "pi",
+          slug: "discovered",
+          project: "~/project-a",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          filePaths: [discoveredPath],
+        },
+      ],
+      "pi",
+    );
+
+    expect(probe.fileCount).toBe(1);
+    expect(probe.newestSourcePath).toBe(discoveredPath);
   });
 
   it("does not mark Pi stale when the sessions directory is missing", async () => {


### PR DESCRIPTION
## Summary
- Preserve newer source sessions when non-discovery cache updates write back enriched metadata
- Build Pi freshness metadata from the sessions actually returned by discovery
- Mark Pi source caches stale when provider state counts disagree with cached records

## Testing
- pnpm --filter vibe-replay test -- server-sources-enrichment.test.ts
- pnpm lint:check
- pnpm --filter vibe-replay build

## Security
- Reviewed the diff for secrets; no credentials, tokens, or environment files are included.