### PR TITLE
chore(cli): replace any[] with precise union type for session picker choices

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1263,7 +1263,7 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
     byProject.get(key)?.push(s);
   }
 
-  const choices: any[] = [];
+  const choices: (Separator | { name: string; value: string })[] = [];
   const projectEntries = [...byProject.entries()];
 
   for (let pi = 0; pi < projectEntries.length; pi++) {


### PR DESCRIPTION
## Summary

- Replace `any[]` with `(Separator | { name: string; value: string })[]` in `formatSessionChoices`
- Net change: -1 +1

## Motivation

`choices: any[]` loses all type information. The array only ever holds two kinds of elements — `Separator` instances (section headers) and `{ name, value }` choice objects fed to `select<string>`. The precise union type makes this explicit, TypeScript can now catch any accidental wrong element pushed into the array, and the return type of `formatSessionChoices` is inferred correctly without `any`.

## Test plan

- [x] `pnpm test` 全绿
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 825KB, CLI-only change, no viewer impact)
- [x] E2E: 没跑，此改动为纯类型注解，零运行时行为变化

> 🤖 Daily auto-quality routine. Self-merged after AI review.