### PR TITLE
Support Git repo filtering for replays

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { Command, program } from "commander";
 import ora from "ora";
 import { setFileCacheAppVersion } from "@vibe-replay/provider-core/cache";
+import { readGitRepo } from "@vibe-replay/provider-core/utils";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText } from "./clean-prompt.js";
 import {
@@ -505,12 +506,14 @@ program
       const project = rawProject.startsWith(home)
         ? `~${rawProject.slice(home.length)}`
         : rawProject;
+      const gitRepo = sessionInfo?.gitRepo || (await readGitRepo(rawProject));
       replay = transformToReplay(parsed, providerName, project, {
         generator: {
           name: "vibe-replay",
           version: CLI_VERSION,
           generatedAt: new Date().toISOString(),
         },
+        gitRepo,
       });
 
       const thinkingStr = replay.meta.stats.thinkingBlocks

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -19,6 +19,7 @@ import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
+import { readGitRepo } from "@vibe-replay/provider-core/utils";
 import { readFileCache, writeFileCache, type FileCacheEntry } from "./cache.js";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
 import { computeDaysUntilCleanup, getClaudeCodeCleanupPeriod } from "./cleanup-warning.js";
@@ -118,6 +119,7 @@ async function unarchiveSlug(baseDir: string, slug: string): Promise<void> {
 /** Scan replay.json files from a single directory */
 async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
   const results: ReplaySummary[] = [];
+  const projectGitRepoCache = new Map<string, string | undefined>();
   let entries: string[];
   try {
     entries = await readdir(baseDir);
@@ -150,6 +152,13 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
 
       const generatorVersion = session.meta.generator?.version;
       const replayOutdated = generatorVersion ? generatorVersion !== CLI_VERSION : false;
+      let gitRepo = session.meta.gitRepo;
+      if (!gitRepo && session.meta.project) {
+        if (!projectGitRepoCache.has(session.meta.project)) {
+          projectGitRepoCache.set(session.meta.project, await readGitRepo(session.meta.project));
+        }
+        gitRepo = projectGitRepoCache.get(session.meta.project);
+      }
 
       results.push({
         slug: entry,
@@ -158,6 +167,7 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
         title: session.meta.title,
         provider: session.meta.provider,
         model: session.meta.model,
+        gitRepo,
         project: session.meta.project,
         startTime: session.meta.startTime,
         endTime: session.meta.endTime,
@@ -283,6 +293,7 @@ interface ReplaySummary {
   title?: string;
   provider: string;
   model?: string;
+  gitRepo?: string;
   project: string;
   startTime: string;
   endTime?: string;
@@ -939,6 +950,7 @@ async function buildSourcesResult(
             title: replay.title,
             provider: replay.provider,
             model: replay.model,
+            gitRepo: replay.gitRepo,
             project: replay.project,
             startTime: replay.startTime,
             endTime: replay.endTime,
@@ -1974,6 +1986,7 @@ export async function startServer(
               version: CLI_VERSION,
               generatedAt: new Date().toISOString(),
             },
+            gitRepo: info.gitRepo,
           });
           // Dedup on the serialized scene array. Hashing only coarse counters
           // (scene count, prompt count, last timestamp) misses content-only
@@ -2418,6 +2431,7 @@ export async function startServer(
       const project = rawProject.startsWith(home)
         ? `~${rawProject.slice(home.length)}`
         : rawProject;
+      const gitRepo = resolved.value.sessionInfo?.gitRepo || (await readGitRepo(rawProject));
 
       const replay = transformToReplay(parsed, body.provider, project, {
         generator: {
@@ -2425,6 +2439,7 @@ export async function startServer(
           version: CLI_VERSION,
           generatedAt: new Date().toISOString(),
         },
+        gitRepo,
       });
 
       if (typeof body.title === "string") {
@@ -2527,6 +2542,7 @@ export async function startServer(
             version: CLI_VERSION,
             generatedAt: new Date().toISOString(),
           },
+          gitRepo: sessionInfo.gitRepo,
         });
 
         // Preserve custom title from old replay

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -256,6 +256,8 @@ export interface ProviderParseResult {
     model?: string;
   }>;
   gitBranch?: string;
+  /** Normalized git remote origin (for example, "owner/repo") */
+  gitRepo?: string;
   /** All branches seen during session in order (if >1) */
   gitBranches?: string[];
   entrypoint?: string;

--- a/packages/provider-core/src/utils.ts
+++ b/packages/provider-core/src/utils.ts
@@ -1,6 +1,6 @@
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 /** Replace $HOME prefix with `~` for display. */
 export function shortenPath(path: string): string {
@@ -74,7 +74,25 @@ export async function readGitRepo(projectDir: string): Promise<string | undefine
   if (!projectDir.trim()) return undefined;
   try {
     const resolved = projectDir.startsWith("~") ? join(homedir(), projectDir.slice(1)) : projectDir;
-    const config = await readFile(join(resolved, ".git", "config"), "utf-8");
+    const gitPath = join(resolved, ".git");
+    let configPath = join(gitPath, "config");
+
+    // In git worktrees, `.git` is a file containing `gitdir: <path>` instead
+    // of a directory. The remote config lives in the common git dir.
+    const gitStat = await stat(gitPath).catch(() => null);
+    if (gitStat?.isFile()) {
+      const gitFile = await readFile(gitPath, "utf-8");
+      const gitdirMatch = gitFile.match(/^gitdir:\s*(.+)$/m);
+      if (!gitdirMatch) return undefined;
+      const gitdir = gitdirMatch[1].trim();
+      const absoluteGitdir = isAbsolute(gitdir) ? gitdir : resolve(resolved, gitdir);
+      const commonDir = await readFile(join(absoluteGitdir, "commondir"), "utf-8").catch(
+        () => "../..",
+      );
+      configPath = join(resolve(absoluteGitdir, commonDir.trim()), "config");
+    }
+
+    const config = await readFile(configPath, "utf-8");
     const match = config.match(/\[remote "origin"\][^[]*?url\s*=\s*(.+)/);
     if (!match) return undefined;
     return normalizeGitUrl(match[1].trim());
@@ -85,16 +103,17 @@ export async function readGitRepo(projectDir: string): Promise<string | undefine
 
 /** Normalize a git remote URL to "owner/repo" format. */
 export function normalizeGitUrl(url: string): string | undefined {
+  const trimmed = url.trim();
   // SCP-style ssh: git@github.com:org/repo.git
-  const scpMatch = url.match(/:([^/][^:]+?)(?:\.git)?\s*$/);
-  if (!url.startsWith("http") && !url.startsWith("ssh://") && scpMatch) {
+  const scpMatch = trimmed.match(/:([^/][^:]+?)(?:\.git)?\s*$/);
+  if (!trimmed.startsWith("http") && !trimmed.startsWith("ssh://") && scpMatch) {
     const path = scpMatch[1];
     const parts = path.split("/");
     if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
   }
   // https/ssh-protocol: https://github.com/org/repo.git or ssh://git@github.com/org/repo
   try {
-    const parsed = new URL(url);
+    const parsed = new URL(trimmed);
     const parts = parsed.pathname
       .replace(/^\//, "")
       .replace(/\.git$/, "")

--- a/packages/provider-core/test/utils.test.ts
+++ b/packages/provider-core/test/utils.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { normalizeGitUrl, readGitRepo } from "../src/utils.js";
+
+describe("normalizeGitUrl", () => {
+  it.each([
+    ["https://github.com/org/repo.git", "org/repo"],
+    ["https://github.com/org/repo", "org/repo"],
+    ["https://github.com/org/sub/repo.git", "org/sub"],
+    ["git@github.com:org/repo.git", "org/repo"],
+    ["ssh://git@github.com/org/repo", "org/repo"],
+    ["https://github.com/org/repo.git   ", "org/repo"],
+  ])("normalizes %s", (input, expected) => {
+    expect(normalizeGitUrl(input)).toBe(expected);
+  });
+
+  it.each(["", "not a url", "https://github.com/org", "git@github.com:org"])(
+    "returns undefined for invalid input %s",
+    (input) => {
+      expect(normalizeGitUrl(input)).toBeUndefined();
+    },
+  );
+});
+
+describe("readGitRepo", () => {
+  it("reads origin from a normal .git/config", async () => {
+    const project = await mkdtemp(join(tmpdir(), "vibe-replay-git-"));
+    await mkdir(join(project, ".git"));
+    await writeFile(
+      join(project, ".git", "config"),
+      '[remote "origin"]\n\turl = git@github.com:org/repo.git\n',
+    );
+
+    await expect(readGitRepo(project)).resolves.toBe("org/repo");
+  });
+
+  it("reads origin from the common git dir for worktrees", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-worktree-"));
+    const project = join(root, "worktree");
+    const gitdir = join(root, ".git", "worktrees", "feature");
+    const commonDir = join(root, ".git");
+    await mkdir(project, { recursive: true });
+    await mkdir(gitdir, { recursive: true });
+    await writeFile(join(project, ".git"), `gitdir: ${gitdir}\n`);
+    await writeFile(join(gitdir, "commondir"), "../..\n");
+    await writeFile(
+      join(commonDir, "config"),
+      '[remote "origin"]\n\turl = https://github.com/org/worktree-repo.git\n',
+    );
+
+    await expect(readGitRepo(project)).resolves.toBe("org/worktree-repo");
+  });
+});

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -34,6 +34,7 @@ export function transformToReplay(
   project: string,
   options?: {
     generator?: ReplaySession["meta"]["generator"];
+    gitRepo?: string;
   },
 ): ReplaySession {
   const scenes: Scene[] = [];
@@ -196,6 +197,10 @@ export function transformToReplay(
           ? { subAgentSummary: syntheticSubAgentSummary }
           : {}),
       ...(parsed.gitBranch ? { gitBranch: parsed.gitBranch } : {}),
+      // Provider metadata wins over caller fallback when both are present.
+      ...(parsed.gitRepo || options?.gitRepo
+        ? { gitRepo: parsed.gitRepo || options?.gitRepo }
+        : {}),
       ...(parsed.gitBranches ? { gitBranches: parsed.gitBranches } : {}),
       ...(parsed.entrypoint ? { entrypoint: parsed.entrypoint } : {}),
       ...(parsed.permissionMode ? { permissionMode: parsed.permissionMode } : {}),

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -653,6 +653,23 @@ describe("transform — metadata", () => {
     expect(replay.meta.generator).toEqual(gen);
   });
 
+  it("includes git repo metadata when provided by the caller", () => {
+    const replay = transformToReplay(buildParsed({}), "claude-code", "~/test", {
+      gitRepo: "tuo-lei/vibe-replay",
+    });
+    expect(replay.meta.gitRepo).toBe("tuo-lei/vibe-replay");
+  });
+
+  it("prefers provider git repo metadata over caller fallback", () => {
+    const replay = transformToReplay(
+      buildParsed({ gitRepo: "provider/repo" }),
+      "claude-code",
+      "~/test",
+      { gitRepo: "fallback/repo" },
+    );
+    expect(replay.meta.gitRepo).toBe("provider/repo");
+  });
+
   it("returns undefined duration when provider duration is missing (no wall-clock fallback)", () => {
     const replay = transformToReplay(
       buildParsed({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -301,6 +301,8 @@ export interface ReplaySession {
     }>;
     /** Git branch (last seen — usually the feature branch) */
     gitBranch?: string;
+    /** Normalized git remote origin (for example, "owner/repo") */
+    gitRepo?: string;
     /** All branches seen during session, in order of appearance (if switched) */
     gitBranches?: string[];
     /** How the session was started: "cli" | "sdk-ts" */

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1039,7 +1039,9 @@ function ReplayCard({
       {/* Row 4: identity */}
       <div className="flex items-center gap-2 text-xs font-mono text-terminal-dimmer flex-wrap">
         <ProviderBadge provider={s.provider} />
-        <span title={isWorktreeReplay ? s.project : undefined}>{displayProject}</span>
+        <span title={s.gitRepo ? s.project : isWorktreeReplay ? s.project : undefined}>
+          {s.gitRepo || displayProject}
+        </span>
         {isWorktreeReplay && (
           <span
             className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider"
@@ -1123,34 +1125,6 @@ function replayStatus(s: SourceSession): { label: string; className: string; tit
     className: "bg-terminal-blue-subtle text-terminal-blue",
     title: "A local replay is ready to view.",
   };
-}
-
-type ReplayFilterStatus = "local" | "shared" | "outdated";
-
-function replayFilterStatus(s: SessionSummary): ReplayFilterStatus {
-  if (s.replayOutdated || s.gist?.outdated) return "outdated";
-  if (s.cloud || s.gist) return "shared";
-  return "local";
-}
-
-function replayFilterStatusLabel(status: ReplayFilterStatus): string {
-  if (status === "shared") return "Shared";
-  if (status === "outdated") return "Needs update";
-  return "Local only";
-}
-
-function replayStatusSortValue(status: ReplayFilterStatus): number {
-  if (status === "shared") return 0;
-  if (status === "local") return 1;
-  return 2;
-}
-
-function sortedReplayStatusEntries(counts: Map<string, number>) {
-  return [...counts.entries()].sort(
-    (a, b) =>
-      replayStatusSortValue(a[0] as ReplayFilterStatus) -
-      replayStatusSortValue(b[0] as ReplayFilterStatus),
-  );
 }
 
 function ActiveFilterChip({
@@ -2566,13 +2540,13 @@ function ReplaysPanel() {
     filter,
     showArchived,
     selectedProviders,
-    selectedReplayStatuses,
+    selectedRepos,
     handleProjectChange,
     handleFilterChange,
     handleProviderSet,
     handleProviderToggle,
-    handleReplayStatusSet,
-    handleReplayStatusToggle,
+    handleRepoSet,
+    handleRepoToggle,
     handleToggleArchived,
     handleClearAllFilters,
   } = usePanelFilters();
@@ -2720,13 +2694,13 @@ function ReplaysPanel() {
     : sessions.filter((s) => !archivedSlugs.has(s.slug));
 
   const selectedProviderSet = new Set(selectedProviders);
-  const selectedReplayStatusSet = new Set(selectedReplayStatuses);
+  const selectedRepoSet = new Set(selectedRepos);
   const query = filter.trim().toLowerCase();
 
   const matchesProviderFilter = (s: SessionSummary) =>
     selectedProviderSet.size === 0 || selectedProviderSet.has(s.provider);
-  const matchesReplayStatusFilter = (s: SessionSummary) =>
-    selectedReplayStatusSet.size === 0 || selectedReplayStatusSet.has(replayFilterStatus(s));
+  const matchesRepoFilter = (s: SessionSummary) =>
+    selectedRepoSet.size === 0 || selectedRepoSet.has(repoFilterValue(s));
   const matchesProjectFilter = (s: SessionSummary) =>
     selectedProjectKey === ALL_PROJECTS || rollupProject(s.project) === selectedProjectKey;
   const matchesSearchFilter = (s: SessionSummary) => {
@@ -2736,6 +2710,7 @@ function ReplaysPanel() {
       replaySuggestedTitle(s),
       s.slug,
       s.project,
+      s.gitRepo,
       s.provider,
       providerDisplayName(s.provider),
       s.model,
@@ -2748,21 +2723,19 @@ function ReplaysPanel() {
 
   const searchMatchedSessions = visibleSessions.filter(matchesSearchFilter);
   const providerFacetSessions = searchMatchedSessions.filter(
-    (s) => matchesReplayStatusFilter(s) && matchesProjectFilter(s),
+    (s) => matchesRepoFilter(s) && matchesProjectFilter(s),
   );
-  const replayStatusFacetSessions = searchMatchedSessions.filter(
+  const repoFacetSessions = searchMatchedSessions.filter(
     (s) => matchesProviderFilter(s) && matchesProjectFilter(s),
   );
   const projectFacetSessions = searchMatchedSessions.filter(
-    (s) => matchesProviderFilter(s) && matchesReplayStatusFilter(s),
+    (s) => matchesProviderFilter(s) && matchesRepoFilter(s),
   );
 
   const providerEntries = sortedFacetEntries(
     facetCountMap(providerFacetSessions, (s) => s.provider),
   );
-  const replayStatusEntries = sortedReplayStatusEntries(
-    facetCountMap(replayStatusFacetSessions, replayFilterStatus),
-  );
+  const repoEntries = sortedFacetEntries(facetCountMap(repoFacetSessions, repoFilterValue));
 
   // Group by project, rolling up Claude agent worktrees under their parent.
   const byProject = new Map<string, SessionSummary[]>();
@@ -2785,14 +2758,14 @@ function ReplaysPanel() {
   const hasActiveFilters =
     Boolean(filter) ||
     selectedProviders.length > 0 ||
-    selectedReplayStatuses.length > 0 ||
+    selectedRepos.length > 0 ||
     selectedProjectKey !== ALL_PROJECTS;
   const [renderLimit, setRenderLimit] = useState(SESSION_RENDER_BATCH_SIZE);
   const providerFilterKey = selectedProviders.join("\0");
-  const replayStatusFilterKey = selectedReplayStatuses.join("\0");
+  const repoFilterKey = selectedRepos.join("\0");
   useEffect(() => {
     setRenderLimit(SESSION_RENDER_BATCH_SIZE);
-  }, [filter, providerFilterKey, replayStatusFilterKey, selectedProjectKey, showArchived]);
+  }, [filter, providerFilterKey, repoFilterKey, selectedProjectKey, showArchived]);
   const renderedReplays = filtered.slice(0, renderLimit);
   const remainingRenderCount = Math.max(0, filtered.length - renderedReplays.length);
   const showInitialLoading = loading && sessions.length === 0;
@@ -2867,12 +2840,12 @@ function ReplaysPanel() {
           />
 
           <FacetSection
-            title="Replay status"
-            entries={replayStatusEntries}
-            selected={selectedReplayStatuses}
-            onToggle={handleReplayStatusToggle}
-            labelFor={(status) => replayFilterStatusLabel(status as ReplayFilterStatus)}
-            max={replayStatusEntries.length}
+            title="Git repo"
+            entries={repoEntries}
+            selected={selectedRepos}
+            onToggle={handleRepoToggle}
+            labelFor={repoFilterLabel}
+            max={8}
           />
 
           <div className="space-y-1 border-t border-terminal-border-subtle pt-4">
@@ -2966,24 +2939,24 @@ function ReplaysPanel() {
             // Single-select controls cannot represent desktop multi-select directly;
             // use a disabled sentinel so mobile still communicates active multi-filter state.
             value={
-              selectedReplayStatuses.length === 1
-                ? selectedReplayStatuses[0]
-                : selectedReplayStatuses.length > 1
+              selectedRepos.length === 1
+                ? selectedRepos[0]
+                : selectedRepos.length > 1
                   ? "__multiple__"
                   : ""
             }
-            onChange={(e) => handleReplayStatusSet(e.target.value ? [e.target.value] : [])}
+            onChange={(e) => handleRepoSet(e.target.value ? [e.target.value] : [])}
             className="w-full bg-terminal-surface rounded-lg px-3 py-2.5 text-sm font-sans text-terminal-text outline-none shadow-layer-sm"
           >
-            {selectedReplayStatuses.length > 1 && (
+            {selectedRepos.length > 1 && (
               <option value="__multiple__" disabled>
-                {selectedReplayStatuses.length} statuses selected
+                {selectedRepos.length} repos selected
               </option>
             )}
-            <option value="">All replay statuses ({replayStatusFacetSessions.length})</option>
-            {replayStatusEntries.map(([status, count]) => (
-              <option key={status} value={status}>
-                {replayFilterStatusLabel(status as ReplayFilterStatus)} ({count})
+            <option value="">All repos ({repoFacetSessions.length})</option>
+            {repoEntries.map(([repo, count]) => (
+              <option key={repo} value={repo}>
+                {repoFilterLabel(repo)} ({count})
               </option>
             ))}
           </select>
@@ -3054,12 +3027,12 @@ function ReplaysPanel() {
                     onRemove={() => handleProviderToggle(provider)}
                   />
                 ))}
-                {selectedReplayStatuses.map((status) => (
+                {selectedRepos.map((repo) => (
                   <ActiveFilterChip
-                    key={status}
-                    label="Status"
-                    value={replayFilterStatusLabel(status as ReplayFilterStatus)}
-                    onRemove={() => handleReplayStatusToggle(status)}
+                    key={repo}
+                    label="Repo"
+                    value={repoFilterLabel(repo)}
+                    onRemove={() => handleRepoToggle(repo)}
                   />
                 ))}
                 {selectedProjectKey !== ALL_PROJECTS && (
@@ -3097,7 +3070,7 @@ function ReplaysPanel() {
               <input
                 value={filter}
                 onChange={(e) => handleFilterChange(e.target.value)}
-                placeholder="Search title, prompt, slug, provider, project..."
+                placeholder="Search title, prompt, slug, provider, repo, project..."
                 className="w-full bg-terminal-surface rounded-lg pl-9 pr-3 py-2.5 text-sm font-mono text-terminal-text placeholder:text-terminal-dimmer outline-none ring-1 ring-transparent focus:ring-terminal-green/40 transition-shadow duration-200 shadow-layer-sm"
               />
             </div>
@@ -3170,12 +3143,12 @@ function ReplaysPanel() {
                   onRemove={() => handleProviderToggle(provider)}
                 />
               ))}
-              {selectedReplayStatuses.map((status) => (
+              {selectedRepos.map((repo) => (
                 <ActiveFilterChip
-                  key={status}
-                  label="Status"
-                  value={replayFilterStatusLabel(status as ReplayFilterStatus)}
-                  onRemove={() => handleReplayStatusToggle(status)}
+                  key={repo}
+                  label="Repo"
+                  value={repoFilterLabel(repo)}
+                  onRemove={() => handleRepoToggle(repo)}
                 />
               ))}
               {selectedProjectKey !== ALL_PROJECTS && (

--- a/packages/viewer/src/hooks/usePanelFilters.ts
+++ b/packages/viewer/src/hooks/usePanelFilters.ts
@@ -40,10 +40,6 @@ function getReposFromUrl(): string[] {
   return getMultiFromUrl("repo");
 }
 
-function getReplayStatusesFromUrl(): string[] {
-  return getMultiFromUrl("replay");
-}
-
 /** Shared URL-synced filter state used by SessionsPanel and ReplaysPanel. */
 export function usePanelFilters() {
   const [selectedProject, setSelectedProject] = useState(getProjectFromUrl);
@@ -51,7 +47,6 @@ export function usePanelFilters() {
   const [showArchived, setShowArchived] = useState(getShowArchivedFromUrl);
   const [selectedProviders, setSelectedProviders] = useState(getProvidersFromUrl);
   const [selectedRepos, setSelectedRepos] = useState(getReposFromUrl);
-  const [selectedReplayStatuses, setSelectedReplayStatuses] = useState(getReplayStatusesFromUrl);
 
   useEffect(() => {
     const handler = () => {
@@ -60,7 +55,6 @@ export function usePanelFilters() {
       setShowArchived(getShowArchivedFromUrl());
       setSelectedProviders(getProvidersFromUrl());
       setSelectedRepos(getReposFromUrl());
-      setSelectedReplayStatuses(getReplayStatusesFromUrl());
     };
     window.addEventListener("popstate", handler);
     return () => window.removeEventListener("popstate", handler);
@@ -100,18 +94,6 @@ export function usePanelFilters() {
     handleRepoSet(next);
   };
 
-  const handleReplayStatusSet = (statuses: string[]) => {
-    setSelectedReplayStatuses(statuses);
-    navigateTo({ replay: multiParam(statuses) }, { notify: false });
-  };
-
-  const handleReplayStatusToggle = (status: string) => {
-    const next = selectedReplayStatuses.includes(status)
-      ? selectedReplayStatuses.filter((s) => s !== status)
-      : [...selectedReplayStatuses, status];
-    handleReplayStatusSet(next);
-  };
-
   const handleToggleArchived = () => {
     const next = !showArchived;
     setShowArchived(next);
@@ -125,7 +107,6 @@ export function usePanelFilters() {
     setFilter("");
     setSelectedProviders([]);
     setSelectedRepos([]);
-    setSelectedReplayStatuses([]);
     navigateTo(
       { project: null, q: null, provider: null, repo: null, replay: null },
       { notify: false },
@@ -138,15 +119,12 @@ export function usePanelFilters() {
     showArchived,
     selectedProviders,
     selectedRepos,
-    selectedReplayStatuses,
     handleProjectChange,
     handleFilterChange,
     handleProviderSet,
     handleProviderToggle,
     handleRepoSet,
     handleRepoToggle,
-    handleReplayStatusSet,
-    handleReplayStatusToggle,
     handleToggleArchived,
     handleClearAllFilters,
   };

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -25,6 +25,7 @@ export interface SessionSummary {
   title?: string;
   provider: string;
   model?: string;
+  gitRepo?: string;
   project: string;
   startTime: string;
   endTime?: string;


### PR DESCRIPTION
## Summary
- Persist normalized `gitRepo` on newly generated replay metadata.
- Backfill replay summaries at scan time by reading the replay project’s git remote when old replay metadata lacks `gitRepo`.
- Replace the Replays tab’s low-value Replay status facet with a Git repo facet, including URL-synced `repo` filters, active chips, mobile selector support, and repo-aware search/card identity.

## Validation
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Browser smoke tested Replays desktop and mobile Git repo filtering with local data.
