### PR TITLE
Polish replay repo filter edge cases

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -116,10 +116,18 @@ async function unarchiveSlug(baseDir: string, slug: string): Promise<void> {
   }
 }
 
+const replayGitRepoByProjectCache = new Map<string, string | undefined>();
+
+async function readReplayGitRepo(project: string): Promise<string | undefined> {
+  if (!replayGitRepoByProjectCache.has(project)) {
+    replayGitRepoByProjectCache.set(project, await readGitRepo(project));
+  }
+  return replayGitRepoByProjectCache.get(project);
+}
+
 /** Scan replay.json files from a single directory */
 async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
   const results: ReplaySummary[] = [];
-  const projectGitRepoCache = new Map<string, string | undefined>();
   let entries: string[];
   try {
     entries = await readdir(baseDir);
@@ -154,10 +162,7 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
       const replayOutdated = generatorVersion ? generatorVersion !== CLI_VERSION : false;
       let gitRepo = session.meta.gitRepo;
       if (!gitRepo && session.meta.project) {
-        if (!projectGitRepoCache.has(session.meta.project)) {
-          projectGitRepoCache.set(session.meta.project, await readGitRepo(session.meta.project));
-        }
-        gitRepo = projectGitRepoCache.get(session.meta.project);
+        gitRepo = await readReplayGitRepo(session.meta.project);
       }
 
       results.push({

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1039,6 +1039,7 @@ function ReplayCard({
       {/* Row 4: identity */}
       <div className="flex items-center gap-2 text-xs font-mono text-terminal-dimmer flex-wrap">
         <ProviderBadge provider={s.provider} />
+        {/* Replays display repo when available; keep the underlying project path discoverable. */}
         <span title={s.gitRepo ? s.project : isWorktreeReplay ? s.project : undefined}>
           {s.gitRepo || displayProject}
         </span>
@@ -1079,7 +1080,7 @@ function projectFilterLabel(project: string, labels: Map<string, string>): strin
 }
 
 function facetSortLabel(value: string): string {
-  return value === NO_REPO_FILTER ? "zzz-no-repo" : value.toLowerCase();
+  return value.toLowerCase();
 }
 
 function facetCountMap<T>(items: T[], keyFor: (session: T) => string): Map<string, number> {
@@ -1093,6 +1094,8 @@ function facetCountMap<T>(items: T[], keyFor: (session: T) => string): Map<strin
 
 function sortedFacetEntries(counts: Map<string, number>) {
   return [...counts.entries()].sort((a, b) => {
+    if (a[0] === NO_REPO_FILTER && b[0] !== NO_REPO_FILTER) return 1;
+    if (b[0] === NO_REPO_FILTER && a[0] !== NO_REPO_FILTER) return -1;
     if (b[1] !== a[1]) return b[1] - a[1];
     return facetSortLabel(a[0]).localeCompare(facetSortLabel(b[0]));
   });


### PR DESCRIPTION
## Summary
- Cache replay git repo backfill lookups across dashboard scans to avoid repeated `.git/config` reads without mutating old replay JSON or share hashes.
- Make `No repo` sorting explicit so it always stays at the bottom of repo facets.
- Document the intentional replay card project-path tooltip when showing repo identity.

## Validation
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Browser smoke tested Replays Git repo facet and active chip.
