### PR TITLE
docs: add Pi to provider lists in README prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx vibe-replay
 
 ### All your sessions, one place
 
-Launch with `npx vibe-replay -d` and see every Claude Code, Cursor, and Codex session across all projects — with activity heatmaps, cost totals, and project analytics.
+Launch with `npx vibe-replay -d` and see every Claude Code, Cursor, Codex, and Pi session across all projects — with activity heatmaps, cost totals, and project analytics.
 
 <p align="center">
   <img src="docs/screenshots/dashboard.png" alt="Local dashboard — browse sessions, activity heatmap, project analytics" width="800" />
@@ -70,7 +70,7 @@ vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/
 ### What the plugin gives your agent
 
 - **Auto-discover sessions** — finds the current session's JSONL file via `$CLAUDE_SESSION_ID`
-- **Search past sessions** — uses `vibe-replay sessions` to find Claude Code, Cursor, and Codex sessions by project, provider, or fuzzy query
+- **Search past sessions** — uses `vibe-replay sessions` to find Claude Code, Cursor, Codex, and Pi sessions by project, provider, or fuzzy query
 - **Generate PR artifacts** — markdown summary + animated GIF + SVG, ready for PR descriptions
 - **Generate HTML replays** — self-contained interactive replay files
 - **PR workflow integration** — agent automatically embeds replay context when you create PRs

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 ```
 AI session files  →  vibe-replay  →  self-contained HTML
 (Claude Code,        (discover,       (animated viewer,
- Cursor, Codex)       parse,           insights panel,
+ Cursor, Codex, Pi)   parse,           insights panel,
                       redact,          offline-ready,
                       transform)       shareable)
 ```

--- a/packages/provider-claude-code/test/claude-code-new-features.test.ts
+++ b/packages/provider-claude-code/test/claude-code-new-features.test.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ReplaySession, Scene } from "@vibe-replay/types";
 import { parseClaudeCodeSession } from "../src/claude-code/parser.js";
 import { transformToReplay } from "./helpers/transform.js";
 
@@ -107,7 +108,7 @@ describe("New features: subagent, duration, metadata, api errors", () => {
   // --- Backward compatibility: old replay without new fields still works ---
   it("old replay JSON without new fields deserializes correctly", () => {
     // Simulate an old replay.json with no new fields
-    const oldReplay = {
+    const oldReplay: ReplaySession = {
       meta: {
         sessionId: "old-session",
         slug: "old-slug",
@@ -132,12 +133,12 @@ describe("New features: subagent, duration, metadata, api errors", () => {
     expect(oldReplay.scenes[1]).not.toHaveProperty("durationMs");
 
     // Access with optional chaining (how viewer does it) should return undefined, not throw
-    const meta = oldReplay.meta as any;
+    const meta = oldReplay.meta;
     expect(meta.gitBranch ?? "none").toBe("none");
     expect(meta.apiErrors?.length ?? 0).toBe(0);
     expect(meta.subAgentSummary?.length ?? 0).toBe(0);
 
-    const scene = oldReplay.scenes[1] as any;
+    const scene = oldReplay.scenes[1] as Extract<Scene, { type: "tool-call" }>;
     expect(scene.subAgent?.agentType ?? "none").toBe("none");
     expect(scene.durationMs ?? 0).toBe(0);
   });

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/diff": "^6.0.0",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,11 +337,11 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@types/react':
-        specifier: ^19.2.15
-        version: 19.2.15
+        specifier: ^19.2.17
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.0.0
-        version: 19.2.3(@types/react@19.2.15)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
@@ -2598,8 +2598,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.15':
-    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -6652,11 +6652,11 @@ snapshots:
 
   '@types/prismjs@1.26.6': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.15
+      '@types/react': 19.2.17
 
-  '@types/react@19.2.15':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
@@ -6691,7 +6691,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:


### PR DESCRIPTION
## Summary

This PR bundles three small, low-risk maintenance changes:

1. **docs**: Add Pi to two README prose sentences that still said "Claude Code, Cursor, and Codex" after Pi support shipped in #318. The Supported Providers table and features bullet already listed Pi — this fixes the inconsistency.
2. **tests**: Type `oldReplay` as `ReplaySession` in `claude-code-new-features.test.ts` and drop the `as any` casts, so the backward-compat test is properly type-checked.
3. **deps**: Bump `@types/react` 19.2.15 → 19.2.17 (patch, dev-only).

## Why the docs change

PR #318 added full Pi provider support and correctly updated the Supported Providers table, but two narrative sentences in the dashboard overview and Claude Code plugin section were missed. Users scanning the README description could incorrectly conclude Pi sessions aren't visible in the dashboard or discoverable via `vibe-replay sessions`.

## Files touched

- `README.md` (+2 / -2)
- `packages/provider-claude-code/test/claude-code-new-features.test.ts` (+4 / -3)
- `packages/viewer/package.json` (+1 / -1)
- `pnpm-lock.yaml` (+9 / -9)

## Out of scope (intentionally)

- Did not update website landing page (`Features.astro` still says "Claude Code + Cursor") — landing page copy needs a human marketing decision.

> 🤖 Weekly auto-docs routine + bundled deps/test maintenance. Needs human review before merge.
