### PR TITLE
chore(release): v0.2.4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
Minimal release PR bumping CLI version `0.2.3` → `0.2.4`.

### Changes since v0.2.3
- feat(dashboard): give each Claude provider a distinct warm hue (#343)
- chore(cli): drop dead cursor sdk-reader re-export stub (#342)
- chore(tests): type oldReplay as ReplaySession, drop as any casts (#339)
- chore(deps): bump @types/react to 19.2.17 (#338)

Verified `node packages/cli/dist/index.js --version` prints `0.2.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)