### PR TITLE
style(viewer): relax dense UI typography

### DIFF
--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -325,9 +325,7 @@ export default function ConversationView({
                   <div className="animate-ping absolute inline-flex h-full w-full rounded-full bg-terminal-orange opacity-40"></div>
                   <div className="relative inline-flex rounded-full h-2 w-2 bg-terminal-orange/80 shadow-[0_0_8px_rgba(251,146,60,0.5)]"></div>
                 </div>
-                <span className="text-[10px] font-sans font-black text-terminal-orange uppercase tracking-[.25em] drop-shadow-sm">
-                  Paused
-                </span>
+                <span className="ui-section-title text-terminal-orange drop-shadow-sm">Paused</span>
               </div>
 
               {/* Right: Interaction Hints */}
@@ -336,18 +334,14 @@ export default function ConversationView({
                   <div className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-terminal-surface-hover/80 border border-terminal-border-subtle/50 text-terminal-text shadow-sm">
                     <span className="text-[11px] font-mono font-bold">&darr;</span>
                   </div>
-                  <span className="text-[10px] font-sans font-bold text-terminal-dim uppercase tracking-widest opacity-80">
-                    Explore
-                  </span>
+                  <span className="ui-caption text-terminal-dim opacity-80">Explore</span>
                 </div>
 
                 <div className="flex items-center gap-3">
                   <div className="flex items-center gap-1.5 px-2 py-0.5 rounded bg-terminal-surface-hover/80 border border-terminal-border-subtle/50 text-terminal-text shadow-sm">
                     <span className="text-[9px] font-mono font-black tracking-tight">SPACE</span>
                   </div>
-                  <span className="text-[10px] font-sans font-bold text-terminal-dim uppercase tracking-widest opacity-80">
-                    Resume
-                  </span>
+                  <span className="ui-caption text-terminal-dim opacity-80">Resume</span>
                 </div>
               </div>
             </div>
@@ -739,9 +733,7 @@ const GroupCard = memo(function GroupCard({
       >
         {userCommentButton}
         <div className="flex items-center gap-2 mb-2.5">
-          <span className="text-[10px] font-sans font-semibold text-terminal-green uppercase tracking-widest">
-            You
-          </span>
+          <span className="ui-section-title text-terminal-green">You</span>
           {group.timestamp && (
             <span className="text-[10px] font-mono text-terminal-dimmer">
               {formatTime(group.timestamp)}
@@ -749,12 +741,10 @@ const GroupCard = memo(function GroupCard({
           )}
           <div className="flex-1" />
           {groupHasFocusedTarget ? (
-            <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-green text-terminal-bg">
-              Jump Target
-            </span>
+            <span className="ui-pill-compact bg-terminal-green text-terminal-bg">Jump Target</span>
           ) : (
             groupHasCurrent && (
-              <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-green-subtle text-terminal-green border border-terminal-green/20">
+              <span className="ui-pill-compact bg-terminal-green-subtle text-terminal-green border border-terminal-green/20">
                 Focused
               </span>
             )
@@ -884,9 +874,7 @@ const GroupCard = memo(function GroupCard({
         }`}
       >
         <div className="flex items-center gap-2 mb-2">
-          <span className="text-[10px] font-sans font-semibold text-terminal-dim uppercase tracking-widest">
-            Context Compaction
-          </span>
+          <span className="ui-section-title">Context Compaction</span>
           {group.timestamp && (
             <span className="text-xs font-mono text-terminal-dimmer">
               {formatTime(group.timestamp)}
@@ -932,9 +920,7 @@ const GroupCard = memo(function GroupCard({
         }`}
       >
         <div className="flex items-center gap-2 mb-2">
-          <span className="text-[10px] font-sans font-semibold text-blue-400/80 uppercase tracking-widest">
-            {label}
-          </span>
+          <span className="ui-section-title text-blue-400/80">{label}</span>
           {group.timestamp && (
             <span className="text-xs font-mono text-terminal-dimmer">
               {formatTime(group.timestamp)}
@@ -992,9 +978,7 @@ const GroupCard = memo(function GroupCard({
       }`}
     >
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-[10px] font-sans font-semibold text-terminal-blue uppercase tracking-widest">
-          Assistant
-        </span>
+        <span className="ui-section-title text-terminal-blue">Assistant</span>
         {group.timestamp && (
           <span className="text-[10px] font-mono text-terminal-dimmer">
             {formatTime(group.timestamp)}
@@ -1002,12 +986,12 @@ const GroupCard = memo(function GroupCard({
         )}
         <div className="flex-1" />
         {groupHasFocusedTarget ? (
-          <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-blue-emphasis text-terminal-blue">
+          <span className="ui-pill-compact bg-terminal-blue-emphasis text-terminal-blue">
             Jump Target
           </span>
         ) : (
           groupHasCurrent && (
-            <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-blue-subtle text-terminal-blue">
+            <span className="ui-pill-compact bg-terminal-blue-subtle text-terminal-blue">
               Focused
             </span>
           )
@@ -1214,9 +1198,7 @@ function CompactAssistantGroup({
       )}
 
       <div className="flex items-center gap-2 mb-2">
-        <span className="text-[10px] font-sans font-semibold text-terminal-blue uppercase tracking-widest">
-          Assistant
-        </span>
+        <span className="ui-section-title text-terminal-blue">Assistant</span>
         {timestamp && (
           <span className="text-[10px] font-mono text-terminal-dimmer">
             {formatTime(timestamp)}
@@ -1229,12 +1211,12 @@ function CompactAssistantGroup({
         )}
         <div className="flex-1" />
         {groupHasFocusedTarget ? (
-          <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-blue-emphasis text-terminal-blue">
+          <span className="ui-pill-compact bg-terminal-blue-emphasis text-terminal-blue">
             Jump Target
           </span>
         ) : (
           groupHasCurrent && (
-            <span className="text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full bg-terminal-blue-subtle text-terminal-blue">
+            <span className="ui-pill-compact bg-terminal-blue-subtle text-terminal-blue">
               Focused
             </span>
           )

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -325,7 +325,9 @@ export default function ConversationView({
                   <div className="animate-ping absolute inline-flex h-full w-full rounded-full bg-terminal-orange opacity-40"></div>
                   <div className="relative inline-flex rounded-full h-2 w-2 bg-terminal-orange/80 shadow-[0_0_8px_rgba(251,146,60,0.5)]"></div>
                 </div>
-                <span className="ui-section-title text-terminal-orange drop-shadow-sm">Paused</span>
+                <span className="text-[10px] font-sans font-black text-terminal-orange uppercase tracking-[.25em] drop-shadow-sm">
+                  Paused
+                </span>
               </div>
 
               {/* Right: Interaction Hints */}

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1477,7 +1477,7 @@ function ActiveFilterChip({
   return (
     <button
       onClick={onRemove}
-      className="inline-flex items-center gap-1.5 rounded-full bg-terminal-surface text-xs font-mono text-terminal-dim ring-1 ring-terminal-border-subtle pl-2.5 pr-2 py-1 hover:text-terminal-text hover:bg-terminal-surface-hover transition-colors"
+      className="ui-pill rounded-full bg-terminal-surface text-terminal-dim ring-1 ring-terminal-border-subtle pl-2.5 pr-2 py-1 hover:text-terminal-text hover:bg-terminal-surface-hover transition-colors"
       title={`Remove ${label}: ${value}`}
     >
       <span className="text-terminal-dimmer">{label}</span>
@@ -1491,9 +1491,7 @@ function FacetHeader({ title, count }: { title: string; count?: number }) {
   return (
     <div className="mb-2 px-3 pt-0.5">
       <div className="flex items-baseline gap-2 min-w-0">
-        <span className="text-xs font-sans font-bold uppercase tracking-wider text-terminal-text truncate">
-          {title}
-        </span>
+        <span className="ui-section-title-strong truncate">{title}</span>
         {count != null && (
           <span className="text-[10px] font-mono tabular-nums text-terminal-dimmer shrink-0">
             {count}
@@ -1564,7 +1562,7 @@ function FacetSection({
       {entries.length > max && !expanded && (
         <button
           onClick={() => setExpanded(true)}
-          className="w-full rounded-md px-3 py-1.5 text-left text-[10px] font-mono text-terminal-dimmer hover:text-terminal-text hover:bg-terminal-surface transition-colors"
+          className="w-full rounded-md px-3 py-1.5 text-left ui-caption-muted hover:text-terminal-text hover:bg-terminal-surface transition-colors"
         >
           Show {entries.length - max} more
         </button>
@@ -1572,7 +1570,7 @@ function FacetSection({
       {entries.length > max && expanded && (
         <button
           onClick={() => setExpanded(false)}
-          className="w-full rounded-md px-3 py-1.5 text-left text-[10px] font-mono text-terminal-dimmer hover:text-terminal-text hover:bg-terminal-surface transition-colors"
+          className="w-full rounded-md px-3 py-1.5 text-left ui-caption-muted hover:text-terminal-text hover:bg-terminal-surface transition-colors"
         >
           Show fewer
         </button>
@@ -2637,11 +2635,11 @@ function SessionsPanel() {
                     {/* Row 3: identity */}
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <ProviderBadge provider={s.provider} />
-                      <span className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim">
+                      <span className="ui-pill bg-terminal-surface-2 text-terminal-dim">
                         {providerDisplayName(s.provider)}
                       </span>
                       <span
-                        className={`text-xs font-mono px-1.5 py-0.5 rounded-md ${
+                        className={`ui-pill font-mono ${
                           s.gitRepo
                             ? "bg-terminal-surface-2 text-terminal-dim"
                             : "bg-terminal-surface-2 text-terminal-dimmer"
@@ -2651,13 +2649,13 @@ function SessionsPanel() {
                         {repoFilterLabel(repoFilterValue(s))}
                       </span>
                       <span
-                        className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim max-w-[260px] truncate"
+                        className="ui-pill font-mono bg-terminal-surface-2 text-terminal-dim max-w-[260px] truncate"
                         title={s.project}
                       >
                         {projectLabel}
                       </span>
                       {branch && (
-                        <span className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim shrink-0 inline-flex items-center gap-0.5">
+                        <span className="ui-pill font-mono bg-terminal-surface-2 text-terminal-dim shrink-0 gap-0.5">
                           <svg
                             width="10"
                             height="10"
@@ -2674,13 +2672,13 @@ function SessionsPanel() {
                         </span>
                       )}
                       {displayModel && (
-                        <span className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
+                        <span className="ui-pill font-mono bg-terminal-surface-2 text-terminal-dimmer">
                           {shortModelName(displayModel)}
                         </span>
                       )}
                       {isWorktree && (
                         <span
-                          className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple shrink-0 uppercase tracking-wider"
+                          className="ui-pill-compact bg-terminal-purple-subtle text-terminal-purple shrink-0"
                           title={`Agent worktree: ${s.project}`}
                         >
                           worktree
@@ -2691,15 +2689,12 @@ function SessionsPanel() {
                     {/* Row 4: data/replay state */}
                     <div className="flex items-center gap-1.5 flex-wrap">
                       <DataLevelBadge state={dataState} compact active={isPriorityEnriching} />
-                      <span
-                        className={`text-xs font-mono px-1.5 py-0.5 rounded-md ${replay.className}`}
-                        title={replay.title}
-                      >
+                      <span className={`ui-pill ${replay.className}`} title={replay.title}>
                         {replay.label}
                       </span>
                       {(s.hasSqlite || s.hasSdk || scanData?.dataSource) && (
                         <span
-                          className={`text-xs font-mono px-1.5 py-0.5 rounded-md ${dataSourceBadgeClass(scanData?.dataSource, s.hasSqlite, s.hasSdk)}`}
+                          className={`ui-pill ${dataSourceBadgeClass(scanData?.dataSource, s.hasSqlite, s.hasSdk)}`}
                           title={dataSourceLabel}
                         >
                           {dataSourceLabel}
@@ -2707,7 +2702,7 @@ function SessionsPanel() {
                       )}
                       {s.spaceId && (
                         <span
-                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          className="ui-pill font-mono bg-terminal-surface-2 text-terminal-dimmer"
                           title={
                             s.spaceIdSetBy
                               ? `Cowork space ${s.spaceId} (${s.spaceIdSetBy})`
@@ -2719,7 +2714,7 @@ function SessionsPanel() {
                       )}
                       {s.pluginsEnabled && (
                         <span
-                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          className="ui-pill bg-terminal-surface-2 text-terminal-dimmer"
                           title="Claude Cowork plugins enabled"
                         >
                           plugins
@@ -2727,7 +2722,7 @@ function SessionsPanel() {
                       )}
                       {s.skillsEnabled && (
                         <span
-                          className="text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer"
+                          className="ui-pill bg-terminal-surface-2 text-terminal-dimmer"
                           title="Claude Cowork skills enabled"
                         >
                           skills
@@ -2747,18 +2742,18 @@ function SessionsPanel() {
                       (s.expiresInDays != null && s.expiresInDays <= EXPIRY_WARN_DAYS)) && (
                       <div className="flex items-center gap-1.5 flex-wrap">
                         {!!displayPromptCount && (
-                          <span className="inline-flex items-center gap-1 text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim">
+                          <span className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dim">
                             {displayPromptCount} prompts
                           </span>
                         )}
                         {!!displayToolCount && (
-                          <span className="inline-flex items-center gap-1 text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-orange-subtle text-terminal-orange">
+                          <span className="ui-pill font-mono tabular-nums bg-terminal-orange-subtle text-terminal-orange">
                             {displayToolCount} tools
                           </span>
                         )}
                         {!!displayDurationMs && (
                           <span
-                            className="inline-flex items-center gap-1 text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim"
+                            className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dim"
                             title="Estimated active duration"
                           >
                             ~{formatDuration(displayDurationMs)}
@@ -2766,20 +2761,20 @@ function SessionsPanel() {
                         )}
                         {!!displayEditCount && (
                           <span
-                            className="inline-flex items-center gap-1 text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim"
+                            className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dim"
                             title="Estimated file edits"
                           >
                             ~{displayEditCount} edits
                           </span>
                         )}
                         {!!displayCost && (
-                          <span className="inline-flex items-center gap-1 text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-green-subtle text-terminal-green">
+                          <span className="ui-pill font-mono tabular-nums bg-terminal-green-subtle text-terminal-green">
                             {formatCost(displayCost)}
                           </span>
                         )}
                         {s.hasPR && (
                           <span
-                            className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-purple-subtle text-terminal-purple"
+                            className="ui-pill bg-terminal-purple-subtle text-terminal-purple"
                             title="Session produced a PR"
                           >
                             PR
@@ -2787,7 +2782,7 @@ function SessionsPanel() {
                         )}
                         {s.isStarred && (
                           <span
-                            className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-orange-subtle text-terminal-orange"
+                            className="ui-pill bg-terminal-orange-subtle text-terminal-orange"
                             title="Starred in Claude Cowork"
                           >
                             starred
@@ -2795,7 +2790,7 @@ function SessionsPanel() {
                         )}
                         {s.fsDetectedFiles && s.fsDetectedFiles.length > 0 && (
                           <span
-                            className="inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dim"
+                            className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dim"
                             title={s.fsDetectedFiles.join("\n")}
                           >
                             {s.fsDetectedFiles.length} files
@@ -2803,7 +2798,7 @@ function SessionsPanel() {
                         )}
                         {s.expiresInDays != null && s.expiresInDays <= EXPIRY_WARN_DAYS && (
                           <span
-                            className={`inline-flex items-center gap-1 text-xs font-mono px-1.5 py-0.5 rounded-md ${
+                            className={`ui-pill ${
                               s.expiresInDays <= 2
                                 ? "bg-terminal-red-subtle text-terminal-red"
                                 : "bg-terminal-orange-subtle text-terminal-orange"
@@ -2818,11 +2813,11 @@ function SessionsPanel() {
                       </div>
                     )}
                     <div className="flex items-center gap-1.5 flex-wrap">
-                      <span className="text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
+                      <span className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dimmer">
                         {formatSize(s.fileSize)}
                       </span>
                       {s.filePaths.length > 1 && (
-                        <span className="text-xs font-mono tabular-nums px-1.5 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
+                        <span className="ui-pill font-mono tabular-nums bg-terminal-surface-2 text-terminal-dimmer">
                           {s.filePaths.length} parts
                         </span>
                       )}

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -466,7 +466,7 @@ function RecentSessionsList({
 }) {
   if (sessions.length === 0) {
     return (
-      <div className="text-center py-6 text-terminal-dimmer text-xs font-mono">
+      <div className="text-center py-6 ui-caption-muted">
         {isLoading
           ? "Loading recent sessions..."
           : "No sessions found. Start Claude, Cursor, or Codex."}
@@ -561,7 +561,7 @@ function RecentSessionsList({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <span
-                className={`rounded-full px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider ${
+                className={`ui-pill-compact ${
                   primaryHasReplay
                     ? "bg-terminal-green-subtle text-terminal-green"
                     : "bg-terminal-blue-subtle text-terminal-blue"
@@ -641,7 +641,7 @@ function RecentReplaysList({
 }) {
   if (replays.length === 0) {
     return (
-      <div className="text-center py-6 text-terminal-dimmer text-xs font-mono">
+      <div className="text-center py-6 ui-caption-muted">
         {isLoading ? "Loading replays..." : "No replays yet. Generate one from the Sessions tab."}
       </div>
     );
@@ -680,7 +680,7 @@ function RecentReplaysList({
           </div>
           <div className="flex items-center gap-2 shrink-0">
             {r.gist?.gistId && (
-              <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple">
+              <span className="ui-pill-compact bg-terminal-purple-subtle text-terminal-purple">
                 published
               </span>
             )}
@@ -777,7 +777,7 @@ function SystemChecksSection() {
   if (loadingChecks) {
     return (
       <div className="bg-terminal-surface rounded-xl px-4 py-3 shadow-layer-sm">
-        <div className="flex items-center gap-2 text-xs font-mono text-terminal-dim">
+        <div className="flex items-center gap-2 ui-caption">
           <span className="w-1.5 h-1.5 rounded-full bg-terminal-blue animate-pulse" />
           Checking local replay tools...
         </div>
@@ -790,14 +790,12 @@ function SystemChecksSection() {
       <div className="bg-terminal-surface rounded-xl px-4 py-3 shadow-layer-sm">
         <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-              System Ready
-            </h3>
-            <p className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
-              Local replay tooling is available.
-            </p>
+            <h3 className="ui-section-title-strong">System Ready</h3>
+            <p className="mt-0.5 ui-caption-muted">Local replay tooling is available.</p>
           </div>
-          <span className="text-[10px] font-mono text-terminal-green">all checks passed</span>
+          <span className="ui-pill-compact bg-terminal-green-subtle text-terminal-green">
+            all checks passed
+          </span>
         </div>
       </div>
     );
@@ -805,9 +803,7 @@ function SystemChecksSection() {
 
   return (
     <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
-      <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-3">
-        System Attention Needed
-      </h3>
+      <h3 className="ui-section-title-strong mb-3">System Attention Needed</h3>
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
         {missingChecks.map((t) => (
           <div
@@ -1233,9 +1229,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm flex flex-col">
             <div className="mb-3 flex min-h-7 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex min-w-0 items-center gap-2">
-                <h2 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                  {activityWindowLabel}
-                </h2>
+                <h2 className="ui-section-title-strong">{activityWindowLabel}</h2>
                 <span className="text-[10px] font-mono text-terminal-dimmer">
                   {activityDateLabel}
                 </span>
@@ -1266,33 +1260,25 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                 <div className="text-xl font-mono font-bold text-terminal-green tabular-nums">
                   <AnimatedValue value={activeSessions} />
                 </div>
-                <div className="text-[10px] font-sans font-bold uppercase tracking-widest text-terminal-dimmer">
-                  sessions
-                </div>
+                <div className="ui-section-title">sessions</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-blue tabular-nums">
                   <AnimatedValue value={activeProjectCount} />
                 </div>
-                <div className="text-[10px] font-sans font-bold uppercase tracking-widest text-terminal-dimmer">
-                  projects
-                </div>
+                <div className="ui-section-title">projects</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-green tabular-nums">
                   <AnimatedValue value={activePrompts} />
                 </div>
-                <div className="text-[10px] font-sans font-bold uppercase tracking-widest text-terminal-dimmer">
-                  turns
-                </div>
+                <div className="ui-section-title">turns</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-orange tabular-nums">
                   <AnimatedValue value={activeToolCalls} />
                 </div>
-                <div className="text-[10px] font-sans font-bold uppercase tracking-widest text-terminal-dimmer">
-                  tools
-                </div>
+                <div className="ui-section-title">tools</div>
               </div>
             </div>
           </div>
@@ -1300,9 +1286,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm flex flex-col">
             <div className="mb-3 flex min-h-7 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex min-w-0 items-center gap-2">
-                <h2 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                  Activity Insights
-                </h2>
+                <h2 className="ui-section-title-strong">Activity Insights</h2>
                 <InfoTooltip>
                   Long-term local AI coding totals and contribution-style activity across this
                   machine. Cached data appears first, then provider scans enrich details in place.
@@ -1345,33 +1329,25 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                 <div className="text-xl font-mono font-bold text-terminal-green tabular-nums">
                   <AnimatedValue value={insights.totalSessions} />
                 </div>
-                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest">
-                  sessions
-                </div>
+                <div className="ui-section-title">sessions</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-blue tabular-nums">
                   <AnimatedValue value={displayProjectCount} />
                 </div>
-                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest">
-                  projects
-                </div>
+                <div className="ui-section-title">projects</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-green tabular-nums">
                   <AnimatedValue value={displayTotalPrompts} />
                 </div>
-                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest">
-                  turns
-                </div>
+                <div className="ui-section-title">turns</div>
               </div>
               <div className="rounded-lg bg-terminal-bg px-3 py-2">
                 <div className="text-xl font-mono font-bold text-terminal-orange tabular-nums">
                   <AnimatedValue value={displayTotalToolCalls} />
                 </div>
-                <div className="text-[10px] font-sans font-bold text-terminal-dimmer uppercase tracking-widest">
-                  tool calls
-                </div>
+                <div className="ui-section-title">tool calls</div>
               </div>
             </div>
 
@@ -1405,9 +1381,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm flex flex-col">
             <div className="flex items-center justify-between mb-3">
               <div className="flex min-w-0 items-center gap-2">
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                  Recent Sessions
-                </h3>
+                <h3 className="ui-section-title-strong">Recent Sessions</h3>
                 <InfoTooltip>
                   Pick up the sessions most likely to need your next action.
                 </InfoTooltip>
@@ -1439,9 +1413,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm flex flex-col">
             <div className="flex items-center justify-between mb-3">
               <div className="flex min-w-0 items-center gap-2">
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                  Recent Replays
-                </h3>
+                <h3 className="ui-section-title-strong">Recent Replays</h3>
                 <InfoTooltip>Open something already generated.</InfoTooltip>
               </div>
               <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
@@ -1471,9 +1443,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           <div className="bg-terminal-surface rounded-xl p-4 shadow-layer-sm">
             <div className="flex items-center justify-between mb-3">
               <div className="flex min-w-0 items-center gap-2">
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-                  Project Shortcuts
-                </h3>
+                <h3 className="ui-section-title-strong">Project Shortcuts</h3>
                 <InfoTooltip>Jump back into the projects with recent AI work.</InfoTooltip>
               </div>
               <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">

--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -42,9 +42,7 @@ type Status = { type: "success" | "error"; text: string } | null;
 function SectionHeader({ title, color }: { title: string; color: string }) {
   return (
     <div className="flex items-center gap-3 mb-4">
-      <span className={`text-[10px] font-sans font-semibold uppercase tracking-widest ${color}`}>
-        {title}
-      </span>
+      <span className={`ui-section-title ${color}`}>{title}</span>
       <div className="flex-1 h-px bg-terminal-border-subtle" />
     </div>
   );
@@ -59,7 +57,7 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       }}
-      className="text-[10px] font-mono text-terminal-dim hover:text-terminal-text transition-colors px-1.5 py-0.5 rounded bg-terminal-surface hover:bg-terminal-surface-hover border border-terminal-border-subtle"
+      className="ui-pill-compact text-terminal-dim hover:text-terminal-text transition-colors rounded bg-terminal-surface hover:bg-terminal-surface-hover border border-terminal-border-subtle"
       title="Copy to clipboard"
     >
       {copied ? "Copied!" : label || "Copy"}
@@ -575,14 +573,12 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
 
   if (readOnly) {
     return (
-      <div className="p-6 text-center text-xs font-mono text-terminal-dim">
-        Export is not available in read-only mode
-      </div>
+      <div className="p-6 text-center ui-caption">Export is not available in read-only mode</div>
     );
   }
 
   const btnBase =
-    "px-4 py-2 text-xs font-mono rounded-lg transition-colors text-center disabled:opacity-50 shrink-0";
+    "px-4 py-2 text-xs font-sans font-semibold rounded-lg transition-colors text-center disabled:opacity-50 shrink-0";
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -595,14 +591,14 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                 {session.meta.title || session.meta.slug}
               </h2>
               {session.meta.provider && (
-                <span className="shrink-0 text-[10px] font-mono text-terminal-dimmer px-1.5 py-0.5 rounded bg-terminal-surface border border-terminal-border-subtle">
+                <span className="ui-pill-compact shrink-0 text-terminal-dimmer bg-terminal-surface border border-terminal-border-subtle">
                   {session.meta.provider}
                 </span>
               )}
             </div>
           )}
           {hasUnsaved && (
-            <div className="text-xs font-mono text-terminal-orange text-center mb-5 px-3 py-2 rounded-lg bg-terminal-orange-subtle border border-terminal-orange/20">
+            <div className="ui-caption text-terminal-orange text-center mb-5 px-3 py-2 rounded-lg bg-terminal-orange-subtle border border-terminal-orange/20">
               You have unsaved annotation changes
             </div>
           )}
@@ -639,7 +635,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           <span className="text-xs font-sans font-bold text-terminal-purple">
                             Cloud Share
                           </span>
-                          <span className="text-[10px] font-mono font-semibold px-2 py-0.5 rounded-md bg-terminal-purple-subtle text-terminal-purple">
+                          <span className="ui-pill-compact font-semibold px-2 bg-terminal-purple-subtle text-terminal-purple">
                             Private
                           </span>
                         </div>
@@ -659,7 +655,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                           <span className="text-xs font-sans font-bold text-terminal-dim">
                             GitHub Gist
                           </span>
-                          <span className="text-[10px] font-mono font-semibold px-2 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
+                          <span className="ui-pill-compact font-semibold px-2 bg-terminal-surface-2 text-terminal-dimmer">
                             Public
                           </span>
                         </div>
@@ -1021,7 +1017,7 @@ export default function ExportView({ actions, viewerMode, readOnly, session }: P
                         <span className="text-sm font-mono font-semibold text-terminal-dim">
                           GitHub Gist
                         </span>
-                        <span className="text-[10px] font-mono font-semibold px-2 py-0.5 rounded-md bg-terminal-surface-2 text-terminal-dimmer">
+                        <span className="ui-pill-compact font-semibold px-2 bg-terminal-surface-2 text-terminal-dimmer">
                           Public
                         </span>
                       </div>

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -528,9 +528,7 @@ function ShareCard({
 
   const MetricLabel = ({ label, title }: { label: string; title?: string }) => (
     <div className="mt-0.5 flex items-center gap-1">
-      <div className="text-[10px] font-sans font-medium text-terminal-dim uppercase tracking-wider">
-        {label}
-      </div>
+      <div className="ui-section-title">{label}</div>
       {title ? <DataQualityIndicator title={title} className="shrink-0" /> : null}
     </div>
   );
@@ -551,7 +549,7 @@ function ShareCard({
             <span className="text-sm font-sans font-bold bg-gradient-to-r from-terminal-green to-terminal-blue bg-clip-text text-transparent">
               vibe-replay
             </span>
-            <span className="text-[10px] font-mono text-terminal-dimmer px-2 py-0.5 rounded-full bg-terminal-surface-2">
+            <span className="ui-pill-compact bg-terminal-surface-2 text-terminal-dimmer">
               {rangeLabel(range)}
             </span>
             {metricQuality.overall ? (
@@ -635,15 +633,9 @@ function ShareCard({
         {/* Footer highlights */}
         <div className="flex items-center justify-between pt-4 border-t border-terminal-border/30">
           <div className="flex items-center gap-4">
-            {streak.current > 0 && (
-              <span className="text-xs font-mono text-terminal-dim">
-                {streak.current} day streak
-              </span>
-            )}
+            {streak.current > 0 && <span className="ui-caption">{streak.current} day streak</span>}
             {bestDay && bestDay.count > 0 && (
-              <span className="text-xs font-mono text-terminal-dim">
-                Most active: {bestDay.day}
-              </span>
+              <span className="ui-caption">Most active: {bestDay.day}</span>
             )}
           </div>
           <span className="text-[10px] font-mono text-terminal-dimmer">vibe-replay.com</span>
@@ -671,9 +663,7 @@ function HighlightCard({
       <div className="flex items-start gap-3">
         <span className="text-lg leading-none mt-0.5">{icon}</span>
         <div className="min-w-0">
-          <div className="text-[10px] font-sans font-bold text-terminal-dim uppercase tracking-widest">
-            {label}
-          </div>
+          <div className="ui-section-title">{label}</div>
           <div className="text-lg font-mono font-bold text-terminal-text mt-0.5">{value}</div>
           {sub && <div className="text-[10px] font-mono text-terminal-dimmer mt-0.5">{sub}</div>}
         </div>
@@ -1239,7 +1229,7 @@ function InsightsLoadingState({
               {hasCachedInsights ? "Refreshing cached insights" : "Loading your insights"}
             </span>
           </div>
-          <p className="mt-1 text-xs font-mono text-terminal-dim">{detail}</p>
+          <p className="mt-1 ui-caption">{detail}</p>
         </div>
         <InsightsPageSkeleton />
       </div>
@@ -1420,7 +1410,7 @@ export default function InsightsPage() {
               <button
                 key={r}
                 onClick={() => setRange(r)}
-                className={`px-3 py-1.5 text-[11px] font-mono rounded-md transition-all ${
+                className={`px-3 py-1.5 text-xs font-sans rounded-md transition-all ${
                   range === r
                     ? "bg-terminal-green-subtle text-terminal-green font-bold"
                     : "text-terminal-dim hover:text-terminal-text"
@@ -1474,9 +1464,7 @@ export default function InsightsPage() {
         {/* Activity Heatmap — always shows full history regardless of range filter */}
         <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider">
-              Activity
-            </h3>
+            <h3 className="ui-section-title-strong">Activity</h3>
             {range !== "all" && (
               <span className="text-[9px] font-mono text-terminal-dimmer">Last 52 weeks</span>
             )}
@@ -1548,17 +1536,13 @@ export default function InsightsPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {userInsights.turnDurationHistogram && (
               <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-                  Turn Duration Distribution
-                </h3>
+                <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
                 <TurnDurationChart histogram={userInsights.turnDurationHistogram} />
               </div>
             )}
             {userInsights.tokenBreakdown && (
               <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-                  Token Usage
-                </h3>
+                <h3 className="ui-section-title-strong mb-4">Token Usage</h3>
                 <TokenBreakdownChart breakdown={userInsights.tokenBreakdown} />
               </div>
             )}
@@ -1568,15 +1552,11 @@ export default function InsightsPage() {
         {/* Two-column: Weekly Trend + Day of Week */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-              Weekly Trend
-            </h3>
+            <h3 className="ui-section-title-strong mb-4">Weekly Trend</h3>
             <WeeklyTrendChart data={weeklyTrend} />
           </div>
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-              Day of Week
-            </h3>
+            <h3 className="ui-section-title-strong mb-4">Day of Week</h3>
             <DayOfWeekChart data={dayOfWeek} />
           </div>
         </div>
@@ -1584,9 +1564,7 @@ export default function InsightsPage() {
         {/* Two-column: Top Projects + Models & Providers */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-              Top Projects
-            </h3>
+            <h3 className="ui-section-title-strong mb-4">Top Projects</h3>
             <TopProjectsList
               projects={rolledTopProjects.map((p) => ({
                 project: p.project,
@@ -1600,16 +1578,12 @@ export default function InsightsPage() {
           </div>
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-5">
             <div>
-              <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-                Models
-              </h3>
+              <h3 className="ui-section-title-strong mb-4">Models</h3>
               <ModelBreakdown models={userInsights.models || {}} />
             </div>
             {Object.keys(userInsights.providers || {}).length > 1 && (
               <div>
-                <h3 className="text-xs font-sans font-semibold text-terminal-text uppercase tracking-wider mb-4">
-                  Providers
-                </h3>
+                <h3 className="ui-section-title-strong mb-4">Providers</h3>
                 <ProviderBreakdown providers={userInsights.providers || {}} />
               </div>
             )}

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -536,7 +536,7 @@ export default function Player({
                 {overlayActions.overlayCount > 0 && (
                   <button
                     onClick={() => overlayActions.toggleAllOriginals()}
-                    className="ui-meta hidden md:flex items-center gap-2"
+                    className="ui-caption hidden md:flex items-center gap-2"
                     title={
                       overlayActions.showAllOriginals
                         ? "Showing originals — click to show modified"
@@ -565,7 +565,7 @@ export default function Player({
                 {/* Comments — desktop: full button, mobile: icon only */}
                 <button
                   onClick={() => setCommentDrawerOpen(true)}
-                  className="ui-meta-strong hidden md:flex items-center gap-1.5 hover:text-terminal-green transition-colors"
+                  className="ui-caption-strong hidden md:flex items-center gap-1.5 hover:text-terminal-green transition-colors"
                   title="Open comments"
                 >
                   <svg

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -536,7 +536,7 @@ export default function Player({
                 {overlayActions.overlayCount > 0 && (
                   <button
                     onClick={() => overlayActions.toggleAllOriginals()}
-                    className="hidden md:flex items-center gap-2 text-xs font-mono text-terminal-dim"
+                    className="ui-meta hidden md:flex items-center gap-2"
                     title={
                       overlayActions.showAllOriginals
                         ? "Showing originals — click to show modified"
@@ -565,7 +565,7 @@ export default function Player({
                 {/* Comments — desktop: full button, mobile: icon only */}
                 <button
                   onClick={() => setCommentDrawerOpen(true)}
-                  className="hidden md:flex items-center gap-1.5 text-xs font-mono font-semibold text-terminal-text hover:text-terminal-green transition-colors"
+                  className="ui-meta-strong hidden md:flex items-center gap-1.5 hover:text-terminal-green transition-colors"
                   title="Open comments"
                 >
                   <svg
@@ -618,7 +618,7 @@ export default function Player({
                 {hasAiStudio && (
                   <button
                     onClick={() => setStudioDrawerOpen(true)}
-                    className="hidden md:flex pl-2 pr-3 py-1 text-[11px] font-mono rounded bg-[rgba(168,85,247,0.1)] hover:bg-[rgba(168,85,247,0.2)] border border-[rgba(168,85,247,0.3)] hover:border-[rgba(168,85,247,0.5)] text-terminal-purple transition-all items-center gap-1.5 relative overflow-hidden group shadow-sm"
+                    className="ui-pill-compact hidden md:flex pl-2 pr-3 rounded bg-[rgba(168,85,247,0.1)] hover:bg-[rgba(168,85,247,0.2)] border border-[rgba(168,85,247,0.3)] hover:border-[rgba(168,85,247,0.5)] text-terminal-purple transition-all relative overflow-hidden group shadow-sm"
                   >
                     <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/5 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000" />
                     <svg
@@ -635,7 +635,7 @@ export default function Player({
                     >
                       <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
                     </svg>
-                    <span className="font-semibold tracking-wide">AI Studio</span>
+                    <span className="font-semibold">AI Studio</span>
                     {(hasAiFeedback || overlayActions.overlayCount > 0) && (
                       <span className="relative flex h-1.5 w-1.5">
                         <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-terminal-purple opacity-75" />
@@ -660,9 +660,7 @@ export default function Player({
                   <div className="flex-1 overflow-y-auto min-h-0">
                     {/* Sidebar Header */}
                     <div className="px-3 py-2 border-b border-terminal-border-subtle flex items-center justify-between group/side">
-                      <span className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest">
-                        Outline
-                      </span>
+                      <span className="ui-section-title">Outline</span>
                       <button
                         onClick={() => setIsOutlineOpen(false)}
                         className="p-1 rounded hover:bg-terminal-surface text-terminal-dimmer hover:text-terminal-text transition-colors"
@@ -697,7 +695,7 @@ export default function Player({
                     <div className="px-3 py-2 border-b border-terminal-border-subtle">
                       <button
                         onClick={() => setActiveView("summary")}
-                        className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest hover:text-terminal-green transition-colors"
+                        className="ui-section-title hover:text-terminal-green transition-colors"
                         title="Open Insights view"
                       >
                         Stats
@@ -915,7 +913,7 @@ export default function Player({
           <div className="flex border-b border-terminal-border-subtle shrink-0">
             <button
               onClick={() => setMobileDrawerTab("outline")}
-              className={`flex-1 px-3 py-2.5 text-[10px] font-sans font-semibold uppercase tracking-widest transition-colors ${
+              className={`ui-section-title flex-1 px-3 py-2.5 transition-colors ${
                 mobileDrawerTab === "outline"
                   ? "text-terminal-green border-b-2 border-terminal-green"
                   : "text-terminal-dim hover:text-terminal-text"
@@ -925,7 +923,7 @@ export default function Player({
             </button>
             <button
               onClick={() => setMobileDrawerTab("comments")}
-              className={`flex-1 px-3 py-2.5 text-[10px] font-sans font-semibold uppercase tracking-widest transition-colors ${
+              className={`ui-section-title flex-1 px-3 py-2.5 transition-colors ${
                 mobileDrawerTab === "comments"
                   ? "text-terminal-green border-b-2 border-terminal-green"
                   : "text-terminal-dim hover:text-terminal-text"

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -121,11 +121,9 @@ export function DataLevelBadge({
 }) {
   return (
     <span
-      className={`relative inline-flex items-center gap-1 overflow-hidden font-mono rounded-md ${
+      className={`relative ui-pill overflow-hidden ${
         state.className
-      } ${active ? "ring-1 ring-terminal-blue/25" : ""} ${
-        compact ? "text-[10px] px-1.5 py-0.5" : "text-xs px-1.5 py-0.5"
-      }`}
+      } ${active ? "ring-1 ring-terminal-blue/25" : ""} ${compact ? "text-[11px] leading-4" : ""}`}
       title={state.description}
     >
       {active && (

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -100,12 +100,10 @@ export default function StatsPanel({ session }: Props) {
   const metricQuality = useMemo(() => getSessionMetricQuality(meta), [meta]);
 
   return (
-    <div className="p-4 space-y-6 text-xs font-mono">
+    <div className="p-4 space-y-6 ui-caption">
       {/* Session info */}
       <div>
-        <div className="text-terminal-dimmer uppercase tracking-widest text-[10px] font-sans font-semibold mb-2">
-          Session
-        </div>
+        <div className="ui-section-title mb-2">Session</div>
         {meta.title && (
           <div className="text-terminal-text text-xs mb-0.5 truncate" title={meta.title}>
             {meta.title}
@@ -119,7 +117,7 @@ export default function StatsPanel({ session }: Props) {
           {meta.provider && <span>{meta.provider}</span>}
           {isWorktree && (
             <span
-              className="px-1 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple uppercase tracking-wider text-[10px]"
+              className="ui-pill-compact bg-terminal-purple-subtle text-terminal-purple"
               title={`Agent worktree: ${meta.project}`}
             >
               worktree
@@ -142,7 +140,7 @@ export default function StatsPanel({ session }: Props) {
           </div>
         )}
         {(meta.entrypoint || meta.permissionMode || meta.memoryMode) && (
-          <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap text-[10px]">
+          <div className="text-terminal-dim mt-0.5 flex items-center gap-1.5 flex-wrap text-xs">
             {meta.entrypoint && (
               <span className="px-1 py-0.5 rounded bg-terminal-surface text-terminal-dim">
                 {meta.entrypoint}
@@ -234,7 +232,7 @@ export default function StatsPanel({ session }: Props) {
 
       {stats.tokenUsage && (
         <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest flex items-center gap-1.5">
+          <div className="ui-section-title mb-2 flex items-center gap-1.5">
             Tokens
             {metricQuality.tokens && <DataQualityIndicator title={metricQuality.tokens} />}
           </div>
@@ -329,9 +327,7 @@ export default function StatsPanel({ session }: Props) {
       {/* PR Links */}
       {meta.prLinks && meta.prLinks.length > 0 && (
         <div>
-          <div className="text-terminal-dimmer mb-1 text-[10px] font-sans font-semibold uppercase tracking-widest">
-            Pull Requests
-          </div>
+          <div className="ui-section-title mb-1">Pull Requests</div>
           <div className="space-y-0.5">
             {meta.prLinks.map((pr) => (
               <a
@@ -360,7 +356,7 @@ export default function StatsPanel({ session }: Props) {
 
       {stats.compactions && stats.compactions.length > 0 && (
         <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
+          <div className="ui-section-title mb-2">
             Context Compactions ({stats.compactions.length})
           </div>
           <div className="space-y-1">
@@ -382,9 +378,7 @@ export default function StatsPanel({ session }: Props) {
 
       {stats.topTools.length > 0 && (
         <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
-            Top Tools
-          </div>
+          <div className="ui-section-title mb-2">Top Tools</div>
           <div className="space-y-1.5">
             {stats.topTools.map(([name, count]) => (
               <div key={name} className="flex items-center gap-2">
@@ -406,9 +400,7 @@ export default function StatsPanel({ session }: Props) {
 
       {(meta.dataSource || meta.dataSourceInfo) && (
         <div>
-          <div className="text-terminal-dimmer mb-2 text-[10px] font-sans font-semibold uppercase tracking-widest">
-            Data Source
-          </div>
+          <div className="ui-section-title mb-2">Data Source</div>
           <div className="text-terminal-dim">
             <span className="text-terminal-blue">
               {formatReplaySourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
@@ -465,9 +457,7 @@ export function StatCard({
       >
         {value}
       </div>
-      <div className="text-terminal-dimmer text-[10px] font-sans font-medium uppercase tracking-widest mt-0.5">
-        {label}
-      </div>
+      <div className="ui-section-title mt-0.5">{label}</div>
     </div>
   );
 }

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -340,12 +340,10 @@ export default function SummaryView({ session }: Props) {
 
         {dataQualityNotes.length > 0 && (
           <div className="rounded border border-terminal-orange/40 bg-terminal-orange/10 px-3 py-2">
-            <div className="text-[10px] font-sans font-semibold text-terminal-orange uppercase tracking-widest mb-1">
-              Data Quality
-            </div>
+            <div className="ui-section-title text-terminal-orange mb-1">Data Quality</div>
             <div className="space-y-0.5">
               {dataQualityNotes.slice(0, 4).map((note) => (
-                <div key={note} className="text-xs font-mono text-terminal-dim">
+                <div key={note} className="ui-caption">
                   {note}
                 </div>
               ))}
@@ -355,9 +353,7 @@ export default function SummaryView({ session }: Props) {
 
         {(meta.dataSource || meta.dataSourceInfo) && (
           <div className="rounded border border-terminal-border-subtle bg-terminal-surface/40 px-3 py-2">
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-              Data Source
-            </div>
+            <div className="ui-section-title mb-1">Data Source</div>
             <div className="text-xs font-mono text-terminal-text">
               {formatReplaySourceLabel(meta.dataSourceInfo?.primary || meta.dataSource)}
             </div>
@@ -399,9 +395,7 @@ export default function SummaryView({ session }: Props) {
             meta.cursorSidecars.restrictAgentModeSwitching !== undefined ||
             meta.cursorSidecars.glassMetaParentAgent) && (
             <div className="rounded border border-terminal-border-subtle bg-terminal-surface/40 px-3 py-2">
-              <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-                Cursor Sidecars
-              </div>
+              <div className="ui-section-title mb-1">Cursor Sidecars</div>
               <div className="space-y-0.5 text-xs font-mono text-terminal-dim">
                 {meta.cursorSidecars.requestContextCount ? (
                   <div>
@@ -448,9 +442,7 @@ export default function SummaryView({ session }: Props) {
 
         {/* Overview: Key Metrics + Duration/Cost + Tokens */}
         <div>
-          <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-3">
-            Overview
-          </div>
+          <div className="ui-section-title mb-3">Overview</div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <StatCard label="Turns" value={stats.userPrompts} color="text-terminal-green" />
             <StatCard label="Tool Calls" value={stats.toolCalls} color="text-terminal-orange" />
@@ -554,9 +546,7 @@ export default function SummaryView({ session }: Props) {
         {/* === Time Series Charts (grouped) === */}
         {hasTurnStats && (
           <div className="space-y-5">
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest">
-              Per-Turn Metrics
-            </div>
+            <div className="ui-section-title">Per-Turn Metrics</div>
             <TokenBurnCurve
               turnStats={meta.stats.turnStats!}
               costEstimate={meta.stats.costEstimate}
@@ -580,9 +570,7 @@ export default function SummaryView({ session }: Props) {
         {/* API Errors */}
         {meta.apiErrors && meta.apiErrors.length > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-              API Issues
-            </div>
+            <div className="ui-section-title mb-2">API Issues</div>
             <div className="text-xs font-mono text-terminal-dim space-y-1">
               {(() => {
                 const errs = meta.apiErrors;
@@ -630,9 +618,7 @@ export default function SummaryView({ session }: Props) {
         {/* Tracked Files */}
         {meta.trackedFiles && meta.trackedFiles.length > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-              Files Tracked ({meta.trackedFiles.length})
-            </div>
+            <div className="ui-section-title mb-2">Files Tracked ({meta.trackedFiles.length})</div>
             <div className="space-y-0.5 max-h-[200px] overflow-y-auto">
               {meta.trackedFiles.map((f) => (
                 <div
@@ -649,7 +635,7 @@ export default function SummaryView({ session }: Props) {
 
         {meta.contextFiles && meta.contextFiles.length > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
+            <div className="ui-section-title mb-2">
               Context Files (inferred, {meta.contextFiles.length})
             </div>
             <div className="space-y-0.5 max-h-[200px] overflow-y-auto">
@@ -669,9 +655,7 @@ export default function SummaryView({ session }: Props) {
         {/* PR Links */}
         {meta.prLinks && meta.prLinks.length > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-              Pull Requests
-            </div>
+            <div className="ui-section-title mb-2">Pull Requests</div>
             <div className="space-y-1">
               {meta.prLinks.map((pr) => (
                 <a
@@ -707,7 +691,7 @@ export default function SummaryView({ session }: Props) {
         {/* Bash Breakdown */}
         {stats.bashCats.length > 1 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
+            <div className="ui-section-title mb-2">
               Bash Commands
               {stats.totalBashErrors > 0 && (
                 <span className="text-terminal-red ml-2 normal-case tracking-normal">
@@ -731,7 +715,7 @@ export default function SummaryView({ session }: Props) {
         {/* Top Tools */}
         {stats.topTools.length > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
+            <div className="ui-section-title mb-2">
               Top Tools
               <span className="text-terminal-dimmer ml-2 normal-case tracking-normal font-mono">
                 {stats.totalTools} total
@@ -770,9 +754,7 @@ export default function SummaryView({ session }: Props) {
         {/* Activity Distribution (heuristic — placed low as reference) */}
         {stats.totalTools > 0 && (
           <div>
-            <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-              Activity Distribution
-            </div>
+            <div className="ui-section-title mb-2">Activity Distribution</div>
             <div className="space-y-1.5">
               {(
                 [
@@ -849,9 +831,7 @@ function SubAgentSummary({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-        Sub-Agents ({subAgents.length})
-      </div>
+      <div className="ui-section-title mb-2">Sub-Agents ({subAgents.length})</div>
       {/* Type breakdown */}
       <div className="flex flex-wrap gap-2 mb-3">
         {types.map(([type, data]) => {
@@ -987,9 +967,7 @@ function TokenBurnCurve({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-        Token Burn{costEstimate ? " & Cost" : ""}
-      </div>
+      <div className="ui-section-title mb-1">Token Burn{costEstimate ? " & Cost" : ""}</div>
       <div className="relative">
         <svg
           ref={ref}
@@ -1085,9 +1063,7 @@ function CacheEfficiencyLine({ turnStats }: { turnStats: TurnStat[] }) {
   return (
     <div className="mt-1">
       <div className="flex items-center gap-2">
-        <span className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest">
-          Cache Hit Rate
-        </span>
+        <span className="ui-section-title">Cache Hit Rate</span>
         <span className="text-[10px] font-mono text-terminal-purple">
           avg {Math.round(avgRatio * 100)}%
         </span>
@@ -1213,7 +1189,7 @@ function ContextWindowChart({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1 flex items-center gap-2">
+      <div className="ui-section-title mb-1 flex items-center gap-2">
         <span>Context Window Usage</span>
         <span className="font-mono text-terminal-cyan">peak {fmtNum(peak)}</span>
       </div>
@@ -1431,9 +1407,7 @@ function TurnDurationChart({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-        Turn Duration
-      </div>
+      <div className="ui-section-title mb-1">Turn Duration</div>
       <div className="relative">
         <div className="flex items-end gap-px h-16" onMouseLeave={() => setHovered(null)}>
           {durations.map((d, i) => {
@@ -1495,9 +1469,7 @@ function ModelBreakdown({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-        Model Breakdown
-      </div>
+      <div className="ui-section-title mb-2">Model Breakdown</div>
       {/* Stacked bar */}
       <div className="flex h-3 rounded-full overflow-hidden gap-px">
         {entries.map(([model, usage], i) => {
@@ -1547,9 +1519,7 @@ function ToolActivityChart({ turns, turnLabels }: { turns: TurnInfo[]; turnLabel
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-1">
-        Tool Calls per Turn
-      </div>
+      <div className="ui-section-title mb-1">Tool Calls per Turn</div>
       <div className="relative">
         <div className="flex items-end gap-px h-16" onMouseLeave={() => setHovered(null)}>
           {counts.map((c, i) => {
@@ -1622,7 +1592,7 @@ function FileActivityHeatmap({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
+      <div className="ui-section-title mb-2">
         File Activity Heatmap
         {capped && (
           <span className="normal-case tracking-normal font-normal ml-2">
@@ -1743,9 +1713,7 @@ function TurnTable({ turns, turnStats }: { turns: TurnInfo[]; turnStats?: TurnSt
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
-        Per-Turn Breakdown
-      </div>
+      <div className="ui-section-title mb-2">Per-Turn Breakdown</div>
       <div className="overflow-x-auto rounded border border-terminal-border-subtle">
         <table className="w-full text-[11px] font-mono border-collapse">
           <thead>
@@ -1941,7 +1909,7 @@ function FileTable({
 
   return (
     <div>
-      <div className="text-[10px] font-sans font-semibold text-terminal-dimmer uppercase tracking-widest mb-2">
+      <div className="ui-section-title mb-2">
         File Impact
         <span className="normal-case tracking-normal ml-1.5">
           ({editedFiles.length} modified

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -116,29 +116,16 @@ const THEME_CLASSES: Record<
   },
 };
 
-/** Agent-type pill — matches the design language of the Assistant group's
- * "Jump Target" / "Focused" pills (rounded-full, sans-serif uppercase). */
+/** Agent-type pill — matches the shared replay status treatment. */
 function AgentTypeBadge({ type }: { type: string }) {
   const c = THEME_CLASSES[agentTheme(type)];
-  return (
-    <span
-      className={`text-[10px] font-sans font-medium uppercase tracking-widest px-2 py-0.5 rounded-full ${c.pill}`}
-    >
-      {type}
-    </span>
-  );
+  return <span className={`ui-pill-compact px-2 ${c.pill}`}>{type}</span>;
 }
 
 /** Section label — matches the "Assistant" header treatment so a subagent
  * card reads as a sibling section, not a tool row. */
 function SubagentLabel({ theme }: { theme: AgentTheme }) {
-  return (
-    <span
-      className={`text-[10px] font-sans font-semibold uppercase tracking-widest ${THEME_CLASSES[theme].text}`}
-    >
-      Subagent
-    </span>
-  );
+  return <span className={`ui-section-title ${THEME_CLASSES[theme].text}`}>Subagent</span>;
 }
 
 function SubAgentBody({ subAgent }: { subAgent: SubAgent }) {
@@ -146,9 +133,7 @@ function SubAgentBody({ subAgent }: { subAgent: SubAgent }) {
     <div className="mt-3 space-y-3">
       {subAgent.prompt && (
         <div>
-          <div className="text-[10px] font-sans font-semibold uppercase tracking-widest text-terminal-dim mb-1.5">
-            Prompt
-          </div>
+          <div className="ui-section-title mb-1.5">Prompt</div>
           <div className="text-[11px] text-terminal-text/85 font-mono whitespace-pre-wrap break-words max-h-[120px] overflow-y-auto rounded-md bg-terminal-surface-inset px-3 py-2">
             {subAgent.prompt}
           </div>
@@ -174,7 +159,7 @@ function SubAgentTrace({ scenes }: { scenes: Scene[] }) {
   return (
     <div>
       <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[10px] font-sans font-semibold uppercase tracking-widest text-terminal-dim">
+        <span className="ui-section-title">
           Trace · {scenes.length} {scenes.length === 1 ? "scene" : "scenes"}
         </span>
         {isLong && (

--- a/packages/viewer/src/components/ViewTabBar.tsx
+++ b/packages/viewer/src/components/ViewTabBar.tsx
@@ -65,7 +65,7 @@ export default function ViewTabBar({
           <button
             key={key}
             onClick={() => handleChange(key)}
-            className={`relative px-4 py-2 text-[11px] font-sans font-semibold uppercase tracking-widest transition-colors ${
+            className={`ui-section-title relative px-4 py-2 transition-colors ${
               activeView === key
                 ? "text-terminal-green border-b-2 border-terminal-green bg-terminal-surface/50"
                 : "text-terminal-dim hover:text-terminal-text hover:bg-terminal-surface-hover"

--- a/packages/viewer/src/styles/index.css
+++ b/packages/viewer/src/styles/index.css
@@ -191,11 +191,7 @@ html.theme-transition *::after {
     @apply font-sans text-xs leading-relaxed text-terminal-dimmer;
   }
 
-  .ui-meta {
-    @apply font-sans text-xs leading-relaxed text-terminal-dim;
-  }
-
-  .ui-meta-strong {
+  .ui-caption-strong {
     @apply font-sans text-xs font-medium leading-relaxed text-terminal-text;
   }
 
@@ -205,10 +201,6 @@ html.theme-transition *::after {
 
   .ui-pill-compact {
     @apply inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-sans leading-4;
-  }
-
-  .ui-code-meta {
-    @apply font-mono text-xs tabular-nums text-terminal-dim;
   }
 }
 

--- a/packages/viewer/src/styles/index.css
+++ b/packages/viewer/src/styles/index.css
@@ -167,6 +167,51 @@ html.theme-transition *::after {
   }
 }
 
+@layer components {
+  /*
+   * Shared UI typography primitives.
+   *
+   * Keep monospace for code, commands, slugs, paths, models, and numbers.
+   * Use these sans-serif classes for chrome, status labels, section titles,
+   * and explanatory copy so dense screens keep a clearer reading hierarchy.
+   */
+  .ui-section-title {
+    @apply font-sans text-xs font-semibold tracking-wide text-terminal-dim;
+  }
+
+  .ui-section-title-strong {
+    @apply font-sans text-xs font-semibold tracking-wide text-terminal-text;
+  }
+
+  .ui-caption {
+    @apply font-sans text-xs leading-relaxed text-terminal-dim;
+  }
+
+  .ui-caption-muted {
+    @apply font-sans text-xs leading-relaxed text-terminal-dimmer;
+  }
+
+  .ui-meta {
+    @apply font-sans text-xs leading-relaxed text-terminal-dim;
+  }
+
+  .ui-meta-strong {
+    @apply font-sans text-xs font-medium leading-relaxed text-terminal-text;
+  }
+
+  .ui-pill {
+    @apply inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-sans leading-5;
+  }
+
+  .ui-pill-compact {
+    @apply inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-sans leading-4;
+  }
+
+  .ui-code-meta {
+    @apply font-mono text-xs tabular-nums text-terminal-dim;
+  }
+}
+
 /* Respect reduced-motion preference */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## Summary
- Add shared viewer typography primitives for UI chrome, captions, pills, and technical metadata.
- Move dense dashboard, replay, insights, summary, and export labels away from tiny monospace uppercase styling.
- Preserve monospace treatment for code-like content such as paths, slugs, models, commands, source text, and numeric metadata.

## Test plan
- [x] pnpm lint:check
- [x] pnpm build


Made with [Cursor](https://cursor.com)