### PR TITLE
docs: add Pi to How It Works ASCII diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 ```
 AI session files  →  vibe-replay  →  self-contained HTML
 (Claude Code,        (discover,       (animated viewer,
- Cursor, Codex)       parse,           insights panel,
+ Cursor, Codex, Pi)   parse,           insights panel,
                       redact,          offline-ready,
                       transform)       shareable)
 ```


### PR DESCRIPTION
## Summary

Adds **Pi** to the "How It Works" ASCII diagram, the last remaining spot in the README that still listed only `(Claude Code, Cursor, Codex)`.

Pi shipped full provider support in #318 and is already listed in:
- the intro tagline
- the dashboard prose ("see every Claude Code, Cursor, Codex, and Pi session")
- the Features bullet
- the Supported Providers table

This brings the diagram in line so the provider list is consistent throughout the README.

## Context

This supersedes the now-closed #341 — that branch had gone stale and would have regressed newer `main` copy. This is the one genuinely net-new line from it, applied cleanly off the latest `main`.

## Files touched

- `README.md` (+1 / -1) — alignment preserved (`parse`/`redact`/`transform` still align at the same column).
