### PR TITLE
chore(tests): drop as any casts in server-sources-enrichment test

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -702,7 +702,7 @@ function enrichmentPriorityScore(
 
 function prioritizeScanInputs(
   inputs: ScanInput[],
-  previousResults: SessionScanResult[],
+  previousResults: Array<Pick<SessionScanResult, "sessionId">>,
   hints: EnrichmentHints = {},
 ): ScanInput[] {
   const previousSessionIds = new Set(previousResults.map((result) => result.sessionId));

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -453,7 +453,7 @@ describe("sources enrichment helpers", () => {
 
     const ordered = __testables.prioritizeScanInputs(
       inputs,
-      [{ sessionId: "already-new" }, { sessionId: "hinted-mid" }] as any[],
+      [{ sessionId: "already-new" }, { sessionId: "hinted-mid" }],
       { slugs: ["mid"] },
     );
 
@@ -515,9 +515,12 @@ describe("sources enrichment helpers", () => {
       },
       {
         role: "assistant",
-        blocks: [{ type: "tool_use" }, { type: "tool_use" }],
+        blocks: [
+          { type: "tool_use" as const, id: "t1", name: "bash", input: {} },
+          { type: "tool_use" as const, id: "t2", name: "bash", input: {} },
+        ],
       },
-    ] as any);
+    ]);
 
     expect(counts).toEqual({ promptCount: 1, toolCallCount: 2 });
   });


### PR DESCRIPTION
## Summary

- Narrow `prioritizeScanInputs` parameter type from `SessionScanResult[]` to `Array<Pick<SessionScanResult, "sessionId">>` — the function only reads `.sessionId` from the array, so the over-broad type was forcing a cast at the test call site (+1 / -1 in server.ts)
- Provide complete `tool_use` block literals (`id`, `name`, `input`) in `countSessionStats` test so the array satisfies `ParsedTurn[]` without a cast (+4 / -2 in test)
- Net: 2 `as any` / `as any[]` casts removed from `server-sources-enrichment.test.ts`

## Motivation

Both casts existed only to paper over structural mismatches that are fixable without changing runtime behavior. Narrowing the parameter type is strictly a widening of what the function accepts (all existing `SessionScanResult[]` callers still type-check). Adding `id`/`name`/`input` to the test blocks makes the intent explicit.

## Test plan

- [x] `pnpm --filter vibe-replay test` — 340 passed, 1 skipped
- [x] `pnpm lint:check` — 0 warnings / 0 errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — 0 errors
- [x] `pnpm build` — successful (viewer 855 kB, unchanged baseline)
- [x] E2E: not run (type-level change, no runtime behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.