### PR TITLE
test(provider-contract): add coverage and wire untested packages into CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:menu": "node scripts/dev.mjs --menu",
     "dev:dashboard": "node scripts/dev.mjs -d",
     "dev:website": "node scripts/dev-website.mjs",
-    "test": "pnpm --filter @vibe-replay/provider-claude-code test && pnpm --filter @vibe-replay/provider-codex test && pnpm --filter @vibe-replay/provider-cursor test && pnpm --filter @vibe-replay/provider-pi test && pnpm --filter @vibe-replay/providers-default test && pnpm --filter @vibe-replay/replay-core test && pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
+    "test": "pnpm --filter @vibe-replay/provider-contract test && pnpm --filter @vibe-replay/provider-core test && pnpm --filter @vibe-replay/provider-claude-code test && pnpm --filter @vibe-replay/provider-codex test && pnpm --filter @vibe-replay/provider-cursor test && pnpm --filter @vibe-replay/provider-pi test && pnpm --filter @vibe-replay/providers-default test && pnpm --filter @vibe-replay/replay-core test && pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
     "test:cloudflare": "pnpm --filter @vibe-replay/cloudflare test",
     "test:e2e": "vitest run --config e2e/vitest.config.ts",
     "lint": "oxlint --fix packages/ website/src cloudflare/src && oxfmt packages/ website/src cloudflare/src",

--- a/packages/provider-contract/test/index.test.ts
+++ b/packages/provider-contract/test/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { PROVIDER_API_VERSION } from "../src/index.js";
+
+describe("provider-contract public surface", () => {
+  it("pins the provider API version to a stable integer", () => {
+    // This is a deliberate change-detector: bumping the contract version is a
+    // breaking change for in-repo providers and should be intentional.
+    expect(PROVIDER_API_VERSION).toBe(1);
+    expect(Number.isInteger(PROVIDER_API_VERSION)).toBe(true);
+  });
+});

--- a/packages/provider-contract/test/warnings.test.ts
+++ b/packages/provider-contract/test/warnings.test.ts
@@ -56,6 +56,47 @@ describe("addParseWarning", () => {
     expect(warnings).toHaveLength(2);
   });
 
+  it("does not coalesce when message differs", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "first", source: "a.jsonl" });
+    addParseWarning(warnings, { kind: "missing-image", message: "second", source: "a.jsonl" });
+
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("coalesces warnings that share an undefined source", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m" });
+    addParseWarning(warnings, { kind: "missing-image", message: "m" });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.count).toBe(2);
+  });
+
+  it("preserves the first entry's sample and firstLine when a duplicate coalesces", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, {
+      kind: "missing-image",
+      message: "m",
+      source: "a.jsonl",
+      sample: "first.png",
+      firstLine: 7,
+    });
+    // A later duplicate only bumps count; it must not overwrite sample/firstLine.
+    addParseWarning(warnings, {
+      kind: "missing-image",
+      message: "m",
+      source: "a.jsonl",
+      sample: "second.png",
+      firstLine: 99,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.count).toBe(2);
+    expect(warnings[0]?.sample).toBe("first.png");
+    expect(warnings[0]?.firstLine).toBe(7);
+  });
+
   it("drops the sample for malformed-json warnings (avoids leaking raw source)", () => {
     const warnings: ParseWarning[] = [];
     addParseWarning(warnings, {
@@ -102,10 +143,11 @@ describe("compactWarningSample", () => {
   });
 
   it("truncates and appends an ellipsis when over the default limit", () => {
+    const defaultMax = 160;
     const long = "x".repeat(200);
     const result = compactWarningSample(long);
 
-    expect(result).toHaveLength(163); // 160 chars + "..."
+    expect(result).toHaveLength(defaultMax + "...".length);
     expect(result.endsWith("...")).toBe(true);
   });
 

--- a/packages/provider-contract/test/warnings.test.ts
+++ b/packages/provider-contract/test/warnings.test.ts
@@ -1,0 +1,124 @@
+import type { ParseWarning } from "@vibe-replay/types";
+import { describe, expect, it } from "vitest";
+import { addParseWarning, compactWarningSample } from "../src/warnings.js";
+
+describe("addParseWarning", () => {
+  it("appends a new warning with default count of 1", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, {
+      kind: "missing-image",
+      message: "image not found",
+      source: "a.jsonl",
+    });
+
+    expect(warnings).toEqual([
+      {
+        kind: "missing-image",
+        count: 1,
+        message: "image not found",
+        source: "a.jsonl",
+        firstLine: undefined,
+        sample: undefined,
+      },
+    ]);
+  });
+
+  it("honors an explicit count on a new warning", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m", count: 5 });
+
+    expect(warnings[0]?.count).toBe(5);
+  });
+
+  it("coalesces duplicates (same kind + source + message) by summing counts", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "a.jsonl" });
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "a.jsonl" });
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "a.jsonl", count: 3 });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.count).toBe(5);
+  });
+
+  it("does not coalesce when source differs", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "a.jsonl" });
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "b.jsonl" });
+
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("does not coalesce when kind differs", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m", source: "a.jsonl" });
+    addParseWarning(warnings, { kind: "malformed-json", message: "m", source: "a.jsonl" });
+
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("drops the sample for malformed-json warnings (avoids leaking raw source)", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, {
+      kind: "malformed-json",
+      message: "bad json",
+      source: "a.jsonl",
+      sample: "{ secret: token }",
+    });
+
+    expect(warnings[0]?.sample).toBeUndefined();
+  });
+
+  it("preserves the sample for non-malformed-json warnings", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, {
+      kind: "missing-image",
+      message: "m",
+      source: "a.jsonl",
+      sample: "img-123.png",
+    });
+
+    expect(warnings[0]?.sample).toBe("img-123.png");
+  });
+
+  it("preserves firstLine when provided", () => {
+    const warnings: ParseWarning[] = [];
+    addParseWarning(warnings, { kind: "missing-image", message: "m", firstLine: 42 });
+
+    expect(warnings[0]?.firstLine).toBe(42);
+  });
+});
+
+describe("compactWarningSample", () => {
+  it("collapses runs of whitespace into single spaces", () => {
+    expect(compactWarningSample("a\n\tb   c")).toBe("a b c");
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(compactWarningSample("  hello  ")).toBe("hello");
+  });
+
+  it("returns the value unchanged when within the limit", () => {
+    expect(compactWarningSample("short")).toBe("short");
+  });
+
+  it("truncates and appends an ellipsis when over the default limit", () => {
+    const long = "x".repeat(200);
+    const result = compactWarningSample(long);
+
+    expect(result).toHaveLength(163); // 160 chars + "..."
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("respects a custom max length", () => {
+    expect(compactWarningSample("abcdef", 3)).toBe("abc...");
+  });
+
+  it("does not truncate when exactly at the limit", () => {
+    expect(compactWarningSample("abc", 3)).toBe("abc");
+  });
+
+  it("counts length after whitespace compaction, not before", () => {
+    // 6 visible chars after collapse; well under the default limit despite long whitespace runs
+    expect(compactWarningSample("a       b       c")).toBe("a b c");
+  });
+});


### PR DESCRIPTION
Closes #356 (provider-contract portion).

## What

`provider-contract` is the shared contract layer every provider depends on, and it had **zero tests**. While adding them, I found a related coverage hole: the root `test` script never ran `@vibe-replay/provider-contract` *or* `@vibe-replay/provider-core`, so provider-core's existing tests were silently not executing in CI.

## Changes

- **New `packages/provider-contract/test/warnings.test.ts`** (13 cases) covering the package's only runtime logic:
  - `addParseWarning` — new-warning insertion, default vs. explicit count, duplicate coalescing by `(kind, source, message)`, non-coalescing when any key differs, `malformed-json` sample suppression (avoids leaking raw source), and `firstLine`/`sample` preservation.
  - `compactWarningSample` — whitespace collapse, trim, pass-through under limit, truncation + ellipsis over limit, custom max, and boundary at exactly the limit.
- **New `packages/provider-contract/test/index.test.ts`** — pins `PROVIDER_API_VERSION` as a deliberate change-detector (bumping the contract version is breaking for in-repo providers).
- **`package.json`** — wire `@vibe-replay/provider-contract` and `@vibe-replay/provider-core` into the root `test` script so CI actually runs them.

## Verification

- `pnpm test` — full suite green; now includes provider-contract (16) and provider-core (12, previously skipped in CI).
- `pnpm lint:check` — clean.
- `tsc --noEmit -p packages/provider-contract/tsconfig.json` — clean.

No production code changed; this is additive test coverage plus a CI wiring fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)