### PR TITLE
refactor(cli): extract scoring weights to constants & share preference helper

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -37,8 +37,6 @@ export const ENRICHMENT_SCORE_WEIGHTS = {
  * a user-requested session is scanned ahead of generic recent ones.
  */
 export const SCAN_INPUT_SCORE_WEIGHTS = {
-  /** Input has not been scanned in a previous pass. */
-  notPreviouslyScanned: 1000,
   /** Input was explicitly requested by id. */
   preferredSessionId: 2000,
   /** Input matches a preferred slug. */
@@ -47,4 +45,7 @@ export const SCAN_INPUT_SCORE_WEIGHTS = {
   preferredProject: 400,
   /** Last activity within RECENT_SESSION_WINDOW_MS. */
   recent: 100,
+  /** Input has not been scanned in a previous pass. Applied directly by
+   * scanInputPriorityScore, not via the shared preferenceScore helper. */
+  notPreviouslyScanned: 1000,
 } as const;

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared numeric constants for the CLI.
+ *
+ * Centralizes "magic numbers" that previously lived inline across modules so
+ * they are named, documented, and tunable in one place.
+ */
+
+/**
+ * A session/scan input is considered "recent" (and gets a freshness boost in
+ * priority scoring) if its last activity is within this window of now.
+ */
+export const RECENT_SESSION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Weights for ranking which already-discovered Cursor sessions to enrich first.
+ * Higher = enriched sooner. Applied in `enrichmentPriorityScore`.
+ */
+export const ENRICHMENT_SCORE_WEIGHTS = {
+  /** Session was explicitly requested by id (e.g. the one the user is viewing). */
+  preferredSessionId: 1000,
+  /** Session matches a preferred slug. */
+  preferredSlug: 800,
+  /** Session belongs to a preferred project. */
+  preferredProject: 400,
+  /** Last activity within RECENT_SESSION_WINDOW_MS. */
+  recent: 100,
+  /** Session has an associated PR link. */
+  hasPR: 25,
+  /** Session has a Cursor SQLite source available. */
+  hasSqlite: 10,
+} as const;
+
+/**
+ * Weights for ordering scan inputs before a (potentially truncated) scan pass.
+ * Distinct from ENRICHMENT_SCORE_WEIGHTS by design: this scheme prioritizes
+ * not-yet-scanned inputs and weights explicit preferences far more heavily so
+ * a user-requested session is scanned ahead of generic recent ones.
+ */
+export const SCAN_INPUT_SCORE_WEIGHTS = {
+  /** Input has not been scanned in a previous pass. */
+  notPreviouslyScanned: 1000,
+  /** Input was explicitly requested by id. */
+  preferredSessionId: 2000,
+  /** Input matches a preferred slug. */
+  preferredSlug: 1600,
+  /** Input belongs to a preferred project. */
+  preferredProject: 400,
+  /** Last activity within RECENT_SESSION_WINDOW_MS. */
+  recent: 100,
+} as const;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -21,6 +21,11 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
 import { readGitRepo } from "@vibe-replay/provider-core/utils";
 import { readFileCache, writeFileCache, type FileCacheEntry } from "./cache.js";
+import {
+  ENRICHMENT_SCORE_WEIGHTS,
+  RECENT_SESSION_WINDOW_MS,
+  SCAN_INPUT_SCORE_WEIGHTS,
+} from "./constants.js";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
 import { computeDaysUntilCleanup, getClaudeCodeCleanupPeriod } from "./cleanup-warning.js";
 import {
@@ -682,21 +687,48 @@ function selectCursorEnrichmentCandidates(
     .slice(0, limit);
 }
 
+/** True when `timestamp` parses and is within RECENT_SESSION_WINDOW_MS of now. */
+function isRecentActivity(timestamp: string | undefined): boolean {
+  if (!timestamp) return false;
+  return Date.now() - Date.parse(timestamp) <= RECENT_SESSION_WINDOW_MS;
+}
+
+/**
+ * Score the preference/recency signals shared by both priority schemes.
+ * Scheme-specific signals (hasPR, not-previously-scanned, etc.) are added by
+ * the caller using its own weights.
+ */
+function preferenceScore(
+  entity: { sessionId: string; slug: string; project: string; timestamp?: string },
+  preferred: { sessionIds: Set<string>; slugs: Set<string>; projects: Set<string> },
+  weights: {
+    preferredSessionId: number;
+    preferredSlug: number;
+    preferredProject: number;
+    recent: number;
+  },
+): number {
+  let score = 0;
+  if (preferred.sessionIds.has(entity.sessionId)) score += weights.preferredSessionId;
+  if (preferred.slugs.has(entity.slug)) score += weights.preferredSlug;
+  if (preferred.projects.has(entity.project)) score += weights.preferredProject;
+  if (isRecentActivity(entity.timestamp)) score += weights.recent;
+  return score;
+}
+
 function enrichmentPriorityScore(
   session: SessionInfo,
   preferredSessionIds: Set<string>,
   preferredSlugs: Set<string>,
   preferredProjects: Set<string>,
 ): number {
-  let score = 0;
-  if (preferredSessionIds.has(session.sessionId)) score += 1000;
-  if (preferredSlugs.has(session.slug)) score += 800;
-  if (preferredProjects.has(session.project)) score += 400;
-  if (session.timestamp && Date.now() - Date.parse(session.timestamp) <= 24 * 60 * 60 * 1000) {
-    score += 100;
-  }
-  if (session.hasPR) score += 25;
-  if (session.hasSqlite) score += 10;
+  let score = preferenceScore(
+    session,
+    { sessionIds: preferredSessionIds, slugs: preferredSlugs, projects: preferredProjects },
+    ENRICHMENT_SCORE_WEIGHTS,
+  );
+  if (session.hasPR) score += ENRICHMENT_SCORE_WEIGHTS.hasPR;
+  if (session.hasSqlite) score += ENRICHMENT_SCORE_WEIGHTS.hasSqlite;
   return score;
 }
 
@@ -737,14 +769,13 @@ function scanInputPriorityScore(
   preferredSlugs: Set<string>,
   preferredProjects: Set<string>,
 ): number {
-  let score = 0;
-  if (!previousSessionIds.has(input.sessionId)) score += 1000;
-  if (preferredSessionIds.has(input.sessionId)) score += 2000;
-  if (preferredSlugs.has(input.slug)) score += 1600;
-  if (preferredProjects.has(input.project)) score += 400;
-  if (input.timestamp && Date.now() - Date.parse(input.timestamp) <= 24 * 60 * 60 * 1000) {
-    score += 100;
-  }
+  let score = preferenceScore(
+    input,
+    { sessionIds: preferredSessionIds, slugs: preferredSlugs, projects: preferredProjects },
+    SCAN_INPUT_SCORE_WEIGHTS,
+  );
+  if (!previousSessionIds.has(input.sessionId))
+    score += SCAN_INPUT_SCORE_WEIGHTS.notPreviouslyScanned;
   return score;
 }
 


### PR DESCRIPTION
Closes #360.

## What

`server.ts` had two priority-scoring functions (`enrichmentPriorityScore`, `scanInputPriorityScore`) with inline magic-number weight tables and a duplicated `24 * 60 * 60 * 1000` recency check.

## Changes

- **New `packages/cli/src/constants.ts`** — named, documented constants:
  - `RECENT_SESSION_WINDOW_MS` (the `24h` window, previously inline in two places)
  - `ENRICHMENT_SCORE_WEIGHTS` and `SCAN_INPUT_SCORE_WEIGHTS` (the two weight tables, now self-documenting)
- **Shared helpers in `server.ts`**:
  - `isRecentActivity(timestamp)` — replaces the duplicated `Date.now() - Date.parse(...)` check
  - `preferenceScore(entity, preferred, weights)` — the preferred-id/slug/project + recency signals both schemes share, parameterized by weights
- Both scoring functions now compose `preferenceScore` and add their **distinct** signals (`hasPR`/`hasSqlite` for enrichment; `notPreviouslyScanned` for scan ordering).

## Design note

The two schemes intentionally keep **different weight tables** — scan ordering weights an explicitly-requested session (`2000`) far above generic recency, while enrichment uses a flatter scale. Rather than flatten them into one obscuring "parameterized mega-function", this unifies only the genuinely shared structure and keeps the differences explicit and named. Local retry/delay numbers in `server.ts` (e.g. `CURSOR_DB_WATCH_RETRY_MS = 15_000`) were already named constants and left as-is.

## Verification

- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped (incl. `server-sources-enrichment.test.ts`, which exercises scoring order).
- `tsc --noEmit -p packages/cli/tsconfig.json` — clean.
- `pnpm lint:check` — clean.

Pure refactor; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)