### PR TITLE
chore(tests): import enrichment helpers directly from server-enrichment module

### DIFF
--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -5,6 +5,12 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { ScanInput } from "../src/scanner.js";
 import type { SourceSummaryRecord } from "../src/server.js";
 import { __testables } from "../src/server.js";
+import {
+  pickSourceRecordForSession,
+  prioritizeScanInputs,
+  selectCursorEnrichmentCandidates,
+  sourceSessionKey,
+} from "../src/server-enrichment.js";
 import type { SessionInfo } from "../src/types.js";
 
 const originalPiSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
@@ -324,7 +330,7 @@ describe("sources enrichment helpers", () => {
       },
     ];
 
-    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources);
+    const candidates = selectCursorEnrichmentCandidates(merged, baseSources);
     expect(candidates).toHaveLength(0);
   });
 
@@ -382,7 +388,7 @@ describe("sources enrichment helpers", () => {
       },
     ];
 
-    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources, 2);
+    const candidates = selectCursorEnrichmentCandidates(merged, baseSources, 2);
     expect(candidates.map((s) => s.sessionId)).toEqual(["cursor-new", "cursor-old"]);
   });
 
@@ -416,7 +422,7 @@ describe("sources enrichment helpers", () => {
       toolCallCount: undefined,
     }));
 
-    const candidates = __testables.selectCursorEnrichmentCandidates(merged, baseSources, {
+    const candidates = selectCursorEnrichmentCandidates(merged, baseSources, {
       slugs: ["visible0"],
       limit: 2,
     });
@@ -451,7 +457,7 @@ describe("sources enrichment helpers", () => {
       },
     ];
 
-    const ordered = __testables.prioritizeScanInputs(
+    const ordered = prioritizeScanInputs(
       inputs,
       [{ sessionId: "already-new" }, { sessionId: "hinted-mid" }],
       { slugs: ["mid"] },
@@ -483,7 +489,7 @@ describe("sources enrichment helpers", () => {
     ]);
     const byKey = new Map<string, SourceSummaryRecord>([
       [
-        __testables.sourceSessionKey("cursor", "~/project-a", "aaaaaaaa"),
+        sourceSessionKey("cursor", "~/project-a", "aaaaaaaa"),
         {
           provider: "cursor",
           sessionId: "cursor-real",
@@ -497,7 +503,7 @@ describe("sources enrichment helpers", () => {
       ],
     ]);
 
-    const picked = __testables.pickSourceRecordForSession(current, bySessionId, byKey);
+    const picked = pickSourceRecordForSession(current, bySessionId, byKey);
     expect(picked?.provider).toBe("cursor");
     expect(picked?.promptCount).toBe(5);
   });


### PR DESCRIPTION
## Summary

- Import `selectCursorEnrichmentCandidates`, `prioritizeScanInputs`, `sourceSessionKey`, and `pickSourceRecordForSession` directly from `server-enrichment.ts` instead of using the `__testables` indirection in `server.ts`
- Net change: +6 import lines, -6 `__testables.X` call sites

## Motivation

PR #365 extracted these four functions from `server.ts` into `server-enrichment.ts` as proper public exports. Tests that exercise them via `__testables` can now import them directly from the module that owns them — a cleaner coupling with no behavior change (same function references at runtime).

## Test plan

- [x] `pnpm test` (CLI) 全绿 — 340 passed, 1 skipped
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871 kB)
- [x] E2E: 未跑 — test-only change, 语义等价已由 tsc 和 unit tests 证明

> 🤖 Daily auto-quality routine. Self-merged after AI review.