### PR TITLE
refactor(cli): validate JSON.parse results instead of any in feedback.ts

### DIFF
--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -473,6 +473,37 @@ function runAgent(prompt: string, cmd: string): Promise<string> {
 // Parsing & validation
 // ---------------------------------------------------------------------------
 
+/** Parse JSON and return it only if it is a non-null object, else null. */
+function parseJsonObject(json: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+}
+
+/** Narrow an unknown value to a plain object record, or null. */
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+/** Keep only the string members of an unknown value (non-arrays yield []). */
+function stringsOnly(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+/**
+ * Return `value` typed as `T` when it is a string present in `allowed`, else
+ * undefined. The cast is justified by the runtime membership check.
+ */
+function asOneOf<T extends string>(value: unknown, allowed: ReadonlySet<T>): T | undefined {
+  return typeof value === "string" && (allowed as ReadonlySet<string>).has(value)
+    ? (value as T)
+    : undefined;
+}
+
 export function parseFeedbackResponse(
   output: string,
   session: ReplaySession,
@@ -480,27 +511,20 @@ export function parseFeedbackResponse(
   const json = extractJson(output);
   if (!json) return null;
 
-  let parsed: any;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return null;
-  }
+  const parsed = parseJsonObject(json);
+  if (!parsed) return null;
 
   // Validate top-level shape
-  if (!parsed || typeof parsed !== "object") return null;
   if (typeof parsed.summary !== "string" || !parsed.summary) return null;
   if (typeof parsed.score !== "number") return null;
-  parsed.score = Math.max(1, Math.min(10, Math.round(parsed.score)));
-  if (!Array.isArray(parsed.strengths)) parsed.strengths = [];
-  if (!Array.isArray(parsed.improvements)) parsed.improvements = [];
-  if (!Array.isArray(parsed.feedbackItems)) parsed.feedbackItems = [];
+  const summary = parsed.summary;
+  const score = Math.max(1, Math.min(10, Math.round(parsed.score)));
 
   // Valid user-prompt scene indices
   const validIndices = new Set(
     session.scenes.map((s, i) => (s.type === "user-prompt" ? i : -1)).filter((i) => i !== -1),
   );
-  const validCategories = new Set([
+  const validCategories = new Set<FeedbackItem["category"]>([
     "clarity",
     "specificity",
     "context",
@@ -509,9 +533,11 @@ export function parseFeedbackResponse(
     "tool-usage",
   ]);
 
+  const feedbackItemsRaw = Array.isArray(parsed.feedbackItems) ? parsed.feedbackItems : [];
   const items: FeedbackItem[] = [];
-  for (const raw of parsed.feedbackItems) {
-    if (!raw || typeof raw !== "object") continue;
+  for (const rawItem of feedbackItemsRaw) {
+    const raw = asRecord(rawItem);
+    if (!raw) continue;
     if (typeof raw.sceneIndex !== "number") continue;
     if (!validIndices.has(raw.sceneIndex)) continue;
     if (typeof raw.title !== "string" || !raw.title) continue;
@@ -521,7 +547,7 @@ export function parseFeedbackResponse(
       sceneIndex: raw.sceneIndex,
       title: raw.title,
       feedback: raw.feedback,
-      category: validCategories.has(raw.category) ? raw.category : "clarity",
+      category: asOneOf(raw.category, validCategories) ?? "clarity",
       improvedPrompt:
         typeof raw.improvedPrompt === "string" && raw.improvedPrompt
           ? raw.improvedPrompt
@@ -530,62 +556,63 @@ export function parseFeedbackResponse(
   }
 
   // Parse new session-level fields (optional — graceful degradation for weaker models)
-  const validOutcomes = new Set([
+  const validOutcomes = new Set<NonNullable<FeedbackResult["outcome"]>>([
     "fully_achieved",
     "mostly_achieved",
     "partially_achieved",
     "not_achieved",
     "unclear",
   ]);
-  const validFrictionTypes = new Set([
+  const validFrictionTypes = new Set<FrictionPoint["type"]>([
     "misunderstood",
     "wrong_approach",
     "buggy_code",
     "excessive_changes",
     "user_unclear",
   ]);
-  const validAiRatings = new Set(["poor", "below_average", "average", "good", "excellent"]);
+  const validAiRatings = new Set<NonNullable<FeedbackResult["aiPerformance"]>["rating"]>([
+    "poor",
+    "below_average",
+    "average",
+    "good",
+    "excellent",
+  ]);
 
-  const outcome = validOutcomes.has(parsed.outcome) ? parsed.outcome : undefined;
+  const outcome = asOneOf(parsed.outcome, validOutcomes);
   const sessionGoal =
     typeof parsed.sessionGoal === "string" && parsed.sessionGoal ? parsed.sessionGoal : undefined;
 
   let frictionPoints: FrictionPoint[] | undefined;
   if (Array.isArray(parsed.frictionPoints) && parsed.frictionPoints.length > 0) {
-    const filtered: FrictionPoint[] = parsed.frictionPoints
-      .filter(
-        (f: any) =>
-          f &&
-          typeof f === "object" &&
-          validFrictionTypes.has(f.type) &&
-          typeof f.description === "string" &&
-          typeof f.turn === "number",
-      )
-      .map((f: any) => ({ type: f.type, description: f.description, turn: f.turn }));
+    const filtered: FrictionPoint[] = [];
+    for (const rawPoint of parsed.frictionPoints) {
+      const f = asRecord(rawPoint);
+      if (!f) continue;
+      const type = asOneOf(f.type, validFrictionTypes);
+      if (!type || typeof f.description !== "string" || typeof f.turn !== "number") continue;
+      filtered.push({ type, description: f.description, turn: f.turn });
+    }
     frictionPoints = filtered.length > 0 ? filtered : undefined;
   }
 
   let aiPerformance: FeedbackResult["aiPerformance"];
-  if (parsed.aiPerformance && typeof parsed.aiPerformance === "object") {
-    const ap = parsed.aiPerformance;
-    if (validAiRatings.has(ap.rating)) {
+  const ap = asRecord(parsed.aiPerformance);
+  if (ap) {
+    const rating = asOneOf(ap.rating, validAiRatings);
+    if (rating) {
       aiPerformance = {
-        rating: ap.rating,
-        strengths: Array.isArray(ap.strengths)
-          ? ap.strengths.filter((s: any) => typeof s === "string")
-          : [],
-        weaknesses: Array.isArray(ap.weaknesses)
-          ? ap.weaknesses.filter((s: any) => typeof s === "string")
-          : [],
+        rating,
+        strengths: stringsOnly(ap.strengths),
+        weaknesses: stringsOnly(ap.weaknesses),
       };
     }
   }
 
   return {
-    summary: parsed.summary,
-    score: parsed.score,
-    strengths: parsed.strengths.filter((s: any) => typeof s === "string"),
-    improvements: parsed.improvements.filter((s: any) => typeof s === "string"),
+    summary,
+    score,
+    strengths: stringsOnly(parsed.strengths),
+    improvements: stringsOnly(parsed.improvements),
     feedbackItems: items,
     outcome,
     sessionGoal,
@@ -987,28 +1014,24 @@ function parseTranslationBatch(
   const json = extractJson(output);
   if (!json) return null;
 
-  let parsed: any;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return null;
-  }
-
+  const parsed = parseJsonObject(json);
   if (!parsed || !Array.isArray(parsed.translations)) return null;
 
   const validIndices = new Set(batchScenes.map((s) => s.index));
   const overlays: SceneOverlay[] = [];
   let skipped = 0;
 
-  for (const item of parsed.translations) {
+  for (const rawItem of parsed.translations) {
+    const item = asRecord(rawItem);
     if (!item || typeof item.sceneIndex !== "number") continue;
     if (!validIndices.has(item.sceneIndex)) continue;
     if (typeof item.translated !== "string") continue;
+    const translated = item.translated;
 
     const scene = batchScenes.find((s) => s.index === item.sceneIndex);
     if (!scene) continue;
 
-    if (item.unchanged || item.translated.trim() === scene.content.trim()) {
+    if (item.unchanged || translated.trim() === scene.content.trim()) {
       skipped++;
       continue;
     }
@@ -1023,7 +1046,7 @@ function parseTranslationBatch(
       sceneIndex: item.sceneIndex,
       field: "content",
       originalValue: scene.content,
-      modifiedValue: item.translated,
+      modifiedValue: translated,
       source,
       createdAt: now,
       updatedAt: now,
@@ -1180,28 +1203,24 @@ function parseToneBatch(
   const json = extractJson(output);
   if (!json) return null;
 
-  let parsed: any;
-  try {
-    parsed = JSON.parse(json);
-  } catch {
-    return null;
-  }
-
+  const parsed = parseJsonObject(json);
   if (!parsed || !Array.isArray(parsed.adjustments)) return null;
 
   const validIndices = new Set(batchScenes.map((s) => s.index));
   const overlays: SceneOverlay[] = [];
   let skipped = 0;
 
-  for (const item of parsed.adjustments) {
+  for (const rawItem of parsed.adjustments) {
+    const item = asRecord(rawItem);
     if (!item || typeof item.sceneIndex !== "number") continue;
     if (!validIndices.has(item.sceneIndex)) continue;
     if (typeof item.adjusted !== "string") continue;
+    const adjusted = item.adjusted;
 
     const scene = batchScenes.find((s) => s.index === item.sceneIndex);
     if (!scene) continue;
 
-    if (item.unchanged || item.adjusted.trim() === scene.content.trim()) {
+    if (item.unchanged || adjusted.trim() === scene.content.trim()) {
       skipped++;
       continue;
     }
@@ -1216,7 +1235,7 @@ function parseToneBatch(
       sceneIndex: item.sceneIndex,
       field: "content",
       originalValue: scene.content,
-      modifiedValue: item.adjusted,
+      modifiedValue: adjusted,
       source,
       createdAt: now,
       updatedAt: now,

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -473,7 +473,7 @@ function runAgent(prompt: string, cmd: string): Promise<string> {
 // Parsing & validation
 // ---------------------------------------------------------------------------
 
-/** Parse JSON and return it only if it is a non-null object, else null. */
+/** Parse JSON and return it only if it is a non-null, non-array object, else null. */
 function parseJsonObject(json: string): Record<string, unknown> | null {
   let parsed: unknown;
   try {
@@ -481,12 +481,14 @@ function parseJsonObject(json: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
-  return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  return asRecord(parsed);
 }
 
-/** Narrow an unknown value to a plain object record, or null. */
+/** Narrow an unknown value to a plain (non-array) object record, or null. */
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 /** Keep only the string members of an unknown value (non-arrays yield []). */

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -276,6 +276,64 @@ interface ScanProgress {
   done: boolean;
 }
 
+/** Token-usage fields read from a JSONL message during scanning. */
+interface ScanLineUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+/** The `message` envelope read from a JSONL scan line. */
+interface ScanLineMessage {
+  role?: string;
+  content?: unknown;
+  id?: string;
+  model?: string;
+  usage?: ScanLineUsage;
+}
+
+/** PR-link payload, present either at the top level of a line or under `data`. */
+interface ScanLinePrLink {
+  prNumber?: number;
+  prUrl?: string;
+  prRepository?: string;
+}
+
+/**
+ * The subset of a JSONL line read during lightweight scanning. Every field is
+ * optional — lines are heterogeneous across providers and validated field by
+ * field. Replaces an untyped `JSON.parse(...)` result.
+ */
+interface ScanLine extends ScanLinePrLink {
+  gitBranch?: string;
+  entrypoint?: string;
+  permissionMode?: string;
+  timestamp?: string;
+  type?: string;
+  subtype?: string;
+  durationMs?: number;
+  customTitle?: string;
+  title?: string;
+  isApiErrorMessage?: boolean;
+  isMeta?: boolean;
+  snapshot?: { timestamp?: string };
+  data?: ScanLinePrLink;
+  message?: ScanLineMessage;
+}
+
+/** A content block read from a sub-agent JSONL message. */
+interface SubAgentBlock {
+  type?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+}
+
+/** The subset of a sub-agent JSONL line read during scanning. */
+interface SubAgentLine {
+  message?: { role?: string; content?: unknown };
+}
+
 /**
  * Scan a single session's JSONL files and extract aggregate metadata.
  * This is much lighter than the full parser — no scene building, no
@@ -355,7 +413,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     for (const line of content.split("\n")) {
       if (!line.trim()) continue;
 
-      let obj: any;
+      let obj: ScanLine;
       try {
         obj = JSON.parse(line);
       } catch {
@@ -364,7 +422,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
 
       // Extract metadata from top-level fields
       if (obj.gitBranch) {
-        const b = obj.gitBranch as string;
+        const b = obj.gitBranch;
         if (gitBranches.length === 0 || gitBranches[gitBranches.length - 1] !== b) {
           gitBranches.push(b);
         }
@@ -518,7 +576,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         }
         for (const saLine of saContent.split("\n")) {
           if (!saLine.trim()) continue;
-          let saObj: any;
+          let saObj: SubAgentLine;
           try {
             saObj = JSON.parse(saLine);
           } catch {
@@ -526,9 +584,9 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
           }
           const saMsg = saObj?.message;
           if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
-          for (const block of saMsg.content) {
+          for (const block of saMsg.content as SubAgentBlock[]) {
             if (block.type !== "tool_use") continue;
-            if (FILE_EDIT_TOOLS.has(block.name)) {
+            if (block.name && FILE_EDIT_TOOLS.has(block.name)) {
               const fp = extractToolFilePath(block.input);
               if (fp) {
                 editCount++;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -462,9 +462,12 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         } else if (Array.isArray(msgContent)) {
           // Check if it has text (not just tool_result)
           const hasText = msgContent.some(
-            (b: any) => (b.type === "text" && b.text?.trim()) || b.type === "_user_images",
+            (b: { type?: string; text?: string }) =>
+              (b.type === "text" && b.text?.trim()) || b.type === "_user_images",
           );
-          const isOnlyToolResult = msgContent.every((b: any) => b.type === "tool_result");
+          const isOnlyToolResult = msgContent.every(
+            (b: { type?: string }) => b.type === "tool_result",
+          );
           if (hasText && !isOnlyToolResult) promptCount++;
         }
       }
@@ -1435,8 +1438,8 @@ function extractMetaText(content: unknown): string {
   if (typeof content === "string") return content;
   if (Array.isArray(content)) {
     return content
-      .filter((b: any) => b.type === "text")
-      .map((b: any) => b.text || "")
+      .filter((b: { type?: string }) => b.type === "text")
+      .map((b: { text?: string }) => b.text || "")
       .join("\n");
   }
   return "";


### PR DESCRIPTION
Closes #359.

## What

The CLI used `let parsed: any` / `let obj: any` right after `JSON.parse` in feedback.ts and scanner.ts, then accessed fields unchecked (the `any` also papered over string-literal-union fields like `category`/`outcome`). This replaces all of them with validated narrowing / typed line interfaces. **Both files are now free of explicit `any`.**

## feedback.ts

- **New validation helpers:** `parseJsonObject` (`JSON.parse` + non-null/non-array object guard), `asRecord`, `stringsOnly`, and a generic `asOneOf<T extends string>` for literal-union fields (the casts are justified by runtime checks).
- **`parseFeedbackResponse`** builds `FeedbackResult` from validated locals instead of mutating a loosely typed object; union fields validated via `asOneOf` against `Set<FeedbackItem["category"]>` etc.
- **`parseTranslationBatch` / `parseToneBatch`** use the same `parseJsonObject` + `asRecord` pattern.

## scanner.ts

- Replaced the `obj: any` / `saObj: any` JSONL accessors in `scanSession` with typed `ScanLine` / `SubAgentLine` interfaces (all fields optional, validated field-by-field) — real field typing, no behavior change.
- Removed the easy `any` lambdas (`extractMetaText` + prompt-content block predicates) via minimal structural param types.

## Behavior preservation

Each validation path maps 1:1 to the original; `feedback.test.ts` and `scanner.test.ts` pass unchanged.

## Verification

- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped.
- `tsc --noEmit -p packages/cli/tsconfig.json` — clean.
- `pnpm lint:check` — clean.
- `grep ': any'` in feedback.ts and scanner.ts — **0 matches**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)