### PR TITLE
refactor(cli): establish error-handling convention, fix bare catch blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,10 @@ The viewer is built once, then the CLI embeds it. The final HTML output is the v
 - **Shared types** live in `packages/types` (`@vibe-replay/types`) — CLI and viewer re-export from there
 - **Secret redaction**: `transform.ts` strips API keys, tokens, PEM keys, paths. `scan.ts` does a second pass on the final output.
 - **`</` escaping**: JSON in `<script>` tags must escape `</` as `<\/` (see `generator.ts`)
+- **Error handling** — pick one of three, deliberately:
+  - **Propagate** when the caller can't proceed without the result (let it throw).
+  - **Log** when a step can be skipped but the failure is diagnostically useful — e.g. one provider failing during discovery shouldn't abort the others, but should be visible under `VIBE_REPLAY_DEBUG` (the dashboard stays quiet by default).
+  - **Silently swallow** only for genuinely-expected, recoverable cases (an optional file that may be absent, a best-effort cache write). Every such empty `catch` **must carry a one-line comment** explaining why it's safe to ignore — a bare `catch {}` is not allowed.
 
 ## Submitting changes
 

--- a/packages/cli/src/server-persistence.ts
+++ b/packages/cli/src/server-persistence.ts
@@ -10,7 +10,10 @@ export async function loadAnnotations(baseDir: string, slug: string): Promise<An
       const raw = await readFile(join(dir, "annotations.json"), "utf-8");
       const anns = JSON.parse(raw) as Annotation[];
       if (Array.isArray(anns)) return anns;
-    } catch {}
+    } catch {
+      // annotations.json is optional and may be absent or corrupt in this dir;
+      // fall through to the next candidate dir and default to [].
+    }
   }
   return [];
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -226,8 +226,9 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
           : undefined,
       });
     } catch {
-      // Skip any replay dir whose replay.json is missing or unreadable rather
-      // than failing the whole scan.
+      // Skip any replay dir that fails to load — missing/unreadable/corrupt
+      // replay.json, annotations, gist or cloud info, or git-repo lookup —
+      // rather than failing the whole scan.
     }
   }
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -225,7 +225,10 @@ async function scanSessionsFromDir(baseDir: string): Promise<ReplaySummary[]> {
             }
           : undefined,
       });
-    } catch {}
+    } catch {
+      // Skip any replay dir whose replay.json is missing or unreadable rather
+      // than failing the whole scan.
+    }
   }
 
   return results;
@@ -2327,7 +2330,14 @@ export async function startServer(
       try {
         const sessions = mergeSameSessions(await provider.discover());
         allSessions.push(...sessions);
-      } catch {}
+      } catch (err) {
+        // One provider failing to discover must not abort discovery for the
+        // rest. Surfaced only under VIBE_REPLAY_DEBUG so the dashboard stays
+        // quiet by default but partial failures remain diagnosable.
+        if (process.env.VIBE_REPLAY_DEBUG) {
+          console.error(`[vibe-replay] ${provider.name} discovery failed:`, err);
+        }
+      }
     }
 
     let entries: string[];


### PR DESCRIPTION
Closes #358.

## What

The CLI had no stated error-handling convention and three bare `catch {}` blocks that swallowed errors with no explanation.

## Changes

- **`server-persistence.ts` `loadAnnotations`** — `annotations.json` is optional; the empty catch now carries a comment (try next dir, default `[]`).
- **`server.ts` `scanSessionsFromDir`** — a malformed/unreadable `replay.json` for one entry is skipped; commented.
- **`server.ts` provider-discovery loop** — previously `catch {}` made a provider's discovery failure vanish entirely. Now the other providers still proceed (fault isolation preserved), but the failure is logged under `VIBE_REPLAY_DEBUG` so it's diagnosable without polluting the default dashboard UX.
- **`CONTRIBUTING.md`** — documents the three-way convention (propagate / log / silently-swallow) and the rule that every intentionally-empty `catch` must carry a reason comment.

## Verification

- No bare `catch {}` remain in `packages/cli/src` (grep clean).
- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped.
- `tsc --noEmit` + `pnpm lint:check` — clean.
- Default behavior unchanged (debug log is opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)