### PR TITLE
chore(lint): enable prefer-const + jsx-a11y rules, document disabled rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -37,7 +37,8 @@
     "react/no-array-index-key": "off",
     "jsx-a11y/alt-text": "error",
     // Warn (not error): pre-existing clickable elements lack keyboard handlers / roles.
-    // Surfaced for incremental fixing without failing CI; promote to error once cleared.
+    // Surfaced for incremental fixing without failing CI.
+    // TODO: fix the ~44 interaction-a11y warnings in the viewer, then promote both to "error".
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
     // Off: this is a CLI tool — console output is part of the primary UX.
@@ -52,7 +53,7 @@
     "unicorn/consistent-function-scoping": "off",
     // Off: stylistic — on*-handler vs addEventListener not enforced.
     "unicorn/prefer-add-event-listener": "off",
-    // Off: stylistic — Array.prototype.sort usage is fine.
+    // Off: the rule flags in-place .sort() mutation; mutating local arrays is acceptable here.
     "unicorn/no-array-sort": "off"
   },
   "ignorePatterns": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,14 +10,20 @@
     "eqeqeq": ["error", "smart"],
     "no-debugger": "error",
     "no-var": "error",
-    "prefer-const": "off",
+    "prefer-const": "error",
     "prefer-template": "warn",
+    // Off: false-positives on async wait-loops whose condition is mutated via refs/timers.
     "no-unmodified-loop-condition": "off",
+    // Off: stylistic — mixed type/value import style is intentionally not enforced.
     "@typescript-eslint/consistent-type-imports": "off",
+    // Off: triple-slash references are used intentionally for ambient .d.ts shims.
     "@typescript-eslint/triple-slash-reference": "off",
     "unicorn/prefer-node-protocol": "warn",
+    // Off: stylistic — .find vs .filter()[0] not worth enforcing.
     "unicorn/prefer-array-find": "off",
+    // Off: the map-then-spread pattern is used deliberately in a few places.
     "oxc/no-map-spread": "off",
+    // Off: superseded by the @typescript-eslint/no-unused-vars entry below (handles _ prefixes).
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "warn",
@@ -25,17 +31,28 @@
     ],
     "react-hooks/rules-of-hooks": "error",
     "react/jsx-key": "error",
+    // Off: React 17+ automatic JSX runtime — no in-scope React import required.
     "react/react-in-jsx-scope": "off",
+    // Off: array-index keys are acceptable for the static, non-reordered lists here.
     "react/no-array-index-key": "off",
-    "jsx-a11y/alt-text": "off",
-    "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/no-static-element-interactions": "off",
+    "jsx-a11y/alt-text": "error",
+    // Warn (not error): pre-existing clickable elements lack keyboard handlers / roles.
+    // Surfaced for incremental fixing without failing CI; promote to error once cleared.
+    "jsx-a11y/click-events-have-key-events": "warn",
+    "jsx-a11y/no-static-element-interactions": "warn",
+    // Off: this is a CLI tool — console output is part of the primary UX.
     "no-console": "off",
+    // Off: pragmatic for the heavy JSON/JSONL data-transformation code paths.
     "no-explicit-any": "off",
+    // Off: sequential awaits in loops are intentional (ordered I/O).
     "no-await-in-loop": "off",
+    // Off: stylistic — small-scope shadowing is allowed.
     "no-shadow": "off",
+    // Off: stylistic — local nested helpers are kept where they're used.
     "unicorn/consistent-function-scoping": "off",
+    // Off: stylistic — on*-handler vs addEventListener not enforced.
     "unicorn/prefer-add-event-listener": "off",
+    // Off: stylistic — Array.prototype.sort usage is fine.
     "unicorn/no-array-sort": "off"
   },
   "ignorePatterns": [


### PR DESCRIPTION
Closes #362.

## What

`.oxlintrc.json` had 19 disabled rules with no stated rationale, and accessibility was entirely unenforced.

## Changes

- **`prefer-const`: off → error** — 0 violations in the tree, so it's enforced with no fixes needed.
- **`jsx-a11y/alt-text`: off → error** — 0 violations.
- **`jsx-a11y/click-events-have-key-events` + `no-static-element-interactions`: off → warn** — these have 44 pre-existing violations (clickable elements lacking keyboard handlers / roles). Per the issue, they're enabled as **warnings first** so they're surfaced for incremental fixing without failing CI (oxlint exits 0 on warnings; verified `pnpm lint:check` passes). Promote to `error` once the backlog is cleared.
- **Rationale comments** added (JSONC) to every intentionally-disabled rule, so the config is self-documenting. oxlint parses the config as JSONC and `oxfmt` only formats `packages/`/`website/src`/`cloudflare/src` (not the root file), so the comments are safe.

## Triage of the 44 warnings

All are interaction-a11y on `<div>`/`<span>` click targets in the viewer (overlays, controls, cards). Fixing them properly means adding `role` + keyboard handlers per element and verifying UX — tracked as incremental follow-up rather than a blind 44-site change in this config PR.

## Verification

- `pnpm lint:check` — exit 0 (44 warnings, **0 errors**).
- Config validated as JSONC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)