### PR TITLE
refactor(cli): extract source-catalog cache cluster + shared server-types (#354 pass 2)

### DIFF
--- a/packages/cli/src/server-source-catalog.ts
+++ b/packages/cli/src/server-source-catalog.ts
@@ -100,6 +100,9 @@ export async function probeSourceRecordsFreshness(
 ): Promise<SourceProviderFreshnessProbe> {
   const probe: SourceProviderFreshnessProbe = {
     provider,
+    // This probe works from a flat list of source filePaths rather than a
+    // directory tree, so there is no real root to report — reuse the provider
+    // name as the label. (walkJsonlFreshness, by contrast, sets a real path.)
     sessionsRoot: provider,
     fileCount: 0,
   };

--- a/packages/cli/src/server-source-catalog.ts
+++ b/packages/cli/src/server-source-catalog.ts
@@ -1,0 +1,254 @@
+/**
+ * Source-session catalog cache helpers: building, normalizing, merging, and
+ * freshness-probing the dashboard's materialized cache of source-session
+ * summaries. Extracted from server.ts (no server state lives here).
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { FileCacheEntry } from "./cache.js";
+import { getPiSessionsDir } from "./providers/pi/config.js";
+import { sourceSessionKey } from "./server-enrichment.js";
+import type {
+  CachedSourceRecord,
+  NormalizedSourceSessionCatalogCache,
+  ProviderDiscoveryState,
+  SourceProviderFreshnessProbe,
+  SourceSessionCatalogCache,
+  SourceSummaryRecord,
+} from "./server-types.js";
+
+export function isSourceSessionCatalogCache(value: unknown): value is SourceSessionCatalogCache {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
+    typeof (value as { discoveredAt?: unknown }).discoveredAt === "string" &&
+    Array.isArray((value as { sessions?: unknown }).sessions)
+  );
+}
+
+export function normalizeSourceSessionCatalogCache(
+  cached: FileCacheEntry<SourceSessionCatalogCache | CachedSourceRecord[]> | null,
+): NormalizedSourceSessionCatalogCache | null {
+  if (!cached) return null;
+  if (Array.isArray(cached.data)) {
+    return {
+      sessions: cached.data,
+      cachedAt: cached.updatedAt,
+      discoveredAt: cached.updatedAt,
+      updatedAt: cached.updatedAt,
+      legacy: true,
+    };
+  }
+  if (isSourceSessionCatalogCache(cached.data)) {
+    return {
+      sessions: cached.data.sessions,
+      cachedAt: cached.updatedAt,
+      discoveredAt: cached.data.discoveredAt || cached.updatedAt,
+      updatedAt: cached.data.updatedAt || cached.updatedAt,
+      providerStates: cached.data.providerStates,
+      legacy: false,
+    };
+  }
+  return null;
+}
+
+export function buildProviderDiscoveryStates(
+  sources: SourceSummaryRecord[],
+  discoveredAt: string,
+): Record<string, ProviderDiscoveryState> {
+  const byProvider = new Map<string, SourceSummaryRecord[]>();
+  for (const source of sources) {
+    const bucket = byProvider.get(source.provider) || [];
+    bucket.push(source);
+    byProvider.set(source.provider, bucket);
+  }
+
+  const states: Record<string, ProviderDiscoveryState> = {};
+  for (const [provider, providerSources] of byProvider) {
+    states[provider] = {
+      provider,
+      discoveredAt,
+      sessionCount: providerSources.length,
+    };
+  }
+  return states;
+}
+
+export function buildSourceSessionCatalogCache(
+  sessions: SourceSummaryRecord[],
+  discoveredAt: string,
+  previous?: NormalizedSourceSessionCatalogCache | null,
+): SourceSessionCatalogCache {
+  const providerStates = {
+    ...previous?.providerStates,
+    ...buildProviderDiscoveryStates(sessions, discoveredAt),
+  };
+  return {
+    schemaVersion: 1,
+    discoveredAt,
+    updatedAt: discoveredAt,
+    providerStates,
+    sessions: sessions as CachedSourceRecord[],
+  };
+}
+
+export async function probeSourceRecordsFreshness(
+  sources: SourceSummaryRecord[],
+  provider: string,
+): Promise<SourceProviderFreshnessProbe> {
+  const probe: SourceProviderFreshnessProbe = {
+    provider,
+    sessionsRoot: provider,
+    fileCount: 0,
+  };
+
+  const paths = new Set(
+    sources
+      .filter((source) => source.provider === provider)
+      .flatMap((source) => source.filePaths || [])
+      .filter(
+        (filePath): filePath is string => typeof filePath === "string" && filePath.length > 0,
+      ),
+  );
+
+  for (const filePath of paths) {
+    const fileStat = await stat(filePath).catch(() => null);
+    if (!fileStat) continue;
+    probe.fileCount += 1;
+    if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
+      probe.newestSourceMtimeMs = fileStat.mtimeMs;
+      probe.newestSourcePath = filePath;
+    }
+  }
+
+  return probe;
+}
+
+export function mergeSourceCatalogSessionUpdates(
+  current: CachedSourceRecord[],
+  updates: CachedSourceRecord[],
+): CachedSourceRecord[] {
+  if (current.length === 0) return updates;
+
+  const bySessionId = new Map<string, CachedSourceRecord>();
+  const byKey = new Map<string, CachedSourceRecord>();
+  for (const update of updates) {
+    byKey.set(sourceSessionKey(update.provider, update.project, update.slug), update);
+    if (typeof update.sessionId === "string" && update.sessionId) {
+      bySessionId.set(update.sessionId, update);
+    }
+  }
+
+  return current.map((session) => {
+    const byId = session.sessionId ? bySessionId.get(session.sessionId) : undefined;
+    const update =
+      (byId?.provider === session.provider ? byId : undefined) ??
+      byKey.get(sourceSessionKey(session.provider, session.project, session.slug));
+    return update ? { ...session, ...update } : session;
+  });
+}
+
+export function updateSourceSessionCatalogSessions(
+  catalog: NormalizedSourceSessionCatalogCache,
+  sessions: CachedSourceRecord[],
+  updatedAt = new Date().toISOString(),
+): SourceSessionCatalogCache {
+  return {
+    schemaVersion: 1,
+    discoveredAt: catalog.discoveredAt || catalog.cachedAt || updatedAt,
+    updatedAt,
+    providerStates: catalog.providerStates,
+    sessions,
+  };
+}
+
+export async function walkJsonlFreshness(
+  root: string,
+  provider: string,
+): Promise<SourceProviderFreshnessProbe> {
+  const probe: SourceProviderFreshnessProbe = {
+    provider,
+    sessionsRoot: root,
+    fileCount: 0,
+  };
+
+  async function walk(dir: string): Promise<void> {
+    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      // Directory missing or unreadable — nothing to probe under it.
+      return;
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const entryPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(entryPath);
+          return;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".jsonl")) return;
+        const fileStat = await stat(entryPath).catch(() => null);
+        if (!fileStat) return;
+        probe.fileCount += 1;
+        if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
+          probe.newestSourceMtimeMs = fileStat.mtimeMs;
+          probe.newestSourcePath = entryPath;
+        }
+      }),
+    );
+  }
+
+  await walk(root);
+  return probe;
+}
+
+export async function probePiSourceFreshness(): Promise<SourceProviderFreshnessProbe> {
+  return walkJsonlFreshness(getPiSessionsDir(), "pi");
+}
+
+export function sourceProviderFingerprint(probe: SourceProviderFreshnessProbe): string {
+  return `${probe.fileCount}:${probe.newestSourcePath || ""}`;
+}
+
+export async function getStaleSourceProviders(
+  catalog: NormalizedSourceSessionCatalogCache | null,
+): Promise<string[]> {
+  if (!catalog) return [];
+  const staleProviders: string[] = [];
+  const piProbe = await probePiSourceFreshness();
+  const piFingerprint = sourceProviderFingerprint(piProbe);
+  const previousPiFingerprint = catalog.providerStates?.pi?.fingerprint;
+  const previousPiSessionCount = catalog.providerStates?.pi?.sessionCount;
+  const cachedPiSessionCount = catalog.sessions.filter(
+    (session) => session.provider === "pi",
+  ).length;
+  if (
+    cachedPiSessionCount > 0 &&
+    typeof previousPiSessionCount === "number" &&
+    previousPiSessionCount !== cachedPiSessionCount
+  ) {
+    staleProviders.push("pi");
+  }
+  if (previousPiFingerprint) {
+    if (piFingerprint !== previousPiFingerprint) staleProviders.push("pi");
+    return [...new Set(staleProviders)];
+  }
+
+  const piDiscoveredAt =
+    catalog.providerStates?.pi?.discoveredAt || catalog.discoveredAt || catalog.cachedAt;
+  const piDiscoveredMs = piDiscoveredAt ? Date.parse(piDiscoveredAt) : Number.NaN;
+  if (
+    piProbe.fileCount > 0 &&
+    piProbe.newestSourceMtimeMs != null &&
+    (catalog.legacy ||
+      !Number.isFinite(piDiscoveredMs) ||
+      piProbe.newestSourceMtimeMs > piDiscoveredMs)
+  ) {
+    staleProviders.push("pi");
+  }
+  return [...new Set(staleProviders)];
+}

--- a/packages/cli/src/server-types.ts
+++ b/packages/cli/src/server-types.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared record and cache types for the dashboard server and its extracted
+ * helper modules (server-source-catalog, server-enrichment, …). Kept in a
+ * dependency-free module so helpers don't need to import back from server.ts.
+ */
+
+import type { ReplaySession } from "./types.js";
+
+export interface SourceSummaryRecord {
+  provider: string;
+  slug: string;
+  project: string;
+  sessionId?: string;
+  promptCount?: number;
+  toolCallCount?: number;
+  filePaths: string[];
+  toolPaths?: string[];
+  hasSqlite?: boolean;
+  hasSdk?: boolean;
+  isStarred?: boolean;
+  spaceId?: string;
+  spaceIdSetBy?: string;
+  pluginsEnabled?: boolean;
+  skillsEnabled?: boolean;
+  fsDetectedFiles?: string[];
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+/** Summary of a generated replay, returned by scanSessionsFromDir / scanSessions */
+export interface ReplaySummary {
+  slug: string;
+  baseDir: string;
+  sessionId: string;
+  title?: string;
+  provider: string;
+  model?: string;
+  gitRepo?: string;
+  project: string;
+  startTime: string;
+  endTime?: string;
+  stats: ReplaySession["meta"]["stats"];
+  replaySize: number;
+  generatorVersion?: string;
+  replayOutdated: boolean;
+  hasAnnotations: boolean;
+  annotationCount: number;
+  firstMessage?: string;
+  messages?: string[];
+  gist?: {
+    gistId?: string;
+    viewerUrl?: string;
+    updatedAt?: string;
+    outdated: boolean;
+  };
+  cloud?: {
+    id: string;
+    url: string;
+    expiresAt?: string;
+    updatedAt?: string;
+  };
+}
+
+/** SourceSummaryRecord enriched with replay info for the sources cache */
+export interface CachedSourceRecord extends SourceSummaryRecord {
+  existingReplay?: string | null;
+  replay?: Omit<ReplaySummary, "baseDir" | "generatorVersion" | "replayOutdated">;
+}
+
+export interface ProviderDiscoveryState {
+  provider: string;
+  discoveredAt: string;
+  sessionCount: number;
+  newestSourceMtimeMs?: number;
+  newestSourcePath?: string;
+  fingerprint?: string;
+}
+
+export interface SourceSessionCatalogCache {
+  schemaVersion: 1;
+  discoveredAt: string;
+  updatedAt?: string;
+  providerStates?: Record<string, ProviderDiscoveryState>;
+  sessions: CachedSourceRecord[];
+}
+
+export interface NormalizedSourceSessionCatalogCache {
+  sessions: CachedSourceRecord[];
+  cachedAt?: string;
+  discoveredAt?: string;
+  updatedAt?: string;
+  providerStates?: Record<string, ProviderDiscoveryState>;
+  legacy?: boolean;
+}
+
+export interface SourceProviderFreshnessProbe {
+  provider: string;
+  sessionsRoot: string;
+  fileCount: number;
+  newestSourceMtimeMs?: number;
+  newestSourcePath?: string;
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -20,7 +20,7 @@ import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
 import { readGitRepo } from "@vibe-replay/provider-core/utils";
-import { readFileCache, writeFileCache, type FileCacheEntry } from "./cache.js";
+import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
 import { computeDaysUntilCleanup, getClaudeCodeCleanupPeriod } from "./cleanup-warning.js";
 import {
@@ -36,7 +36,6 @@ import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { parseCodexLines } from "./providers/codex/parser.js";
-import { getPiSessionsDir } from "./providers/pi/config.js";
 import { parsePiLines } from "./providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
@@ -70,6 +69,25 @@ import {
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
 } from "./server-enrichment.js";
+import {
+  buildSourceSessionCatalogCache,
+  getStaleSourceProviders,
+  mergeSourceCatalogSessionUpdates,
+  normalizeSourceSessionCatalogCache,
+  probePiSourceFreshness,
+  probeSourceRecordsFreshness,
+  sourceProviderFingerprint,
+  updateSourceSessionCatalogSessions,
+} from "./server-source-catalog.js";
+import type {
+  CachedSourceRecord,
+  NormalizedSourceSessionCatalogCache,
+  ReplaySummary,
+  SourceSessionCatalogCache,
+  SourceSummaryRecord,
+} from "./server-types.js";
+
+export type { SourceSummaryRecord } from "./server-types.js";
 import { loadAnnotations, saveAnnotations, saveOverlays } from "./server-persistence.js";
 import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
@@ -282,101 +300,6 @@ async function loadSessionFromDisk(baseDir: string, slug: string): Promise<Repla
   return session;
 }
 
-export interface SourceSummaryRecord {
-  provider: string;
-  slug: string;
-  project: string;
-  sessionId?: string;
-  promptCount?: number;
-  toolCallCount?: number;
-  filePaths: string[];
-  toolPaths?: string[];
-  hasSqlite?: boolean;
-  hasSdk?: boolean;
-  isStarred?: boolean;
-  spaceId?: string;
-  spaceIdSetBy?: string;
-  pluginsEnabled?: boolean;
-  skillsEnabled?: boolean;
-  fsDetectedFiles?: string[];
-  timestamp: string;
-  [key: string]: unknown;
-}
-
-/** Summary of a generated replay, returned by scanSessionsFromDir / scanSessions */
-interface ReplaySummary {
-  slug: string;
-  baseDir: string;
-  sessionId: string;
-  title?: string;
-  provider: string;
-  model?: string;
-  gitRepo?: string;
-  project: string;
-  startTime: string;
-  endTime?: string;
-  stats: ReplaySession["meta"]["stats"];
-  replaySize: number;
-  generatorVersion?: string;
-  replayOutdated: boolean;
-  hasAnnotations: boolean;
-  annotationCount: number;
-  firstMessage?: string;
-  messages?: string[];
-  gist?: {
-    gistId?: string;
-    viewerUrl?: string;
-    updatedAt?: string;
-    outdated: boolean;
-  };
-  cloud?: {
-    id: string;
-    url: string;
-    expiresAt?: string;
-    updatedAt?: string;
-  };
-}
-
-/** SourceSummaryRecord enriched with replay info for the sources cache */
-interface CachedSourceRecord extends SourceSummaryRecord {
-  existingReplay?: string | null;
-  replay?: Omit<ReplaySummary, "baseDir" | "generatorVersion" | "replayOutdated">;
-}
-
-interface ProviderDiscoveryState {
-  provider: string;
-  discoveredAt: string;
-  sessionCount: number;
-  newestSourceMtimeMs?: number;
-  newestSourcePath?: string;
-  fingerprint?: string;
-}
-
-interface SourceSessionCatalogCache {
-  schemaVersion: 1;
-  discoveredAt: string;
-  updatedAt?: string;
-  providerStates?: Record<string, ProviderDiscoveryState>;
-  sessions: CachedSourceRecord[];
-}
-
-interface NormalizedSourceSessionCatalogCache {
-  sessions: CachedSourceRecord[];
-  cachedAt?: string;
-  discoveredAt?: string;
-  updatedAt?: string;
-  providerStates?: Record<string, ProviderDiscoveryState>;
-  legacy?: boolean;
-}
-
-interface SourceProviderFreshnessProbe {
-  provider: string;
-  sessionsRoot: string;
-  fileCount: number;
-  newestSourceMtimeMs?: number;
-  newestSourcePath?: string;
-}
-
 interface SourcesEnrichmentStatus {
   running: boolean;
   processed: number;
@@ -391,240 +314,6 @@ interface PersistedInsightsCache {
   userInsights: UserInsights | null;
   projectInsights: Array<[string, ProjectInsights]>;
   computedAt: string | null;
-}
-
-function isSourceSessionCatalogCache(value: unknown): value is SourceSessionCatalogCache {
-  return (
-    !!value &&
-    typeof value === "object" &&
-    (value as { schemaVersion?: unknown }).schemaVersion === 1 &&
-    typeof (value as { discoveredAt?: unknown }).discoveredAt === "string" &&
-    Array.isArray((value as { sessions?: unknown }).sessions)
-  );
-}
-
-function normalizeSourceSessionCatalogCache(
-  cached: FileCacheEntry<SourceSessionCatalogCache | CachedSourceRecord[]> | null,
-): NormalizedSourceSessionCatalogCache | null {
-  if (!cached) return null;
-  if (Array.isArray(cached.data)) {
-    return {
-      sessions: cached.data,
-      cachedAt: cached.updatedAt,
-      discoveredAt: cached.updatedAt,
-      updatedAt: cached.updatedAt,
-      legacy: true,
-    };
-  }
-  if (isSourceSessionCatalogCache(cached.data)) {
-    return {
-      sessions: cached.data.sessions,
-      cachedAt: cached.updatedAt,
-      discoveredAt: cached.data.discoveredAt || cached.updatedAt,
-      updatedAt: cached.data.updatedAt || cached.updatedAt,
-      providerStates: cached.data.providerStates,
-      legacy: false,
-    };
-  }
-  return null;
-}
-
-function buildProviderDiscoveryStates(
-  sources: SourceSummaryRecord[],
-  discoveredAt: string,
-): Record<string, ProviderDiscoveryState> {
-  const byProvider = new Map<string, SourceSummaryRecord[]>();
-  for (const source of sources) {
-    const bucket = byProvider.get(source.provider) || [];
-    bucket.push(source);
-    byProvider.set(source.provider, bucket);
-  }
-
-  const states: Record<string, ProviderDiscoveryState> = {};
-  for (const [provider, providerSources] of byProvider) {
-    states[provider] = {
-      provider,
-      discoveredAt,
-      sessionCount: providerSources.length,
-    };
-  }
-  return states;
-}
-
-function buildSourceSessionCatalogCache(
-  sessions: SourceSummaryRecord[],
-  discoveredAt: string,
-  previous?: NormalizedSourceSessionCatalogCache | null,
-): SourceSessionCatalogCache {
-  const providerStates = {
-    ...previous?.providerStates,
-    ...buildProviderDiscoveryStates(sessions, discoveredAt),
-  };
-  return {
-    schemaVersion: 1,
-    discoveredAt,
-    updatedAt: discoveredAt,
-    providerStates,
-    sessions: sessions as CachedSourceRecord[],
-  };
-}
-
-async function probeSourceRecordsFreshness(
-  sources: SourceSummaryRecord[],
-  provider: string,
-): Promise<SourceProviderFreshnessProbe> {
-  const probe: SourceProviderFreshnessProbe = {
-    provider,
-    sessionsRoot: provider,
-    fileCount: 0,
-  };
-
-  const paths = new Set(
-    sources
-      .filter((source) => source.provider === provider)
-      .flatMap((source) => source.filePaths || [])
-      .filter(
-        (filePath): filePath is string => typeof filePath === "string" && filePath.length > 0,
-      ),
-  );
-
-  for (const filePath of paths) {
-    const fileStat = await stat(filePath).catch(() => null);
-    if (!fileStat) continue;
-    probe.fileCount += 1;
-    if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
-      probe.newestSourceMtimeMs = fileStat.mtimeMs;
-      probe.newestSourcePath = filePath;
-    }
-  }
-
-  return probe;
-}
-
-function mergeSourceCatalogSessionUpdates(
-  current: CachedSourceRecord[],
-  updates: CachedSourceRecord[],
-): CachedSourceRecord[] {
-  if (current.length === 0) return updates;
-
-  const bySessionId = new Map<string, CachedSourceRecord>();
-  const byKey = new Map<string, CachedSourceRecord>();
-  for (const update of updates) {
-    byKey.set(sourceSessionKey(update.provider, update.project, update.slug), update);
-    if (typeof update.sessionId === "string" && update.sessionId) {
-      bySessionId.set(update.sessionId, update);
-    }
-  }
-
-  return current.map((session) => {
-    const byId = session.sessionId ? bySessionId.get(session.sessionId) : undefined;
-    const update =
-      (byId?.provider === session.provider ? byId : undefined) ??
-      byKey.get(sourceSessionKey(session.provider, session.project, session.slug));
-    return update ? { ...session, ...update } : session;
-  });
-}
-
-function updateSourceSessionCatalogSessions(
-  catalog: NormalizedSourceSessionCatalogCache,
-  sessions: CachedSourceRecord[],
-  updatedAt = new Date().toISOString(),
-): SourceSessionCatalogCache {
-  return {
-    schemaVersion: 1,
-    discoveredAt: catalog.discoveredAt || catalog.cachedAt || updatedAt,
-    updatedAt,
-    providerStates: catalog.providerStates,
-    sessions,
-  };
-}
-
-async function walkJsonlFreshness(
-  root: string,
-  provider: string,
-): Promise<SourceProviderFreshnessProbe> {
-  const probe: SourceProviderFreshnessProbe = {
-    provider,
-    sessionsRoot: root,
-    fileCount: 0,
-  };
-
-  async function walk(dir: string): Promise<void> {
-    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
-    try {
-      entries = await readdir(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    await Promise.all(
-      entries.map(async (entry) => {
-        const entryPath = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          await walk(entryPath);
-          return;
-        }
-        if (!entry.isFile() || !entry.name.endsWith(".jsonl")) return;
-        const fileStat = await stat(entryPath).catch(() => null);
-        if (!fileStat) return;
-        probe.fileCount += 1;
-        if (probe.newestSourceMtimeMs == null || fileStat.mtimeMs > probe.newestSourceMtimeMs) {
-          probe.newestSourceMtimeMs = fileStat.mtimeMs;
-          probe.newestSourcePath = entryPath;
-        }
-      }),
-    );
-  }
-
-  await walk(root);
-  return probe;
-}
-
-async function probePiSourceFreshness(): Promise<SourceProviderFreshnessProbe> {
-  return walkJsonlFreshness(getPiSessionsDir(), "pi");
-}
-
-function sourceProviderFingerprint(probe: SourceProviderFreshnessProbe): string {
-  return `${probe.fileCount}:${probe.newestSourcePath || ""}`;
-}
-
-async function getStaleSourceProviders(
-  catalog: NormalizedSourceSessionCatalogCache | null,
-): Promise<string[]> {
-  if (!catalog) return [];
-  const staleProviders: string[] = [];
-  const piProbe = await probePiSourceFreshness();
-  const piFingerprint = sourceProviderFingerprint(piProbe);
-  const previousPiFingerprint = catalog.providerStates?.pi?.fingerprint;
-  const previousPiSessionCount = catalog.providerStates?.pi?.sessionCount;
-  const cachedPiSessionCount = catalog.sessions.filter(
-    (session) => session.provider === "pi",
-  ).length;
-  if (
-    cachedPiSessionCount > 0 &&
-    typeof previousPiSessionCount === "number" &&
-    previousPiSessionCount !== cachedPiSessionCount
-  ) {
-    staleProviders.push("pi");
-  }
-  if (previousPiFingerprint) {
-    if (piFingerprint !== previousPiFingerprint) staleProviders.push("pi");
-    return [...new Set(staleProviders)];
-  }
-
-  const piDiscoveredAt =
-    catalog.providerStates?.pi?.discoveredAt || catalog.discoveredAt || catalog.cachedAt;
-  const piDiscoveredMs = piDiscoveredAt ? Date.parse(piDiscoveredAt) : Number.NaN;
-  if (
-    piProbe.fileCount > 0 &&
-    piProbe.newestSourceMtimeMs != null &&
-    (catalog.legacy ||
-      !Number.isFinite(piDiscoveredMs) ||
-      piProbe.newestSourceMtimeMs > piDiscoveredMs)
-  ) {
-    staleProviders.push("pi");
-  }
-  return [...new Set(staleProviders)];
 }
 
 function normalizeSessionProjectsForHome(sessions: SessionInfo[], home: string): SessionInfo[] {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -86,8 +86,6 @@ import type {
   SourceSessionCatalogCache,
   SourceSummaryRecord,
 } from "./server-types.js";
-
-export type { SourceSummaryRecord } from "./server-types.js";
 import { loadAnnotations, saveAnnotations, saveOverlays } from "./server-persistence.js";
 import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
@@ -115,6 +113,9 @@ import { localDayKey, normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
 export { resolveGenerateInputs } from "./server-core.js";
+// Re-exported for tests that import it from "../src/server.js" (kept stable
+// after the type moved to server-types.ts).
+export type { SourceSummaryRecord } from "./server-types.js";
 
 // ─── Archive helpers (directory-based, one marker file per slug) ────
 


### PR DESCRIPTION
Refs #354 (second extraction pass).

## What

Continues breaking up `server.ts`. Moves the **source-session catalog cache** cluster into `server-source-catalog.ts` and introduces a dependency-free `server-types.ts` for the shared record/cache types.

## Changes

- **New `server-types.ts`** — shared types: `SourceSummaryRecord`, `ReplaySummary`, `CachedSourceRecord`, `ProviderDiscoveryState`, `SourceSessionCatalogCache`, `NormalizedSourceSessionCatalogCache`, `SourceProviderFreshnessProbe`. Lives in a leaf module so helpers don't import back from `server.ts`.
- **New `server-source-catalog.ts`** — `isSourceSessionCatalogCache`, `normalize…`, `buildProviderDiscoveryStates`, `buildSourceSessionCatalogCache`, `probeSourceRecordsFreshness`, `mergeSourceCatalogSessionUpdates`, `updateSourceSessionCatalogSessions`, `walkJsonlFreshness`, `probePiSourceFreshness`, `sourceProviderFingerprint`, `getStaleSourceProviders`. Depends on `server-types.ts` + `server-enrichment.ts` (`sourceSessionKey`), not on `server.ts`.
- **`server.ts`** — imports the types and functions back; **re-exports `SourceSummaryRecord`** so existing test imports (`../src/server.js`) keep working; `__testables` re-imports the moved functions (zero test changes). Dropped now-unused `getPiSessionsDir` / `FileCacheEntry` imports.

## Result

- `server.ts`: **3573 → 3263 lines**. New modules: `server-source-catalog.ts` (254) + `server-types.ts` (102).

## Verification

- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped (incl. `server-sources-enrichment.test.ts`, which exercises the moved catalog functions via `__testables`).
- `tsc --noEmit` + `pnpm lint:check` — clean.

## Remaining (kept in #354)

The big item — decomposing `startServer`'s inline route handlers into `server-routes/*` register functions — is still the bulk of the file and a separate, larger effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)