### PR TITLE
chore(providers): drop dead sql-js-shim stubs in cursor and codex

### DIFF
--- a/packages/provider-codex/src/sql-js-shim.ts
+++ b/packages/provider-codex/src/sql-js-shim.ts
@@ -1,1 +1,0 @@
-/// <reference path="./sql-js.d.ts" />

--- a/packages/provider-cursor/src/sql-js-shim.ts
+++ b/packages/provider-cursor/src/sql-js-shim.ts
@@ -1,1 +1,0 @@
-/// <reference path="./sql-js.d.ts" />


### PR DESCRIPTION
## Summary

- Delete `packages/provider-cursor/src/sql-js-shim.ts` (1 line)
- Delete `packages/provider-codex/src/sql-js-shim.ts` (1 line)
- Net change: -2 lines across 2 files

## Motivation

Each shim file contains only `/// <reference path="./sql-js.d.ts" />` and is never imported or referenced by any other file. The type declaration it points to (`sql-js.d.ts`) is already:

1. Included in TypeScript compilation automatically via `"include": ["src"]` in both packages' `tsconfig.json`
2. Directly referenced with `/// <reference path="../sql-js.d.ts" />` in every file that actually uses `SQL.Database` (`cursor/sqlite-reader.ts`, `cursor/sdk-reader.ts`, `codex/discover.ts`)

The shim files are pure dead code — semantically equivalent to deleting them. This follows the same pattern as #374 which dropped the dead `sql-js.d.ts` from the CLI package.

## Test plan

- [x] `pnpm test` 全绿 (340 + 177 tests passing)
- [x] `pnpm lint:check` 零 warning
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm --filter @vibe-replay/provider-cursor exec tsc --noEmit` 零错
- [x] `pnpm --filter @vibe-replay/provider-codex exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB)
- [x] E2E: 未跑 (纯结构性删除，类型层面可证明等价)

> 🤖 Daily auto-quality routine. Self-merged after AI review.