### PR TITLE
chore(provider-cursor): dedupe parseJson helper, import from tool-mapping

### DIFF
--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -17,7 +17,7 @@ import {
 } from "./sanitize.js";
 import { createRetryableInit, CURSOR_CHATS_DIR, workspaceHash } from "./sqlite-io.js";
 // Local use requires named imports in addition to the compatibility re-exports below.
-import { mapCursorToolName, mapToolArgs } from "./tool-mapping.js";
+import { mapCursorToolName, mapToolArgs, parseJson } from "./tool-mapping.js";
 
 export { storeDbPath, workspaceHash } from "./sqlite-io.js";
 export { mapCursorToolName, mapToolArgs } from "./tool-mapping.js";
@@ -693,15 +693,6 @@ function valueToString(value: unknown): string {
   if (value instanceof Uint8Array) return new TextDecoder().decode(value);
   if (value == null) return "";
   return String(value);
-}
-
-function parseJson<T = any>(raw: unknown): T | null {
-  if (typeof raw !== "string") return null;
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return null;
-  }
 }
 
 function parseJsonColumn(value: unknown): unknown {

--- a/packages/provider-cursor/src/cursor/tool-mapping.ts
+++ b/packages/provider-cursor/src/cursor/tool-mapping.ts
@@ -1,4 +1,4 @@
-function parseJson<T = any>(raw: unknown): T | null {
+export function parseJson<T = any>(raw: unknown): T | null {
   if (typeof raw !== "string") return null;
   try {
     return JSON.parse(raw) as T;


### PR DESCRIPTION
## Summary

- `parseJson<T>` was defined identically in both `sqlite-reader.ts` and `tool-mapping.ts` (byte-for-byte same 7-line implementation)
- Export it from `tool-mapping.ts`, import it in `sqlite-reader.ts` where already imports `mapCursorToolName` and `mapToolArgs` from that file
- Net change: -9 lines

## Motivation

Eliminates a duplicated helper that lived unnoticed because both files are large. The implementations are provably identical, so deduplication carries zero semantic risk.

## Test plan

- [x] `pnpm test` 全绿 (110 + 340 + 177 tests)
- [x] `pnpm lint:check` 零 warning / error on changed files
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB)
- [x] E2E: 没跑 (纯函数抽取,无行为变化,E2E 是锦上添花)

> 🤖 Daily auto-quality routine. Self-merged after AI review.