### PR TITLE
chore(provider-cursor): dedupe SESSION_ID_RE, import from sqlite-reader

### DIFF
--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -19,6 +19,7 @@ import {
   mapCursorToolName,
   mapToolArgs,
   parseCursorSqlite,
+  SESSION_ID_RE,
 } from "./sqlite-reader.js";
 import { addParseWarning } from "@vibe-replay/provider-contract/warnings";
 
@@ -44,8 +45,6 @@ export function createCursorParser(deps: Partial<CursorParserDependencies> = {})
   return (filePaths: string | string[], sessionInfo?: SessionInfo): Promise<ProviderParseResult> =>
     parseCursorSessionWithDependencies(filePaths, sessionInfo, resolved);
 }
-
-const CURSOR_UUID_SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function toErrorMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
@@ -219,7 +218,7 @@ function sessionIdFromStoreDbPath(path: string): string | undefined {
   const parts = normalized.split("/");
   if (parts.at(-1) !== "store.db") return undefined;
   const rawSessionId = parts.at(-2)?.trim();
-  if (!rawSessionId || !CURSOR_UUID_SESSION_ID_RE.test(rawSessionId)) return undefined;
+  if (!rawSessionId || !SESSION_ID_RE.test(rawSessionId)) return undefined;
   return rawSessionId;
 }
 

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -22,7 +22,7 @@ import { mapCursorToolName, mapToolArgs, parseJson } from "./tool-mapping.js";
 export { storeDbPath, workspaceHash } from "./sqlite-io.js";
 export { mapCursorToolName, mapToolArgs } from "./tool-mapping.js";
 
-const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const MIN_STORE_DB_SIZE = 8192;
 const MAX_CURSOR_REQUEST_CONTEXT_ROWS = 500;


### PR DESCRIPTION
## Summary

- `SESSION_ID_RE` and `CURSOR_UUID_SESSION_ID_RE` in `packages/provider-cursor/src/cursor/` were identical UUID regex patterns defined independently in two files
- Export `SESSION_ID_RE` from `sqlite-reader.ts`; import it in `parser.ts` replacing `CURSOR_UUID_SESSION_ID_RE`
- Net diff: -4 +3 lines across 2 files

## Motivation

Identical regex in two sibling files is a latent divergence risk — if the pattern ever needs updating (e.g. support for non-standard UUID formats), only one copy gets updated. The fix is purely structural: same regex, same semantics, single canonical definition.

## Test plan

- [x] `pnpm test` 全绿 (517 tests)
- [x] `pnpm lint:check` 零 warning (on changed files)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB < 1MB)
- [x] E2E: 没跑 — 改动是纯结构性重命名，等价性由 TS 编译器和现有单测保证

> 🤖 Daily auto-quality routine. Self-merged after AI review.