### PR TITLE
chore(cli): dedupe FILE_EDIT_TOOLS + file-path helpers, import from provider-core

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -15,19 +15,18 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
+import {
+  FILE_EDIT_TOOLS,
+  extractToolFilePath,
+  extractToolFilePaths,
+} from "@vibe-replay/provider-core/utils";
 import { estimateCost, estimateCostSimple } from "./pricing.js";
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { parsePiSession } from "./providers/pi/parser.js";
 import type { ProviderParseResult } from "./providers/types.js";
 import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
-import {
-  FILE_EDIT_TOOLS,
-  extractToolFilePath,
-  extractToolFilePaths,
-  localDayKey,
-  shortenPath,
-} from "./utils.js";
+import { localDayKey, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
 const SCANNER_VERSION = 8;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -17,34 +17,6 @@ export function normalizeTitle(value?: string): string | undefined {
   return cleaned || undefined;
 }
 
-/** Tool names that modify files on disk. Used to count edits and track modified files. */
-export const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
-  "Edit",
-  "MultiEdit",
-  "Write",
-  "NotebookEdit",
-  "Delete",
-]);
-
-/** Extract file path from tool input, handling different provider field names. */
-export function extractToolFilePath(
-  input: Record<string, unknown> | undefined,
-): string | undefined {
-  return extractToolFilePaths(input)[0];
-}
-
-/** Extract one or more file paths from tool input, handling provider-specific field names. */
-export function extractToolFilePaths(input: Record<string, unknown> | undefined): string[] {
-  if (!input) return [];
-  const plural = input.file_paths ?? input.filePaths ?? input.paths;
-  const paths = Array.isArray(plural)
-    ? plural.filter((fp): fp is string => typeof fp === "string" && fp.trim().length > 0)
-    : [];
-  const singular = input.file_path ?? input.filePath ?? input.path ?? input.relativeWorkspacePath;
-  if (typeof singular === "string" && singular.trim()) paths.unshift(singular);
-  return [...new Set(paths)];
-}
-
 /**
  * Format a timestamp as YYYY-MM-DD in the local timezone.
  * Critical for day-bucketing: slicing an ISO string gives UTC, which shifts


### PR DESCRIPTION
## Summary

- Drop `FILE_EDIT_TOOLS`, `extractToolFilePath`, `extractToolFilePaths` from `packages/cli/src/utils.ts`
- Update `packages/cli/src/scanner.ts` to import these three from `@vibe-replay/provider-core/utils`
- Net: -29 lines in utils.ts, scanner.ts import restructured, zero callers change

## Motivation

All three were byte-for-byte identical copies of the exports already in `provider-core/src/utils.ts`.
`scanner.ts` already has `@vibe-replay/provider-core` in scope (it imports `estimateActiveDuration` from `provider-core/duration`), so this is a pure import-source swap with no semantic change.

## Test plan

- [x] `pnpm test` 全绿 (340 CLI + 177 viewer tests passed)
- [x] `pnpm lint:check` 零 error (44 pre-existing viewer jsx-a11y warnings unchanged)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB < 1MB)
- [x] E2E: 没跑，pure import-source swap 无运行时行为变化，E2E 不增加置信度

> 🤖 Daily auto-quality routine. Self-merged after AI review.