### PR TITLE
test(cli): raise gif-export suite timeout to 60s to stop Windows flake

### DIFF
--- a/packages/cli/test/gif-export.test.ts
+++ b/packages/cli/test/gif-export.test.ts
@@ -140,4 +140,7 @@ describe("generateGitHubGif", () => {
     expect(gif[0]).toBe(0x47); // G
     expect(gif.length).toBeGreaterThan(100);
   });
-}, 30_000);
+  // GIF generation rasterizes several SVG frames and is CPU-heavy; it can take
+  // ~35s on slower Windows CI runners. Keep the timeout generous so these tests
+  // don't flake there.
+}, 60_000);


### PR DESCRIPTION
## Problem

The `generateGitHubGif` test suite has flaked on `windows-smoke` several times recently (e.g. on #364, #383) with `Test timed out in 30000ms` — the magic-bytes test took ~37s. GIF generation rasterizes several SVG frames and is genuinely CPU-heavy; the Windows CI runners are slow enough to intermittently exceed the suite's 30s timeout. It's a pure timing flake — unrelated to the changes in those PRs.

## Fix

Bump the `describe("generateGitHubGif", ...)` suite timeout from 30s → 60s (with a comment explaining why). No production code touched.

## Verification

- `pnpm --filter vibe-replay test gif-export` — 7 passed.
- lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)