### PR TITLE
test(viewer): add Player + Dashboard smoke tests (closes #355)

### DIFF
--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -1,24 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubBrowserAPIs } from "../../test-utils/jsdom-stubs";
 import Dashboard from "../Dashboard";
 
-beforeAll(() => {
-  Element.prototype.scrollIntoView = vi.fn();
-  Element.prototype.scrollTo = vi.fn();
-  class StubObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-    takeRecords() {
-      return [];
-    }
-  }
-  vi.stubGlobal("IntersectionObserver", StubObserver);
-  vi.stubGlobal("ResizeObserver", StubObserver);
-});
-
 beforeEach(() => {
+  stubBrowserAPIs();
   // Dashboard fetches replay/source data on mount. Reject so it exercises its
   // error/empty handling instead of hitting the network — modelling each
   // endpoint's exact response shape is out of scope for a smoke test.
@@ -30,7 +17,10 @@ beforeEach(() => {
   );
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("Dashboard (smoke)", () => {
   it("renders its chrome (search + facets) without crashing", () => {

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import Dashboard from "../Dashboard";
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.scrollTo = vi.fn();
+  class StubObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  vi.stubGlobal("IntersectionObserver", StubObserver);
+  vi.stubGlobal("ResizeObserver", StubObserver);
+});
+
+beforeEach(() => {
+  // Dashboard fetches replay/source data on mount. Reject so it exercises its
+  // error/empty handling instead of hitting the network — modelling each
+  // endpoint's exact response shape is out of scope for a smoke test.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      throw new Error("network disabled in test");
+    }),
+  );
+});
+
+afterEach(cleanup);
+
+describe("Dashboard (smoke)", () => {
+  it("renders its chrome (search + facets) without crashing", () => {
+    render(<Dashboard />);
+    // Static chrome rendered before data loads (mobile + desktop search boxes).
+    expect(screen.getAllByPlaceholderText(/search/i).length).toBeGreaterThan(0);
+    // Sidebar facet headers.
+    expect(screen.getByText(/Provider/)).toBeTruthy();
+    expect(screen.getByText(/Project path/)).toBeTruthy();
+  });
+
+  it("kicks off a data fetch on mount", async () => {
+    render(<Dashboard />);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    // (The post-fetch view depends on each endpoint's exact response shape, so
+    // asserting it is out of scope for this smoke test — the mount + load path
+    // not throwing is the signal.)
+  });
+});

--- a/packages/viewer/src/components/__tests__/player.test.tsx
+++ b/packages/viewer/src/components/__tests__/player.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { ReplaySession } from "../../types";
+import { textResponse, thinking, userPrompt } from "../../engine/__tests__/helpers";
+import type { ViewPrefs } from "../../hooks/useViewPrefs";
+import Player from "../Player";
+
+// jsdom doesn't implement these browser APIs; Player uses them from effects.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.scrollTo = vi.fn();
+  class StubObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  vi.stubGlobal("IntersectionObserver", StubObserver);
+  vi.stubGlobal("ResizeObserver", StubObserver);
+});
+
+afterEach(cleanup);
+
+const VIEW_PREFS: ViewPrefs = {
+  displayMode: "all",
+  hideThinking: false,
+  collapseAllTools: false,
+  promptsOnly: false,
+};
+
+function makeSession(): ReplaySession {
+  const scenes = [userPrompt("first"), thinking(), textResponse(), userPrompt("second")];
+  return {
+    meta: {
+      sessionId: "s1",
+      slug: "test-session",
+      provider: "claude-code",
+      startTime: "2025-01-01T00:00:00Z",
+      cwd: "~/Code/x",
+      project: "~/Code/x",
+      stats: { sceneCount: scenes.length, userPrompts: 2, toolCalls: 0 },
+    },
+    scenes,
+  } as unknown as ReplaySession;
+}
+
+describe("Player (smoke)", () => {
+  it("mounts a session and shows the landing screen first", () => {
+    render(
+      <Player
+        session={makeSession()}
+        viewPrefs={VIEW_PREFS}
+        activeView="replay"
+        setActiveView={vi.fn()}
+      />,
+    );
+    // Player opens on the landing hero, not the playback chrome.
+    expect(screen.getAllByText(/Watch Replay/i).length).toBeGreaterThan(0);
+    expect(screen.queryByTitle(/^Play\/Pause/)).toBeNull();
+  });
+
+  it("reveals the playback controls after entering the replay", () => {
+    render(
+      <Player
+        session={makeSession()}
+        viewPrefs={VIEW_PREFS}
+        activeView="replay"
+        setActiveView={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getAllByText(/Watch Replay/i)[0]);
+    // The Controls play/pause button is a stable signal the player chrome rendered.
+    expect(screen.getAllByTitle(/^Play\/Pause/).length).toBeGreaterThan(0);
+  });
+
+  it("renders an empty session without crashing", () => {
+    const empty = {
+      meta: { ...makeSession().meta, stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 } },
+      scenes: [],
+    } as unknown as ReplaySession;
+    expect(() =>
+      render(
+        <Player
+          session={empty}
+          viewPrefs={VIEW_PREFS}
+          activeView="replay"
+          setActiveView={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/viewer/src/components/__tests__/player.test.tsx
+++ b/packages/viewer/src/components/__tests__/player.test.tsx
@@ -1,28 +1,19 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplaySession } from "../../types";
 import { textResponse, thinking, userPrompt } from "../../engine/__tests__/helpers";
 import type { ViewPrefs } from "../../hooks/useViewPrefs";
+import { stubBrowserAPIs } from "../../test-utils/jsdom-stubs";
 import Player from "../Player";
 
-// jsdom doesn't implement these browser APIs; Player uses them from effects.
-beforeAll(() => {
-  Element.prototype.scrollIntoView = vi.fn();
-  Element.prototype.scrollTo = vi.fn();
-  class StubObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-    takeRecords() {
-      return [];
-    }
-  }
-  vi.stubGlobal("IntersectionObserver", StubObserver);
-  vi.stubGlobal("ResizeObserver", StubObserver);
-});
+// jsdom doesn't implement the scroll/observer APIs Player uses from effects.
+beforeEach(stubBrowserAPIs);
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 const VIEW_PREFS: ViewPrefs = {
   displayMode: "all",

--- a/packages/viewer/src/test-utils/jsdom-stubs.ts
+++ b/packages/viewer/src/test-utils/jsdom-stubs.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+
+/**
+ * Stub the browser APIs jsdom doesn't implement but our components touch from
+ * effects (scroll APIs) or observers. Call from `beforeAll`; pair with
+ * `vi.unstubAllGlobals()` in `afterEach`/`afterAll` to undo the global stubs.
+ */
+export function stubBrowserAPIs(): void {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.scrollTo = vi.fn();
+  class StubObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  }
+  vi.stubGlobal("IntersectionObserver", StubObserver);
+  vi.stubGlobal("ResizeObserver", StubObserver);
+}


### PR DESCRIPTION
Closes #355.

Completes the component coverage from #373, using the same jsdom + `@testing-library/react` infra.

## Tests (202 → 207)

- **`Player` (3)**: opens on the landing hero (asserts no playback controls yet), reveals the `Controls` after clicking "Watch Replay", and renders an **empty session** without crashing. Stubs `scrollIntoView`/`scrollTo` + `IntersectionObserver`/`ResizeObserver` (jsdom gaps Player touches from effects).
- **`Dashboard` (2)**: renders its chrome (search + sidebar facets) on mount, and initiates a data fetch. Network is stubbed.

## Scope note

The Dashboard's *post-fetch* view depends on each API endpoint's exact response shape; modelling all of those is beyond a smoke test, so these assert the initial render + that the load path is kicked off (and doesn't throw). Deeper data-flow tests can mock per-endpoint responses as a follow-up.

With this, all five components/hooks named in #355 (usePlayback, useSessionLoader, Controls, Player, Dashboard) have coverage.

## Verification
- `pnpm --filter @vibe-replay/viewer test` — 207 passed.
- `lint:check` + viewer `tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)