### PR TITLE
refactor(cli): extract archive routes into server-routes/archive.ts (#354 pass 3)

### DIFF
--- a/packages/cli/src/server-routes/archive.ts
+++ b/packages/cli/src/server-routes/archive.ts
@@ -1,0 +1,55 @@
+import { mkdir, readdir, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Hono } from "hono";
+import { safeSlug } from "../server-core.js";
+
+/** Archive marker directory (one empty file per archived slug). */
+const ARCHIVE_DIR = ".archive";
+
+async function getArchivedSlugs(baseDir: string): Promise<Set<string>> {
+  try {
+    const entries = await readdir(join(baseDir, ARCHIVE_DIR));
+    return new Set(entries);
+  } catch {
+    // No archive dir yet — nothing archived.
+    return new Set();
+  }
+}
+
+async function archiveSlug(baseDir: string, slug: string): Promise<void> {
+  const dir = join(baseDir, ARCHIVE_DIR);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, slug), "");
+}
+
+async function unarchiveSlug(baseDir: string, slug: string): Promise<void> {
+  try {
+    await unlink(join(baseDir, ARCHIVE_DIR, slug));
+  } catch {
+    /* already gone */
+  }
+}
+
+/** Archive routes — directory-based, one marker file per slug. */
+export function registerArchiveRoutes(app: Hono, deps: { baseDir: string }): void {
+  const { baseDir } = deps;
+
+  app.get("/api/archived", async (c) => {
+    const slugs = await getArchivedSlugs(baseDir);
+    return c.json({ slugs: [...slugs] });
+  });
+
+  app.post("/api/archive/:slug", async (c) => {
+    const slug = safeSlug(c.req.param("slug"));
+    if (!slug) return c.json({ error: "invalid slug" }, 400);
+    await archiveSlug(baseDir, slug);
+    return c.json({ ok: true });
+  });
+
+  app.delete("/api/archive/:slug", async (c) => {
+    const slug = safeSlug(c.req.param("slug"));
+    if (!slug) return c.json({ error: "invalid slug" }, 400);
+    await unarchiveSlug(baseDir, slug);
+    return c.json({ ok: true });
+  });
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -87,6 +87,7 @@ import type {
   SourceSummaryRecord,
 } from "./server-types.js";
 import { loadAnnotations, saveAnnotations, saveOverlays } from "./server-persistence.js";
+import { registerArchiveRoutes } from "./server-routes/archive.js";
 import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
   buildInsightsSyncBatches,
@@ -116,33 +117,6 @@ export { resolveGenerateInputs } from "./server-core.js";
 // Re-exported for tests that import it from "../src/server.js" (kept stable
 // after the type moved to server-types.ts).
 export type { SourceSummaryRecord } from "./server-types.js";
-
-// ─── Archive helpers (directory-based, one marker file per slug) ────
-
-const ARCHIVE_DIR = ".archive";
-
-async function getArchivedSlugs(baseDir: string): Promise<Set<string>> {
-  try {
-    const entries = await readdir(join(baseDir, ARCHIVE_DIR));
-    return new Set(entries);
-  } catch {
-    return new Set();
-  }
-}
-
-async function archiveSlug(baseDir: string, slug: string): Promise<void> {
-  const dir = join(baseDir, ARCHIVE_DIR);
-  await mkdir(dir, { recursive: true });
-  await writeFile(join(dir, slug), "");
-}
-
-async function unarchiveSlug(baseDir: string, slug: string): Promise<void> {
-  try {
-    await unlink(join(baseDir, ARCHIVE_DIR, slug));
-  } catch {
-    /* already gone */
-  }
-}
 
 const replayGitRepoByProjectCache = new Map<string, string | undefined>();
 
@@ -1760,25 +1734,7 @@ export async function startServer(
   app.delete("/api/sessions/:slug", deleteReplay);
   app.delete("/api/replays/:slug", deleteReplay);
 
-  // --- Archive: directory-based, one marker file per slug ---
-  app.get("/api/archived", async (c) => {
-    const slugs = await getArchivedSlugs(baseDir);
-    return c.json({ slugs: [...slugs] });
-  });
-
-  app.post("/api/archive/:slug", async (c) => {
-    const slug = safeSlug(c.req.param("slug"));
-    if (!slug) return c.json({ error: "invalid slug" }, 400);
-    await archiveSlug(baseDir, slug);
-    return c.json({ ok: true });
-  });
-
-  app.delete("/api/archive/:slug", async (c) => {
-    const slug = safeSlug(c.req.param("slug"));
-    if (!slug) return c.json({ error: "invalid slug" }, 400);
-    await unarchiveSlug(baseDir, slug);
-    return c.json({ ok: true });
-  });
+  registerArchiveRoutes(app, { baseDir });
 
   // --- Source sessions: discover raw AI coding sessions from all providers ---
   const getCachedSourceSessions = async (c: Context) => {


### PR DESCRIPTION
Refs #354 (third extraction pass — first of the route-handler decomposition).

## What

Begins decomposing `startServer`'s inline routes. Moves the **archive** endpoints + their helpers into `server-routes/archive.ts`, following the existing `registerSessionAssetRoutes(app, deps)` pattern.

- Routes: `GET /api/archived`, `POST /api/archive/:slug`, `DELETE /api/archive/:slug`.
- Helpers: `getArchivedSlugs` / `archiveSlug` / `unarchiveSlug` + the `ARCHIVE_DIR` constant (all used only by these routes).
- `registerArchiveRoutes(app, { baseDir })` — the routes only close over `baseDir`, so the dependency surface is minimal.

## Result

- `server.ts`: 3263 → 3219.

## Verification
- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped.
- `tsc --noEmit` + `lint:check` — clean.
- Verbatim move, no behavior change (CI e2e exercises the editor server).

## Note on remaining work (#354)

Archive was the cleanest route group (only `baseDir`). The remaining `startServer` routes are progressively more coupled to its local state (caches, watchers, enrichment status, auth/background-scan state), so each subsequent group needs more deps threading. This stays open as an ongoing, incremental decomposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)