### PR TITLE
chore(provider-cursor): type SQL locals as SqlJsStatic instead of any

### DIFF
--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -1,4 +1,5 @@
 /// <reference path="../sql-js.d.ts" />
+import type { SqlJsStatic } from "sql.js";
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -407,7 +408,7 @@ async function openGlobalStateDb(): Promise<CachedGlobalStateDb | null> {
     return cachedGlobalStateDb;
   }
 
-  let SQL: any;
+  let SQL: SqlJsStatic;
   try {
     SQL = await getSqlJs();
   } catch {
@@ -1138,7 +1139,7 @@ function buildHashToProjectMap(decodedWorkspacePaths: string[]): Map<string, str
  * Returns null if the DB is empty, corrupt, or has no meta table.
  */
 async function readStoreDbMeta(dbPath: string): Promise<StoreDbMetaPreview | null> {
-  let SQL: any;
+  let SQL: SqlJsStatic;
   try {
     SQL = await getSqlJs();
   } catch {
@@ -1632,7 +1633,7 @@ async function parseCursorStoreDb(
     }
   }
 
-  let SQL: any;
+  let SQL: SqlJsStatic;
   try {
     SQL = await getSqlJs();
   } catch {


### PR DESCRIPTION
## Summary

- Replace `let SQL: any` with `let SQL: SqlJsStatic` at the 3 call sites in `sqlite-reader.ts` where sql.js is initialised
- Add `import type { SqlJsStatic } from "sql.js"` (the ambient d.ts already exists via `/// <reference path>`)
- Net change: +4 / -3 lines in 1 file

## Motivation

`getSqlJs()` is typed as `() => Promise<SqlJsStatic>` (inferred via `createRetryableInit<SqlJsStatic>`), so the `let SQL: any` annotation was just discarding a known type.  Narrowing it lets TypeScript verify that `new SQL.Database(...)` is called correctly without the silent `any` escape hatch.  Zero runtime impact — annotation only.

## Test plan

- [x] `pnpm test` all green
- [x] `pnpm lint:check` zero warnings / errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` zero errors
- [x] `pnpm build` successful (viewer 916 KB, CLI 577 KB — unchanged from main)
- [x] E2E: not run (type-annotation-only change; no behaviour to verify)

> 🤖 Daily auto-quality routine. Self-merged after AI review.