### PR TITLE
refactor(cli): extract auth routes into server-routes/auth.ts (#354 pass 5)

### DIFF
--- a/packages/cli/src/server-routes/auth.ts
+++ b/packages/cli/src/server-routes/auth.ts
@@ -1,0 +1,157 @@
+import type { Hono } from "hono";
+import { saveAuthToken } from "../publishers/cloud.js";
+import type { AuthSession } from "../server-auth.js";
+
+interface AuthRouteDeps {
+  cloudApiBaseUrl: string;
+  readLocalAuthSession: AuthSession["readLocalAuthSession"];
+  isAuthValid: AuthSession["isAuthValid"];
+  clearLocalAuthSession: AuthSession["clearLocalAuthSession"];
+  /** Fire-and-forget insights sync, run after a successful login. */
+  autoSyncInsights: () => Promise<void>;
+}
+
+/** Local auth routes — status, session, logout, and the CLI OAuth login flow. */
+export function registerAuthRoutes(app: Hono, deps: AuthRouteDeps): void {
+  const {
+    cloudApiBaseUrl,
+    readLocalAuthSession,
+    isAuthValid,
+    clearLocalAuthSession,
+    autoSyncInsights,
+  } = deps;
+
+  app.get("/api/auth/status", async (c) => {
+    const auth = readLocalAuthSession();
+    if (!auth) return c.json({ authenticated: false, user: null });
+    const valid = await isAuthValid();
+    if (!valid) return c.json({ authenticated: false, user: null });
+    return c.json({ authenticated: true, user: auth.user || null });
+  });
+
+  // Better Auth-shaped local session endpoint for editor mode parity.
+  app.get("/api/auth/get-session", async (c) => {
+    const auth = readLocalAuthSession();
+    if (!auth) return c.json({ session: null, user: null });
+    const valid = await isAuthValid();
+    if (!valid) return c.json({ session: null, user: null });
+    return c.json({
+      session: { token: auth.token },
+      user: auth.user,
+    });
+  });
+
+  app.post("/api/auth/logout", async (c) => {
+    await clearLocalAuthSession();
+    return c.json({ success: true });
+  });
+
+  // Alias for cloud worker parity; keep /api/auth/logout for backward compatibility
+  app.post("/api/auth/sign-out", async (c) => {
+    await clearLocalAuthSession();
+    return c.json({ success: true });
+  });
+
+  // Auth login — start OAuth flow, return URL for browser to open
+  app.post("/api/auth/login", async (c) => {
+    const { randomUUID } = await import("node:crypto");
+    const http = await import("node:http");
+
+    const apiUrl = cloudApiBaseUrl;
+    const nonce = randomUUID();
+
+    // Start a temporary localhost server to receive the OAuth callback
+    return new Promise<Response>((resolveResponse) => {
+      let responded = false;
+      const respond = (r: Response) => {
+        if (responded) return;
+        responded = true;
+        resolveResponse(r);
+      };
+
+      const server = http.createServer((req, res) => {
+        if (req.method === "OPTIONS") {
+          res.writeHead(200, {
+            "Access-Control-Allow-Origin": apiUrl,
+            "Access-Control-Allow-Methods": "POST",
+            "Access-Control-Allow-Headers": "Content-Type",
+          });
+          res.end();
+          return;
+        }
+        if (req.method === "POST" && req.url === "/callback") {
+          let body = "";
+          let destroyed = false;
+          req.on("data", (chunk: string) => {
+            body += chunk;
+            if (body.length > 1_000_000) {
+              destroyed = true;
+              res.writeHead(413);
+              res.end();
+              req.destroy();
+            }
+          });
+          req.on("end", async () => {
+            if (destroyed) return;
+            try {
+              const data = JSON.parse(body);
+              if (data.nonce !== nonce) {
+                res.writeHead(403);
+                res.end("Forbidden");
+                server.close();
+                return;
+              }
+              res.writeHead(200, {
+                "Content-Type": "text/plain",
+                "Access-Control-Allow-Origin": apiUrl,
+              });
+              res.end("OK");
+
+              // Save auth keyed by current API environment
+              await saveAuthToken({ token: data.token, user: data.user }, cloudApiBaseUrl);
+
+              // Auto-sync insights to cloud after login (fire-and-forget)
+              autoSyncInsights().catch(() => {});
+            } catch {
+              res.writeHead(400);
+              res.end("Bad Request");
+            }
+            server.close();
+          });
+          return;
+        }
+        res.writeHead(404);
+        res.end();
+      });
+
+      server.on("error", (err) => {
+        respond(c.json({ error: `OAuth server failed: ${err.message}` }, 500));
+        // Close the server so a post-listen error doesn't leak until the 5-minute timeout
+        try {
+          server.close();
+        } catch {
+          /* already closed */
+        }
+      });
+
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") {
+          server.close();
+          respond(c.json({ error: "Failed to get server address" }, 500));
+          return;
+        }
+        const loginUrl = `${apiUrl}/auth/cli-login?port=${addr.port}&nonce=${nonce}`;
+        respond(c.json({ url: loginUrl }));
+      });
+
+      // Timeout after 5 minutes
+      setTimeout(
+        () => {
+          server.close();
+        },
+        5 * 60 * 1000,
+      );
+    });
+  });
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -42,12 +42,7 @@ import {
   resolveCursorLiveWatchPaths,
 } from "./providers/cursor/sqlite-reader.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
-import {
-  getApiUrl,
-  loadSavedCloudInfo,
-  publishCloudWithOverlays,
-  saveAuthToken,
-} from "./publishers/cloud.js";
+import { getApiUrl, loadSavedCloudInfo, publishCloudWithOverlays } from "./publishers/cloud.js";
 import {
   checkPublishStatus,
   loadSavedGistInfo,
@@ -84,6 +79,7 @@ import type {
 import { loadAnnotations, saveAnnotations, saveOverlays } from "./server-persistence.js";
 import { createAuthSession } from "./server-auth.js";
 import { registerArchiveRoutes } from "./server-routes/archive.js";
+import { registerAuthRoutes } from "./server-routes/auth.js";
 import { registerSessionAssetRoutes } from "./server-routes/session-assets.js";
 import {
   buildInsightsSyncBatches,
@@ -2206,138 +2202,12 @@ export async function startServer(
     }
   }
 
-  app.get("/api/auth/status", async (c) => {
-    const auth = readLocalAuthSession();
-    if (!auth) return c.json({ authenticated: false, user: null });
-    const valid = await isAuthValid();
-    if (!valid) return c.json({ authenticated: false, user: null });
-    return c.json({ authenticated: true, user: auth.user || null });
-  });
-
-  // Better Auth-shaped local session endpoint for editor mode parity.
-  app.get("/api/auth/get-session", async (c) => {
-    const auth = readLocalAuthSession();
-    if (!auth) return c.json({ session: null, user: null });
-    const valid = await isAuthValid();
-    if (!valid) return c.json({ session: null, user: null });
-    return c.json({
-      session: { token: auth.token },
-      user: auth.user,
-    });
-  });
-
-  app.post("/api/auth/logout", async (c) => {
-    await clearLocalAuthSession();
-    return c.json({ success: true });
-  });
-
-  // Alias for cloud worker parity; keep /api/auth/logout for backward compatibility
-  app.post("/api/auth/sign-out", async (c) => {
-    await clearLocalAuthSession();
-    return c.json({ success: true });
-  });
-
-  // Auth login — start OAuth flow, return URL for browser to open
-  app.post("/api/auth/login", async (c) => {
-    const { randomUUID } = await import("node:crypto");
-    const http = await import("node:http");
-
-    const apiUrl = cloudApiBaseUrl;
-    const nonce = randomUUID();
-
-    // Start a temporary localhost server to receive the OAuth callback
-    return new Promise<Response>((resolveResponse) => {
-      let responded = false;
-      const respond = (r: Response) => {
-        if (responded) return;
-        responded = true;
-        resolveResponse(r);
-      };
-
-      const server = http.createServer((req, res) => {
-        if (req.method === "OPTIONS") {
-          res.writeHead(200, {
-            "Access-Control-Allow-Origin": apiUrl,
-            "Access-Control-Allow-Methods": "POST",
-            "Access-Control-Allow-Headers": "Content-Type",
-          });
-          res.end();
-          return;
-        }
-        if (req.method === "POST" && req.url === "/callback") {
-          let body = "";
-          let destroyed = false;
-          req.on("data", (chunk: string) => {
-            body += chunk;
-            if (body.length > 1_000_000) {
-              destroyed = true;
-              res.writeHead(413);
-              res.end();
-              req.destroy();
-            }
-          });
-          req.on("end", async () => {
-            if (destroyed) return;
-            try {
-              const data = JSON.parse(body);
-              if (data.nonce !== nonce) {
-                res.writeHead(403);
-                res.end("Forbidden");
-                server.close();
-                return;
-              }
-              res.writeHead(200, {
-                "Content-Type": "text/plain",
-                "Access-Control-Allow-Origin": apiUrl,
-              });
-              res.end("OK");
-
-              // Save auth keyed by current API environment
-              await saveAuthToken({ token: data.token, user: data.user }, cloudApiBaseUrl);
-
-              // Auto-sync insights to cloud after login (fire-and-forget)
-              autoSyncInsights().catch(() => {});
-            } catch {
-              res.writeHead(400);
-              res.end("Bad Request");
-            }
-            server.close();
-          });
-          return;
-        }
-        res.writeHead(404);
-        res.end();
-      });
-
-      server.on("error", (err) => {
-        respond(c.json({ error: `OAuth server failed: ${err.message}` }, 500));
-        // Close the server so a post-listen error doesn't leak until the 5-minute timeout
-        try {
-          server.close();
-        } catch {
-          /* already closed */
-        }
-      });
-
-      server.listen(0, "127.0.0.1", () => {
-        const addr = server.address();
-        if (!addr || typeof addr === "string") {
-          server.close();
-          respond(c.json({ error: "Failed to get server address" }, 500));
-          return;
-        }
-        const loginUrl = `${apiUrl}/auth/cli-login?port=${addr.port}&nonce=${nonce}`;
-        respond(c.json({ url: loginUrl }));
-      });
-
-      // Timeout after 5 minutes
-      setTimeout(
-        () => {
-          server.close();
-        },
-        5 * 60 * 1000,
-      );
-    });
+  registerAuthRoutes(app, {
+    cloudApiBaseUrl,
+    readLocalAuthSession,
+    isAuthValid,
+    clearLocalAuthSession,
+    autoSyncInsights,
   });
 
   // Proxy cloud APIs via local auth session (BFF mode for editor)


### PR DESCRIPTION
Refs #354 (fifth extraction pass — builds on the auth-session manager from #390).

## What

With the auth-session now a clean dependency (`server-auth.ts`), this moves the 5 auth endpoints out of `startServer` into `server-routes/auth.ts`:

- `GET /api/auth/status`, `GET /api/auth/get-session`, `POST /api/auth/logout`, `POST /api/auth/sign-out`, and `POST /api/auth/login` (the CLI OAuth flow that spins up a temporary localhost callback server).
- `registerAuthRoutes(app, { cloudApiBaseUrl, readLocalAuthSession, isAuthValid, clearLocalAuthSession, autoSyncInsights })`. `saveAuthToken` is imported directly by the module and dropped from `server.ts`'s imports.

## Result

- `server.ts`: 3097 → 2967. New `server-routes/auth.ts`: 157 lines.
- Cumulative across #354: server.ts is now **3761 → 2967** (~800 lines out) across 5 passes (`server-enrichment`, `server-source-catalog` + `server-types`, `server-routes/archive`, `server-auth`, `server-routes/auth`).

## Verification

- `pnpm --filter vibe-replay test` — 340 passed, 1 skipped.
- `tsc --noEmit` + `lint:check` — clean.
- Server boot + auth wiring verified via the `editor-server` + `cli-smoke` e2e.

Per the agreed plan, this is the last high-value pass for now — #354 stays open as an ongoing, incremental decomposition (the remaining `startServer` routes — sources/enrichment, generate, cloud-proxy, gist, export, system-checks — are more coupled and each is its own follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)