### PR TITLE
chore(provider-cursor): extract parseChatMetaHex helper, dedupe 3 occurrences

### DIFF
--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -1152,7 +1152,7 @@ async function readStoreDbMeta(dbPath: string): Promise<StoreDbMetaPreview | nul
     const metaRows = db.exec("SELECT value FROM meta WHERE key = '0'");
     if (!metaRows.length || !metaRows[0].values.length) return null;
     const metaHex = metaRows[0].values[0][0] as string;
-    const meta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8")) as ChatMeta;
+    const meta = parseChatMetaHex(metaHex);
     const rootId = meta.latestRootBlobId;
     if (!rootId) return { meta, hasReplayableRoot: false };
     const rootRows = db.exec("SELECT data FROM blobs WHERE id = ?", [rootId]);
@@ -1443,6 +1443,10 @@ interface StoreDbMetaPreview {
   hasReplayableRoot: boolean;
 }
 
+function parseChatMetaHex(hex: string): ChatMeta {
+  return JSON.parse(Buffer.from(hex, "hex").toString("utf-8")) as ChatMeta;
+}
+
 interface CursorBlock {
   type: string;
   text?: string;
@@ -1648,7 +1652,7 @@ async function parseCursorStoreDb(
     if (!metaRows.length || !metaRows[0].values.length) return null;
 
     const metaHex = metaRows[0].values[0][0] as string;
-    const metaJson: ChatMeta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
+    const metaJson = parseChatMetaHex(metaHex);
     const rootId = metaJson.latestRootBlobId;
     if (!rootId) return null;
 
@@ -1717,7 +1721,7 @@ async function parseCursorStoreDbWithSqliteCli(
 
   // If sqlite3 returns malformed data, let the caller fall back to the sql.js
   // path below; that path has historically handled store.db quirks well.
-  const metaJson: ChatMeta = JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8"));
+  const metaJson = parseChatMetaHex(metaHex);
   const rootId = metaJson.latestRootBlobId;
   if (!rootId) return null;
 


### PR DESCRIPTION
## Summary

- Extract `parseChatMetaHex(hex: string): ChatMeta` helper in `packages/provider-cursor/src/cursor/sqlite-reader.ts`
- Replace 3 identical occurrences of `JSON.parse(Buffer.from(metaHex, "hex").toString("utf-8")) as ChatMeta` with the helper
- Net change: +4 lines helper, -3 duplicated call-sites

## Motivation

The hex-decode-then-JSON-parse pattern for `ChatMeta` appeared 3 times in the same file (`readStoreDbMeta`, `parseCursorStoreDb`, `parseCursorStoreDbWithSqliteCli`). Extracting it into a named helper eliminates the repetition and gives the operation a searchable name. Semantically equivalent: the helper is a pure pass-through of the same expression.

## Test plan

- [x] `pnpm test` 全绿 (25+12 test files, 517 tests)
- [x] `pnpm lint:check` 零 warning (44 existing viewer-only warnings unchanged)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB < 1MB limit)
- [x] E2E: 没跑 (structural dedup only, no runtime behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.