### PR TITLE
chore(provider-cursor): type CachedSqlJsDb.db and sqlJsRows param as Database

### DIFF
--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -1,5 +1,5 @@
 /// <reference path="../sql-js.d.ts" />
-import type { SqlJsStatic } from "sql.js";
+import type { Database, SqlJsStatic } from "sql.js";
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { readdir, readFile, stat } from "node:fs/promises";
@@ -42,7 +42,7 @@ const getSqlJs = createRetryableInit(async () => {
 interface CachedSqlJsDb {
   dbPath: string;
   backend: "sqljs";
-  db: any;
+  db: Database;
   size: number;
   mtimeMs: number;
   walSize: number;
@@ -314,7 +314,7 @@ async function querySqliteCliText(dbPath: string, sql: string): Promise<string> 
   return stdout.replace(/\r?\n$/, "");
 }
 
-function sqlJsRows(db: any, sql: string): Record<string, any>[] {
+function sqlJsRows(db: Database, sql: string): Record<string, any>[] {
   const result = db.exec(sql);
   if (!result.length) return [];
   const [{ columns, values }] = result;


### PR DESCRIPTION
## Summary

- Add `Database` to the sql.js import alongside `SqlJsStatic`
- Type `CachedSqlJsDb.db` field as `Database` instead of `any`
- Type `sqlJsRows(db: Database, ...)` parameter instead of `any`
- Net: -3 +3 lines (same count, no additions)

## Motivation

Follow-up to #388 which typed `let SQL: SqlJsStatic` in three functions. The `Database` interface was already declared in `sql-js.d.ts`; this makes the two remaining `any` occurrences in the same domain explicit. Semantically equivalent — `new SQL.Database(...)` already returns `Database`, so this only makes the implicit type visible to the compiler.

## Test plan

- [x] `pnpm test` 全绿 (656 tests)
- [x] `pnpm lint:check` 零新 warning (44 pre-existing, all in viewer)
- [x] `node_modules/.bin/tsc --noEmit -p packages/provider-cursor/tsconfig.json` 零错
- [x] `node_modules/.bin/tsc --noEmit -p packages/cli/tsconfig.json` 零错
- [x] `pnpm build` 成功 (viewer 915KB)
- [x] E2E: 未跑 (纯类型变更，无运行时路径)

> 🤖 Daily auto-quality routine. Self-merged after AI review.