### PR TITLE
chore(provider-codex): type QueryExecResult.values as SqlValue[][]

### DIFF
--- a/packages/provider-codex/src/codex/discover.ts
+++ b/packages/provider-codex/src/codex/discover.ts
@@ -237,7 +237,7 @@ async function readThreadRowsFromStateDb(): Promise<CodexThreadRow[]> {
       `);
       const table = result[0];
       if (!table) return [];
-      return table.values.map((values: any[]) => {
+      return table.values.map((values) => {
         const row: Record<string, any> = {};
         table.columns.forEach((col: string, i: number) => {
           row[col] = values[i];

--- a/packages/provider-codex/src/sql-js.d.ts
+++ b/packages/provider-codex/src/sql-js.d.ts
@@ -1,7 +1,9 @@
 declare module "sql.js" {
+  type SqlValue = string | number | null | Uint8Array;
+
   interface QueryExecResult {
     columns: string[];
-    values: any[][];
+    values: SqlValue[][];
   }
 
   interface Statement {


### PR DESCRIPTION
## Summary

- Add `SqlValue = string | number | null | Uint8Array` type to `packages/provider-codex/src/sql-js.d.ts`
- Change `QueryExecResult.values` from `any[][]` to `SqlValue[][]`
- Remove redundant `any[]` annotation in the `discover.ts` row-mapping callback (now inferred correctly as `SqlValue[]`)
- Net change: +4 / -2

## Motivation

Parallel fix to #396 (cursor provider). The codex provider had the same `sql-js.d.ts` stub with `values: any[][]`; typing it as `SqlValue[][]` is semantically equivalent because SQL.js only returns `string | number | null | Uint8Array` values. Zero runtime impact — types only.

## Test plan

- [x] `pnpm test` 全绿 (25+12 test files, 517 tests passed)
- [x] `pnpm lint:check` 零 warning (for touched files)
- [x] `pnpm --filter @vibe-replay/provider-codex exec tsc --noEmit` 零错
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` 零错
- [x] `pnpm build` 成功 (viewer 871KB < 1MB)
- [x] E2E: 没跑，本次是 types-only 改动，无运行时行为变化

> 🤖 Daily auto-quality routine. Self-merged after AI review.