### PR TITLE
Dedupe Cowork replay echo prompts

### DIFF
--- a/packages/provider-claude-code/src/claude-cowork/parser.ts
+++ b/packages/provider-claude-code/src/claude-cowork/parser.ts
@@ -66,6 +66,8 @@ function humanUserReplayKeys(obj: Record<string, unknown>): string[] {
   if (typeof content === "string") {
     keys.push(`content:${content}`);
   } else if (Array.isArray(content)) {
+    // Key text blocks only. Image-only prompts without UUID intentionally fall
+    // through as non-dedupable so we preserve rather than accidentally drop them.
     const text = content
       .filter(
         (block): block is { text?: unknown; type?: unknown } =>

--- a/packages/provider-claude-code/src/claude-cowork/parser.ts
+++ b/packages/provider-claude-code/src/claude-cowork/parser.ts
@@ -13,6 +13,7 @@ import type { SessionInfo } from "@vibe-replay/provider-contract";
  *   - `session_id`           → `sessionId`
  *   - `parent_tool_use_id`   → `parentToolUseID`
  *   - `_audit_timestamp`     → fallback `timestamp`
+ *   - `isReplay: true` human user records duplicate the host-loop originals.
  *   - Extra types like `rate_limit_event`, `tool_use_summary` — parser ignores them.
  *   - Missing `cwd` / `gitBranch` / `custom-title` — supplied by sibling metadata JSON.
  */
@@ -34,11 +35,74 @@ export function normalizeCoworkLine(line: string, onMalformedJson?: () => void):
     obj.parentToolUseID = obj.parent_tool_use_id;
     delete obj.parent_tool_use_id;
   }
-  if (!obj.timestamp && typeof obj._audit_timestamp === "string") {
-    obj.timestamp = obj._audit_timestamp;
+  const auditTimestamp = obj["_audit_timestamp"];
+  if (!obj.timestamp && typeof auditTimestamp === "string") {
+    obj.timestamp = auditTimestamp;
   }
 
   return JSON.stringify(obj);
+}
+
+function humanUserReplayKeys(obj: Record<string, unknown>): string[] {
+  if (obj.type !== "user" || !obj.message || typeof obj.message !== "object") return [];
+  const message = obj.message as { role?: unknown; content?: unknown };
+  if (message.role !== "user") return [];
+
+  const content = message.content;
+  const hasHumanContent =
+    typeof content === "string" ||
+    (Array.isArray(content) &&
+      content.some(
+        (block) =>
+          block &&
+          typeof block === "object" &&
+          ((block as { type?: unknown }).type === "text" ||
+            (block as { type?: unknown }).type === "image"),
+      ));
+  if (!hasHumanContent) return [];
+
+  const keys: string[] = [];
+  if (typeof obj.uuid === "string" && obj.uuid) keys.push(`uuid:${obj.uuid}`);
+  if (typeof content === "string") {
+    keys.push(`content:${content}`);
+  } else if (Array.isArray(content)) {
+    const text = content
+      .filter(
+        (block): block is { text?: unknown; type?: unknown } =>
+          !!block && typeof block === "object" && (block as { type?: unknown }).type === "text",
+      )
+      .map((block) => block.text)
+      .filter((text): text is string => typeof text === "string" && text.length > 0)
+      .join("\n");
+    if (text) keys.push(`content:${text}`);
+  }
+  return keys;
+}
+
+function isDuplicateCoworkReplayUser(
+  obj: Record<string, unknown>,
+  originalUserKeys: Set<string>,
+): boolean {
+  if (obj.isReplay !== true) return false;
+  const keys = humanUserReplayKeys(obj);
+  return keys.some((key) => originalUserKeys.has(key));
+}
+
+function collectOriginalCoworkUserKeys(lines: string[]): Set<string> {
+  const keys = new Set<string>();
+  for (const raw of lines) {
+    const t = raw.trim();
+    if (!t) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(t) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (obj.isReplay === true) continue;
+    for (const key of humanUserReplayKeys(obj)) keys.add(key);
+  }
+  return keys;
 }
 
 /**
@@ -56,10 +120,17 @@ export async function parseClaudeCoworkSession(
   for (const fp of paths) {
     const content = await readFile(fp, "utf-8");
     const lines = content.split("\n");
+    const originalUserKeys = collectOriginalCoworkUserKeys(lines);
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
       const raw = lines[lineIndex];
       const t = raw.trim();
       if (!t) continue;
+      try {
+        const obj = JSON.parse(t) as Record<string, unknown>;
+        if (isDuplicateCoworkReplayUser(obj, originalUserKeys)) continue;
+      } catch {
+        // Let normalizeCoworkLine report malformed JSON consistently below.
+      }
       const line = normalizeCoworkLine(t, () => {
         addParseWarning(parseWarnings, {
           kind: "malformed-json",

--- a/packages/provider-claude-code/test/claude-cowork-parser.test.ts
+++ b/packages/provider-claude-code/test/claude-cowork-parser.test.ts
@@ -96,6 +96,76 @@ describe("parseClaudeCoworkSession", () => {
     expect((toolUses[0] as { name: string }).name).toBe("mcp__workspace__bash");
   });
 
+  it("skips Cowork replay echo user messages when the original is present", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cowork-replay-echo-"));
+    const auditPath = join(tempDir, "audit.jsonl");
+    const prompt = "Why does Cowork show duplicate user messages?";
+    const lines = [
+      {
+        type: "user",
+        uuid: "same-user-message",
+        session_id: "cowork-session",
+        message: { role: "user", content: prompt },
+        _audit_timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        type: "user",
+        uuid: "same-user-message",
+        session_id: "cli-session",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        isReplay: true,
+        message: { role: "user", content: prompt },
+      },
+      {
+        type: "assistant",
+        session_id: "cli-session",
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg_001",
+          role: "assistant",
+          content: [{ type: "text", text: "Only one user prompt should be rendered." }],
+        },
+        _audit_timestamp: "2026-01-01T00:00:02.000Z",
+      },
+    ];
+    await writeFile(auditPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+
+    try {
+      const result = await parseClaudeCoworkSession(auditPath);
+      const userTurns = result.turns.filter((turn) => turn.role === "user");
+      expect(userTurns).toHaveLength(1);
+      expect(userTurns[0].blocks).toEqual([{ type: "text", text: prompt }]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps Cowork replay user messages when no original is present", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cowork-replay-only-"));
+    const auditPath = join(tempDir, "audit.jsonl");
+    const prompt = "This older Cowork audit only has the replayed prompt.";
+    await writeFile(
+      auditPath,
+      `${JSON.stringify({
+        type: "user",
+        uuid: "replay-only-user-message",
+        session_id: "cli-session",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        isReplay: true,
+        message: { role: "user", content: prompt },
+      })}\n`,
+    );
+
+    try {
+      const result = await parseClaudeCoworkSession(auditPath);
+      const userTurns = result.turns.filter((turn) => turn.role === "user");
+      expect(userTurns).toHaveLength(1);
+      expect(userTurns[0].blocks).toEqual([{ type: "text", text: prompt }]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("overlays title, model, startTime from sessionInfo when missing in audit", async () => {
     const info: SessionInfo = {
       provider: "claude-cowork",

--- a/packages/provider-claude-code/test/claude-cowork-parser.test.ts
+++ b/packages/provider-claude-code/test/claude-cowork-parser.test.ts
@@ -166,6 +166,49 @@ describe("parseClaudeCoworkSession", () => {
     }
   });
 
+  it("skips Cowork replay echo user messages with array text content", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cowork-replay-array-"));
+    const auditPath = join(tempDir, "audit.jsonl");
+    const prompt = "The user prompt is stored as a text block array.";
+    const content = [{ type: "text", text: prompt }];
+    const lines = [
+      {
+        type: "user",
+        session_id: "cowork-session",
+        message: { role: "user", content },
+        _audit_timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        type: "user",
+        session_id: "cli-session",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        isReplay: true,
+        message: { role: "user", content },
+      },
+      {
+        type: "assistant",
+        session_id: "cli-session",
+        message: {
+          model: "claude-opus-4-6",
+          id: "msg_001",
+          role: "assistant",
+          content: [{ type: "text", text: "Array-format echo should be deduped too." }],
+        },
+        _audit_timestamp: "2026-01-01T00:00:02.000Z",
+      },
+    ];
+    await writeFile(auditPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+
+    try {
+      const result = await parseClaudeCoworkSession(auditPath);
+      const userTurns = result.turns.filter((turn) => turn.role === "user");
+      expect(userTurns).toHaveLength(1);
+      expect(userTurns[0].blocks).toEqual([{ type: "text", text: prompt }]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("overlays title, model, startTime from sessionInfo when missing in audit", async () => {
     const info: SessionInfo = {
       provider: "claude-cowork",


### PR DESCRIPTION
## Summary
- Skip duplicate Cowork `isReplay: true` human user echo records when the original host-loop prompt is present
- Preserve replay-only user records for older/partial Cowork audit logs
- Add regression coverage for duplicate and replay-only Cowork prompt handling

## Validation
- pnpm --filter @vibe-replay/provider-claude-code test
- pnpm exec tsc --noEmit -p packages/provider-claude-code/tsconfig.json
