### PR TITLE
chore(provider-codex): dedupe contentText helper, import from constants

### DIFF
--- a/packages/provider-codex/src/codex/constants.ts
+++ b/packages/provider-codex/src/codex/constants.ts
@@ -51,3 +51,18 @@ export function codexStripTwoPass(text: string): string {
   }
   return result;
 }
+
+export function contentText(content: any): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part?.type === "output_text" || part?.type === "input_text" || part?.type === "text") {
+        return part.text || "";
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}

--- a/packages/provider-codex/src/codex/discover.ts
+++ b/packages/provider-codex/src/codex/discover.ts
@@ -7,7 +7,12 @@ import { createInterface } from "node:readline";
 import { cleanPromptText } from "@vibe-replay/provider-core/clean-prompt";
 import type { SessionInfo } from "@vibe-replay/provider-contract";
 import { readGitRepo, shortenPath } from "@vibe-replay/provider-core/utils";
-import { CODEX_CONTEXT_TAGS, codexStripTwoPass, isCodexToolCallType } from "./constants.js";
+import {
+  CODEX_CONTEXT_TAGS,
+  codexStripTwoPass,
+  contentText,
+  isCodexToolCallType,
+} from "./constants.js";
 
 const STATE_DB_FILENAME = "state_5.sqlite";
 
@@ -321,21 +326,6 @@ function recordDiscoveredPrompt(
   promptSeen.set(key, [...previous, Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time]);
   if (prompts.length < 2) prompts.push((text || "[Image]").slice(0, 200));
   return true;
-}
-
-function contentText(content: any): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) => {
-      if (typeof part === "string") return part;
-      if (part?.type === "output_text" || part?.type === "input_text" || part?.type === "text") {
-        return part.text || "";
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
 }
 
 function isCodexContextMessage(text: string): boolean {

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -5,7 +5,7 @@ import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "@vibe-replay/provider-contract";
 import type { Compaction, ProviderParseResult, TokenUsage } from "@vibe-replay/provider-contract";
 import { addParseWarning } from "@vibe-replay/provider-contract/warnings";
-import { codexStripTwoPass, isCodexToolCallType } from "./constants.js";
+import { codexStripTwoPass, contentText, isCodexToolCallType } from "./constants.js";
 
 interface PendingTool {
   id: string;
@@ -507,21 +507,6 @@ function isCompactionSummaryText(text: string): boolean {
   // Codex-native compactions emit `response_item.compaction`; this keeps
   // compatibility with imported/bridged transcripts that use Claude's preamble.
   return text.startsWith("This session is being continued from a previous conversation");
-}
-
-function contentText(content: any): string {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((part) => {
-      if (typeof part === "string") return part;
-      if (part?.type === "output_text" || part?.type === "input_text" || part?.type === "text") {
-        return part.text || "";
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
 }
 
 function contentImages(content: any): string[] {


### PR DESCRIPTION
## Summary

- Extract identical `contentText(content: any): string` function from both `codex/parser.ts` and `codex/discover.ts` into the shared `codex/constants.ts`
- Both callers now import from `./constants.js`
- Net: -10 lines (+15 in constants, -14 in discover, -16 in parser)

## Motivation

`contentText` was copy-pasted byte-for-byte between the two files. Extracting it to `constants.ts` (which both files already import) eliminates the duplication. Semantically equivalent: no logic change, only consolidation.

## Test plan

- [x] `pnpm test` 全绿 (339 passed, 2 skipped)
- [x] lint check on modified files: zero warnings
- [x] `pnpm build` 成功 (viewer 915KB)
- [x] E2E: skipped (structural/type change, no runtime behavior change)

> 🤖 Daily auto-quality routine. Self-merged after AI review.