### PR TITLE
chore(provider-claude-code): type subagent JSONL obj as RawMessage

### DIFF
--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -954,9 +954,9 @@ async function readSubagents(
     for (const line of content.split("\n")) {
       lineNumber++;
       if (!line.trim()) continue;
-      let obj: any;
+      let obj: RawMessage;
       try {
-        obj = JSON.parse(line);
+        obj = JSON.parse(line) as RawMessage;
       } catch {
         addParseWarning(parseWarnings, {
           kind: "malformed-json",


### PR DESCRIPTION
## Summary

- In `scanSubAgent`, replace `let obj: any` with `let obj: RawMessage` (2-line change)
- `RawMessage` is already imported at the top of this file and used in the main parse loop (line 133)

## Motivation

Subagent JSONL files use the same format as the main Claude Code JSONL, so `RawMessage` is the correct type. Eliminates the only `as any` type in `provider-claude-code`'s production source. All property accesses (`obj.type`, `obj.message.*`, `obj.timestamp`) are already covered by `RawMessage`'s fields.

## Test plan

- [x] `pnpm test` 全绿 (657 tests)
- [x] `pnpm lint:check` 零 warning on changed file
- [x] `tsc --noEmit` 零错 on provider-claude-code
- [x] `pnpm build` 成功 (viewer 915KB)
- [x] E2E: 未跑 (纯 type-level 改动，语义等价可证明)

> 🤖 Daily auto-quality routine. Self-merged after AI review.