### PR TITLE
chore(cli): remove dead claude-cowork re-export shims

### DIFF
--- a/packages/cli/src/providers/claude-cowork/discover.ts
+++ b/packages/cli/src/providers/claude-cowork/discover.ts
@@ -1,5 +1,0 @@
-export {
-  discoverClaudeCoworkSessions,
-  discoverCoworkFromDir,
-  extractCoworkSessionInfo,
-} from "@vibe-replay/provider-claude-code/claude-cowork/discover";

--- a/packages/cli/src/providers/claude-cowork/index.ts
+++ b/packages/cli/src/providers/claude-cowork/index.ts
@@ -1,1 +1,0 @@
-export { claudeCoworkProvider } from "@vibe-replay/provider-claude-code/claude-cowork";

--- a/packages/cli/src/providers/claude-cowork/parser.ts
+++ b/packages/cli/src/providers/claude-cowork/parser.ts
@@ -1,4 +1,0 @@
-export {
-  normalizeCoworkLine,
-  parseClaudeCoworkSession,
-} from "@vibe-replay/provider-claude-code/claude-cowork/parser";


### PR DESCRIPTION
## Summary

- Removes `packages/cli/src/providers/claude-cowork/{discover,index,parser}.ts`, which only re-exported symbols from `@vibe-replay/provider-claude-code` and had zero importers left anywhere in the repo.
- Net: -10 lines, 0 additions.

## Motivation

These files are leftovers from the earlier migration of provider logic into standalone `@vibe-replay/provider-*` packages. `cli/src/providers/*` now imports parsers directly from the provider packages (see `server.ts`, `scanner.ts`), so these three re-export shims are unreferenced. Confirmed via `knip` (flagged as unused files) and a repo-wide `grep` for `providers/claude-cowork` — zero hits outside the deleted files themselves. The package has no `exports` field exposing internal source paths (only ships `dist` + `assets`), so there's no external consumer either. Deletion is behavior-neutral: nothing imported these files, so nothing changes at runtime.

## Test plan

- [x] `pnpm test` — all green (CLI + viewer + provider packages)
- [x] `pnpm lint:check` — zero new warnings/errors (pre-existing viewer-only warnings unchanged)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — zero errors
- [x] `pnpm build` — succeeds, viewer 915.23kB (unchanged from baseline; this change doesn't touch viewer)
- [x] Repo-wide grep confirms zero references to the deleted files

> 🤖 Daily auto-quality routine. Self-merged after AI review.