### PR TITLE
chore(cli): remove dead codex re-export shims in cli/src/providers

### DIFF
--- a/packages/cli/src/providers/codex/constants.ts
+++ b/packages/cli/src/providers/codex/constants.ts
@@ -1,5 +1,0 @@
-export {
-  CODEX_CONTEXT_TAGS,
-  codexStripTwoPass,
-  isCodexToolCallType,
-} from "@vibe-replay/provider-codex/constants";

--- a/packages/cli/src/providers/codex/discover.ts
+++ b/packages/cli/src/providers/codex/discover.ts
@@ -1,4 +1,0 @@
-export {
-  discoverCodexSessions,
-  extractCodexSessionInfo,
-} from "@vibe-replay/provider-codex/discover";

--- a/packages/cli/src/providers/codex/index.ts
+++ b/packages/cli/src/providers/codex/index.ts
@@ -1,1 +1,0 @@
-export { codexProvider } from "@vibe-replay/provider-codex";


### PR DESCRIPTION
## Summary

- Delete `constants.ts`, `discover.ts`, and `index.ts` under `packages/cli/src/providers/codex/` — pure re-export shims left over from splitting the codex provider into `@vibe-replay/provider-codex`, with zero remaining imports anywhere in the repo.
- Net: -10 +0 lines (3 files deleted).

## Motivation

Confirmed dead via `knip` (flagged as unused files) and a repo-wide `rg` for their import paths — nothing imports them, so removal is a no-op at runtime. `parser.ts` in the same directory is still actively used (imported by `server.ts`/`scanner.ts`) and is untouched.

## Test plan

- [x] `pnpm test` all green (CLI + viewer + provider packages)
- [x] `pnpm lint:check` zero errors (pre-existing viewer a11y warnings unrelated, unchanged)
- [x] `pnpm typecheck` zero errors across all packages
- [x] `pnpm build` succeeds (viewer 915.23kB, under the 1MB budget)
- [x] `pnpm test:e2e` all green (33 passed, 40 skipped as usual)

> 🤖 Daily auto-quality routine. Self-merged after AI review.