### PR TITLE
chore(cli): remove dead pricing re-export shim in cli/src

### DIFF
--- a/packages/cli/src/pricing.ts
+++ b/packages/cli/src/pricing.ts
@@ -1,6 +1,0 @@
-export {
-  estimateCost,
-  estimateCostSimple,
-  getModelContextLimit,
-  getModelPricing,
-} from "@vibe-replay/replay-core/pricing";

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -20,7 +20,7 @@ import {
   extractToolFilePath,
   extractToolFilePaths,
 } from "@vibe-replay/provider-core/utils";
-import { estimateCost, estimateCostSimple } from "./pricing.js";
+import { estimateCost, estimateCostSimple } from "@vibe-replay/replay-core/pricing";
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { parsePiSession } from "./providers/pi/parser.js";


### PR DESCRIPTION
## Summary

- `packages/cli/src/pricing.ts` was a pure re-export shim forwarding to `@vibe-replay/replay-core/pricing` with zero added logic
- It had exactly one consumer (`scanner.ts`); pointed that import directly at `@vibe-replay/replay-core/pricing` and deleted the shim
- Net: -7 +1 lines, 2 files

## Motivation

Removing the indirection is semantically a no-op at runtime (same exported functions, same module ultimately resolved) — it just cuts one hop of re-export that no longer serves a purpose now that pricing logic lives in `replay-core`. Matches the pattern from #407/#408/#409.

## Test plan

- [x] `pnpm test` — all green (CLI + all provider packages + viewer)
- [x] `pnpm lint:check` — zero warnings/errors outside `packages/viewer/` (viewer warnings are pre-existing and untouched)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — zero errors
- [x] `pnpm build` — succeeds, viewer bundle unchanged at 915.23 kB (well under the 1MB budget in CLAUDE.md)
- [x] `pnpm test:e2e` — 33 passed, 40 skipped (pre-existing skips), 0 failures

> 🤖 Daily auto-quality routine. Self-merged after AI review.