### PR TITLE
chore(cloudflare): dedupe UNIQUE constraint check, drop unsafe any casts

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -41,6 +41,10 @@ function isDev(env: { BETTER_AUTH_URL?: string }): boolean {
   return !!env.BETTER_AUTH_URL?.startsWith("http://localhost");
 }
 
+function isUniqueConstraintError(e: unknown): boolean {
+  return Boolean((e as { message?: string } | undefined)?.message?.includes("UNIQUE"));
+}
+
 function isSafeCallbackPath(value: string): boolean {
   return value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\");
 }
@@ -1527,8 +1531,8 @@ app.post("/api/insights/profile", async (c) => {
 
     try {
       await db.update(insightProfiles).set(updates).where(eq(insightProfiles.id, existing.id));
-    } catch (e: any) {
-      if (e?.message?.includes("UNIQUE")) {
+    } catch (e) {
+      if (isUniqueConstraintError(e)) {
         return c.json({ error: "Slug already taken" }, 409);
       }
       throw e;
@@ -1573,8 +1577,8 @@ app.post("/api/insights/profile", async (c) => {
       enabled: body.enabled !== false,
       config: JSON.stringify(config),
     });
-  } catch (e: any) {
-    if (e?.message?.includes("UNIQUE")) {
+  } catch (e) {
+    if (isUniqueConstraintError(e)) {
       return c.json({ error: "Profile already exists" }, 409);
     }
     throw e;


### PR DESCRIPTION
## Summary

- Extract `isUniqueConstraintError(e: unknown)` helper in `cloudflare/src/worker.ts` and reuse it in both insight-profile catch blocks, replacing the duplicated `catch (e: any) { e?.message?.includes("UNIQUE") }` pattern.
- Net: +8 / -4 lines.

## Motivation

The same unsafely-typed (`any`) UNIQUE-constraint check was duplicated in two catch blocks (create/update insight profile). A single named helper removes the duplication and the `any` cast is now scoped and documented in one place. The helper reproduces the exact original runtime behavior (optional-chained `.message?.includes("UNIQUE")`), so this is a pure refactor with zero behavior change.

## Test plan

- [x] `pnpm test` all green (CLI + viewer + provider packages)
- [x] `pnpm test:cloudflare` all green (10/10)
- [x] `pnpm lint:check` zero new warnings/errors (only pre-existing viewer a11y warnings, unrelated)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` and `cloudflare` tsc — zero errors
- [x] `pnpm build` succeeds (viewer 915KB, within budget)
- [x] `pnpm test:e2e` — 33 passed, 40 skipped (pre-existing skip set), 0 failed

> 🤖 Daily auto-quality routine. Self-merged after AI review.