### PR TITLE
chore(provider-claude-code): dedupe tool_use regex, share via provider-core

### DIFF
--- a/packages/provider-claude-code/src/claude-code/discover.ts
+++ b/packages/provider-claude-code/src/claude-code/discover.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { cleanPromptText, isSystemGeneratedMessage } from "@vibe-replay/provider-core/clean-prompt";
 import type { SessionInfo } from "@vibe-replay/provider-contract";
-import { readGitRepo, shortenPath } from "@vibe-replay/provider-core/utils";
+import { readGitRepo, shortenPath, TOOL_USE_RE } from "@vibe-replay/provider-core/utils";
 
 const CLAUDE_DIR = join(homedir(), ".claude", "projects");
 
@@ -118,7 +118,6 @@ export async function extractSessionInfo(
   // fields (e.g. inside user-pasted JSON content).
   const tail: string[] = [];
 
-  const toolUseRe = /"type"\s*:\s*"tool_use"/g;
   const modelRe = /"model"\s*:\s*"(claude-[^"]+)"/;
   const durationRe = /"durationMs"\s*:\s*(\d+)/;
   const editToolRe = /"name"\s*:\s*"(Edit|Write|MultiEdit|NotebookEdit)"/;
@@ -142,7 +141,7 @@ export async function extractSessionInfo(
         // Extremely rare in practice; the fast string check avoids JSON-parsing every line.
         promptCount++;
       }
-      const toolMatches = line.match(toolUseRe);
+      const toolMatches = line.match(TOOL_USE_RE);
       if (toolMatches) {
         toolCallCount += toolMatches.length;
         if (editToolRe.test(line)) editCountEst++;

--- a/packages/provider-claude-code/src/claude-cowork/discover.ts
+++ b/packages/provider-claude-code/src/claude-cowork/discover.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { isSystemGeneratedMessage, previewPrompt } from "@vibe-replay/provider-core/clean-prompt";
 import type { SessionInfo } from "@vibe-replay/provider-contract";
-import { readGitRepo } from "@vibe-replay/provider-core/utils";
+import { readGitRepo, TOOL_USE_RE } from "@vibe-replay/provider-core/utils";
 
 /**
  * Claude Desktop stores Cowork (autonomous agent mode) sessions separately from
@@ -137,7 +137,6 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
   // so using it here would permanently break replay linking for Cowork.
   const sessionId = meta.sessionId.replace(/^local_/, "");
 
-  const toolUseRe = /"type"\s*:\s*"tool_use"/g;
   const PROMPT_SCAN_LINES = 200;
   let lineCount = 0;
   let toolCallCount = 0;
@@ -153,7 +152,7 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
       if (!line) continue;
       lineCount++;
       if (earlyLines.length < PROMPT_SCAN_LINES) earlyLines.push(line);
-      const m = line.match(toolUseRe);
+      const m = line.match(TOOL_USE_RE);
       if (m) toolCallCount += m.length;
       if (
         (line.includes('"type":"user"') || line.includes('"type": "user"')) &&

--- a/packages/provider-core/src/utils.ts
+++ b/packages/provider-core/src/utils.ts
@@ -26,6 +26,9 @@ export const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
   "Delete",
 ]);
 
+/** Matches a JSONL record's `"type": "tool_use"` field for cheap regex-based counting. */
+export const TOOL_USE_RE = /"type"\s*:\s*"tool_use"/g;
+
 /** Extract file path from tool input, handling different provider field names. */
 export function extractToolFilePath(
   input: Record<string, unknown> | undefined,


### PR DESCRIPTION
## Summary

- Extracts the identical `/"type"\s*:\s*"tool_use"/g` regex literal, duplicated in `claude-code/discover.ts` and `claude-cowork/discover.ts`, into a shared `TOOL_USE_RE` export in `provider-core/utils.ts` (both files already import `readGitRepo` from that module).
- Net: +7 -6 (3 files).

## Motivation

Same regex literal copy-pasted in two files within the same package; both use it identically via `.match()` (global-flag regexes reset `lastIndex` on every `.match()` call, so sharing one instance across call sites is behavior-neutral). A third occurrence exists in `packages/provider-cursor/src/cursor/discover.ts` but was left out to keep this PR within the 3-file scope for a single package.

## Test plan

- [x] `pnpm test` all green (unit tests across all packages)
- [x] `pnpm lint:check` zero new warnings (pre-existing viewer a11y warnings only, unrelated)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` zero errors
- [x] `pnpm build` succeeds (viewer 915KB, within the project's <1MB budget)
- [x] `pnpm test:e2e` all green (33 passed, 40 skipped as usual)

> 🤖 Daily auto-quality routine. Self-merged after AI review.