### PR TITLE
chore(cloudflare): dedupe replay meta-summary block in worker.ts

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -519,17 +519,7 @@ app.post("/api/cloud-replays", async (c) => {
       id,
       userId,
       storageType: "r2",
-      title: String(meta.title || meta.slug || "Untitled").slice(0, 200),
-      provider: String(meta.provider || "unknown").slice(0, 50),
-      model: meta.model ? String(meta.model).slice(0, 100) : null,
-      sceneCount: clamp(stats.sceneCount, 0, 100_000),
-      userPrompts: clamp(stats.userPrompts, 0, 10_000),
-      toolCalls: clamp(stats.toolCalls, 0, 100_000),
-      durationMs: clamp(stats.durationMs, 0, 86_400_000),
-      costEstimate:
-        stats.costEstimate != null
-          ? String(Math.max(0, Math.min(Number(stats.costEstimate) || 0, 100_000)))
-          : null,
+      ...summarizeReplayMetaFields(meta, stats, meta.slug),
       firstMessage: extractFirstUserPrompt(body.replay),
       sizeBytes,
       visibility,
@@ -2135,6 +2125,23 @@ interface ReplayMetaSummary {
   firstMessage: string | null;
 }
 
+/** Normalize meta/stats fields shared by cloud-replay upload, JSON extraction, and gist import. */
+function summarizeReplayMetaFields(meta: any, stats: any, titleFallback: unknown) {
+  return {
+    title: String(meta.title || titleFallback || "Untitled").slice(0, 200),
+    provider: String(meta.provider || "unknown").slice(0, 50),
+    model: meta.model ? String(meta.model).slice(0, 100) : null,
+    sceneCount: clamp(stats.sceneCount, 0, 100_000),
+    userPrompts: clamp(stats.userPrompts, 0, 10_000),
+    toolCalls: clamp(stats.toolCalls, 0, 100_000),
+    durationMs: clamp(stats.durationMs, 0, 86_400_000),
+    costEstimate:
+      stats.costEstimate != null
+        ? String(Math.max(0, Math.min(Number(stats.costEstimate) || 0, 100_000)))
+        : null,
+  };
+}
+
 /** Extract replay metadata from raw JSON string (used by gist endpoints) */
 function extractMetaFromJson(json: string): ReplayMetaSummary {
   const meta = extractMeta(json);
@@ -2154,17 +2161,7 @@ function extractMetaFromJson(json: string): ReplayMetaSummary {
   }
   const stats = meta.stats || {};
   return {
-    title: String(meta.title || meta.project || "Untitled").slice(0, 200),
-    provider: String(meta.provider || "unknown").slice(0, 50),
-    model: meta.model ? String(meta.model).slice(0, 100) : null,
-    sceneCount: clamp(stats.sceneCount, 0, 100_000),
-    userPrompts: clamp(stats.userPrompts, 0, 10_000),
-    toolCalls: clamp(stats.toolCalls, 0, 100_000),
-    durationMs: clamp(stats.durationMs, 0, 86_400_000),
-    costEstimate:
-      stats.costEstimate != null
-        ? String(Math.max(0, Math.min(Number(stats.costEstimate) || 0, 100_000)))
-        : null,
+    ...summarizeReplayMetaFields(meta, stats, meta.project),
     firstMessage,
   };
 }
@@ -2529,17 +2526,7 @@ async function fetchGistMeta(
   const gistOwner = gistData.owner?.login || null;
 
   return {
-    title: String(meta.title || meta.project || "Untitled").slice(0, 200),
-    provider: String(meta.provider || "unknown").slice(0, 50),
-    model: meta.model ? String(meta.model).slice(0, 100) : null,
-    sceneCount: clamp(stats.sceneCount, 0, 100_000),
-    userPrompts: clamp(stats.userPrompts, 0, 10_000),
-    toolCalls: clamp(stats.toolCalls, 0, 100_000),
-    durationMs: clamp(stats.durationMs, 0, 86_400_000),
-    costEstimate:
-      stats.costEstimate != null
-        ? String(Math.max(0, Math.min(Number(stats.costEstimate) || 0, 100_000)))
-        : null,
+    ...summarizeReplayMetaFields(meta, stats, meta.project),
     firstMessage,
     gistOwner,
   };


### PR DESCRIPTION
## Summary

- Extracts the repeated title/provider/model/stats/costEstimate normalization block (identical across 3 call sites) into a single `summarizeReplayMetaFields()` helper in `cloudflare/src/worker.ts`
- Net: -33 +20 lines

## Motivation

The 7-field block (`title`, `provider`, `model`, `sceneCount`, `userPrompts`, `toolCalls`, `durationMs`, `costEstimate`) appeared verbatim in the `/api/cloud-replays` upload handler, `extractMetaFromJson`, and `fetchGistMeta`, with only the title's fallback key differing (`meta.slug` vs `meta.project`). Extraction is purely mechanical — same inputs, same computation, same output shape — so this is semantically equivalent to the original code.

## Test plan

- [x] `pnpm test` all green (cloudflare: 10/10, cli: 334/335 +1 skipped, viewer: 207/207)
- [x] `pnpm lint:check` zero warnings/errors on touched file
- [x] `pnpm --filter cloudflare exec tsc --noEmit` zero errors
- [x] `pnpm build` succeeds (viewer 915.23kB, unaffected — this change doesn't touch packages/viewer)
- [x] E2E: not run (cloudflare/worker change, no local D1/R2 harness in this environment; unit test coverage for the three call sites is green)

> 🤖 Daily auto-quality routine. Self-merged after AI review.