### PR TITLE
Fix replay session timestamp bounds

### DIFF
--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrLink, SubAgent, TurnStat } from "@vibe-replay/types";
 import { isSystemGeneratedMessage } from "@vibe-replay/provider-core/clean-prompt";
-import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
+import { estimateActiveDuration, getTimestampBounds } from "@vibe-replay/provider-core/duration";
 import type { ContentBlock, ParsedTurn, RawMessage } from "@vibe-replay/provider-contract";
 import type { Compaction, ProviderParseResult, TokenUsage } from "@vibe-replay/provider-contract";
 import { addParseWarning } from "@vibe-replay/provider-contract/warnings";
@@ -30,6 +30,11 @@ export interface ParseClaudeCodeLinesOptions {
    * omit it for sources (e.g. Cowork audit.jsonl) that don't have subagent files.
    */
   subagentsSourcePath?: string;
+  /**
+   * Derive session bounds from all event timestamps. Cowork disables this so
+   * its sibling metadata timestamp keeps the existing overlay semantics.
+   */
+  deriveTimestampBounds?: boolean;
 }
 
 export async function parseClaudeCodeLines(
@@ -217,8 +222,9 @@ export async function parseClaudeCodeLines(
     }
 
     if (obj.type === "file-history-snapshot") {
-      if (!startTime && obj.snapshot?.timestamp) {
-        startTime = obj.snapshot.timestamp;
+      if (obj.snapshot?.timestamp) {
+        if (!startTime) startTime = obj.snapshot.timestamp;
+        allTimestamps.push(obj.snapshot.timestamp);
       }
       const backups = obj.snapshot?.trackedFileBackups;
       if (backups && typeof backups === "object") {
@@ -605,6 +611,12 @@ export async function parseClaudeCodeLines(
           ...(worktreeBranch ? { branch: worktreeBranch } : {}),
         }
       : undefined;
+
+  if (options.deriveTimestampBounds !== false) {
+    const timestampBounds = getTimestampBounds(allTimestamps);
+    startTime = timestampBounds.startTime || startTime;
+    endTime = timestampBounds.endTime || endTime;
+  }
 
   return {
     sessionId,

--- a/packages/provider-claude-code/src/claude-cowork/parser.ts
+++ b/packages/provider-claude-code/src/claude-cowork/parser.ts
@@ -148,7 +148,7 @@ export async function parseClaudeCoworkSession(
 
   // Cowork transcripts are self-contained — no sibling `agents/` directory, so
   // subagentsSourcePath is intentionally omitted (parser will use an empty map).
-  const result = await parseClaudeCodeLines(normalized);
+  const result = await parseClaudeCodeLines(normalized, { deriveTimestampBounds: false });
   if (parseWarnings.length > 0) {
     result.parseWarnings = [...parseWarnings, ...(result.parseWarnings || [])];
   }

--- a/packages/provider-claude-code/test/claude-code-prompt-source.test.ts
+++ b/packages/provider-claude-code/test/claude-code-prompt-source.test.ts
@@ -36,4 +36,14 @@ describe("Claude Code: promptSource field", () => {
     const userScenes = replay.scenes.filter((s) => s.type === "user-prompt");
     expect(userScenes).toHaveLength(2);
   });
+
+  it("derives session bounds from message timestamps when no file-history snapshot exists", async () => {
+    const parsed = await parseClaudeCodeSession(FIXTURE);
+    expect(parsed.startTime).toBe("2026-06-09T09:00:00Z");
+    expect(parsed.endTime).toBe("2026-06-09T09:01:05Z");
+
+    const replay = transformToReplay(parsed, "claude-code", "~/test");
+    expect(replay.meta.startTime).toBe("2026-06-09T09:00:00Z");
+    expect(replay.meta.endTime).toBe("2026-06-09T09:01:05Z");
+  });
 });

--- a/packages/provider-core/src/duration.ts
+++ b/packages/provider-core/src/duration.ts
@@ -30,3 +30,30 @@ export function estimateActiveDuration(
 
   return active > 0 ? active : undefined;
 }
+
+/** Return the earliest and latest valid timestamps without assuming input order. */
+export function getTimestampBounds(timestamps: Array<string | undefined>): {
+  startTime?: string;
+  endTime?: string;
+} {
+  let startTime: string | undefined;
+  let endTime: string | undefined;
+  let startMs = Number.POSITIVE_INFINITY;
+  let endMs = Number.NEGATIVE_INFINITY;
+
+  for (const timestamp of timestamps) {
+    if (!timestamp) continue;
+    const time = Date.parse(timestamp);
+    if (!Number.isFinite(time)) continue;
+    if (time < startMs) {
+      startMs = time;
+      startTime = timestamp;
+    }
+    if (time > endMs) {
+      endMs = time;
+      endTime = timestamp;
+    }
+  }
+
+  return { startTime, endTime };
+}

--- a/packages/provider-core/test/duration.test.ts
+++ b/packages/provider-core/test/duration.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getTimestampBounds } from "../src/duration.js";
+
+describe("getTimestampBounds", () => {
+  it("returns chronological bounds for unordered timestamps", () => {
+    expect(
+      getTimestampBounds(["2026-06-09T09:01:05Z", "2026-06-09T09:00:00Z", "2026-06-09T09:01:00Z"]),
+    ).toEqual({
+      startTime: "2026-06-09T09:00:00Z",
+      endTime: "2026-06-09T09:01:05Z",
+    });
+  });
+
+  it("ignores missing and invalid timestamps", () => {
+    expect(getTimestampBounds([undefined, "not-a-date"])).toEqual({
+      startTime: undefined,
+      endTime: undefined,
+    });
+  });
+});

--- a/packages/replay-core/package.json
+++ b/packages/replay-core/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@vibe-replay/provider-contract": "workspace:*",
+    "@vibe-replay/provider-core": "workspace:*",
     "@vibe-replay/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import { getTimestampBounds } from "@vibe-replay/provider-core/duration";
 import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
 import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/provider-contract";
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
@@ -160,6 +161,14 @@ export function transformToReplay(
   // prompt-to-turn-end wall time inferred from local bubble timestamps.
   const durationMs =
     parsed.totalDurationMs && parsed.totalDurationMs > 0 ? parsed.totalDurationMs : undefined;
+  const turnTimestampBounds = getTimestampBounds(parsed.turns.map((turn) => turn.timestamp));
+  const startTime =
+    parsed.startTime ||
+    turnTimestampBounds.startTime ||
+    parsed.endTime ||
+    options?.generator?.generatedAt ||
+    new Date().toISOString();
+  const endTime = parsed.endTime || turnTimestampBounds.endTime;
 
   return {
     meta: {
@@ -169,8 +178,8 @@ export function transformToReplay(
       provider,
       dataSource: parsed.dataSource,
       dataSourceInfo: parsed.dataSourceInfo,
-      startTime: parsed.startTime || new Date().toISOString(),
-      endTime: parsed.endTime,
+      startTime,
+      endTime,
       model: parsed.model,
       cwd: redactFilePath(parsed.cwd),
       project,

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -653,6 +653,23 @@ describe("transform — metadata", () => {
     expect(replay.meta.generator).toEqual(gen);
   });
 
+  it("derives missing session bounds from valid turn timestamps", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [
+          assistantTextTurn("Done", { timestamp: "2025-01-01T00:02:00Z" }),
+          userTurn("Start", { timestamp: "2025-01-01T00:00:00Z" }),
+          assistantTextTurn("Invalid timestamp", { timestamp: "not-a-date" }),
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+
+    expect(replay.meta.startTime).toBe("2025-01-01T00:00:00Z");
+    expect(replay.meta.endTime).toBe("2025-01-01T00:02:00Z");
+  });
+
   it("includes git repo metadata when provided by the caller", () => {
     const replay = transformToReplay(buildParsed({}), "claude-code", "~/test", {
       gitRepo: "tuo-lei/vibe-replay",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       '@vibe-replay/provider-contract':
         specifier: workspace:*
         version: link:../provider-contract
+      '@vibe-replay/provider-core':
+        specifier: workspace:*
+        version: link:../provider-core
       '@vibe-replay/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

- derive Claude Code session start/end bounds from all valid event timestamps
- fall back to turn timestamps when a provider omits replay session bounds
- preserve Claude Cowork's existing sibling-metadata overlay behavior
- add shared timestamp-boundary regression coverage

## Why

Claude Code sessions without a `file-history-snapshot` could receive the replay generation time as `meta.startTime`, which made replay timelines and dashboard date aggregation inaccurate.

## Compatibility

- no replay schema or provider contract fields changed
- existing provider-reported timestamps still take precedence
- Cowork timestamp overlay semantics remain unchanged
- the current generation-time fallback remains only for sessions with no valid provider or turn timestamps

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @vibe-replay/provider-hermes test`
- `pnpm test:cloudflare`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Session and replay start/end times are now derived from available message and turn timestamps when provider timing data is missing.
  - Timestamp detection works correctly even when events are out of order.
  - Missing or invalid timestamps are safely ignored, improving reliability of displayed session durations and timelines.
  - File-history timestamps are included when determining session boundaries.
- **Bug Fixes**
  - Improved timing accuracy for sessions without file-history snapshots or complete provider metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->