### PR TITLE
Redact replay data source metadata

### DIFF
--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -4,7 +4,7 @@ import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricin
 import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/provider-contract";
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
-import type { ReplaySession, Scene, SubAgent } from "@vibe-replay/types";
+import type { DataSourceInfo, ReplaySession, Scene, SubAgent } from "@vibe-replay/types";
 import { estimateTokens } from "./utils/tokenEstimate.js";
 
 type ToolCallScene = Extract<Scene, { type: "tool-call" }>;
@@ -177,7 +177,7 @@ export function transformToReplay(
       title: parsed.title,
       provider,
       dataSource: parsed.dataSource,
-      dataSourceInfo: parsed.dataSourceInfo,
+      dataSourceInfo: redactDataSourceInfo(parsed.dataSourceInfo),
       startTime,
       endTime,
       model: parsed.model,
@@ -303,6 +303,16 @@ function redactWarningText(value: string): string {
     /[A-Za-z0-9_-]{4,}\.\.\.\[REDACTED\]/g,
     "[REDACTED]",
   );
+}
+
+function redactDataSourceInfo(info: DataSourceInfo | undefined): DataSourceInfo | undefined {
+  if (!info) return undefined;
+  return {
+    primary: info.primary,
+    sources: info.sources.map(redactWarningText),
+    ...(info.supplements ? { supplements: info.supplements.map(redactWarningText) } : {}),
+    ...(info.notes ? { notes: info.notes.map(redactWarningText) } : {}),
+  };
 }
 
 function redactWarningPaths(value: string): string {

--- a/packages/replay-core/test/transform-security.test.ts
+++ b/packages/replay-core/test/transform-security.test.ts
@@ -230,6 +230,33 @@ describe("path redaction", () => {
     expect(replay.meta.cwd).toBe("~/my-workspace");
   });
 
+  it("redacts paths and secrets in data source metadata", () => {
+    const parsed = makeParsed([], {
+      dataSource: "jsonl",
+      dataSourceInfo: {
+        primary: "jsonl",
+        sources: [`${HOME}/.codex/sessions/session.jsonl`],
+        supplements: [`Parsed from ${HOME}/private/transcript.jsonl`],
+        notes: [
+          `Database: C:\\Users\\alice\\AppData\\Local\\opencode\\opencode.db`,
+          `Credential: ${EXAMPLE_GH_PAT}`,
+        ],
+      },
+    });
+
+    const replay = transform(parsed);
+    const serialized = JSON.stringify(replay.meta.dataSourceInfo);
+    expect(serialized).not.toContain(HOME);
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain(EXAMPLE_GH_PAT);
+    expect(replay.meta.dataSourceInfo).toEqual({
+      primary: "jsonl",
+      sources: ["~/.codex/sessions/session.jsonl"],
+      supplements: ["Parsed from ~/private/transcript.jsonl"],
+      notes: ["Database: ~\\AppData\\Local\\opencode\\opencode.db", "Credential: [REDACTED]"],
+    });
+  });
+
   it("redacts multiple home dir occurrences in one string", () => {
     const parsed = makeParsed([
       {


### PR DESCRIPTION
## Summary

- redact home-directory paths in replay `dataSourceInfo` sources, supplements, and notes
- sanitize Windows user-profile paths in diagnostic metadata
- apply the existing secret redaction boundary to data-source metadata
- add regression coverage for POSIX paths, Windows paths, and credentials

## Why

Provider parsers can report absolute local source paths, including OpenCode/Hermes database locations and Codex transcript paths. `transformToReplay` previously copied this metadata directly into shareable replay JSON and HTML.

## Compatibility

- no replay schema or provider contract changes
- data-source labels and quality notes remain present
- only sensitive path prefixes and secrets are redacted
- existing scene and metric behavior is unchanged

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @vibe-replay/provider-hermes test`
- `pnpm test:cloudflare`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection of replay metadata by redacting sensitive home-directory paths and GitHub credentials from data-source details.
  * Applied redaction consistently across nested source information, supplements, and notes while preserving essential data-source fields.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->