### PR TITLE
Fix Claude subagent token aggregation

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { generateOutput } from "../packages/cli/src/generator.ts";
@@ -54,8 +54,7 @@ export async function generateTestReplay(
     }
   }
 
-  const tmpDir = join(tmpdir(), `vibe-replay-e2e-${Date.now()}-${options.sceneCount || "default"}`);
-  await mkdir(tmpDir, { recursive: true });
+  const tmpDir = await mkdtemp(join(tmpdir(), "vibe-replay-e2e-"));
 
   // Generate into a slug-based subdirectory (mirrors real usage)
   const slug = session.meta.slug || "test-session";

--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -950,8 +950,7 @@ async function readSubagents(
     let thinkingBlocks = 0;
     let textResponses = 0;
     const scenes: SubAgentParsed["scenes"] = [];
-    const saUsage = { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 };
-    let hasUsage = false;
+    const saUsageByMessageId = new Map<string, TokenUsage>();
 
     // Track tool results for enrichment
     const saToolResults = new Map<string, string>();
@@ -1015,17 +1014,15 @@ async function readSubagents(
           model = obj.message.model;
         }
 
-        // Accumulate usage
+        // Keep the last cumulative usage snapshot for each streamed message.
         const u = obj.message.usage;
         if (u && msgId) {
-          // Only count final usage per message ID
-          if (!saAssistantBlocks.has(msgId)) {
-            hasUsage = true;
-            saUsage.inputTokens += u.input_tokens || 0;
-            saUsage.outputTokens += u.output_tokens || 0;
-            saUsage.cacheCreationTokens += u.cache_creation_input_tokens || 0;
-            saUsage.cacheReadTokens += u.cache_read_input_tokens || 0;
-          }
+          saUsageByMessageId.set(msgId, {
+            inputTokens: u.input_tokens || 0,
+            outputTokens: u.output_tokens || 0,
+            cacheCreationTokens: u.cache_creation_input_tokens || 0,
+            cacheReadTokens: u.cache_read_input_tokens || 0,
+          });
         }
 
         if (!saAssistantBlocks.has(msgId)) {
@@ -1081,6 +1078,18 @@ async function readSubagents(
     // Cap scenes to keep HTML size reasonable
     const maxScenes = 60;
     const cappedScenes = scenes.length > maxScenes ? scenes.slice(0, maxScenes) : scenes;
+    const saUsage =
+      saUsageByMessageId.size > 0
+        ? [...saUsageByMessageId.values()].reduce<TokenUsage>(
+            (total, usage) => ({
+              inputTokens: total.inputTokens + usage.inputTokens,
+              outputTokens: total.outputTokens + usage.outputTokens,
+              cacheCreationTokens: total.cacheCreationTokens + usage.cacheCreationTokens,
+              cacheReadTokens: total.cacheReadTokens + usage.cacheReadTokens,
+            }),
+            { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0 },
+          )
+        : undefined;
 
     result.set(agentId, {
       agentId,
@@ -1090,7 +1099,7 @@ async function readSubagents(
       toolCalls,
       thinkingBlocks,
       textResponses,
-      tokenUsage: hasUsage ? saUsage : undefined,
+      tokenUsage: saUsage,
       model,
       scenes: cappedScenes,
     });

--- a/packages/provider-claude-code/test/cost-estimation.test.ts
+++ b/packages/provider-claude-code/test/cost-estimation.test.ts
@@ -1,3 +1,5 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { estimateCostSimple } from "@vibe-replay/replay-core/pricing";
@@ -100,6 +102,96 @@ describe("parser — per-model token usage breakdown", () => {
     expect(Object.keys(byModel)).toEqual(["claude-sonnet-4-20250514"]);
     expect(byModel["claude-sonnet-4-20250514"].inputTokens).toBe(result.tokenUsage!.inputTokens);
     expect(byModel["claude-sonnet-4-20250514"].outputTokens).toBe(result.tokenUsage!.outputTokens);
+  });
+
+  it("uses the final cumulative usage snapshot in subagent metadata", async () => {
+    const tempDir = await mkdtemp(resolve(tmpdir(), "vibe-replay-subagent-usage-"));
+    const mainPath = resolve(tempDir, "session.jsonl");
+    const subagentsDir = resolve(tempDir, "session", "subagents");
+    await mkdir(subagentsDir, { recursive: true });
+
+    const mainLines = [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "parent-message",
+          model: "claude-sonnet-4-20250514",
+          content: [
+            {
+              type: "tool_use",
+              id: "agent-tool",
+              name: "Agent",
+              input: { prompt: "Inspect the project", subagent_type: "Explore" },
+            },
+          ],
+        },
+        timestamp: "2026-01-01T00:00:00Z",
+      },
+      {
+        type: "progress",
+        parentToolUseID: "agent-tool",
+        data: { type: "agent_progress", agentId: "sub1" },
+        timestamp: "2026-01-01T00:00:01Z",
+      },
+    ];
+    const subagentLines = [
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "streamed-message",
+          model: "claude-haiku-4-5-20251001",
+          content: [{ type: "text", text: "Inspecting" }],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 10,
+            cache_creation_input_tokens: 20,
+            cache_read_input_tokens: 30,
+          },
+        },
+        timestamp: "2026-01-01T00:00:02Z",
+      },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "streamed-message",
+          model: "claude-haiku-4-5-20251001",
+          content: [{ type: "text", text: "Inspection complete" }],
+          usage: {
+            input_tokens: 400,
+            output_tokens: 40,
+            cache_creation_input_tokens: 50,
+            cache_read_input_tokens: 60,
+          },
+        },
+        timestamp: "2026-01-01T00:00:03Z",
+      },
+    ];
+
+    await writeFile(mainPath, mainLines.map((line) => JSON.stringify(line)).join("\n"));
+    await writeFile(
+      resolve(subagentsDir, "agent-sub1.jsonl"),
+      subagentLines.map((line) => JSON.stringify(line)).join("\n"),
+    );
+
+    try {
+      const result = await parseClaudeCodeSession(mainPath);
+      const agentBlock = result.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use" && block.name === "Agent");
+
+      expect(agentBlock?.type).toBe("tool_use");
+      expect(agentBlock?.type === "tool_use" && agentBlock._subAgent?.tokenUsage).toEqual({
+        inputTokens: 400,
+        outputTokens: 40,
+        cacheCreationTokens: 50,
+        cacheReadTokens: 60,
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- keep the final cumulative token snapshot for each streamed Claude subagent message
- aggregate subagent token metadata after message-level deduplication
- add a regression test with repeated snapshots for the same subagent message ID

## Why

The main Claude parser already uses last-snapshot-wins semantics for streamed assistant messages. Subagent metadata instead accumulated only the first snapshot, which could under-report subagent tokens and cost when later records carried the final cumulative usage.

## Compatibility

- no replay schema or provider contract changes
- main-session token aggregation is unchanged
- sessions with one usage record per subagent message produce identical values
- only repeated cumulative snapshots now use their final value

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @vibe-replay/provider-hermes test`
- `pnpm test:cloudflare`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subagent usage and cost tracking by using the latest cumulative usage data for each message.
  * Corrected aggregated usage reporting when sessions contain repeated usage updates.
  * Prevented usage details from being reported when no usage data is available.

* **Tests**
  * Added regression coverage for repeated usage snapshots in Claude Code sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->