### PR TITLE
Align Pi active duration estimates

### DIFF
--- a/packages/provider-pi/src/pi/parser.ts
+++ b/packages/provider-pi/src/pi/parser.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
+import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "@vibe-replay/provider-contract";
 import type { ProviderParseResult, TokenUsage } from "@vibe-replay/provider-contract";
@@ -686,19 +687,4 @@ function buildTurnStat(
     ...(tokenUsage ? { tokenUsage } : {}),
     ...(contextTokens ? { contextTokens } : {}),
   };
-}
-
-function estimateActiveDuration(timestamps: string[]): number | undefined {
-  if (timestamps.length < 2) return undefined;
-  const sorted = timestamps
-    .map((timestamp) => Date.parse(timestamp))
-    .filter((timestamp) => !Number.isNaN(timestamp))
-    .sort((a, b) => a - b);
-  if (sorted.length < 2) return undefined;
-  let total = 0;
-  for (let i = 1; i < sorted.length; i++) {
-    const gap = sorted[i] - sorted[i - 1];
-    if (gap > 0 && gap < 30 * 60_000) total += gap;
-  }
-  return total || undefined;
 }

--- a/packages/provider-pi/test/parser.test.ts
+++ b/packages/provider-pi/test/parser.test.ts
@@ -574,4 +574,44 @@ describe("Pi parser", () => {
       expect(parsed.dataSourceInfo?.notes).toEqual(["1 off-branch Pi entries were omitted."]);
     });
   });
+
+  it.each([10, 40])(
+    "caps a %i-minute idle gap consistently with other providers",
+    async (gapMinutes) => {
+      const start = "2026-01-01T00:00:00.000Z";
+      const end = new Date(Date.parse(start) + gapMinutes * 60_000).toISOString();
+      const lines = [
+        {
+          type: "session",
+          version: 3,
+          id: `pi-duration-${gapMinutes}`,
+          timestamp: start,
+          cwd: "/Users/test/project",
+        },
+        {
+          type: "message",
+          id: "user1",
+          parentId: null,
+          timestamp: start,
+          message: { role: "user", content: [{ type: "text", text: "Start work" }] },
+        },
+        {
+          type: "message",
+          id: "assistant1",
+          parentId: "user1",
+          timestamp: end,
+          message: {
+            role: "assistant",
+            model: "gpt-5.5",
+            content: [{ type: "text", text: "Done" }],
+          },
+        },
+      ];
+
+      await withPiFixture(lines, async (path) => {
+        const parsed = await parsePiSession(path);
+        expect(parsed.totalDurationMs).toBe(5 * 60_000);
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- use the shared provider-core active-duration estimator for Pi sessions
- cap long idle gaps at five minutes, matching Claude, Codex, OpenCode, and Hermes
- add regression coverage for 10-minute and 40-minute gaps

## Why

Pi had a private duration algorithm that counted gaps below 30 minutes in full and dropped gaps at or above 30 minutes entirely. The same activity pattern therefore produced different dashboard duration totals depending on provider.

## Compatibility

- no replay schema or provider contract changes
- short gaps below five minutes are unchanged
- only inferred active-duration estimates for longer gaps are normalized
- provider-reported tool durations and token metrics are unchanged

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @vibe-replay/provider-hermes test`
- `pnpm test:cloudflare`
- `pnpm build`
