### PR TITLE
Avoid fabricated costs for unknown models

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -21,7 +21,7 @@ import {
   extractToolFilePath,
   extractToolFilePaths,
 } from "@vibe-replay/provider-core/utils";
-import { estimateCost, estimateCostSimple } from "@vibe-replay/replay-core/pricing";
+import { estimateCostIfKnown, estimateCostSimpleIfKnown } from "@vibe-replay/replay-core/pricing";
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseClaudeCoworkSession } from "@vibe-replay/provider-claude-code/claude-cowork/parser";
 import { parseCursorSession } from "./providers/cursor/parser.js";
@@ -691,9 +691,9 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
   // Estimate cost
   let costEstimate: number | undefined;
   if (Object.keys(usageByModel).length > 0) {
-    costEstimate = estimateCost(usageByModel);
+    costEstimate = estimateCostIfKnown(usageByModel);
   } else if (tokenUsage && model) {
-    costEstimate = estimateCostSimple(tokenUsage, model);
+    costEstimate = estimateCostSimpleIfKnown(tokenUsage, model);
   }
 
   // Derive duration: prefer turn_duration sum (CLI), fall back to active-duration estimate (VS Code)
@@ -735,6 +735,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
     turnDurations: turnDurations.length > 0 ? turnDurations : undefined,
+    dataQualityNotes: costDataQualityNotes(undefined, tokenUsage, costEstimate),
   };
 }
 
@@ -1019,7 +1020,11 @@ function buildScanResultFromParsed(
     skillsUsed: parsed.skillsUsed,
     mcpServersUsed: parsed.mcpServersUsed,
     dataSource: parsed.dataSource,
-    dataQualityNotes: parsed.dataSourceInfo?.notes,
+    dataQualityNotes: costDataQualityNotes(
+      parsed.dataSourceInfo?.notes,
+      parsed.tokenUsage,
+      costEstimate,
+    ),
     turnStatCount: parsed.turnStats?.length,
     turnDurations: parsed.turnStats
       ?.map((t) => t.durationMs)
@@ -1040,9 +1045,25 @@ function firstUserPrompt(turns: ProviderParseResult["turns"]): string | undefine
 }
 
 function estimateParsedCost(parsed: ProviderParseResult): number | undefined {
-  if (parsed.tokenUsageByModel) return estimateCost(parsed.tokenUsageByModel);
-  if (parsed.tokenUsage && parsed.model) return estimateCostSimple(parsed.tokenUsage, parsed.model);
+  if (parsed.tokenUsageByModel) return estimateCostIfKnown(parsed.tokenUsageByModel);
+  if (parsed.tokenUsage && parsed.model)
+    return estimateCostSimpleIfKnown(parsed.tokenUsage, parsed.model);
   return undefined;
+}
+
+const UNKNOWN_COST_NOTE =
+  "Cost estimate is unavailable because model pricing or attribution is unknown.";
+
+function costDataQualityNotes(
+  notes: string[] | undefined,
+  tokenUsage: TokenUsage | undefined,
+  costEstimate: number | undefined,
+): string[] | undefined {
+  const result = [...(notes || [])];
+  if (tokenUsage && costEstimate === undefined && !result.includes(UNKNOWN_COST_NOTE)) {
+    result.push(UNKNOWN_COST_NOTE);
+  }
+  return result.length > 0 ? result : undefined;
 }
 
 // ─── Cache management ───────────────────────────────────────────────

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1054,6 +1054,7 @@ function estimateParsedCost(parsed: ProviderParseResult): number | undefined {
 const UNKNOWN_COST_NOTE =
   "Cost estimate is unavailable because model pricing or attribution is unknown.";
 
+/** Preserve provider notes while explaining why token usage has no cost value. */
 function costDataQualityNotes(
   notes: string[] | undefined,
   tokenUsage: TokenUsage | undefined,

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -386,6 +386,44 @@ describe("scanSession", () => {
     expect(result.costEstimate).toBeGreaterThan(0);
   });
 
+  it("keeps tokens but omits fabricated cost for an unknown model", async () => {
+    const path = join(tmpDir, "unknown-model-session.jsonl");
+    await writeFile(
+      path,
+      makeLine({
+        type: "assistant",
+        timestamp: "2025-03-20T10:00:05Z",
+        message: {
+          role: "assistant",
+          id: "unknown-model-message",
+          model: "local-model",
+          content: [{ type: "text", text: "Done" }],
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 100,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "unknown-model-session",
+      provider: "claude-code",
+      project: "~/project",
+      slug: "unknown-model",
+      filePaths: [path],
+    });
+
+    expect(result.tokenUsage?.inputTokens).toBe(1000);
+    expect(result.costEstimate).toBeUndefined();
+    expect(result.dataQualityNotes).toContain(
+      "Cost estimate is unavailable because model pricing or attribution is unknown.",
+    );
+  });
+
   it("extracts entrypoint and permissionMode", async () => {
     const result = await scanSession({
       sessionId: "test-session-1",

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -103,11 +103,13 @@ export function getKnownModelPricing(model: string): ModelPricing | undefined {
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   // Opus: 4.6/4.5 → new pricing, 4.1 and earlier → legacy
+  if (hasUnsupportedClaudeMajor(lower, "opus")) return undefined;
   if (lower.includes("opus-4-6") || lower.includes("opus-4-5")) return MODEL_PRICING["opus-4-new"];
   const explicitOpusMinor = lower.match(/opus-4-(\d{1,2})(?:-|$)/)?.[1];
   if (explicitOpusMinor && Number(explicitOpusMinor) > 6) return undefined;
   if (lower.includes("opus")) return MODEL_PRICING.opus;
   // Sonnet: 4.6/4.5 → new pricing, Sonnet 4 → explicit, earlier → standard
+  if (hasUnsupportedClaudeMajor(lower, "sonnet")) return undefined;
   if (lower.includes("sonnet-4-6") || lower.includes("sonnet-4-5"))
     return MODEL_PRICING["sonnet-4-new"];
   const explicitSonnetMinor = lower.match(/sonnet-4-(\d{1,2})(?:-|$)/)?.[1];
@@ -115,11 +117,20 @@ export function getKnownModelPricing(model: string): ModelPricing | undefined {
   if (lower.includes("sonnet-4")) return MODEL_PRICING["sonnet-4"];
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
   // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
+  if (hasUnsupportedClaudeMajor(lower, "haiku")) return undefined;
   if (lower.includes("haiku-4-5") || lower.includes("haiku-4-6")) return MODEL_PRICING["haiku-4-5"];
   const explicitHaikuMinor = lower.match(/haiku-4-(\d{1,2})(?:-|$)/)?.[1];
   if (explicitHaikuMinor && Number(explicitHaikuMinor) > 6) return undefined;
   if (lower.includes("haiku")) return MODEL_PRICING.haiku;
   return undefined;
+}
+
+/** Reject explicitly versioned Claude families outside the supported 3.x/4.x generations. */
+function hasUnsupportedClaudeMajor(model: string, family: "opus" | "sonnet" | "haiku"): boolean {
+  const familyFirst = model.match(new RegExp(`${family}-(\\d+)(?:-|$)`))?.[1];
+  const versionFirst = model.match(new RegExp(`claude-(\\d+)(?:-\\d+)?-${family}(?:-|$)`))?.[1];
+  const major = versionFirst || familyFirst;
+  return major !== undefined && major !== "3" && major !== "4";
 }
 
 // Non-Claude context window limits. Claude models are handled by name detection below.

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -110,6 +110,8 @@ export function getKnownModelPricing(model: string): ModelPricing | undefined {
   // Sonnet: 4.6/4.5 → new pricing, Sonnet 4 → explicit, earlier → standard
   if (lower.includes("sonnet-4-6") || lower.includes("sonnet-4-5"))
     return MODEL_PRICING["sonnet-4-new"];
+  const explicitSonnetMinor = lower.match(/sonnet-4-(\d{1,2})(?:-|$)/)?.[1];
+  if (explicitSonnetMinor && Number(explicitSonnetMinor) > 6) return undefined;
   if (lower.includes("sonnet-4")) return MODEL_PRICING["sonnet-4"];
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
   // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
@@ -183,6 +185,7 @@ export function estimateCostSimple(usage: TokenUsage, model: string): number {
 
 /** Estimate a complete per-model cost only when every model has known pricing. */
 export function estimateCostIfKnown(usageByModel: Record<string, TokenUsage>): number | undefined {
+  if (Object.keys(usageByModel).length === 0) return undefined;
   let total = 0;
   for (const [model, usage] of Object.entries(usageByModel)) {
     const pricing = getKnownModelPricing(model);

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -103,34 +103,53 @@ export function getKnownModelPricing(model: string): ModelPricing | undefined {
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   // Opus: 4.6/4.5 → new pricing, 4.1 and earlier → legacy
-  if (hasUnsupportedClaudeMajor(lower, "opus")) return undefined;
-  if (lower.includes("opus-4-6") || lower.includes("opus-4-5")) return MODEL_PRICING["opus-4-new"];
-  const explicitOpusMinor = lower.match(/opus-4-(\d{1,2})(?:-|$)/)?.[1];
-  if (explicitOpusMinor && Number(explicitOpusMinor) > 6) return undefined;
+  const opusVersion = parseClaudeVersion(lower, "opus");
+  if (isUnsupportedClaudeVersion(opusVersion)) return undefined;
+  if (opusVersion?.major === 4 && (opusVersion.minor === 5 || opusVersion.minor === 6))
+    return MODEL_PRICING["opus-4-new"];
   if (lower.includes("opus")) return MODEL_PRICING.opus;
   // Sonnet: 4.6/4.5 → new pricing, Sonnet 4 → explicit, earlier → standard
-  if (hasUnsupportedClaudeMajor(lower, "sonnet")) return undefined;
-  if (lower.includes("sonnet-4-6") || lower.includes("sonnet-4-5"))
+  const sonnetVersion = parseClaudeVersion(lower, "sonnet");
+  if (isUnsupportedClaudeVersion(sonnetVersion)) return undefined;
+  if (sonnetVersion?.major === 4 && (sonnetVersion.minor === 5 || sonnetVersion.minor === 6))
     return MODEL_PRICING["sonnet-4-new"];
-  const explicitSonnetMinor = lower.match(/sonnet-4-(\d{1,2})(?:-|$)/)?.[1];
-  if (explicitSonnetMinor && Number(explicitSonnetMinor) > 6) return undefined;
   if (lower.includes("sonnet-4")) return MODEL_PRICING["sonnet-4"];
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
   // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
-  if (hasUnsupportedClaudeMajor(lower, "haiku")) return undefined;
-  if (lower.includes("haiku-4-5") || lower.includes("haiku-4-6")) return MODEL_PRICING["haiku-4-5"];
-  const explicitHaikuMinor = lower.match(/haiku-4-(\d{1,2})(?:-|$)/)?.[1];
-  if (explicitHaikuMinor && Number(explicitHaikuMinor) > 6) return undefined;
+  const haikuVersion = parseClaudeVersion(lower, "haiku");
+  if (isUnsupportedClaudeVersion(haikuVersion)) return undefined;
+  if (haikuVersion?.major === 4 && (haikuVersion.minor === 5 || haikuVersion.minor === 6))
+    return MODEL_PRICING["haiku-4-5"];
   if (lower.includes("haiku")) return MODEL_PRICING.haiku;
   return undefined;
 }
 
-/** Reject explicitly versioned Claude families outside the supported 3.x/4.x generations. */
-function hasUnsupportedClaudeMajor(model: string, family: "opus" | "sonnet" | "haiku"): boolean {
-  const familyFirst = model.match(new RegExp(`${family}-(\\d+)(?:-|$)`))?.[1];
-  const versionFirst = model.match(new RegExp(`claude-(\\d+)(?:-\\d+)?-${family}(?:-|$)`))?.[1];
-  const major = versionFirst || familyFirst;
-  return major !== undefined && major !== "3" && major !== "4";
+interface ClaudeVersion {
+  major: number;
+  minor?: number;
+}
+
+/** Parse both `claude-opus-4-6` and `claude-4-6-opus` version layouts. */
+function parseClaudeVersion(
+  model: string,
+  family: "opus" | "sonnet" | "haiku",
+): ClaudeVersion | undefined {
+  const versionFirst = model.match(new RegExp(`(?:^|-)claude-(\\d+)(?:-(\\d+))?-${family}(?:-|$)`));
+  const familyFirst = model.match(new RegExp(`(?:^|-)${family}-(\\d+)(?:-(\\d+))?(?:-|$)`));
+  const match = versionFirst || familyFirst;
+  if (!match) return undefined;
+  const minorToken = match[2];
+  return {
+    major: Number(match[1]),
+    ...(minorToken && minorToken.length <= 2 ? { minor: Number(minorToken) } : {}),
+  };
+}
+
+/** Reject future Claude generations and unsupported 4.x minor versions. */
+function isUnsupportedClaudeVersion(version: ClaudeVersion | undefined): boolean {
+  if (!version) return false;
+  if (version.major !== 3 && version.major !== 4) return true;
+  return version.major === 4 && version.minor !== undefined && version.minor > 6;
 }
 
 // Non-Claude context window limits. Claude models are handled by name detection below.

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -113,7 +113,7 @@ export function getKnownModelPricing(model: string): ModelPricing | undefined {
   if (isUnsupportedClaudeVersion(sonnetVersion)) return undefined;
   if (sonnetVersion?.major === 4 && (sonnetVersion.minor === 5 || sonnetVersion.minor === 6))
     return MODEL_PRICING["sonnet-4-new"];
-  if (lower.includes("sonnet-4")) return MODEL_PRICING["sonnet-4"];
+  if (sonnetVersion?.major === 4 || lower.includes("sonnet-4")) return MODEL_PRICING["sonnet-4"];
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
   // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
   const haikuVersion = parseClaudeVersion(lower, "haiku");
@@ -139,9 +139,10 @@ function parseClaudeVersion(
   const match = versionFirst || familyFirst;
   if (!match) return undefined;
   const minorToken = match[2];
+  const isReleaseDate = minorToken ? /^(?:19|20)\d{6}$/.test(minorToken) : false;
   return {
     major: Number(match[1]),
-    ...(minorToken && minorToken.length <= 2 ? { minor: Number(minorToken) } : {}),
+    ...(minorToken && !isReleaseDate ? { minor: Number(minorToken) } : {}),
   };
 }
 

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -91,6 +91,11 @@ const DEFAULT_PRICING = MODEL_PRICING.sonnet;
  * Checks specific version patterns first, then falls back to family names.
  */
 export function getModelPricing(model: string): ModelPricing {
+  return getKnownModelPricing(model) || DEFAULT_PRICING;
+}
+
+/** Resolve pricing only when the model family/version is known. */
+export function getKnownModelPricing(model: string): ModelPricing | undefined {
   const lower = model.toLowerCase();
   // GPT-5.x prices from OpenAI's public API pricing table.
   // Check mini before gpt-5.4 so "gpt-5.4-mini" is not shadowed.
@@ -99,6 +104,8 @@ export function getModelPricing(model: string): ModelPricing {
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
   // Opus: 4.6/4.5 → new pricing, 4.1 and earlier → legacy
   if (lower.includes("opus-4-6") || lower.includes("opus-4-5")) return MODEL_PRICING["opus-4-new"];
+  const explicitOpusMinor = lower.match(/opus-4-(\d{1,2})(?:-|$)/)?.[1];
+  if (explicitOpusMinor && Number(explicitOpusMinor) > 6) return undefined;
   if (lower.includes("opus")) return MODEL_PRICING.opus;
   // Sonnet: 4.6/4.5 → new pricing, Sonnet 4 → explicit, earlier → standard
   if (lower.includes("sonnet-4-6") || lower.includes("sonnet-4-5"))
@@ -107,8 +114,10 @@ export function getModelPricing(model: string): ModelPricing {
   if (lower.includes("sonnet")) return MODEL_PRICING.sonnet;
   // Haiku: 4.5/4.6 → new pricing, 3.5 and earlier → legacy
   if (lower.includes("haiku-4-5") || lower.includes("haiku-4-6")) return MODEL_PRICING["haiku-4-5"];
+  const explicitHaikuMinor = lower.match(/haiku-4-(\d{1,2})(?:-|$)/)?.[1];
+  if (explicitHaikuMinor && Number(explicitHaikuMinor) > 6) return undefined;
   if (lower.includes("haiku")) return MODEL_PRICING.haiku;
-  return DEFAULT_PRICING;
+  return undefined;
 }
 
 // Non-Claude context window limits. Claude models are handled by name detection below.
@@ -170,4 +179,21 @@ export function estimateCost(usageByModel: Record<string, TokenUsage>): number {
  */
 export function estimateCostSimple(usage: TokenUsage, model: string): number {
   return computeCost(usage, getModelPricing(model));
+}
+
+/** Estimate a complete per-model cost only when every model has known pricing. */
+export function estimateCostIfKnown(usageByModel: Record<string, TokenUsage>): number | undefined {
+  let total = 0;
+  for (const [model, usage] of Object.entries(usageByModel)) {
+    const pricing = getKnownModelPricing(model);
+    if (!pricing) return undefined;
+    total += computeCost(usage, pricing);
+  }
+  return total;
+}
+
+/** Estimate a single-model cost without applying the legacy Sonnet fallback. */
+export function estimateCostSimpleIfKnown(usage: TokenUsage, model: string): number | undefined {
+  const pricing = getKnownModelPricing(model);
+  return pricing ? computeCost(usage, pricing) : undefined;
 }

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { getTimestampBounds } from "@vibe-replay/provider-core/duration";
-import { estimateCost, estimateCostSimple, getModelContextLimit } from "./pricing.js";
+import { estimateCostIfKnown, estimateCostSimpleIfKnown, getModelContextLimit } from "./pricing.js";
 import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/provider-contract";
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
@@ -151,10 +151,9 @@ export function transformToReplay(
   // Estimate cost based on per-model pricing (USD)
   let costEstimate: number | undefined;
   if (parsed.tokenUsageByModel) {
-    costEstimate = estimateCost(parsed.tokenUsageByModel);
+    costEstimate = estimateCostIfKnown(parsed.tokenUsageByModel);
   } else if (parsed.tokenUsage) {
-    // Empty string falls back to Sonnet rates via getModelPricing default
-    costEstimate = estimateCostSimple(parsed.tokenUsage, parsed.model || "");
+    costEstimate = estimateCostSimpleIfKnown(parsed.tokenUsage, parsed.model || "");
   }
 
   // Duration comes from provider-specific parsing. For Cursor this can be

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -108,6 +108,7 @@ describe("getModelPricing — model family detection", () => {
     expect(getKnownModelPricing("some-unknown-model")).toBeUndefined();
     expect(getKnownModelPricing("claude-opus-4-8")).toBeUndefined();
     expect(getKnownModelPricing("claude-opus-4-10")).toBeUndefined();
+    expect(getKnownModelPricing("claude-sonnet-4-8")).toBeUndefined();
     expect(getKnownModelPricing("claude-haiku-4-8")).toBeUndefined();
     expect(getModelPricing("some-unknown-model").inputRate).toBe(3);
   });
@@ -294,6 +295,7 @@ describe("estimateCost — per-model breakdown", () => {
     };
 
     expect(estimateCostSimpleIfKnown(usage, "local-model")).toBeUndefined();
+    expect(estimateCostIfKnown({})).toBeUndefined();
     expect(
       estimateCostIfKnown({
         "claude-sonnet-4-6": usage,

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -113,6 +113,10 @@ describe("getModelPricing — model family detection", () => {
     expect(getKnownModelPricing("claude-opus-5")).toBeUndefined();
     expect(getKnownModelPricing("claude-sonnet-5")).toBeUndefined();
     expect(getKnownModelPricing("claude-haiku-5")).toBeUndefined();
+    for (const family of ["opus", "sonnet", "haiku"]) {
+      expect(getKnownModelPricing(`claude-${family}-4-60`)).toBeUndefined();
+      expect(getKnownModelPricing(`claude-4-8-${family}`)).toBeUndefined();
+    }
     expect(getModelPricing("some-unknown-model").inputRate).toBe(3);
   });
 

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   estimateCost,
+  estimateCostIfKnown,
   estimateCostSimple,
+  estimateCostSimpleIfKnown,
   getModelContextLimit,
+  getKnownModelPricing,
   getModelPricing,
 } from "../src/pricing.js";
 import type { TokenUsage } from "@vibe-replay/provider-contract";
@@ -99,6 +102,14 @@ describe("getModelPricing — model family detection", () => {
     const p = getModelPricing("");
     expect(p.inputRate).toBe(3);
     expect(p.outputRate).toBe(15);
+  });
+
+  it("distinguishes unknown pricing without changing the legacy fallback", () => {
+    expect(getKnownModelPricing("some-unknown-model")).toBeUndefined();
+    expect(getKnownModelPricing("claude-opus-4-8")).toBeUndefined();
+    expect(getKnownModelPricing("claude-opus-4-10")).toBeUndefined();
+    expect(getKnownModelPricing("claude-haiku-4-8")).toBeUndefined();
+    expect(getModelPricing("some-unknown-model").inputRate).toBe(3);
   });
 
   it("is case-insensitive", () => {
@@ -272,5 +283,23 @@ describe("estimateCost — per-model breakdown", () => {
     // Haiku 4.5: 1*0.1 + 5*0.01 = 0.1 + 0.05 = 0.15
     // Total: 1.35
     expect(estimateCost(usageByModel)).toBeCloseTo(1.35, 2);
+  });
+
+  it("does not fabricate a cost when any model has unknown pricing", () => {
+    const usage: TokenUsage = {
+      inputTokens: 1000,
+      outputTokens: 100,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+    };
+
+    expect(estimateCostSimpleIfKnown(usage, "local-model")).toBeUndefined();
+    expect(
+      estimateCostIfKnown({
+        "claude-sonnet-4-6": usage,
+        "local-model": usage,
+      }),
+    ).toBeUndefined();
+    expect(estimateCostIfKnown({ "claude-sonnet-4-6": usage })).toBeCloseTo(0.0045, 4);
   });
 });

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -117,6 +117,11 @@ describe("getModelPricing — model family detection", () => {
       expect(getKnownModelPricing(`claude-${family}-4-60`)).toBeUndefined();
       expect(getKnownModelPricing(`claude-4-8-${family}`)).toBeUndefined();
     }
+    expect(getKnownModelPricing("claude-opus-4-100")).toBeUndefined();
+    expect(getKnownModelPricing("claude-4-600-haiku")).toBeUndefined();
+    expect(getKnownModelPricing("claude-4-1-sonnet")).toBe(
+      getKnownModelPricing("claude-sonnet-4-1"),
+    );
     expect(getModelPricing("some-unknown-model").inputRate).toBe(3);
   });
 

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -110,6 +110,9 @@ describe("getModelPricing — model family detection", () => {
     expect(getKnownModelPricing("claude-opus-4-10")).toBeUndefined();
     expect(getKnownModelPricing("claude-sonnet-4-8")).toBeUndefined();
     expect(getKnownModelPricing("claude-haiku-4-8")).toBeUndefined();
+    expect(getKnownModelPricing("claude-opus-5")).toBeUndefined();
+    expect(getKnownModelPricing("claude-sonnet-5")).toBeUndefined();
+    expect(getKnownModelPricing("claude-haiku-5")).toBeUndefined();
     expect(getModelPricing("some-unknown-model").inputRate).toBe(3);
   });
 

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -594,6 +594,32 @@ describe("transform — cost estimation", () => {
     expect(replay.meta.stats.costEstimate).toBeUndefined();
   });
 
+  it("returns undefined cost when model pricing is unknown", () => {
+    const replay = transformToReplay(
+      buildParsed({ model: "local-model", tokenUsage: baseUsage }),
+      "opencode",
+      "~/test",
+    );
+    expect(replay.meta.stats.tokenUsage).toEqual(baseUsage);
+    expect(replay.meta.stats.costEstimate).toBeUndefined();
+  });
+
+  it("returns undefined cost when a per-model breakdown is only partially priced", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        model: "claude-sonnet-4-6",
+        tokenUsage: baseUsage,
+        tokenUsageByModel: {
+          "claude-sonnet-4-6": baseUsage,
+          "local-model": baseUsage,
+        },
+      }),
+      "opencode",
+      "~/test",
+    );
+    expect(replay.meta.stats.costEstimate).toBeUndefined();
+  });
+
   it("includes cache tokens in cost", () => {
     const usage: TokenUsage = {
       inputTokens: 0,

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -33,7 +33,7 @@ export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[
   }
   if (!meta.stats.tokenUsage) {
     notes.push("Token and cost metrics may be unavailable.");
-  } else if (meta.model && meta.stats.costEstimate === undefined) {
+  } else if (meta.stats.costEstimate === undefined) {
     notes.push("Cost estimate is unavailable because model pricing or attribution is unknown.");
   }
 

--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -33,6 +33,8 @@ export function getSessionDataQualityNotes(meta: ReplaySession["meta"]): string[
   }
   if (!meta.stats.tokenUsage) {
     notes.push("Token and cost metrics may be unavailable.");
+  } else if (meta.model && meta.stats.costEstimate === undefined) {
+    notes.push("Cost estimate is unavailable because model pricing or attribution is unknown.");
   }
 
   return [...new Set(notes)];

--- a/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
+++ b/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
@@ -52,4 +52,14 @@ describe("getSessionDataQualityNotes", () => {
       "1 image file skipped in cursor transcript image reference.",
     ]);
   });
+
+  it("explains why token usage can exist without a cost estimate", () => {
+    const meta = metaWithWarnings([]);
+    meta.provider = "opencode";
+    meta.model = "local-model";
+
+    expect(getSessionDataQualityNotes(meta)).toContain(
+      "Cost estimate is unavailable because model pricing or attribution is unknown.",
+    );
+  });
 });

--- a/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
+++ b/packages/viewer/src/components/__tests__/data-quality-indicator.test.ts
@@ -22,6 +22,7 @@ function metaWithWarnings(
         cacheCreationTokens: 0,
         cacheReadTokens: 0,
       },
+      costEstimate: 0.001,
     },
     parseWarnings,
   };
@@ -57,6 +58,17 @@ describe("getSessionDataQualityNotes", () => {
     const meta = metaWithWarnings([]);
     meta.provider = "opencode";
     meta.model = "local-model";
+    delete meta.stats.costEstimate;
+
+    expect(getSessionDataQualityNotes(meta)).toContain(
+      "Cost estimate is unavailable because model pricing or attribution is unknown.",
+    );
+  });
+
+  it("explains missing cost when model attribution is absent", () => {
+    const meta = metaWithWarnings([]);
+    meta.provider = "opencode";
+    delete meta.stats.costEstimate;
 
     expect(getSessionDataQualityNotes(meta)).toContain(
       "Cost estimate is unavailable because model pricing or attribution is unknown.",


### PR DESCRIPTION
## Summary

- add non-fallback pricing lookup and cost-estimation APIs
- omit replay and dashboard cost estimates when any model price is unknown
- preserve existing legacy pricing APIs and known-model behavior
- surface a data-quality explanation when tokens exist but cost cannot be estimated
- reject unknown future Opus/Haiku minor versions instead of applying stale family rates

## Why

Unknown OpenCode, Hermes, local, and future model IDs were silently priced at Sonnet rates. This produced a precise-looking dollar value with no evidence that the rate was applicable.

## Compatibility

- existing `getModelPricing`, `estimateCost`, and `estimateCostSimple` behavior is unchanged
- new safe APIs are additive
- replay/provider schemas are unchanged
- known Claude and GPT-5.x cost estimates remain identical
- token usage remains available when cost pricing is unknown

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @vibe-replay/provider-hermes test`
- `pnpm test:cloudflare`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost reporting for sessions using unknown or unsupported models.
  * Preserved token usage while leaving cost estimates unavailable when pricing cannot be determined.
  * Added clear data-quality notes when costs are unknown or cannot be attributed.
* **Tests**
  * Added coverage for unknown models, partial pricing data, and local-model sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->