### PR TITLE
Preserve multi-file patch diffs

### DIFF
--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -755,6 +755,52 @@ describe("Codex parser", () => {
     });
   });
 
+  it("preserves multi-file apply_patch contents through replay transform", () => {
+    const patch = `*** Begin Patch
+*** Update File: src/app.ts
+@@
+-export const enabled = false;
++export const enabled = true;
+*** Add File: src/auth.ts
++export const auth = true;
+*** End Patch`;
+    const parsed = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:25:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-multi-patch", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T10:25:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "custom_tool_call",
+            name: "apply_patch",
+            call_id: "patch_multi",
+            input: patch,
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+    const replay = transformToReplay(parsed, "codex", "~/project");
+    const scene = replay.scenes.find((item) => item.type === "tool-call");
+
+    expect(scene?.type).toBe("tool-call");
+    expect(scene?.type === "tool-call" && scene.diffs).toEqual([
+      {
+        filePath: "src/app.ts",
+        oldContent: "export const enabled = false;",
+        newContent: "export const enabled = true;",
+      },
+      {
+        filePath: "src/auth.ts",
+        oldContent: "",
+        newContent: "export const auth = true;",
+      },
+    ]);
+  });
+
   it("parses Codex developer messages as context injections", () => {
     const result = parseCodexLines(
       [

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -4,7 +4,7 @@ import { estimateCostIfKnown, estimateCostSimpleIfKnown, getModelContextLimit } 
 import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/provider-contract";
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
-import type { DataSourceInfo, ReplaySession, Scene, SubAgent } from "@vibe-replay/types";
+import type { DataSourceInfo, FileDiff, ReplaySession, Scene, SubAgent } from "@vibe-replay/types";
 import { estimateTokens } from "./utils/tokenEstimate.js";
 
 type ToolCallScene = Extract<Scene, { type: "tool-call" }>;
@@ -246,16 +246,25 @@ export function transformToReplay(
   };
 }
 
-function buildFileDiff(
-  toolName: string,
-  input: Record<string, any>,
-): ToolCallScene["diff"] | undefined {
+function buildFileDiffs(toolName: string, input: Record<string, any>): FileDiff[] {
+  if (toolName === "Edit") {
+    const patch =
+      typeof input.patch === "string"
+        ? input.patch
+        : typeof input.value === "string"
+          ? input.value
+          : undefined;
+    const patchDiffs = patch ? parseApplyPatchDiffs(patch) : [];
+    if (patchDiffs.length > 0) return patchDiffs;
+  }
   if (toolName === "Edit" && input.file_path) {
-    return {
-      filePath: redactFilePath(input.file_path),
-      oldContent: redactDiffContent(input.old_string),
-      newContent: redactDiffContent(input.new_string),
-    };
+    return [
+      {
+        filePath: redactFilePath(input.file_path),
+        oldContent: redactDiffContent(input.old_string),
+        newContent: redactDiffContent(input.new_string),
+      },
+    ];
   }
   if (toolName === "MultiEdit" && input.file_path && Array.isArray(input.edits)) {
     const edits = input.edits.filter((edit: unknown): edit is Record<string, any> => {
@@ -264,31 +273,72 @@ function buildFileDiff(
     if (edits.length > 0) {
       // MultiEdit records independent replacements, not full before/after file
       // states. Show a synthetic chunk list so the replay still surfaces what changed.
-      return {
-        filePath: redactFilePath(input.file_path),
-        oldContent: edits.map((edit) => redactDiffContent(edit.old_string)).join("\n\n"),
-        newContent: edits.map((edit) => redactDiffContent(edit.new_string)).join("\n\n"),
-      };
+      return [
+        {
+          filePath: redactFilePath(input.file_path),
+          oldContent: edits.map((edit) => redactDiffContent(edit.old_string)).join("\n\n"),
+          newContent: edits.map((edit) => redactDiffContent(edit.new_string)).join("\n\n"),
+        },
+      ];
     }
   }
   if (toolName === "Write" && input.file_path) {
-    return {
-      filePath: redactFilePath(input.file_path),
-      oldContent: "",
-      newContent: truncate(redactDiffContent(input.content), 3000),
-    };
+    return [
+      {
+        filePath: redactFilePath(input.file_path),
+        oldContent: "",
+        newContent: truncate(redactDiffContent(input.content), 3000),
+      },
+    ];
   }
   if (toolName === "Delete" && input.file_path) {
-    return {
-      filePath: redactFilePath(input.file_path),
-      oldContent:
-        typeof input.old_string === "string"
-          ? redactDiffContent(input.old_string)
-          : "(file deleted)",
-      newContent: "",
-    };
+    return [
+      {
+        filePath: redactFilePath(input.file_path),
+        oldContent:
+          typeof input.old_string === "string"
+            ? redactDiffContent(input.old_string)
+            : "(file deleted)",
+        newContent: "",
+      },
+    ];
   }
-  return undefined;
+  return [];
+}
+
+/** Parse Codex/Pi `*** Update File:` patch sections into replay-native file diffs. */
+function parseApplyPatchDiffs(patch: string): FileDiff[] {
+  const markers = [...patch.matchAll(/^\*\*\*\s+(Update|Add|Delete)\s+File:\s+(.+)$/gm)];
+  return markers.map((marker, index) => {
+    const action = marker[1];
+    const start = marker.index ?? 0;
+    const end = markers[index + 1]?.index ?? patch.length;
+    const section = patch.slice(start, end);
+    const oldLines: string[] = [];
+    const newLines: string[] = [];
+    let inHunk = action === "Add" || action === "Delete";
+
+    for (const line of section.split("\n").slice(1)) {
+      if (line.startsWith("*** ")) continue;
+      if (line.startsWith("@@")) {
+        inHunk = true;
+        continue;
+      }
+      if (!inHunk) continue;
+      if (line.startsWith("-")) oldLines.push(line.slice(1));
+      else if (line.startsWith("+")) newLines.push(line.slice(1));
+      else if (line.startsWith(" ")) {
+        oldLines.push(line.slice(1));
+        newLines.push(line.slice(1));
+      }
+    }
+
+    return {
+      filePath: redactFilePath(marker[2].trim()),
+      oldContent: redactDiffContent(oldLines.join("\n")),
+      newContent: redactDiffContent(newLines.join("\n")),
+    };
+  });
 }
 
 function redactDiffContent(value: unknown): string {
@@ -348,9 +398,10 @@ function buildToolScene(
     ...(images && images.length > 0 ? { images } : {}),
   };
 
-  const diff = buildFileDiff(toolName, input);
-  if (diff) {
-    scene.diff = diff;
+  const diffs = buildFileDiffs(toolName, input);
+  if (diffs.length > 0) {
+    scene.diff = diffs[0];
+    if (diffs.length > 1) scene.diffs = diffs;
   } else if (toolName === "Bash" && input.command) {
     scene.bashOutput = {
       command: redactSecrets(redactPath(input.command)),
@@ -509,9 +560,10 @@ function redactSubAgentScene(s: Scene): Scene {
       ...(resultTokens > 0 ? { resultTokens } : {}),
     };
 
-    const diff = buildFileDiff(toolName, input);
-    if (diff) {
-      scene.diff = diff;
+    const diffs = buildFileDiffs(toolName, input);
+    if (diffs.length > 0) {
+      scene.diff = diffs[0];
+      if (diffs.length > 1) scene.diffs = diffs;
     }
 
     return scene;

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -319,6 +319,42 @@ describe("transform — tool scene enrichment", () => {
     expect(scene.type === "tool-call" && scene.diff?.newContent).toBe("const x = 2;");
   });
 
+  it("preserves every file in a multi-file apply_patch call", () => {
+    const patch = `*** Begin Patch
+*** Update File: src/app.ts
+@@
+-const enabled = false;
++const enabled = true;
+*** Add File: src/new.ts
++export const created = true;
+*** End Patch`;
+    const replay = transformToReplay(
+      buildParsed({ turns: [assistantToolTurn("Edit", { value: patch }, "Done")] }),
+      "codex",
+      "~/test",
+    );
+    const scene = replay.scenes[0];
+
+    expect(scene.type).toBe("tool-call");
+    expect(scene.type === "tool-call" && scene.diff).toEqual({
+      filePath: "src/app.ts",
+      oldContent: "const enabled = false;",
+      newContent: "const enabled = true;",
+    });
+    expect(scene.type === "tool-call" && scene.diffs).toEqual([
+      {
+        filePath: "src/app.ts",
+        oldContent: "const enabled = false;",
+        newContent: "const enabled = true;",
+      },
+      {
+        filePath: "src/new.ts",
+        oldContent: "",
+        newContent: "export const created = true;",
+      },
+    ]);
+  });
+
   it("enriches Write tool with diff (empty old)", () => {
     const replay = transformToReplay(
       buildParsed({

--- a/packages/replay-core/test/transform-security.test.ts
+++ b/packages/replay-core/test/transform-security.test.ts
@@ -572,6 +572,40 @@ describe("secret redaction in transform", () => {
     expect(scene.diff?.newContent).toContain("[REDACTED]");
     expect(scene.diff?.newContent).toContain("~/created.env");
   });
+
+  it("redacts every file in a multi-file patch diff", () => {
+    const patch = `*** Begin Patch
+*** Update File: ${HOME}/project/app.ts
+@@
+-const token = "old";
++const token = "safe";
+*** Add File: ${HOME}/project/secret.ts
++export const token = "${EXAMPLE_GH_PAT}";
+*** End Patch`;
+    const replay = transform(
+      makeParsed([
+        {
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool_use",
+              id: "patch-1",
+              name: "Edit",
+              input: { value: patch },
+              _result: "Done",
+            },
+          ],
+        },
+      ]),
+    );
+    const scene = replay.scenes[0] as ToolCallScene;
+    const serialized = JSON.stringify(scene.diffs);
+
+    expect(scene.diffs).toHaveLength(2);
+    expect(serialized).not.toContain(HOME);
+    expect(serialized).not.toContain(EXAMPLE_GH_PAT);
+    expect(serialized).toContain("[REDACTED]");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -65,6 +65,12 @@ export interface SubAgent {
   scenes: Scene[];
 }
 
+export interface FileDiff {
+  filePath: string;
+  oldContent: string;
+  newContent: string;
+}
+
 export type Scene =
   | { type: "user-prompt"; content: string; timestamp?: string; images?: string[] }
   | { type: "compaction-summary"; content: string; timestamp?: string }
@@ -90,7 +96,10 @@ export type Scene =
       result: string;
       timestamp?: string;
       isError?: boolean;
-      diff?: { filePath: string; oldContent: string; newContent: string };
+      /** Primary/first diff, retained for backward compatibility. */
+      diff?: FileDiff;
+      /** All file diffs when one tool call changes multiple files. */
+      diffs?: FileDiff[];
       bashOutput?: { command: string; stdout: string };
       images?: string[];
       subAgent?: SubAgent;

--- a/packages/viewer/src/components/LandingHero.tsx
+++ b/packages/viewer/src/components/LandingHero.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { ReplaySession } from "../types";
+import { getToolDiffs } from "../utils/sceneDiffs";
 import { providerDisplayName, rollupProject } from "./dashboard-utils";
 import { formatDuration } from "./StatsPanel";
 
@@ -51,8 +52,8 @@ export default function LandingHero({ session, onStart, onViewInsights }: Props)
   const filesModified = useMemo(() => {
     const fileSet = new Set<string>();
     for (const scene of scenes) {
-      if (scene.type === "tool-call" && scene.diff) {
-        fileSet.add(scene.diff.filePath);
+      if (scene.type === "tool-call") {
+        for (const diff of getToolDiffs(scene)) fileSet.add(diff.filePath);
       }
     }
     return fileSet.size;

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { ReplaySession } from "../types";
+import { getToolDiffs } from "../utils/sceneDiffs";
 import { formatReplaySourceLabel } from "../utils/format";
 import {
   DataQualityIndicator,
@@ -38,18 +39,19 @@ export default function StatsPanel({ session }: Props) {
           break;
         case "tool-call": {
           toolCounts.set(scene.toolName, (toolCounts.get(scene.toolName) || 0) + 1);
-          if (scene.diff) {
+          const diffs = getToolDiffs(scene);
+          if (diffs.length > 0) {
             editCount++;
-            filesModified.add(scene.diff.filePath);
+            for (const diff of diffs) filesModified.add(diff.filePath);
           }
           if (scene.subAgent) {
             subAgentCount++;
             delegatedTools += scene.subAgent.toolCalls;
             // Count file modifications from sub-agent scenes
             for (const saScene of scene.subAgent.scenes) {
-              if (saScene.type === "tool-call" && saScene.diff) {
+              if (saScene.type === "tool-call" && getToolDiffs(saScene).length > 0) {
                 editCount++;
-                filesModified.add(saScene.diff.filePath);
+                for (const diff of getToolDiffs(saScene)) filesModified.add(diff.filePath);
               }
             }
           }

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { computeCacheHitRate, computeContextLayers, turnCacheHitRate } from "../engine";
 import type { ReplaySession, TurnStat } from "../types";
+import { getToolDiffs } from "../utils/sceneDiffs";
 import { formatReplaySourceLabel } from "../utils/format";
 import {
   DataQualityIndicator,
@@ -185,13 +186,13 @@ export default function SummaryView({ session }: Props) {
             const fp = scene.input?.file_path as string | undefined;
             if (fp) getFile(fp).readCount++;
           } else if (tn === "Edit" || tn === "Write") {
-            if (scene.diff) {
-              const f = getFile(scene.diff.filePath);
+            for (const diff of getToolDiffs(scene)) {
+              const f = getFile(diff.filePath);
               f.editCount++;
               const turnIdx = turns.length; // current turn (1-indexed)
               f.turnEdits.set(turnIdx, (f.turnEdits.get(turnIdx) || 0) + 1);
-              const oldL = scene.diff.oldContent ? scene.diff.oldContent.split("\n").length : 0;
-              const newL = scene.diff.newContent ? scene.diff.newContent.split("\n").length : 0;
+              const oldL = diff.oldContent ? diff.oldContent.split("\n").length : 0;
+              const newL = diff.newContent ? diff.newContent.split("\n").length : 0;
               f.linesAdded += Math.max(0, newL - oldL);
               f.linesRemoved += Math.max(0, oldL - newL);
             }

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from "react";
 import type { Scene, SubAgent } from "../types";
 import { displayToolName } from "../utils/toolName";
+import { getToolDiffs } from "../utils/sceneDiffs";
 import { ErrorBadge, ToolDuration, ToolTokens } from "./Badges";
 import BashBlock from "./BashBlock";
 import CodeDiffBlock from "./CodeDiffBlock";
@@ -286,19 +287,39 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
     );
   }
 
-  // Special rendering for Edit/Write with diff
-  if (scene.diff) {
+  // Special rendering for Edit/Write with one or more file diffs
+  const diffs = getToolDiffs(scene);
+  if (diffs.length === 1) {
     return (
       <CodeDiffBlock
         toolName={scene.toolName}
-        filePath={scene.diff.filePath}
-        oldContent={scene.diff.oldContent}
-        newContent={scene.diff.newContent}
+        filePath={diffs[0].filePath}
+        oldContent={diffs[0].oldContent}
+        newContent={diffs[0].newContent}
         isActive={isActive}
         isError={scene.isError}
         durationMs={scene.durationMs}
         resultTokens={scene.resultTokens}
       />
+    );
+  }
+  if (diffs.length > 1) {
+    return (
+      <div className="space-y-3">
+        {diffs.map((diff, index) => (
+          <CodeDiffBlock
+            key={`${diff.filePath}-${index}`}
+            toolName={scene.toolName}
+            filePath={diff.filePath}
+            oldContent={diff.oldContent}
+            newContent={diff.newContent}
+            isActive={isActive}
+            isError={scene.isError}
+            durationMs={index === 0 ? scene.durationMs : undefined}
+            resultTokens={index === 0 ? scene.resultTokens : undefined}
+          />
+        ))}
+      </div>
     );
   }
 

--- a/packages/viewer/src/components/__tests__/tool-call-diffs.test.tsx
+++ b/packages/viewer/src/components/__tests__/tool-call-diffs.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Scene } from "../../types";
+import ToolCallBlock from "../ToolCallBlock";
+
+afterEach(cleanup);
+
+describe("ToolCallBlock multi-file diffs", () => {
+  it("renders every changed file while retaining the primary diff", () => {
+    const diffs = [
+      { filePath: "src/app.ts", oldContent: "old", newContent: "new" },
+      { filePath: "src/auth.ts", oldContent: "before", newContent: "after" },
+    ];
+    const scene: Extract<Scene, { type: "tool-call" }> = {
+      type: "tool-call",
+      toolName: "Edit",
+      input: {},
+      result: "Done",
+      diff: diffs[0],
+      diffs,
+    };
+
+    render(<ToolCallBlock scene={scene} isActive={false} />);
+
+    expect(screen.getByText("src/app.ts")).toBeTruthy();
+    expect(screen.getByText("src/auth.ts")).toBeTruthy();
+  });
+});

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -3,6 +3,7 @@ export type {
   Annotation,
   DataSource,
   DataSourceInfo,
+  FileDiff,
   OverlaySource,
   PrLink,
   ReplaySession,

--- a/packages/viewer/src/utils/__tests__/scene-diffs.test.ts
+++ b/packages/viewer/src/utils/__tests__/scene-diffs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { Scene } from "../../types";
+import { getToolDiffs } from "../sceneDiffs";
+
+function toolScene(
+  overrides: Partial<Extract<Scene, { type: "tool-call" }>>,
+): Extract<Scene, { type: "tool-call" }> {
+  return { type: "tool-call", toolName: "Edit", input: {}, result: "", ...overrides };
+}
+
+describe("getToolDiffs", () => {
+  it("falls back to the legacy primary diff", () => {
+    const diff = { filePath: "a.ts", oldContent: "a", newContent: "b" };
+    expect(getToolDiffs(toolScene({ diff }))).toEqual([diff]);
+  });
+
+  it("prefers the complete multi-file diff list", () => {
+    const primary = { filePath: "a.ts", oldContent: "a", newContent: "b" };
+    const diffs = [primary, { filePath: "b.ts", oldContent: "", newContent: "new" }];
+    expect(getToolDiffs(toolScene({ diff: primary, diffs }))).toEqual(diffs);
+  });
+});

--- a/packages/viewer/src/utils/feedback-export.ts
+++ b/packages/viewer/src/utils/feedback-export.ts
@@ -1,5 +1,6 @@
 import type { Annotation, ReplaySession, Scene } from "../types";
 import { displayToolName } from "./toolName";
+import { getToolDiffs } from "./sceneDiffs";
 
 const MAX_CONTEXT_CHARS = 1_200;
 
@@ -44,7 +45,8 @@ export function sceneFeedbackContext(scene: Scene): { text: string; language?: s
       return { text: truncate(scene.content), language: "markdown" };
     case "tool-call": {
       const parts = [`Tool: ${displayToolName(scene.toolName)}`];
-      if (scene.diff?.filePath) parts.push(`File: ${scene.diff.filePath}`);
+      const files = getToolDiffs(scene).map((diff) => diff.filePath);
+      if (files.length > 0) parts.push(`Files: ${files.join(", ")}`);
       if (scene.bashOutput?.command) parts.push(`Command: ${scene.bashOutput.command}`);
       if (scene.isError) parts.push("Result: error");
       const input = JSON.stringify(scene.input, null, 2);

--- a/packages/viewer/src/utils/sceneDiffs.ts
+++ b/packages/viewer/src/utils/sceneDiffs.ts
@@ -1,0 +1,9 @@
+import type { FileDiff, Scene } from "../types";
+
+type ToolScene = Extract<Scene, { type: "tool-call" }>;
+
+/** Return all diffs while remaining compatible with replay files that only have `diff`. */
+export function getToolDiffs(scene: ToolScene): FileDiff[] {
+  if (scene.diffs?.length) return scene.diffs;
+  return scene.diff ? [scene.diff] : [];
+}


### PR DESCRIPTION
## Summary

- parse every file section from Codex/Pi `apply_patch` payloads
- add additive `Scene.diffs` metadata while retaining `Scene.diff` as the primary/first diff
- render all changed files in the viewer
- include every changed file in stats, insights, landing summaries, and feedback context
- add parser→transform, security, compatibility, and component coverage

## Why

A single Codex `apply_patch` call can update several files. The replay previously kept only file attribution and rendered an empty/representative single diff, hiding most of the actual change.

## Compatibility

- `Scene.diff` is retained unchanged for old viewers and consumers
- `Scene.diffs` is optional and additive
- old replay files with only `diff` continue through the viewer fallback
- single-file Edit/Write/Delete behavior remains unchanged

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`
