### PR TITLE
Prevent unrelated session merges

### DIFF
--- a/packages/cli/scripts/eval-session-query.ts
+++ b/packages/cli/scripts/eval-session-query.ts
@@ -1,6 +1,6 @@
 import { deduplicateSessionsByProvider, getAllProviders } from "../src/providers/index.js";
 import { queryLocalSessions, type SessionQueryMatch } from "../src/session-query.js";
-import type { SessionInfo } from "../src/types.js";
+import { mergeSameSessions } from "../src/session-merge.js";
 
 type QueryMode = "strict" | "any" | "brief";
 
@@ -333,19 +333,6 @@ function aggregate(
     negativeReturned:
       rows.find((row) => row.evalCase.intent === "Negative control.")?.[mode].count || 0,
   };
-}
-
-function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
-  const groups = new Map<string, SessionInfo[]>();
-  for (const session of sessions) {
-    const key = `${session.project}::${session.slug}`;
-    groups.set(key, [...(groups.get(key) || []), session]);
-  }
-
-  return [...groups.values()].map((group) => {
-    group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-    return group[0];
-  });
 }
 
 function normalizedResultText(match: SessionQueryMatch): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from "./publishers/gist.js";
 import { publishLocal } from "./publishers/local.js";
 import { scanForSecrets } from "./scan.js";
+import { mergeSameSessions } from "./session-merge.js";
 import { startDashboard, startServer } from "./server.js";
 import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
 import { transformToReplay } from "./transform.js";
@@ -1337,58 +1338,4 @@ function formatSessionChoices(sessions: SessionInfo[], cleanupPeriodDays?: numbe
   }
 
   return choices;
-}
-
-/**
- * Merge multiple JSONL files that share the same slug + project into one entry.
- * Claude Code creates a new file per /resume, but they're the same logical session.
- * We keep the most recent file as the representative and sum up the stats.
- */
-function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
-  const groups = new Map<string, SessionInfo[]>();
-
-  for (const s of sessions) {
-    const key = `${s.project}::${s.slug}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)?.push(s);
-  }
-
-  const result: SessionInfo[] = [];
-  for (const group of groups.values()) {
-    if (group.length === 1) {
-      result.push(group[0]);
-      continue;
-    }
-
-    // Sort by timestamp descending — pick the latest as representative
-    group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-    const latest = group[0];
-
-    // Collect all file paths sorted by timestamp ascending (chronological order)
-    const allPaths = group
-      .slice()
-      .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
-      .flatMap((s) => s.filePaths);
-
-    const promptCount = group.some((s) => s.promptCount != null)
-      ? group.reduce((sum, s) => sum + (s.promptCount || 0), 0)
-      : undefined;
-    const toolCallCount = group.some((s) => s.toolCallCount != null)
-      ? group.reduce((sum, s) => sum + (s.toolCallCount || 0), 0)
-      : undefined;
-
-    result.push({
-      ...latest,
-      lineCount: group.reduce((sum, s) => sum + s.lineCount, 0),
-      fileSize: group.reduce((sum, s) => sum + s.fileSize, 0),
-      filePaths: allPaths,
-      toolPaths: [...new Set(group.flatMap((s) => s.toolPaths || []))],
-      promptCount,
-      toolCallCount,
-    });
-  }
-
-  // Re-sort by timestamp descending
-  result.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-  return result;
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -50,6 +50,7 @@ import {
   type SavedGistInfo,
 } from "./publishers/gist.js";
 import { scanForSecrets } from "./scan.js";
+import { mergeSameSessions } from "./session-merge.js";
 import {
   type EnrichmentHints,
   enrichmentHintsFromBody,
@@ -538,49 +539,6 @@ async function readClaudeSessionState(sessionId: string): Promise<LiveSessionSta
     // Dead PID — don't return yet; another file may be the live one.
   }
   return "stopped";
-}
-
-function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
-  const groups = new Map<string, SessionInfo[]>();
-  for (const s of sessions) {
-    const key = `${s.project}::${s.slug}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)?.push(s);
-  }
-
-  const result: SessionInfo[] = [];
-  for (const group of groups.values()) {
-    if (group.length === 1) {
-      result.push(group[0]);
-      continue;
-    }
-    group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-    const latest = group[0];
-    const allPaths = group
-      .slice()
-      .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
-      .flatMap((s) => s.filePaths);
-
-    const promptCount = group.some((s) => s.promptCount != null)
-      ? group.reduce((sum, s) => sum + (s.promptCount || 0), 0)
-      : undefined;
-    const toolCallCount = group.some((s) => s.toolCallCount != null)
-      ? group.reduce((sum, s) => sum + (s.toolCallCount || 0), 0)
-      : undefined;
-
-    result.push({
-      ...latest,
-      lineCount: group.reduce((sum, s) => sum + s.lineCount, 0),
-      fileSize: group.reduce((sum, s) => sum + s.fileSize, 0),
-      filePaths: allPaths,
-      toolPaths: [...new Set(group.flatMap((s) => s.toolPaths || []))],
-      promptCount,
-      toolCallCount,
-    });
-  }
-
-  result.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
-  return result;
 }
 
 export async function startServer(

--- a/packages/cli/src/session-merge.ts
+++ b/packages/cli/src/session-merge.ts
@@ -1,0 +1,57 @@
+import type { SessionInfo } from "./types.js";
+
+const RESUMABLE_PROVIDERS = new Set(["claude-code", "claude-desktop"]);
+
+function logicalSessionKey(session: SessionInfo): string {
+  if (RESUMABLE_PROVIDERS.has(session.provider)) {
+    return `${session.provider}::${session.project}::${session.slug}`;
+  }
+  return `${session.provider}::${session.sessionId || session.filePath}`;
+}
+
+/** Merge only provider formats that intentionally split one logical session across resume files. */
+export function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
+  const groups = new Map<string, SessionInfo[]>();
+  for (const session of sessions) {
+    const key = logicalSessionKey(session);
+    groups.set(key, [...(groups.get(key) || []), session]);
+  }
+
+  const result: SessionInfo[] = [];
+  for (const group of groups.values()) {
+    if (group.length === 1) {
+      result.push(group[0]);
+      continue;
+    }
+
+    group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    const latest = group[0];
+    const filePaths = [
+      ...new Set(
+        group
+          .slice()
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+          .flatMap((session) => session.filePaths),
+      ),
+    ];
+    const promptCount = group.some((session) => session.promptCount != null)
+      ? group.reduce((sum, session) => sum + (session.promptCount || 0), 0)
+      : undefined;
+    const toolCallCount = group.some((session) => session.toolCallCount != null)
+      ? group.reduce((sum, session) => sum + (session.toolCallCount || 0), 0)
+      : undefined;
+
+    result.push({
+      ...latest,
+      lineCount: group.reduce((sum, session) => sum + session.lineCount, 0),
+      fileSize: group.reduce((sum, session) => sum + session.fileSize, 0),
+      filePaths,
+      toolPaths: [...new Set(group.flatMap((session) => session.toolPaths || []))],
+      promptCount,
+      toolCallCount,
+    });
+  }
+
+  result.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return result;
+}

--- a/packages/cli/test/session-merge.test.ts
+++ b/packages/cli/test/session-merge.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { mergeSameSessions } from "../src/session-merge.js";
+import type { SessionInfo } from "../src/types.js";
+
+function session(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    provider: "claude-code",
+    sessionId: "session-1",
+    slug: "shared-slug",
+    project: "/project",
+    cwd: "/project",
+    version: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    lineCount: 10,
+    fileSize: 100,
+    filePath: "/sessions/one.jsonl",
+    filePaths: ["/sessions/one.jsonl"],
+    firstPrompt: "First prompt",
+    ...overrides,
+  };
+}
+
+describe("mergeSameSessions", () => {
+  it("merges chronological Claude resume shards and deduplicates paths", () => {
+    const merged = mergeSameSessions([
+      session({ promptCount: 1, toolCallCount: 2 }),
+      session({
+        sessionId: "session-2",
+        timestamp: "2026-01-01T01:00:00.000Z",
+        filePath: "/sessions/two.jsonl",
+        filePaths: ["/sessions/one.jsonl", "/sessions/two.jsonl"],
+        lineCount: 20,
+        fileSize: 200,
+        promptCount: 3,
+        toolCallCount: 4,
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      sessionId: "session-2",
+      lineCount: 30,
+      fileSize: 300,
+      promptCount: 4,
+      toolCallCount: 6,
+      filePaths: ["/sessions/one.jsonl", "/sessions/two.jsonl"],
+    });
+  });
+
+  it("does not merge independent non-resumable sessions with the same slug and project", () => {
+    const merged = mergeSameSessions([
+      session({ provider: "opencode", sessionId: "ses_one" }),
+      session({
+        provider: "opencode",
+        sessionId: "ses_two",
+        filePath: "/db#session:ses_two",
+        filePaths: ["/db#session:ses_two"],
+      }),
+    ]);
+
+    expect(merged.map((item) => item.sessionId).sort()).toEqual(["ses_one", "ses_two"]);
+  });
+
+  it("does not merge sessions across providers even when their native identity matches", () => {
+    const merged = mergeSameSessions([
+      session({ provider: "claude-code" }),
+      session({ provider: "pi" }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+    expect(new Set(merged.map((item) => item.provider))).toEqual(new Set(["claude-code", "pi"]));
+  });
+
+  it("keeps newest sessions first", () => {
+    const merged = mergeSameSessions([
+      session({ provider: "pi", sessionId: "old" }),
+      session({
+        provider: "pi",
+        sessionId: "new",
+        timestamp: "2026-01-02T00:00:00.000Z",
+      }),
+    ]);
+
+    expect(merged.map((item) => item.sessionId)).toEqual(["new", "old"]);
+  });
+});


### PR DESCRIPTION
## Summary

- centralize logical-session merging for CLI, dashboard server, and evaluation tooling
- merge slug-based resume shards only for Claude Code/Desktop
- keep non-resumable providers isolated by provider + native session ID
- deduplicate chronological source paths while preserving existing aggregate stats
- add collision and resume regression coverage

## Why

The previous global `project + slug` key could concatenate unrelated OpenCode, Pi, Codex, or cross-provider sessions and then parse them with the wrong provider.

## Compatibility

- Claude resume shard behavior and aggregate counts are preserved
- no replay/provider schema changes
- no provider discovery contract changes
- only false-positive session merges are prevented

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`