### PR TITLE
Scope insight identity by provider

### DIFF
--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -77,8 +77,15 @@ function migrateInsightsStore(raw: Partial<InsightsStore>): InsightsStore {
     };
   }
 
-  // Future migrations go here:
-  // if (v < 2) { ... }
+  // v1 → v2: records are now keyed by provider + sessionId during merge.
+  // No record rewrite is needed because both fields already existed in v1.
+  if (v < 2) {
+    return {
+      schemaVersion: INSIGHTS_SCHEMA_VERSION,
+      lastUpdated: raw.lastUpdated || new Date().toISOString(),
+      sessions: Array.isArray(raw.sessions) ? raw.sessions : [],
+    };
+  }
 
   // Ensure required fields exist even for current/future schema versions
   return {
@@ -130,8 +137,12 @@ export function scanResultToInsight(scan: SessionScanResult): SessionInsight {
 }
 
 // ---------------------------------------------------------------------------
-// Merge — upsert by sessionId, never delete
+// Merge — upsert by provider + sessionId, never delete
 // ---------------------------------------------------------------------------
+
+function insightKey(provider: string, sessionId: string): string {
+  return `${provider}::${sessionId}`;
+}
 
 /**
  * Merge new scan results into the insights store.
@@ -145,11 +156,12 @@ export function mergeInsights(
 ): InsightsStore {
   const byId = new Map<string, SessionInsight>();
   for (const existing of store.sessions) {
-    byId.set(existing.sessionId, existing);
+    byId.set(insightKey(existing.provider, existing.sessionId), existing);
   }
 
   for (const scan of scanResults) {
-    const existing = byId.get(scan.sessionId);
+    const key = insightKey(scan.provider, scan.sessionId);
+    const existing = byId.get(key);
     if (existing) {
       // Update with fresh scan data but preserve original provenance
       const updated = scanResultToInsight(scan);
@@ -158,9 +170,9 @@ export function mergeInsights(
       // Preserve original capture machine (session belongs to where it ran, not where it's re-scanned)
       updated.machineId = existing.machineId ?? updated.machineId;
       updated.machineName = existing.machineName ?? updated.machineName;
-      byId.set(scan.sessionId, updated);
+      byId.set(key, updated);
     } else {
-      byId.set(scan.sessionId, scanResultToInsight(scan));
+      byId.set(key, scanResultToInsight(scan));
     }
   }
 

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -31,7 +31,7 @@ import type { DataSource, PrLink, SessionInfo, TokenUsage } from "./types.js";
 import { localDayKey, shortenPath } from "./utils.js";
 
 // Bump this when we extract new fields — forces re-scan of all sessions.
-const SCANNER_VERSION = 9;
+const SCANNER_VERSION = 10;
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -96,7 +96,7 @@ interface ScanCacheEntry {
 
 export interface ScanCacheData {
   scannerVersion: number;
-  entries: Record<string, ScanCacheEntry>; // keyed by sessionId
+  entries: Record<string, ScanCacheEntry>; // keyed by provider + sessionId
 }
 
 export interface ProjectInsights {
@@ -277,6 +277,11 @@ export interface ScanInput {
   discoveryDurationMs?: number;
   discoveryTokenUsage?: SessionScanResult["tokenUsage"];
   discoveryCostEstimate?: number;
+}
+
+/** Keep provider-native IDs isolated when caching cross-provider scan results. */
+export function scanCacheEntryKey(session: Pick<ScanInput, "provider" | "sessionId">): string {
+  return `${session.provider}::${session.sessionId}`;
 }
 
 interface ScanProgress {
@@ -1167,7 +1172,8 @@ export async function runBackgroundScan(
 
   const processSession = async (index: number): Promise<void> => {
     const session = sessions[index];
-    const cached = cache.entries[session.sessionId];
+    const cacheKey = scanCacheEntryKey(session);
+    const cached = cache.entries[cacheKey];
     const cacheCheck = await checkCache(cached, session);
 
     if (cacheCheck.valid && cached) {
@@ -1181,7 +1187,7 @@ export async function runBackgroundScan(
           valid: false;
           meta: { mtimeMs: number; fileSize: number };
         };
-        cache.entries[session.sessionId] = {
+        cache.entries[cacheKey] = {
           mtimeMs: meta.mtimeMs,
           fileSize: meta.fileSize,
           scannedAt: new Date().toISOString(),

--- a/packages/cli/test/insights.test.ts
+++ b/packages/cli/test/insights.test.ts
@@ -135,6 +135,27 @@ describe("mergeInsights", () => {
     });
     expect(updated?.updatedAt).toBeDefined();
   });
+
+  it("keeps identical native session IDs isolated by provider", () => {
+    const merged = mergeInsights(
+      makeStore([
+        makeInsight({ provider: "claude-code", sessionId: "shared", promptCount: 1 }),
+        makeInsight({ provider: "cursor", sessionId: "shared", promptCount: 2 }),
+      ]),
+      [
+        makeScan({ provider: "cursor", sessionId: "shared", promptCount: 7 }),
+        makeScan({ provider: "pi", sessionId: "shared", promptCount: 3 }),
+      ],
+    );
+
+    expect(
+      merged.sessions.map((session) => [session.provider, session.sessionId, session.promptCount]),
+    ).toEqual([
+      ["claude-code", "shared", 1],
+      ["cursor", "shared", 7],
+      ["pi", "shared", 3],
+    ]);
+  });
 });
 
 describe("aggregateDailyInsights", () => {

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -7,6 +7,7 @@ import {
   aggregateUserInsights,
   type SessionScanResult,
   scanSession,
+  scanCacheEntryKey,
 } from "../src/scanner.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────
@@ -174,6 +175,12 @@ afterAll(async () => {
 // ─── Scanner tests ──────────────────────────────────────────────────
 
 describe("scanSession", () => {
+  it("uses provider-scoped cache identities", () => {
+    expect(scanCacheEntryKey({ provider: "claude-code", sessionId: "shared" })).not.toBe(
+      scanCacheEntryKey({ provider: "cursor", sessionId: "shared" }),
+    );
+  });
+
   it("extracts session metadata correctly", async () => {
     const result = await scanSession({
       sessionId: "test-session-1",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -167,7 +167,7 @@ export interface SessionOverlays {
 // ---------------------------------------------------------------------------
 
 /** Schema version for the insights store. Bump when adding breaking changes. */
-export const INSIGHTS_SCHEMA_VERSION = 1;
+export const INSIGHTS_SCHEMA_VERSION = 2;
 
 /**
  * A single session's insights — lightweight metadata persisted locally so it


### PR DESCRIPTION
## Summary

- key scanner cache entries by provider + native session ID
- key durable insight upserts by provider + native session ID
- bump scanner cache version to invalidate ambiguous entries
- migrate the insights store from schema v1 to v2 without rewriting records
- add cross-provider collision coverage

## Why

Different providers can emit the same native session ID. Session discovery now keeps them separate, but scanner cache and durable insights could still overwrite one provider with another.

## Compatibility

- existing insight records are preserved during v1→v2 migration
- no per-record fields are removed or renamed
- scanner cache is safely rebuilt
- daily/cloud aggregation wire format is unchanged

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`