### PR TITLE
Version and validate replay schemas

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -2084,6 +2084,14 @@ function getBaseUrl(c: Context<HonoEnv>): string {
  * Intentionally loose — only checks fields the viewer needs to render.
  */
 function validateReplaySchema(replay: any): string | null {
+  if (
+    replay?.schemaVersion !== undefined &&
+    (!Number.isInteger(replay.schemaVersion) ||
+      replay.schemaVersion < 1 ||
+      replay.schemaVersion > 1)
+  ) {
+    return `Unsupported replay schema version: ${String(replay.schemaVersion)}`;
+  }
   if (!replay.meta || typeof replay.meta !== "object") {
     return "Missing meta object";
   }

--- a/e2e/generated-html.test.ts
+++ b/e2e/generated-html.test.ts
@@ -132,6 +132,11 @@ describe("Generated HTML E2E", () => {
     expect(hasData).toBe(true);
   });
 
+  it("embeds the current replay schema version", async () => {
+    const schemaVersion = await page.evaluate(() => window.__VIBE_REPLAY_DATA__?.schemaVersion);
+    expect(schemaVersion).toBe(1);
+  });
+
   it("renders correct number of scenes", async () => {
     const embeddedSceneCount = await page.evaluate(() => {
       return window.__VIBE_REPLAY_DATA__?.scenes?.length ?? 0;

--- a/packages/cli/test/replay-schema-validation.test.ts
+++ b/packages/cli/test/replay-schema-validation.test.ts
@@ -7,6 +7,14 @@ import { describe, expect, it } from "vitest";
  * this test and cloudflare/src/worker.ts's validateReplaySchema.
  */
 function validateReplaySchema(replay: any): string | null {
+  if (
+    replay?.schemaVersion !== undefined &&
+    (!Number.isInteger(replay.schemaVersion) ||
+      replay.schemaVersion < 1 ||
+      replay.schemaVersion > 1)
+  ) {
+    return `Unsupported replay schema version: ${String(replay.schemaVersion)}`;
+  }
   if (!replay.meta || typeof replay.meta !== "object") {
     return "Missing meta object";
   }
@@ -52,6 +60,14 @@ describe("replay schema validation", () => {
 
   it("accepts a valid replay", () => {
     expect(validateReplaySchema(validReplay)).toBeNull();
+  });
+
+  it("accepts legacy and current schema versions but rejects future versions", () => {
+    expect(validateReplaySchema(validReplay)).toBeNull();
+    expect(validateReplaySchema({ ...validReplay, schemaVersion: 1 })).toBeNull();
+    expect(validateReplaySchema({ ...validReplay, schemaVersion: 2 })).toBe(
+      "Unsupported replay schema version: 2",
+    );
   });
 
   it("accepts replay with empty scenes array", () => {

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -5,6 +5,7 @@ import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/pr
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
 import type { DataSourceInfo, FileDiff, ReplaySession, Scene, SubAgent } from "@vibe-replay/types";
+import { REPLAY_SCHEMA_VERSION } from "@vibe-replay/types";
 import { estimateTokens } from "./utils/tokenEstimate.js";
 
 type ToolCallScene = Extract<Scene, { type: "tool-call" }>;
@@ -170,6 +171,7 @@ export function transformToReplay(
   const endTime = parsed.endTime || turnTimestampBounds.endTime;
 
   return {
+    schemaVersion: REPLAY_SCHEMA_VERSION,
     meta: {
       sessionId: parsed.sessionId,
       slug: parsed.slug,

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -1,8 +1,8 @@
 import { homedir } from "node:os";
 import { describe, expect, it } from "vitest";
-import type { ProviderParseResult, TokenUsage } from "@vibe-replay/provider-contract";
+import type { ParsedTurn, ProviderParseResult, TokenUsage } from "@vibe-replay/provider-contract";
 import { transformToReplay } from "../src/transform.js";
-import type { ParsedTurn } from "@vibe-replay/types";
+import { REPLAY_SCHEMA_VERSION } from "@vibe-replay/types";
 
 /** Build a minimal ProviderParseResult for testing */
 function buildParsed(overrides: Partial<ProviderParseResult> = {}): ProviderParseResult {
@@ -694,6 +694,7 @@ describe("transform — metadata", () => {
       "~/project",
     );
     expect(replay.meta.sessionId).toBe("s1");
+    expect(replay.schemaVersion).toBe(REPLAY_SCHEMA_VERSION);
     expect(replay.meta.slug).toBe("sl1");
     expect(replay.meta.title).toBe("My Title");
     expect(replay.meta.provider).toBe("cursor");

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -169,6 +169,9 @@ export interface SessionOverlays {
 /** Schema version for the insights store. Bump when adding breaking changes. */
 export const INSIGHTS_SCHEMA_VERSION = 2;
 
+/** Current replay JSON schema. Missing means a legacy v0 replay. */
+export const REPLAY_SCHEMA_VERSION = 1;
+
 /**
  * A single session's insights — lightweight metadata persisted locally so it
  * survives after source JSONL files are deleted (e.g. Claude Code 30-day cleanup).
@@ -267,6 +270,8 @@ export interface SessionScanWireData {
 }
 
 export interface ReplaySession {
+  /** Optional for backward compatibility with replays generated before schema versioning. */
+  schemaVersion?: number;
   meta: {
     sessionId: string;
     slug: string;

--- a/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
@@ -11,7 +11,18 @@ const win = window as unknown as {
 
 // A minimal stand-in — the loader passes the object through unchanged and the
 // tests only assert status/mode, never the session shape.
-const fakeSession = { scenes: [], meta: {} } as unknown as ReplaySession;
+const fakeSession: ReplaySession = {
+  meta: {
+    sessionId: "session-1",
+    slug: "session-1",
+    provider: "claude-code",
+    startTime: "2026-01-01T00:00:00.000Z",
+    cwd: "~/project",
+    project: "~/project",
+    stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 },
+  },
+  scenes: [],
+};
 
 function setSearch(search: string) {
   window.history.replaceState({}, "", search || "/");

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ReplaySession } from "../types";
+import { parseReplaySession } from "../utils/replaySchema";
 
 export type ViewerMode = "embedded" | "editor" | "readonly";
 
@@ -219,7 +220,17 @@ function startLiveStream(
       return;
     }
     if (payload.type === "session" && payload.session) {
-      lastSession = payload.session;
+      try {
+        lastSession = parseReplaySession(payload.session);
+      } catch (error) {
+        liveStatus = {
+          ...liveStatus,
+          state: "error",
+          error: error instanceof Error ? error.message : "Invalid live replay payload",
+        };
+        emit();
+        return;
+      }
       liveStatus = {
         state: "open",
         scenes: payload.session.scenes.length,
@@ -266,7 +277,7 @@ function startLiveStream(
 async function loadSession(): Promise<LoadResult | "dashboard"> {
   // 1. Embedded data (from CLI generator)
   if (window.__VIBE_REPLAY_DATA__) {
-    return { session: window.__VIBE_REPLAY_DATA__, mode: "embedded" };
+    return { session: parseReplaySession(window.__VIBE_REPLAY_DATA__), mode: "embedded" };
   }
 
   const params = new URLSearchParams(window.location.search);
@@ -292,7 +303,7 @@ async function loadSession(): Promise<LoadResult | "dashboard"> {
       const { rawUrl } = await resolveGistUrl((data as any).gistId);
       return { session: await fetchJson(rawUrl), mode: "readonly" };
     }
-    return { session: data as ReplaySession, mode: "readonly" };
+    return { session: parseReplaySession(data), mode: "readonly" };
   }
 
   // 3. Gist parameter — always check (works in any mode)
@@ -321,7 +332,7 @@ async function loadSession(): Promise<LoadResult | "dashboard"> {
     if (slug) {
       const resp = await fetch(`/api/session?slug=${encodeURIComponent(slug)}`);
       if (!resp.ok) throw new Error(`Session not found: ${slug}`);
-      const session = (await resp.json()) as ReplaySession;
+      const session = parseReplaySession(await resp.json());
       return { session, mode: "editor" };
     }
 
@@ -340,7 +351,7 @@ async function loadSession(): Promise<LoadResult | "dashboard"> {
   if (file) {
     const resp = await fetch(file);
     if (!resp.ok) throw new Error(`Failed to load file: ${resp.status}`);
-    return { session: (await resp.json()) as ReplaySession, mode: "embedded" };
+    return { session: parseReplaySession(await resp.json()), mode: "embedded" };
   }
 
   // No data source — show dashboard/landing page
@@ -352,7 +363,7 @@ async function fetchJson(url: string): Promise<ReplaySession> {
   if (!resp.ok) throw new Error(`Failed to fetch: ${resp.status} ${resp.statusText}`);
   const text = await resp.text();
   if (text.trimStart().startsWith("{")) {
-    return JSON.parse(text) as ReplaySession;
+    return parseReplaySession(JSON.parse(text));
   }
   throw new Error("URL must point to a vibe-replay JSON replay file");
 }

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -1,4 +1,5 @@
 // Shared types — single source of truth
+export { INSIGHTS_SCHEMA_VERSION, REPLAY_SCHEMA_VERSION } from "@vibe-replay/types";
 export type {
   Annotation,
   DataSource,

--- a/packages/viewer/src/utils/__tests__/replay-schema.test.ts
+++ b/packages/viewer/src/utils/__tests__/replay-schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { REPLAY_SCHEMA_VERSION } from "../../types";
+import { parseReplaySession } from "../replaySchema";
+
+function replay(overrides: Record<string, unknown> = {}) {
+  return {
+    meta: { sessionId: "session-1", provider: "claude-code" },
+    scenes: [{ type: "user-prompt", content: "Hello" }],
+    ...overrides,
+  };
+}
+
+describe("parseReplaySession", () => {
+  it("accepts legacy replays without a schema version", () => {
+    expect(parseReplaySession(replay()).schemaVersion).toBeUndefined();
+  });
+
+  it("accepts the current replay schema", () => {
+    expect(parseReplaySession(replay({ schemaVersion: REPLAY_SCHEMA_VERSION })).schemaVersion).toBe(
+      REPLAY_SCHEMA_VERSION,
+    );
+  });
+
+  it("rejects future replay schemas with a descriptive error", () => {
+    expect(() => parseReplaySession(replay({ schemaVersion: REPLAY_SCHEMA_VERSION + 1 }))).toThrow(
+      "Unsupported replay schema version",
+    );
+  });
+
+  it("rejects malformed scene envelopes", () => {
+    expect(() => parseReplaySession(replay({ scenes: [{ type: "future-scene" }] }))).toThrow(
+      "unsupported scene at index 0",
+    );
+  });
+});

--- a/packages/viewer/src/utils/replaySchema.ts
+++ b/packages/viewer/src/utils/replaySchema.ts
@@ -1,0 +1,57 @@
+import { REPLAY_SCHEMA_VERSION, type ReplaySession } from "../types";
+
+const SCENE_TYPES = new Set([
+  "user-prompt",
+  "compaction-summary",
+  "context-injection",
+  "thinking",
+  "text-response",
+  "tool-call",
+]);
+
+/** Validate replay identity, scene envelopes, and forward schema compatibility. */
+export function parseReplaySession(value: unknown): ReplaySession {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Invalid replay: expected an object");
+  }
+  const replay = value as Record<string, unknown>;
+  const version = replay.schemaVersion;
+  if (
+    version !== undefined &&
+    (!Number.isInteger(version) ||
+      (version as number) < 1 ||
+      (version as number) > REPLAY_SCHEMA_VERSION)
+  ) {
+    throw new Error(
+      `Unsupported replay schema version: ${String(version)} (viewer supports ${REPLAY_SCHEMA_VERSION})`,
+    );
+  }
+
+  const meta = replay.meta;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    throw new Error("Invalid replay: missing meta object");
+  }
+  const typedMeta = meta as Record<string, unknown>;
+  if (typeof typedMeta.sessionId !== "string" || !typedMeta.sessionId) {
+    throw new Error("Invalid replay: missing meta.sessionId");
+  }
+  if (typeof typedMeta.provider !== "string" || !typedMeta.provider) {
+    throw new Error("Invalid replay: missing meta.provider");
+  }
+  if (!Array.isArray(replay.scenes)) {
+    throw new Error("Invalid replay: missing scenes array");
+  }
+  for (let index = 0; index < replay.scenes.length; index++) {
+    const scene = replay.scenes[index];
+    if (
+      !scene ||
+      typeof scene !== "object" ||
+      Array.isArray(scene) ||
+      typeof (scene as { type?: unknown }).type !== "string" ||
+      !SCENE_TYPES.has((scene as { type: string }).type)
+    ) {
+      throw new Error(`Invalid replay: unsupported scene at index ${index}`);
+    }
+  }
+  return value as ReplaySession;
+}


### PR DESCRIPTION
## Summary

- add additive replay `schemaVersion` metadata to newly generated sessions
- keep missing schema versions compatible as legacy replay files
- validate embedded, editor, file, URL, Gist, cloud, and live-SSE replay payloads
- reject unsupported future schemas with a descriptive viewer error
- apply the same version boundary to cloud uploads
- add unit, loader, cloud-contract, transform, and generated-HTML coverage

## Compatibility

- `schemaVersion` is optional in `ReplaySession`
- old replay files without the field remain accepted
- current generated files use schema version 1
- no existing scene or metadata field changes

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`