### PR TITLE
Refresh provider and architecture docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,28 +35,32 @@ See `src/hooks/__tests__/usePlayback.test.tsx` for the pattern.
 
 ## Architecture
 
-pnpm monorepo with three packages:
+pnpm monorepo with shared foundations, provider packages, and app layers:
 
-- **`packages/cli`** — CLI tool published as `vibe-replay` on npm. Discovers sessions, parses them, transforms into scenes, and generates output.
-- **`packages/viewer`** — React app built into a single HTML file (~430KB) via `vite-plugin-singlefile`. Handles playback, annotations, theming, and search.
 - **`packages/types`** — Shared TypeScript types (`@vibe-replay/types`). Both CLI and viewer re-export from here.
+- **`packages/provider-contract` / `provider-core`** — Stable provider interfaces and shared discovery/parser utilities.
+- **`packages/provider-*`** — Provider-owned discovery and parsing for Claude, Codex, Cursor, OpenCode, Hermes, and Pi.
+- **`packages/providers-default`** — Default provider registry and cross-provider discovery deduplication.
+- **`packages/replay-core`** — Provider-neutral scene transformation, redaction, token estimates, and pricing.
+- **`packages/cli`** — CLI tool published as `vibe-replay` on npm. Discovers sessions, generates replays, and serves the local dashboard/editor.
+- **`packages/viewer`** — React app built into a single HTML file (~920KB) via `vite-plugin-singlefile`. Handles playback, annotations, insights, theming, and search.
 
 ### Data flow
 
 ```
 Session files (JSONL / SQLite)
-  → providers/discover.ts    find sessions on disk
-  → providers/parser.ts      parse into ParsedTurn[]
-  → transform.ts             convert to Scene[], redact secrets/paths
-  → generator.ts             inject JSON into viewer HTML
-  → output                   vibe-replay/<slug>/index.html + replay.json
+  → provider-*/discover.ts       find sessions on disk
+  → provider-*/parser.ts         parse into ParsedTurn[]
+  → replay-core/transform.ts     convert to Scene[], redact secrets/paths
+  → cli/generator.ts             inject JSON into viewer HTML
+  → output                       vibe-replay/<slug>/index.html + replay.json
 ```
 
 ### Dashboard terminology and caches
 
 The dashboard uses product terminology that distinguishes original AI sessions from generated replays:
 
-- **Sessions** in the UI are **Source Sessions**: raw/discovered AI coding sessions from providers such as Claude, Cursor, Codex, and Pi. They may or may not have a generated replay yet.
+- **Sessions** in the UI are **Source Sessions**: raw/discovered AI coding sessions from providers such as Claude, Cursor, Codex, OpenCode, Hermes, and Pi. They may or may not have a generated replay yet.
 - **Raw transcript/provider data** is provider-owned local storage, such as Claude JSONL, Codex JSONL, Pi JSONL under `~/.pi/agent/sessions`, or Cursor SQLite/globalStorage data.
 - **Replays** are generated Vibe Replay artifacts under `vibe-replay/<slug>/`, including `index.html` and `replay.json`.
 - **Replay Summaries** are lightweight listings of generated replay artifacts.
@@ -149,10 +153,11 @@ The viewer runs in three modes, determined at load time:
 
 ### Adding a new provider
 
-1. Create `providers/<name>/discover.ts` — scan disk for sessions, return `SessionInfo[]`
-2. Create `providers/<name>/parser.ts` — parse files into `ParsedTurn[]`
-3. Create `providers/<name>/index.ts` — implement the `Provider` interface
-4. Register in `providers/index.ts`
+1. Create `packages/provider-<name>/src/<name>/discover.ts` — scan disk for sessions, return `SessionInfo[]`
+2. Create `packages/provider-<name>/src/<name>/parser.ts` — parse files into `ParsedTurn[]`
+3. Create `packages/provider-<name>/src/<name>/index.ts` — implement the `Provider` interface
+4. Register the provider in `packages/providers-default/src/index.ts`
+5. Add the package test command to the root `pnpm test` chain
 
 ## Build pipeline
 
@@ -169,7 +174,7 @@ The viewer is built once, then the CLI embeds it. The final HTML output is the v
 
 - **pnpm** only — no npm/yarn
 - **TypeScript strict mode**, ESM throughout
-- **Viewer must stay under 500KB** after build (currently ~430KB)
+- **Viewer must stay under 1MB** after build (currently ~920KB)
 - **Output HTML must be fully self-contained** — no automatic external requests; remote media requires explicit user consent
 - **Shared types** live in `packages/types` (`@vibe-replay/types`) — CLI and viewer re-export from there
 - **Secret redaction**: `transform.ts` strips API keys, tokens, PEM keys, paths. `scan.ts` does a second pass on the final output.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/vibe-replay)](https://www.npmjs.com/package/vibe-replay)
 [![license](https://img.shields.io/npm/l/vibe-replay)](./LICENSE)
 
-Turn Claude Code, Cursor, Codex, and Pi sessions into shareable, interactive replays.
+Turn Claude, Cursor, Codex, OpenCode, Hermes, and Pi sessions into shareable, interactive replays.
 
 ### The problem
 
@@ -31,7 +31,7 @@ npx vibe-replay
 
 ### All your sessions, one place
 
-Launch with `npx vibe-replay -d` and see every Claude Code, Cursor, Codex, and Pi session across all projects — with a daily activity snapshot, activity heatmaps, cost totals, and project analytics. Search sessions, filter by git repo, and generate any replay in one click.
+Launch with `npx vibe-replay -d` and see every Claude, Cursor, Codex, OpenCode, Hermes, and Pi session across all projects — with a daily activity snapshot, activity heatmaps, cost totals, and project analytics. Search sessions, filter by git repo, and generate any replay in one click.
 
 <p align="center">
   <img src="docs/screenshots/dashboard.png" alt="Local dashboard — browse sessions, activity heatmap, project analytics" width="800" />
@@ -70,7 +70,7 @@ vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/
 ### What the plugin gives your agent
 
 - **Auto-discover sessions** — finds the current session's JSONL file via `$CLAUDE_SESSION_ID`
-- **Search past sessions** — uses `vibe-replay sessions` to find Claude Code, Cursor, Codex, and Pi sessions by project, provider, or fuzzy query
+- **Search past sessions** — uses `vibe-replay sessions` to find Claude, Cursor, Codex, OpenCode, Hermes, and Pi sessions by project, provider, or fuzzy query
 - **Generate PR artifacts** — markdown summary + animated GIF + SVG, ready for PR descriptions
 - **Generate HTML replays** — self-contained interactive replay files
 - **PR workflow integration** — agent automatically embeds replay context when you create PRs
@@ -125,7 +125,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 - **Zero config** — one command, no setup, no account. Works instantly with existing sessions
 - **Cross-platform** — runs on macOS, Linux, and Windows
 - **Single HTML file** — self-contained, works offline, and makes no automatic external requests. Remote image attachments load only after an explicit click
-- **Claude Code, Cursor, Codex, and Pi** — all providers auto-discovered, including multi-file and resumed sessions
+- **Claude, Cursor, Codex, OpenCode, Hermes, and Pi** — all providers auto-discovered, including multi-file and resumed sessions
 - **Local dashboard** — browse and search every session, filter by git repo, with activity heatmaps, per-project analytics, and a personal-insights view across all your coding
 - **Share & export** — GitHub Gist, animated SVG, GIF, markdown summary, or cloud upload. Secret redaction built in
 - **Sub-agent visualization** — see delegated tool calls and sub-agent trees rendered inline
@@ -141,6 +141,8 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 | Claude Cowork | Supported (agent-mode sessions) |
 | Codex | Supported (web search, GPT-5.x models, task timings, memory mode) |
 | Cursor | Supported (SQLite + JSONL + SDK store, auto-discovered) |
+| OpenCode | Supported (SQLite sessions, tools, reasoning, and compaction) |
+| Hermes | Supported (SQLite sessions, tools, reasoning, and compaction) |
 | Pi | Supported (JSONL tree sessions, branching, compaction summaries) |
 | More coming soon | — |
 
@@ -148,9 +150,9 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 
 ```
 AI session files  →  vibe-replay  →  self-contained HTML
-(Claude Code,        (discover,       (animated viewer,
- Cursor, Codex, Pi)   parse,           insights panel,
-                      redact,          offline-ready,
+(Claude/Cursor,      (discover,       (animated viewer,
+ Codex/OpenCode,      parse,           insights panel,
+ Hermes/Pi)           redact,          offline-ready,
                       transform)       shareable)
 ```
 


### PR DESCRIPTION
## Summary

- list OpenCode and Hermes across product-facing provider references
- update the monorepo architecture to include provider contracts, provider packages, registry, and replay core
- correct provider package paths and registration instructions
- align the documented viewer size with the current ~920KB build and 1MB limit

## Compatibility

Documentation only; no runtime, schema, or API changes.

## Validation

- `git diff --check`
- latest main full lint/typecheck/unit/cloud/build/E2E audit completed before this documentation pass