### PR TITLE
Scope annotation drafts by provider

### DIFF
--- a/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Annotation, ReplaySession } from "../../types";
+import {
+  annotationStorageKey,
+  legacyAnnotationStorageKey,
+  useAnnotations,
+} from "../useAnnotations";
+
+function session(provider: string): ReplaySession {
+  return {
+    meta: {
+      sessionId: "shared-session",
+      slug: "shared-session",
+      provider,
+      startTime: "2026-01-01T00:00:00.000Z",
+      cwd: "~/project",
+      project: "~/project",
+      stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 },
+    },
+    scenes: [],
+  };
+}
+
+const annotation: Annotation = {
+  id: "annotation-1",
+  sceneIndex: 0,
+  body: "Keep this note",
+  author: "Reviewer",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  resolved: false,
+};
+
+beforeEach(() => localStorage.clear());
+afterEach(cleanup);
+
+describe("useAnnotations storage identity", () => {
+  it("keeps identical native session IDs isolated by provider", () => {
+    expect(annotationStorageKey("claude-code", "shared-session")).not.toBe(
+      annotationStorageKey("cursor", "shared-session"),
+    );
+  });
+
+  it("loads and migrates legacy session-only drafts", async () => {
+    localStorage.setItem(
+      legacyAnnotationStorageKey("shared-session"),
+      JSON.stringify([annotation]),
+    );
+
+    const { result } = renderHook(() => useAnnotations(session("claude-code"), "embedded"));
+    expect(result.current.annotations).toEqual([annotation]);
+
+    await waitFor(() => {
+      expect(localStorage.getItem(annotationStorageKey("claude-code", "shared-session"))).toBe(
+        JSON.stringify([annotation]),
+      );
+    });
+    expect(localStorage.getItem(legacyAnnotationStorageKey("shared-session"))).toBeNull();
+  });
+});

--- a/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
@@ -8,7 +8,11 @@ import {
   useAnnotations,
 } from "../useAnnotations";
 
-function session(provider: string): ReplaySession {
+function session(provider: string, sceneCount = 30): ReplaySession {
+  const scenes: ReplaySession["scenes"] = Array.from({ length: sceneCount }, (_, index) => ({
+    type: "user-prompt",
+    content: `Prompt ${index}`,
+  }));
   return {
     meta: {
       sessionId: "shared-session",
@@ -17,9 +21,9 @@ function session(provider: string): ReplaySession {
       startTime: "2026-01-01T00:00:00.000Z",
       cwd: "~/project",
       project: "~/project",
-      stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 },
+      stats: { sceneCount, userPrompts: sceneCount, toolCalls: 0 },
     },
-    scenes: [],
+    scenes,
   };
 }
 
@@ -41,15 +45,20 @@ describe("useAnnotations storage identity", () => {
     expect(annotationStorageKey("claude-code", "shared-session")).not.toBe(
       annotationStorageKey("cursor", "shared-session"),
     );
+    expect(annotationStorageKey("claude-code", "shared-session")).not.toBe(
+      legacyAnnotationStorageKey("claude-code:shared-session"),
+    );
   });
 
-  it("loads and migrates legacy session-only drafts", async () => {
+  it.each([30, 500])("loads and migrates legacy drafts for %i scenes", async (sceneCount) => {
     localStorage.setItem(
       legacyAnnotationStorageKey("shared-session"),
       JSON.stringify([annotation]),
     );
 
-    const { result } = renderHook(() => useAnnotations(session("claude-code"), "embedded"));
+    const { result } = renderHook(() =>
+      useAnnotations(session("claude-code", sceneCount), "embedded"),
+    );
     expect(result.current.annotations).toEqual([annotation]);
 
     await waitFor(() => {
@@ -60,27 +69,38 @@ describe("useAnnotations storage identity", () => {
     expect(localStorage.getItem(legacyAnnotationStorageKey("shared-session"))).toBeNull();
   });
 
-  it("reloads provider-scoped drafts when the replay identity changes", async () => {
-    const cursorAnnotation = { ...annotation, id: "cursor-note", body: "Cursor note" };
-    localStorage.setItem(
-      annotationStorageKey("claude-code", "shared-session"),
-      JSON.stringify([annotation]),
-    );
-    localStorage.setItem(
-      annotationStorageKey("cursor", "shared-session"),
-      JSON.stringify([cursorAnnotation]),
-    );
+  it("preserves an intentionally empty scoped draft over embedded annotations", () => {
+    localStorage.setItem(annotationStorageKey("claude-code", "shared-session"), "[]");
+    const replay = { ...session("claude-code"), annotations: [annotation] };
 
-    const { result, rerender } = renderHook(
-      ({ provider }) => useAnnotations(session(provider), "embedded"),
-      { initialProps: { provider: "claude-code" } },
-    );
-    expect(result.current.annotations).toEqual([annotation]);
-
-    rerender({ provider: "cursor" });
-    await waitFor(() => expect(result.current.annotations).toEqual([cursorAnnotation]));
-    expect(localStorage.getItem(annotationStorageKey("cursor", "shared-session"))).toBe(
-      JSON.stringify([cursorAnnotation]),
-    );
+    const { result } = renderHook(() => useAnnotations(replay, "embedded"));
+    expect(result.current.annotations).toEqual([]);
   });
+
+  it.each([30, 500])(
+    "reloads provider-scoped drafts across %i-scene replay changes",
+    async (sceneCount) => {
+      const cursorAnnotation = { ...annotation, id: "cursor-note", body: "Cursor note" };
+      localStorage.setItem(
+        annotationStorageKey("claude-code", "shared-session"),
+        JSON.stringify([annotation]),
+      );
+      localStorage.setItem(
+        annotationStorageKey("cursor", "shared-session"),
+        JSON.stringify([cursorAnnotation]),
+      );
+
+      const { result, rerender } = renderHook(
+        ({ provider }) => useAnnotations(session(provider, sceneCount), "embedded"),
+        { initialProps: { provider: "claude-code" } },
+      );
+      expect(result.current.annotations).toEqual([annotation]);
+
+      rerender({ provider: "cursor" });
+      await waitFor(() => expect(result.current.annotations).toEqual([cursorAnnotation]));
+      expect(localStorage.getItem(annotationStorageKey("cursor", "shared-session"))).toBe(
+        JSON.stringify([cursorAnnotation]),
+      );
+    },
+  );
 });

--- a/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
@@ -59,4 +59,28 @@ describe("useAnnotations storage identity", () => {
     });
     expect(localStorage.getItem(legacyAnnotationStorageKey("shared-session"))).toBeNull();
   });
+
+  it("reloads provider-scoped drafts when the replay identity changes", async () => {
+    const cursorAnnotation = { ...annotation, id: "cursor-note", body: "Cursor note" };
+    localStorage.setItem(
+      annotationStorageKey("claude-code", "shared-session"),
+      JSON.stringify([annotation]),
+    );
+    localStorage.setItem(
+      annotationStorageKey("cursor", "shared-session"),
+      JSON.stringify([cursorAnnotation]),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ provider }) => useAnnotations(session(provider), "embedded"),
+      { initialProps: { provider: "claude-code" } },
+    );
+    expect(result.current.annotations).toEqual([annotation]);
+
+    rerender({ provider: "cursor" });
+    await waitFor(() => expect(result.current.annotations).toEqual([cursorAnnotation]));
+    expect(localStorage.getItem(annotationStorageKey("cursor", "shared-session"))).toBe(
+      JSON.stringify([cursorAnnotation]),
+    );
+  });
 });

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -69,8 +69,12 @@ export interface AnnotationActions {
 
 const LS_PREFIX = "vibe-replay-annotations-";
 
-function storageKey(sessionId: string): string {
+export function legacyAnnotationStorageKey(sessionId: string): string {
   return LS_PREFIX + sessionId;
+}
+
+export function annotationStorageKey(provider: string, sessionId: string): string {
+  return `${LS_PREFIX}${encodeURIComponent(provider)}:${sessionId}`;
 }
 
 export function useAnnotations(
@@ -78,6 +82,7 @@ export function useAnnotations(
   mode: ViewerMode = "embedded",
 ): AnnotationActions {
   const sessionId = session.meta.sessionId;
+  const provider = session.meta.provider;
   const isEditor = mode === "editor";
 
   // Save HTML only works from self-contained production builds (data embedded inline)
@@ -89,7 +94,9 @@ export function useAnnotations(
     const embedded = session.annotations ?? [];
     if (isEditor) return embedded; // Editor mode: server is source of truth
     try {
-      const draft = localStorage.getItem(storageKey(sessionId));
+      const draft =
+        localStorage.getItem(annotationStorageKey(provider, sessionId)) ??
+        localStorage.getItem(legacyAnnotationStorageKey(sessionId));
       if (draft) {
         const parsed = JSON.parse(draft) as Annotation[];
         if (parsed.length > 0 || embedded.length === 0) return parsed;
@@ -133,11 +140,12 @@ export function useAnnotations(
     }
     // Non-editor: save to localStorage
     try {
-      localStorage.setItem(storageKey(sessionId), JSON.stringify(annotations));
+      localStorage.setItem(annotationStorageKey(provider, sessionId), JSON.stringify(annotations));
+      localStorage.removeItem(legacyAnnotationStorageKey(sessionId));
     } catch {
       /* quota exceeded — silent */
     }
-  }, [annotations, sessionId, isEditor]);
+  }, [annotations, provider, sessionId, isEditor]);
 
   const annotatedScenes = useMemo(() => computeAnnotatedScenes(annotations), [annotations]);
 
@@ -215,11 +223,12 @@ export function useAnnotations(
 
     setSavedSnapshot(annotations);
     try {
-      localStorage.removeItem(storageKey(sessionId));
+      localStorage.removeItem(annotationStorageKey(provider, sessionId));
+      localStorage.removeItem(legacyAnnotationStorageKey(sessionId));
     } catch {
       /* ignore */
     }
-  }, [session, annotations, sessionId, isEditor]);
+  }, [session, annotations, provider, sessionId, isEditor]);
 
   const downloadJson = useCallback(() => {
     const updatedSession: ReplaySession = { ...session, annotations };
@@ -236,11 +245,12 @@ export function useAnnotations(
 
     setSavedSnapshot(annotations);
     try {
-      localStorage.removeItem(storageKey(sessionId));
+      localStorage.removeItem(annotationStorageKey(provider, sessionId));
+      localStorage.removeItem(legacyAnnotationStorageKey(sessionId));
     } catch {
       /* ignore */
     }
-  }, [session, annotations, sessionId]);
+  }, [session, annotations, provider, sessionId]);
 
   // Editor mode: server-side gist publishing
   const [gistPublishing, setGistPublishing] = useState(false);

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -67,29 +67,37 @@ export interface AnnotationActions {
   aiCoachRunning: boolean;
 }
 
-const LS_PREFIX = "vibe-replay-annotations-";
+const LEGACY_LS_PREFIX = "vibe-replay-annotations-";
+const SCOPED_LS_PREFIX = "vibe-replay-provider-annotations-";
 
 export function legacyAnnotationStorageKey(sessionId: string): string {
-  return LS_PREFIX + sessionId;
+  return LEGACY_LS_PREFIX + sessionId;
 }
 
 export function annotationStorageKey(provider: string, sessionId: string): string {
-  return `${LS_PREFIX}${encodeURIComponent(provider)}:${sessionId}`;
+  return `${SCOPED_LS_PREFIX}${encodeURIComponent(provider)}:${encodeURIComponent(sessionId)}`;
 }
 
 function loadAnnotationDraft(session: ReplaySession, isEditor: boolean): Annotation[] {
   const embedded = session.annotations ?? [];
   if (isEditor) return embedded;
+  let drafts: Array<string | null>;
   try {
-    const draft =
-      localStorage.getItem(annotationStorageKey(session.meta.provider, session.meta.sessionId)) ??
-      localStorage.getItem(legacyAnnotationStorageKey(session.meta.sessionId));
-    if (draft) {
-      const parsed = JSON.parse(draft) as Annotation[];
-      if (parsed.length > 0 || embedded.length === 0) return parsed;
-    }
+    drafts = [
+      localStorage.getItem(annotationStorageKey(session.meta.provider, session.meta.sessionId)),
+      localStorage.getItem(legacyAnnotationStorageKey(session.meta.sessionId)),
+    ];
   } catch {
-    /* ignore malformed or unavailable local drafts */
+    return embedded;
+  }
+  for (const draft of drafts) {
+    if (draft === null) continue;
+    try {
+      const parsed: unknown = JSON.parse(draft);
+      if (Array.isArray(parsed)) return parsed as Annotation[];
+    } catch {
+      // Try the fallback draft when the scoped value is malformed.
+    }
   }
   return embedded;
 }

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -77,6 +77,23 @@ export function annotationStorageKey(provider: string, sessionId: string): strin
   return `${LS_PREFIX}${encodeURIComponent(provider)}:${sessionId}`;
 }
 
+function loadAnnotationDraft(session: ReplaySession, isEditor: boolean): Annotation[] {
+  const embedded = session.annotations ?? [];
+  if (isEditor) return embedded;
+  try {
+    const draft =
+      localStorage.getItem(annotationStorageKey(session.meta.provider, session.meta.sessionId)) ??
+      localStorage.getItem(legacyAnnotationStorageKey(session.meta.sessionId));
+    if (draft) {
+      const parsed = JSON.parse(draft) as Annotation[];
+      if (parsed.length > 0 || embedded.length === 0) return parsed;
+    }
+  } catch {
+    /* ignore malformed or unavailable local drafts */
+  }
+  return embedded;
+}
+
 export function useAnnotations(
   session: ReplaySession,
   mode: ViewerMode = "embedded",
@@ -84,31 +101,29 @@ export function useAnnotations(
   const sessionId = session.meta.sessionId;
   const provider = session.meta.provider;
   const isEditor = mode === "editor";
+  const storageIdentity = `${isEditor ? "editor" : "local"}::${provider}::${sessionId}`;
 
   // Save HTML only works from self-contained production builds (data embedded inline)
   // or in editor mode (server generates it).
   const canSaveHtml = !!window.__VIBE_REPLAY_DATA__ || isEditor;
 
   // Initialize from embedded data, then overlay localStorage draft
-  const [annotations, setAnnotations] = useState<Annotation[]>(() => {
-    const embedded = session.annotations ?? [];
-    if (isEditor) return embedded; // Editor mode: server is source of truth
-    try {
-      const draft =
-        localStorage.getItem(annotationStorageKey(provider, sessionId)) ??
-        localStorage.getItem(legacyAnnotationStorageKey(sessionId));
-      if (draft) {
-        const parsed = JSON.parse(draft) as Annotation[];
-        if (parsed.length > 0 || embedded.length === 0) return parsed;
-      }
-    } catch {
-      /* ignore */
-    }
-    return embedded;
-  });
+  const [annotations, setAnnotations] = useState<Annotation[]>(() =>
+    loadAnnotationDraft(session, isEditor),
+  );
 
   // Track whether we've diverged from embedded/server state
   const [savedSnapshot, setSavedSnapshot] = useState<Annotation[]>(() => session.annotations ?? []);
+  const loadedIdentityRef = useRef(storageIdentity);
+  const skipAutosaveIdentityRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (loadedIdentityRef.current === storageIdentity) return;
+    loadedIdentityRef.current = storageIdentity;
+    skipAutosaveIdentityRef.current = storageIdentity;
+    setAnnotations(loadAnnotationDraft(session, isEditor));
+    setSavedSnapshot(session.annotations ?? []);
+  }, [isEditor, session, storageIdentity]);
 
   const hasUnsaved = hasUnsavedChanges(annotations, savedSnapshot);
 
@@ -116,6 +131,10 @@ export function useAnnotations(
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (skipAutosaveIdentityRef.current === storageIdentity) {
+      skipAutosaveIdentityRef.current = null;
+      return;
+    }
     if (isEditor) {
       // Debounced save to server API
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -145,7 +164,7 @@ export function useAnnotations(
     } catch {
       /* quota exceeded — silent */
     }
-  }, [annotations, provider, sessionId, isEditor]);
+  }, [annotations, provider, sessionId, storageIdentity, isEditor]);
 
   const annotatedScenes = useMemo(() => computeAnnotatedScenes(annotations), [annotations]);
 


### PR DESCRIPTION
## Summary

- key non-editor annotation drafts by provider + native session ID
- keep identical session IDs from different providers isolated
- read the legacy session-only key as a fallback
- migrate legacy drafts to the provider-scoped key on autosave
- clear both keys after export

## Compatibility

- existing annotation drafts are preserved and migrated automatically
- editor/server persistence is unchanged
- no replay schema or API changes

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented annotations from mixing between different replay providers that use the same session ID.
  * Annotations now reload correctly when the replay provider, session, or editor identity changes.
  * Preserved compatibility with existing saved annotations by migrating legacy drafts automatically.
  * Preserved intentionally empty annotation drafts during storage and migration.
  * Prevented automatic reloads from unintentionally triggering saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->