### PR TITLE
Scope replay linkage by provider

### DIFF
--- a/packages/cli/src/server-core.ts
+++ b/packages/cli/src/server-core.ts
@@ -97,7 +97,9 @@ export function resolveGenerateInputs(
 
   let sessionInfo: SessionInfo | undefined;
   if (requestedSessionSlug) {
-    const slugMatches = discoveredSessions.filter((s) => s.slug === requestedSessionSlug);
+    const slugMatches = discoveredSessions.filter(
+      (s) => s.provider === body.provider && s.slug === requestedSessionSlug,
+    );
     if (requestedSessionProject) {
       sessionInfo = slugMatches.find(
         (s) => normalizeProjectPath(s.project) === requestedSessionProject,
@@ -107,7 +109,9 @@ export function resolveGenerateInputs(
   }
   // Fallback: match by sessionId (covers old JSONL files where slug differs from replay slug)
   if (!sessionInfo && typeof body.sessionId === "string" && body.sessionId) {
-    sessionInfo = discoveredSessions.find((s) => s.sessionId === body.sessionId);
+    sessionInfo = discoveredSessions.find(
+      (s) => s.provider === body.provider && s.sessionId === body.sessionId,
+    );
   }
 
   const fallbackFilePaths = sessionInfo?.filePaths || [];

--- a/packages/cli/src/server-enrichment.ts
+++ b/packages/cli/src/server-enrichment.ts
@@ -47,12 +47,22 @@ export function sourceSessionKey(provider: string, project: string, slug: string
   return `${provider}::${project}::${slug}`;
 }
 
+export function providerSessionKey(provider: string, sessionId: string): string {
+  return `${provider}::${sessionId}`;
+}
+
+export function providerSlugKey(provider: string, slug: string): string {
+  return `${provider}::${slug}`;
+}
+
 export function pickSourceRecordForSession<T extends EnrichmentSourceRecord>(
   session: Pick<SessionInfo, "provider" | "sessionId" | "project" | "slug">,
   bySessionId: Map<string, T>,
   byKey: Map<string, T>,
 ): T | undefined {
-  const byIdMatch = bySessionId.get(session.sessionId);
+  const byIdMatch =
+    bySessionId.get(providerSessionKey(session.provider, session.sessionId)) ??
+    bySessionId.get(session.sessionId);
   return (
     (byIdMatch?.provider === session.provider ? byIdMatch : undefined) ??
     byKey.get(sourceSessionKey(session.provider, session.project, session.slug))
@@ -72,7 +82,7 @@ export function selectCursorEnrichmentCandidates(
   const mergedBySessionId = new Map<string, SessionInfo>();
   const mergedByKey = new Map<string, SessionInfo>();
   for (const session of merged) {
-    mergedBySessionId.set(session.sessionId, session);
+    mergedBySessionId.set(providerSessionKey(session.provider, session.sessionId), session);
     mergedByKey.set(sourceSessionKey(session.provider, session.project, session.slug), session);
   }
 
@@ -93,7 +103,9 @@ export function selectCursorEnrichmentCandidates(
         (s.hasSqlite || s.filePaths.length > 0),
     )
     .map((s) => {
-      const byId = s.sessionId ? mergedBySessionId.get(s.sessionId) : undefined;
+      const byId = s.sessionId
+        ? mergedBySessionId.get(providerSessionKey(s.provider, s.sessionId))
+        : undefined;
       return byId || mergedByKey.get(sourceSessionKey(s.provider, s.project, s.slug));
     })
     .filter((s): s is SessionInfo => Boolean(s))

--- a/packages/cli/src/server-source-catalog.ts
+++ b/packages/cli/src/server-source-catalog.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import type { FileCacheEntry } from "./cache.js";
 import { getPiSessionsDir } from "./providers/pi/config.js";
 import { sourceSessionKey } from "./server-enrichment.js";
+import { providerSessionKey } from "./server-enrichment.js";
 import type {
   CachedSourceRecord,
   NormalizedSourceSessionCatalogCache,
@@ -140,12 +141,14 @@ export function mergeSourceCatalogSessionUpdates(
   for (const update of updates) {
     byKey.set(sourceSessionKey(update.provider, update.project, update.slug), update);
     if (typeof update.sessionId === "string" && update.sessionId) {
-      bySessionId.set(update.sessionId, update);
+      bySessionId.set(providerSessionKey(update.provider, update.sessionId), update);
     }
   }
 
   return current.map((session) => {
-    const byId = session.sessionId ? bySessionId.get(session.sessionId) : undefined;
+    const byId = session.sessionId
+      ? bySessionId.get(providerSessionKey(session.provider, session.sessionId))
+      : undefined;
     const update =
       (byId?.provider === session.provider ? byId : undefined) ??
       byKey.get(sourceSessionKey(session.provider, session.project, session.slug));

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -56,6 +56,8 @@ import {
   enrichmentHintsFromBody,
   mergeEnrichmentHints,
   pickSourceRecordForSession,
+  providerSessionKey,
+  providerSlugKey,
   prioritizeScanInputs,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
@@ -333,7 +335,7 @@ function extractPromptPreviewsFromTurns(turns: ParsedTurn[], limit = 3): string[
   return prompts;
 }
 
-/** Build dual lookup maps for replays — match by slug or sessionId */
+/** Build provider-scoped replay lookup maps by slug and native session ID. */
 function buildReplayMaps(replays: ReplaySummary[]): {
   bySlug: Map<string, ReplaySummary>;
   bySessionId: Map<string, ReplaySummary>;
@@ -341,8 +343,8 @@ function buildReplayMaps(replays: ReplaySummary[]): {
   const bySlug = new Map<string, ReplaySummary>();
   const bySessionId = new Map<string, ReplaySummary>();
   for (const r of replays) {
-    bySlug.set(r.slug, r);
-    if (r.sessionId) bySessionId.set(r.sessionId, r);
+    bySlug.set(providerSlugKey(r.provider, r.slug), r);
+    if (r.sessionId) bySessionId.set(providerSessionKey(r.provider, r.sessionId), r);
   }
   return { bySlug, bySessionId };
 }
@@ -396,13 +398,15 @@ async function buildSourcesResult(
     const key = sourceSessionKey(prev.provider, prev.project, prev.slug);
     previousByKey.set(key, prev);
     if (typeof prev.sessionId === "string" && prev.sessionId) {
-      previousBySessionId.set(prev.sessionId, prev);
+      previousBySessionId.set(providerSessionKey(prev.provider, prev.sessionId), prev);
     }
   }
 
   return merged.map((s) => {
     const previous = pickSourceRecordForSession(s, previousBySessionId, previousByKey);
-    const replay = replayBySlug.get(s.slug) || replayBySessionId.get(s.sessionId);
+    const replay =
+      replayBySlug.get(providerSlugKey(s.provider, s.slug)) ||
+      replayBySessionId.get(providerSessionKey(s.provider, s.sessionId));
     const promptCount = s.promptCount ?? previous?.promptCount;
     const toolCallCount = s.toolCallCount ?? previous?.toolCallCount;
     return {
@@ -637,7 +641,8 @@ export async function startServer(
       let changed = false;
       const updated = cached.sessions.map((s) => {
         const replay =
-          bySlug.get(s.slug) || (s.sessionId ? bySessionId.get(s.sessionId) : undefined);
+          bySlug.get(providerSlugKey(s.provider, s.slug)) ||
+          (s.sessionId ? bySessionId.get(providerSessionKey(s.provider, s.sessionId)) : undefined);
         const hadReplay = !!s.existingReplay;
         const hasReplay = !!replay;
         if (
@@ -740,7 +745,7 @@ export async function startServer(
       for (const source of enrichedSources) {
         byKey.set(sourceSessionKey(source.provider, source.project, source.slug), source);
         if (typeof source.sessionId === "string" && source.sessionId) {
-          bySessionId.set(source.sessionId, source);
+          bySessionId.set(providerSessionKey(source.provider, source.sessionId), source);
         }
       }
 
@@ -1965,7 +1970,9 @@ export async function startServer(
         }
 
         // Find source session by sessionId
-        const sessionInfo = allSessions.find((s) => s.sessionId === sessionId);
+        const sessionInfo = allSessions.find(
+          (s) => s.provider === providerName && s.sessionId === sessionId,
+        );
         if (!sessionInfo || sessionInfo.filePaths.length === 0) {
           results.push({ slug, status: "skipped: source not found" });
           continue;
@@ -2923,6 +2930,7 @@ export async function startDashboard(
 }
 
 export const __testables = {
+  buildReplayMaps,
   buildSourcesResult,
   buildSourceSessionCatalogCache,
   buildInsightsSyncBatches,
@@ -2931,6 +2939,8 @@ export const __testables = {
   mergeSourceCatalogSessionUpdates,
   normalizeSourceSessionCatalogCache,
   pickSourceRecordForSession,
+  providerSessionKey,
+  providerSlugKey,
   probePiSourceFreshness,
   probeSourceRecordsFreshness,
   prioritizeScanInputs,

--- a/packages/cli/test/server-generate.test.ts
+++ b/packages/cli/test/server-generate.test.ts
@@ -151,6 +151,36 @@ describe("resolveGenerateInputs", () => {
     expect(resolved.value.sessionInfo?.slug).toBe("newslug0");
   });
 
+  it("does not resolve a slug or session ID from a different provider", () => {
+    const resolved = resolveGenerateInputs(
+      {
+        provider: "cursor",
+        filePaths: [],
+        sessionSlug: "shared01",
+        sessionId: "shared-id",
+      },
+      [
+        makeSession({
+          provider: "claude-code",
+          slug: "shared01",
+          sessionId: "shared-id",
+          filePaths: ["/tmp/claude.jsonl"],
+          toolPaths: [],
+        }),
+        makeSession({
+          provider: "cursor",
+          slug: "cursor01",
+          sessionId: "cursor-id",
+          filePaths: [],
+          toolPaths: [],
+        }),
+      ],
+    );
+
+    expect(resolved.ok).toBe(false);
+    expect(resolved.ok === false && resolved.error).toContain("filePaths is required");
+  });
+
   it("uses explicit tool paths instead of discovered tool paths", () => {
     const resolved = resolveGenerateInputs(
       {

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -8,6 +8,8 @@ import { __testables } from "../src/server.js";
 import {
   pickSourceRecordForSession,
   prioritizeScanInputs,
+  providerSessionKey,
+  providerSlugKey,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
 } from "../src/server-enrichment.js";
@@ -145,6 +147,36 @@ describe("sources enrichment helpers", () => {
     expect(merged).toHaveLength(2);
     expect(merged.find((session) => session.slug === "pi-old")?.promptCount).toBe(5);
     expect(merged.find((session) => session.slug === "pi-new")?.promptCount).toBe(1);
+  });
+
+  it("keeps source catalog updates isolated across providers with the same session ID", () => {
+    const current: Parameters<typeof __testables.mergeSourceCatalogSessionUpdates>[0] = [
+      {
+        provider: "claude-code",
+        sessionId: "shared-id",
+        slug: "claude-session",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/claude.jsonl"],
+        promptCount: 1,
+      },
+      {
+        provider: "cursor",
+        sessionId: "shared-id",
+        slug: "cursor-session",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/cursor.jsonl"],
+        promptCount: 2,
+      },
+    ];
+    const updates: Parameters<typeof __testables.mergeSourceCatalogSessionUpdates>[1] = [
+      { ...current[1], promptCount: 9 },
+    ];
+
+    const merged = __testables.mergeSourceCatalogSessionUpdates(current, updates);
+    expect(merged.find((session) => session.provider === "claude-code")?.promptCount).toBe(1);
+    expect(merged.find((session) => session.provider === "cursor")?.promptCount).toBe(9);
   });
 
   it("marks Pi source sessions stale when a JSONL mtime is newer than discovery", async () => {
@@ -506,6 +538,35 @@ describe("sources enrichment helpers", () => {
     const picked = pickSourceRecordForSession(current, bySessionId, byKey);
     expect(picked?.provider).toBe("cursor");
     expect(picked?.promptCount).toBe(5);
+  });
+
+  it("builds provider-scoped replay linkage maps", () => {
+    type Replay = Parameters<typeof __testables.buildReplayMaps>[0][number];
+    const replay = (provider: string): Replay => ({
+      slug: "shared-slug",
+      baseDir: "/tmp/replays",
+      sessionId: "shared-id",
+      provider,
+      project: "~/project",
+      startTime: "2026-01-01T00:00:00.000Z",
+      stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 },
+      replaySize: 100,
+      replayOutdated: false,
+      hasAnnotations: false,
+      annotationCount: 0,
+    });
+    const maps = __testables.buildReplayMaps([replay("claude-code"), replay("cursor")]);
+
+    expect(maps.bySessionId.get(providerSessionKey("claude-code", "shared-id"))?.provider).toBe(
+      "claude-code",
+    );
+    expect(maps.bySessionId.get(providerSessionKey("cursor", "shared-id"))?.provider).toBe(
+      "cursor",
+    );
+    expect(maps.bySlug.get(providerSlugKey("claude-code", "shared-slug"))?.provider).toBe(
+      "claude-code",
+    );
+    expect(maps.bySlug.get(providerSlugKey("cursor", "shared-slug"))?.provider).toBe("cursor");
   });
 
   it("counts prompts/tools from parsed turns with compaction exclusion", () => {


### PR DESCRIPTION
## Summary

- key replay/source linkage maps by provider + slug and provider + session ID
- key source-catalog updates and enrichment lookups by provider + session ID
- prevent generation/regeneration from resolving a source owned by another provider
- retain project+slug fallback within the same provider
- add replay-map, source-update, cache-pick, and generation regression coverage

## Why

Cross-provider native ID or slug collisions could mark the wrong source as replayed, apply enrichment to the wrong row, or regenerate a replay from another provider's source.

## Compatibility

- no schema/API changes
- same-provider replay and source linkage is unchanged
- existing project+slug fallback remains
- only cross-provider false matches are rejected

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sessions, replays, and source records from being incorrectly matched across different providers when they share the same session ID or slug.
  - Improved session resolution and enrichment while preserving legacy fallback behavior.
- **Tests**
  - Added coverage for provider-specific matching and cross-provider collision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->