### PR TITLE
Fix Cowork session time bounds

### DIFF
--- a/packages/provider-claude-code/src/claude-cowork/parser.ts
+++ b/packages/provider-claude-code/src/claude-cowork/parser.ts
@@ -159,8 +159,9 @@ export async function parseClaudeCoworkSession(
   if (sessionInfo) {
     if (!result.title && sessionInfo.title) result.title = sessionInfo.title;
     if (!result.model && sessionInfo.model) result.model = sessionInfo.model;
-    if (!result.startTime && sessionInfo.timestamp) result.startTime = sessionInfo.timestamp;
-    const endBounds = getTimestampBounds([result.endTime, sessionInfo.timestamp]);
+    const metadataTimestamp = getTimestampBounds([sessionInfo.timestamp]).startTime;
+    if (!result.startTime && metadataTimestamp) result.startTime = metadataTimestamp;
+    const endBounds = getTimestampBounds([result.endTime, metadataTimestamp]);
     result.endTime = endBounds.endTime || result.startTime;
     if (!result.cwd && sessionInfo.cwd) result.cwd = sessionInfo.cwd;
   }

--- a/packages/provider-claude-code/src/claude-cowork/parser.ts
+++ b/packages/provider-claude-code/src/claude-cowork/parser.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { parseClaudeCodeLines } from "../claude-code/parser.js";
+import { getTimestampBounds } from "@vibe-replay/provider-core/duration";
 import type { ProviderParseResult } from "@vibe-replay/provider-contract";
 import { addParseWarning } from "@vibe-replay/provider-contract/warnings";
 import type { SessionInfo } from "@vibe-replay/provider-contract";
@@ -148,7 +149,7 @@ export async function parseClaudeCoworkSession(
 
   // Cowork transcripts are self-contained — no sibling `agents/` directory, so
   // subagentsSourcePath is intentionally omitted (parser will use an empty map).
-  const result = await parseClaudeCodeLines(normalized, { deriveTimestampBounds: false });
+  const result = await parseClaudeCodeLines(normalized);
   if (parseWarnings.length > 0) {
     result.parseWarnings = [...parseWarnings, ...(result.parseWarnings || [])];
   }
@@ -159,6 +160,8 @@ export async function parseClaudeCoworkSession(
     if (!result.title && sessionInfo.title) result.title = sessionInfo.title;
     if (!result.model && sessionInfo.model) result.model = sessionInfo.model;
     if (!result.startTime && sessionInfo.timestamp) result.startTime = sessionInfo.timestamp;
+    const endBounds = getTimestampBounds([result.endTime, sessionInfo.timestamp]);
+    result.endTime = endBounds.endTime || result.startTime;
     if (!result.cwd && sessionInfo.cwd) result.cwd = sessionInfo.cwd;
   }
 

--- a/packages/provider-claude-code/test/claude-cowork-parser.test.ts
+++ b/packages/provider-claude-code/test/claude-cowork-parser.test.ts
@@ -234,6 +234,41 @@ describe("parseClaudeCoworkSession", () => {
     expect(result.endTime).toBe("2025-06-15T09:03:20.000Z");
   });
 
+  it("does not emit invalid metadata timestamps when audit timestamps are absent", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cowork-time-"));
+    const auditPath = join(tempDir, "audit.jsonl");
+    await writeFile(
+      auditPath,
+      JSON.stringify({
+        type: "user",
+        session_id: "cowork-no-time",
+        message: { role: "user", content: "Inspect the workspace" },
+      }),
+    );
+    const info: SessionInfo = {
+      provider: "claude-cowork",
+      sessionId: "cowork-no-time",
+      slug: "cowork-no-time",
+      project: "Cowork",
+      cwd: "/sessions/no-time",
+      version: "",
+      timestamp: "not-a-date",
+      lineCount: 1,
+      fileSize: 100,
+      filePath: auditPath,
+      filePaths: [auditPath],
+      firstPrompt: "Inspect the workspace",
+    };
+
+    try {
+      const result = await parseClaudeCoworkSession(auditPath, info);
+      expect(result.startTime).toBeUndefined();
+      expect(result.endTime).toBeUndefined();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("sessionId matches what discover derives from the sibling metadata JSON", async () => {
     // Guards against the replay-linking bug: discover MUST use metadata.sessionId
     // (minus the `local_` prefix) because that's what audit.jsonl's outer-wrapper

--- a/packages/provider-claude-code/test/claude-cowork-parser.test.ts
+++ b/packages/provider-claude-code/test/claude-cowork-parser.test.ts
@@ -209,7 +209,7 @@ describe("parseClaudeCoworkSession", () => {
     }
   });
 
-  it("overlays title, model, startTime from sessionInfo when missing in audit", async () => {
+  it("uses audit start time and metadata last activity as the end bound", async () => {
     const info: SessionInfo = {
       provider: "claude-cowork",
       sessionId: "cowork-session-002",
@@ -230,7 +230,8 @@ describe("parseClaudeCoworkSession", () => {
 
     expect(result.title).toBe("Research Cowork session storage");
     expect(result.model).toBe("claude-opus-4-6");
-    expect(result.startTime).toBe("2025-06-15T09:03:20.000Z");
+    expect(result.startTime).toBe("2025-06-15T09:00:00.000Z");
+    expect(result.endTime).toBe("2025-06-15T09:03:20.000Z");
   });
 
   it("sessionId matches what discover derives from the sibling metadata JSON", async () => {


### PR DESCRIPTION
## Summary

- derive Cowork start time from the earliest audit event
- treat sibling metadata `lastActivityAt` as an end-time bound instead of a start time
- retain a metadata-only fallback when audit timestamps are unavailable
- update regression coverage to assert chronological bounds

## Real-data evidence

A local Cowork session produced `startTime=2026-08-06T00:06:58.176Z` and `endTime=2026-08-06T00:06:47.308Z`. After this change it produces `startTime=2026-08-05T23:34:45.178Z` and `endTime=2026-08-06T00:06:58.176Z`.

## Compatibility

- no schema/API changes
- title/model/cwd overlay behavior is unchanged
- metadata-only sessions still receive valid start/end bounds

## Validation

- real local Cowork parse/generate audit
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session timing accuracy when processing normalized activity records.
  - Session start and end times now correctly reflect available audit and metadata timestamps, with reliable fallbacks when timing information is incomplete or invalid.

- **Tests**
  - Expanded coverage for timestamp handling, including missing and invalid metadata timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->