### PR TITLE
Reduce serialized JSON secret scan noise

### DIFF
--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -76,14 +76,15 @@ const SCAN_RULES: { id: string; label: string; pattern: RegExp }[] = [
   {
     id: "db-uri",
     label: "Database Connection URI",
-    pattern: /(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis):\/\/[^:]+:[^@]+@[^\s"']+/gi,
+    pattern:
+      /(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|redis):\/\/[^:\s"'\\]+:[^@\s"'\\]+@[^\s"'\\]+/gi,
   },
   // Generic high-value env vars
   {
     id: "env-secret",
     label: "Environment Secret",
     pattern:
-      /(?:API_?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)(?![a-zA-Z])[_A-Z]*\s*[=:]\s*["']?[^\s"'\n]{8,}/gi,
+      /(?:API_?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)(?![a-zA-Z])[_A-Z]*\s*[=:]\s*["']?[^\s"'\\\n]{8,}/gi,
   },
 ];
 

--- a/packages/cli/test/scan.test.ts
+++ b/packages/cli/test/scan.test.ts
@@ -83,6 +83,18 @@ describe("scanForSecrets", () => {
     expect(findings.length).toBeGreaterThan(0);
   });
 
+  it("does not extend short env values across serialized newlines", () => {
+    expect(scanForSecrets(JSON.stringify({ output: "GH_TOKEN=set\nstore" }))).toEqual([]);
+    expect(
+      scanForSecrets(JSON.stringify({ patch: "export const auth = true;\n*** End Patch" })),
+    ).toEqual([]);
+  });
+
+  it("does not combine segmented source strings into a database URI", () => {
+    const source = ["postgres://", "admin", ":", "supersecret", "@", "db.example.com"];
+    expect(scanForSecrets(JSON.stringify({ source }))).toEqual([]);
+  });
+
   it("skips already-redacted values", () => {
     const findings = scanForSecrets(`{"key": "sk-pro...[REDACTED]"}`);
     expect(findings).toEqual([]);


### PR DESCRIPTION
## Summary

- stop generic env-secret matching at serialized backslash escapes
- require database URI credentials to remain within one serialized token
- preserve detection of real env secrets and credentialed database URIs
- add regression coverage for `GH_TOKEN=set\n...`, source-code `auth = true`, and segmented URI literals

## Real-data evidence

The current 847-scene Pi replay previously produced false warnings from test source strings and `GH_TOKEN=set`; rescanning the same generated replay after this change returns zero findings. Sanitized manual review confirmed the previous matches were not credentials.

## Compatibility

- dedicated API key/token/JWT rules are unchanged
- real long env values and contiguous database URIs remain detected
- no replay schema or generation changes

## Validation

- real serialized replay scan
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy for database connection strings and environment secrets.
  * Reduced false positives for short secret values, serialized multiline text, and fragmented source strings.

* **Tests**
  * Added regression coverage for the updated detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->