### PR TITLE
chore(release): v0.2.5

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
Minimal release PR bumping the CLI version from `0.2.4` to `0.2.5`.

## Highlights since v0.2.4

- improved Claude, Cowork, Cursor, Pi, OpenCode, and Hermes session fidelity
- fixed replay timestamp bounds and aligned active-duration estimation
- added provider-scoped identity for discovery, caches, insights, annotations, and replay linkage
- preserved multi-file patch diffs throughout parsing, replay data, viewer rendering, and insights
- added replay schema versioning and runtime validation while retaining legacy replay compatibility
- prevented automatic external image requests and redacted data-source metadata
- stopped fabricating costs for unknown models and improved data-quality explanations
- added Hermes tests to the default CI suite
- reduced serialized-JSON secret scanner false positives

## Release validation completed

- real local data discovery across Claude Code, Claude Cowork, Cursor, OpenCode, and Pi
- real replay generation/browser checks across 1–847 scenes
- real dashboard scan over 2,120 source sessions
- full lint, typecheck, unit/provider/cloud, build, E2E, Windows smoke, and audit checks
- `node packages/cli/dist/index.js --version` reports `0.2.5`

## Release flow

This PR only changes `packages/cli/package.json`. After merge, publishing GitHub Release `v0.2.5` will trigger `.github/workflows/release.yml`, which builds, validates, publishes to npm, and smoke-tests the registry package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI package to version 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->