### PR TITLE
Fix AI Studio tool fallback and prefer Cursor Agent

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -123,6 +123,8 @@ export interface FeedbackToolFallbackResult<T> {
   fallbackUsed: boolean;
 }
 
+const AI_STUDIO_OPERATION_TIMEOUT_MS = 600_000;
+
 /**
  * Run an AI Studio operation with the preferred tool first, then each remaining
  * detected tool in priority order. A thrown error or null result advances to
@@ -131,7 +133,8 @@ export interface FeedbackToolFallbackResult<T> {
 export async function runWithFeedbackToolFallback<T>(
   tools: FeedbackTool[],
   preferredToolName: FeedbackTool["name"] | undefined,
-  run: (tool: FeedbackTool) => Promise<T | null>,
+  run: (tool: FeedbackTool, signal: AbortSignal) => Promise<T | null>,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {},
 ): Promise<FeedbackToolFallbackResult<T>> {
   if (tools.length === 0) throw new Error("No AI CLI tools are available");
 
@@ -145,26 +148,47 @@ export async function runWithFeedbackToolFallback<T>(
   const orderedTools = [preferredTool, ...tools.filter((tool) => tool !== preferredTool)];
   const attemptedTools: FeedbackTool["name"][] = [];
   const failures: string[] = [];
+  const timeoutMs = Math.max(1, options.timeoutMs ?? AI_STUDIO_OPERATION_TIMEOUT_MS);
+  const controller = new AbortController();
+  const cancelFromCaller = () => controller.abort(options.signal?.reason);
+  if (options.signal?.aborted) cancelFromCaller();
+  else options.signal?.addEventListener("abort", cancelFromCaller, { once: true });
+  const deadline = setTimeout(
+    () => controller.abort(new Error("operation deadline exceeded")),
+    timeoutMs,
+  );
 
-  for (const tool of orderedTools) {
-    attemptedTools.push(tool.name);
-    try {
-      const result = await run(tool);
-      if (result !== null) {
-        return {
-          result,
-          tool,
-          attemptedTools,
-          fallbackUsed: attemptedTools.length > 1,
-        };
+  try {
+    for (const tool of orderedTools) {
+      if (controller.signal.aborted) break;
+      attemptedTools.push(tool.name);
+      try {
+        const result = await run(tool, controller.signal);
+        if (controller.signal.aborted) break;
+        if (result !== null) {
+          return {
+            result,
+            tool,
+            attemptedTools,
+            fallbackUsed: attemptedTools.length > 1,
+          };
+        }
+        failures.push(`${tool.name}: invalid output`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "unknown error";
+        failures.push(`${tool.name}: ${message.replace(/\s+/g, " ").trim()}`);
+        if (controller.signal.aborted) break;
       }
-      failures.push(`${tool.name}: invalid output`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "unknown error";
-      failures.push(`${tool.name}: ${message.replace(/\s+/g, " ").trim()}`);
     }
+  } finally {
+    clearTimeout(deadline);
+    options.signal?.removeEventListener("abort", cancelFromCaller);
   }
 
+  if (controller.signal.aborted) {
+    const outcome = options.signal?.aborted ? "cancelled" : `timed out after ${timeoutMs}ms`;
+    throw new Error(`AI Studio operation ${outcome} (${failures.join("; ")})`);
+  }
   throw new Error(`All available AI CLI tools failed (${failures.join("; ")})`);
 }
 
@@ -417,30 +441,40 @@ CRITICAL RULES:
 // Execution
 // ---------------------------------------------------------------------------
 
-async function executeFeedback(prompt: string, tool: FeedbackTool): Promise<string> {
+async function executeFeedback(
+  prompt: string,
+  tool: FeedbackTool,
+  signal?: AbortSignal,
+): Promise<string> {
   if (tool.name === "claude") {
-    return runClaude(prompt, tool.command);
+    return runClaude(prompt, tool.command, signal);
   }
   if (tool.name === "agent") {
-    return runAgent(prompt, tool.command);
+    return runAgent(prompt, tool.command, signal);
   }
   if (tool.name === "hermes") {
-    return runHermes(prompt, tool.command);
+    return runHermes(prompt, tool.command, signal);
   }
-  return runOpencode(prompt, tool.command);
+  return runOpencode(prompt, tool.command, signal);
 }
 
-function runClaude(prompt: string, cmd: string): Promise<string> {
-  return runClaudeAttempt(prompt, cmd, false);
+function runClaude(prompt: string, cmd: string, signal?: AbortSignal): Promise<string> {
+  return runClaudeAttempt(prompt, cmd, false, signal);
 }
 
-function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean): Promise<string> {
+function runClaudeAttempt(
+  prompt: string,
+  cmd: string,
+  promptAsArgument: boolean,
+  signal?: AbortSignal,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const args = promptAsArgument
       ? ["-p", prompt, "--output-format", "json"]
       : ["-p", "--output-format", "json"];
     const proc = spawnTool(cmd, args, {
       env: { ...process.env, NO_COLOR: "1" },
+      signal,
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -452,6 +486,7 @@ function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean
 
     proc.on("close", (code) => {
       const cleanStdout = stripAnsi(stdout).trim();
+      const cleanStderr = stripAnsi(stderr).trim();
       if (code === 0) {
         try {
           const parsed = JSON.parse(cleanStdout);
@@ -461,15 +496,18 @@ function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean
         }
       } else if (
         !IS_WINDOWS &&
+        !signal?.aborted &&
         !promptAsArgument &&
-        cleanStdout.includes("Input must be provided either through stdin or as a prompt argument")
+        `${cleanStdout}\n${cleanStderr}`.includes(
+          "Input must be provided either through stdin or as a prompt argument",
+        )
       ) {
         // Some managed Claude launchers do not forward stdin to the child CLI.
         // Retry with Claude's supported positional prompt form. Keep stdin as
         // the default so large prompts do not hit command-line length limits
         // on normal installations. Windows launchers use a shell, so dynamic
         // prompt arguments are intentionally excluded there.
-        resolve(runClaudeAttempt(prompt, cmd, true));
+        resolve(runClaudeAttempt(prompt, cmd, true, signal));
       } else {
         reject(new Error(`claude exited ${code}: ${stderr.slice(0, 500)}`));
       }
@@ -482,11 +520,12 @@ function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean
   });
 }
 
-function runOpencode(prompt: string, cmd: string): Promise<string> {
+function runOpencode(prompt: string, cmd: string, signal?: AbortSignal): Promise<string> {
   return new Promise((resolve, reject) => {
     // Use stdin pipe: opencode reads from stdin when run without message args
     const proc = spawnTool(cmd, ["run"], {
       env: { ...process.env, NO_COLOR: "1", TERM: "dumb" },
+      signal,
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -511,12 +550,13 @@ function runOpencode(prompt: string, cmd: string): Promise<string> {
   });
 }
 
-function runHermes(prompt: string, cmd: string): Promise<string> {
+function runHermes(prompt: string, cmd: string, signal?: AbortSignal): Promise<string> {
   return new Promise((resolve, reject) => {
     // `hermes chat -q` runs a single query non-interactively; `-Q` (quiet)
     // suppresses the banner/spinner so stdout is the final response only.
     const proc = spawnTool(cmd, ["chat", "-q", prompt, "-Q", "--no-restore-cwd"], {
       env: { ...process.env, NO_COLOR: "1", TERM: "dumb" },
+      signal,
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -538,10 +578,11 @@ function runHermes(prompt: string, cmd: string): Promise<string> {
   });
 }
 
-function runAgent(prompt: string, cmd: string): Promise<string> {
+function runAgent(prompt: string, cmd: string, signal?: AbortSignal): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawnTool(cmd, ["-p", "--output-format", "json", "--mode", "ask", "--trust"], {
       env: { ...process.env, NO_COLOR: "1" },
+      signal,
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -1004,7 +1045,7 @@ export function feedbackToAnnotations(feedback: FeedbackResult): Annotation[] {
 export async function generateFeedback(
   session: ReplaySession,
   tool: FeedbackTool,
-  { debug = false }: { debug?: boolean } = {},
+  { debug = false, signal }: { debug?: boolean; signal?: AbortSignal } = {},
 ): Promise<{ annotations: Annotation[]; result: FeedbackResult } | null> {
   if (session.meta.stats.userPrompts === 0) {
     return null;
@@ -1018,7 +1059,7 @@ export async function generateFeedback(
     writeFileSync("/tmp/vibe-feedback-prompt.txt", prompt);
   }
 
-  const output = await executeFeedback(prompt, tool);
+  const output = await executeFeedback(prompt, tool, signal);
 
   if (debug) {
     const { writeFileSync } = await import("node:fs");
@@ -1102,6 +1143,28 @@ interface TranslationResult {
   stats: { translated: number; skipped: number };
 }
 
+interface OverlayBatchResult {
+  overlays: SceneOverlay[];
+  skipped: number;
+}
+
+function aggregateOverlayBatches(
+  batchResults: Array<OverlayBatchResult | null>,
+): OverlayBatchResult | null {
+  if (batchResults.some((result) => result === null)) return null;
+
+  const overlays: SceneOverlay[] = [];
+  let skipped = 0;
+  for (const result of batchResults) {
+    if (!result) return null;
+    overlays.push(...result.overlays);
+    skipped += result.skipped;
+  }
+
+  if (overlays.length === 0 && skipped === 0) return null;
+  return { overlays, skipped };
+}
+
 /** Max scenes per batch to avoid LLM output truncation */
 const TRANSLATE_BATCH_SIZE = 30;
 
@@ -1164,6 +1227,7 @@ export async function generateTranslation(
   session: ReplaySession,
   tool: FeedbackTool,
   opts: { targetLang: string; sourceLang?: string },
+  execution: { signal?: AbortSignal } = {},
 ): Promise<TranslationResult | null> {
   if (session.scenes.length === 0) return null;
 
@@ -1187,24 +1251,16 @@ export async function generateTranslation(
         { ...session, scenes: rebuildScenesForBatch(session.scenes, batch) },
         opts,
       );
-      const output = await executeFeedback(prompt, tool);
+      const output = await executeFeedback(prompt, tool, execution.signal);
       return parseTranslationBatch(output, batch, opts, now);
     }),
   );
 
-  const allOverlays: SceneOverlay[] = [];
-  let totalSkipped = 0;
-  for (const result of batchResults) {
-    if (result) {
-      allOverlays.push(...result.overlays);
-      totalSkipped += result.skipped;
-    }
-  }
-
-  if (allOverlays.length === 0 && totalSkipped === 0) return null;
+  const aggregate = aggregateOverlayBatches(batchResults);
+  if (!aggregate) return null;
   return {
-    overlays: allOverlays,
-    stats: { translated: allOverlays.length, skipped: totalSkipped },
+    overlays: aggregate.overlays,
+    stats: { translated: aggregate.overlays.length, skipped: aggregate.skipped },
   };
 }
 
@@ -1367,6 +1423,7 @@ export async function generateToneAdjustment(
   session: ReplaySession,
   tool: FeedbackTool,
   opts: { style: "professional" | "neutral" | "friendly" },
+  execution: { signal?: AbortSignal } = {},
 ): Promise<ToneResult | null> {
   if (session.meta.stats.userPrompts === 0) return null;
 
@@ -1392,24 +1449,16 @@ export async function generateToneAdjustment(
         { ...session, scenes: rebuildScenesForToneBatch(session.scenes, batch) },
         opts,
       );
-      const output = await executeFeedback(prompt, tool);
+      const output = await executeFeedback(prompt, tool, execution.signal);
       return parseToneBatch(output, batch, opts, now);
     }),
   );
 
-  const allOverlays: SceneOverlay[] = [];
-  let totalSkipped = 0;
-  for (const result of batchResults) {
-    if (result) {
-      allOverlays.push(...result.overlays);
-      totalSkipped += result.skipped;
-    }
-  }
-
-  if (allOverlays.length === 0 && totalSkipped === 0) return null;
+  const aggregate = aggregateOverlayBatches(batchResults);
+  if (!aggregate) return null;
   return {
-    overlays: allOverlays,
-    stats: { adjusted: allOverlays.length, skipped: totalSkipped },
+    overlays: aggregate.overlays,
+    stats: { adjusted: aggregate.overlays.length, skipped: aggregate.skipped },
   };
 }
 
@@ -1417,10 +1466,13 @@ export async function generateToneAdjustment(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/* eslint-disable no-control-regex -- ANSI sequences intentionally contain control characters. */
 export function stripAnsi(str: string): string {
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1B\[[0-9;?]*[ -/]*[@-~]/g, "").replace(/\x1B\][^\x07]*\x07/g, "");
+  return str
+    .replace(/\x1B\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1B\][\s\S]*?(?:\x07|\x1B\\)/g, "");
 }
+/* eslint-enable no-control-regex */
 
 /**
  * Resolve a command to its absolute path, cross-platform. Uses `where` on
@@ -1445,4 +1497,4 @@ function locateCommand(cmd: string): Promise<string | null> {
   });
 }
 
-export const __testables = { runClaude };
+export const __testables = { aggregateOverlayBatches, runClaude };

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -81,7 +81,7 @@ export interface FeedbackResult {
 // Detection
 // ---------------------------------------------------------------------------
 
-const TOOL_PRIORITY: FeedbackTool["name"][] = ["claude", "agent", "opencode", "hermes"];
+const TOOL_PRIORITY: FeedbackTool["name"][] = ["agent", "claude", "opencode", "hermes"];
 
 /** Detect available AI CLI tools and pick a default by priority. */
 export async function detectFeedbackTools(): Promise<{
@@ -92,8 +92,8 @@ export async function detectFeedbackTools(): Promise<{
   const insideClaude = !!process.env.CLAUDECODE;
 
   const candidates: { name: FeedbackTool["name"]; cmd: string }[] = [
-    ...(!insideClaude ? [{ name: "claude" as const, cmd: "claude" }] : []),
     { name: "agent" as const, cmd: "agent" },
+    ...(!insideClaude ? [{ name: "claude" as const, cmd: "claude" }] : []),
     { name: "opencode" as const, cmd: "opencode" },
     { name: "hermes" as const, cmd: "hermes" },
   ];
@@ -114,6 +114,58 @@ export async function detectFeedbackTools(): Promise<{
     ) || null;
 
   return { tools, defaultTool };
+}
+
+export interface FeedbackToolFallbackResult<T> {
+  result: T;
+  tool: FeedbackTool;
+  attemptedTools: FeedbackTool["name"][];
+  fallbackUsed: boolean;
+}
+
+/**
+ * Run an AI Studio operation with the preferred tool first, then each remaining
+ * detected tool in priority order. A thrown error or null result advances to
+ * the next tool; no partial result is persisted by this helper.
+ */
+export async function runWithFeedbackToolFallback<T>(
+  tools: FeedbackTool[],
+  preferredToolName: FeedbackTool["name"] | undefined,
+  run: (tool: FeedbackTool) => Promise<T | null>,
+): Promise<FeedbackToolFallbackResult<T>> {
+  if (tools.length === 0) throw new Error("No AI CLI tools are available");
+
+  const preferredTool = preferredToolName
+    ? tools.find((tool) => tool.name === preferredToolName)
+    : tools[0];
+  if (!preferredTool) {
+    throw new Error(`Requested AI CLI tool is not available: ${preferredToolName}`);
+  }
+
+  const orderedTools = [preferredTool, ...tools.filter((tool) => tool !== preferredTool)];
+  const attemptedTools: FeedbackTool["name"][] = [];
+  const failures: string[] = [];
+
+  for (const tool of orderedTools) {
+    attemptedTools.push(tool.name);
+    try {
+      const result = await run(tool);
+      if (result !== null) {
+        return {
+          result,
+          tool,
+          attemptedTools,
+          fallbackUsed: attemptedTools.length > 1,
+        };
+      }
+      failures.push(`${tool.name}: invalid output`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      failures.push(`${tool.name}: ${message.replace(/\s+/g, " ").trim()}`);
+    }
+  }
+
+  throw new Error(`All available AI CLI tools failed (${failures.join("; ")})`);
 }
 
 // ---------------------------------------------------------------------------
@@ -379,8 +431,15 @@ async function executeFeedback(prompt: string, tool: FeedbackTool): Promise<stri
 }
 
 function runClaude(prompt: string, cmd: string): Promise<string> {
+  return runClaudeAttempt(prompt, cmd, false);
+}
+
+function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawnTool(cmd, ["-p", "--output-format", "json"], {
+    const args = promptAsArgument
+      ? ["-p", prompt, "--output-format", "json"]
+      : ["-p", "--output-format", "json"];
+    const proc = spawnTool(cmd, args, {
       env: { ...process.env, NO_COLOR: "1" },
       timeout: 600_000,
       stdio: ["pipe", "pipe", "pipe"],
@@ -392,13 +451,23 @@ function runClaude(prompt: string, cmd: string): Promise<string> {
     proc.stderr.on("data", (d) => (stderr += d.toString()));
 
     proc.on("close", (code) => {
+      const cleanStdout = stripAnsi(stdout).trim();
       if (code === 0) {
         try {
-          const parsed = JSON.parse(stdout);
-          resolve(parsed.result || stdout);
+          const parsed = JSON.parse(cleanStdout);
+          resolve(parsed.result || cleanStdout);
         } catch {
-          resolve(stdout);
+          resolve(cleanStdout);
         }
+      } else if (
+        !promptAsArgument &&
+        cleanStdout.includes("Input must be provided either through stdin or as a prompt argument")
+      ) {
+        // Some managed Claude launchers do not forward stdin to the child CLI.
+        // Retry with Claude's supported positional prompt form. Keep stdin as
+        // the default so large prompts do not hit command-line length limits
+        // on normal installations.
+        resolve(runClaudeAttempt(prompt, cmd, true));
       } else {
         reject(new Error(`claude exited ${code}: ${stderr.slice(0, 500)}`));
       }
@@ -406,7 +475,7 @@ function runClaude(prompt: string, cmd: string): Promise<string> {
 
     proc.on("error", (err) => reject(new Error(`Failed to start claude: ${err.message}`)));
 
-    proc.stdin.write(prompt);
+    if (!promptAsArgument) proc.stdin.write(prompt);
     proc.stdin.end();
   });
 }
@@ -1348,7 +1417,7 @@ export async function generateToneAdjustment(
 
 export function stripAnsi(str: string): string {
   // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "").replace(/\x1B\][^\x07]*\x07/g, "");
+  return str.replace(/\x1B\[[0-9;?]*[ -/]*[@-~]/g, "").replace(/\x1B\][^\x07]*\x07/g, "");
 }
 
 /**
@@ -1373,3 +1442,5 @@ function locateCommand(cmd: string): Promise<string | null> {
     proc.on("error", reject);
   });
 }
+
+export const __testables = { runClaude };

--- a/packages/cli/src/feedback.ts
+++ b/packages/cli/src/feedback.ts
@@ -460,13 +460,15 @@ function runClaudeAttempt(prompt: string, cmd: string, promptAsArgument: boolean
           resolve(cleanStdout);
         }
       } else if (
+        !IS_WINDOWS &&
         !promptAsArgument &&
         cleanStdout.includes("Input must be provided either through stdin or as a prompt argument")
       ) {
         // Some managed Claude launchers do not forward stdin to the child CLI.
         // Retry with Claude's supported positional prompt form. Keep stdin as
         // the default so large prompts do not hit command-line length limits
-        // on normal installations.
+        // on normal installations. Windows launchers use a shell, so dynamic
+        // prompt arguments are intentionally excluded there.
         resolve(runClaudeAttempt(prompt, cmd, true));
       } else {
         reject(new Error(`claude exited ${code}: ${stderr.slice(0, 500)}`));

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -28,6 +28,7 @@ import {
   generateFeedback,
   generateToneAdjustment,
   generateTranslation,
+  runWithFeedbackToolFallback,
 } from "./feedback.js";
 import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
@@ -2683,10 +2684,10 @@ export async function startServer(
           400,
         );
       }
-      const tool = requestedToolName
+      const preferredTool = requestedToolName
         ? detected.tools.find((t) => t.name === requestedToolName) || null
         : detected.defaultTool;
-      if (!tool) {
+      if (!preferredTool) {
         return c.json(
           { error: `Requested AI Coach tool is not available: ${requestedToolName}` },
           400,
@@ -2695,10 +2696,12 @@ export async function startServer(
 
       const targetSession = await loadSessionFromDisk(baseDir, result.slug);
 
-      const fb = await generateFeedback(targetSession, tool);
-      if (!fb) {
-        return c.json({ error: "Could not generate feedback (invalid AI output)" }, 500);
-      }
+      const fallbackResult = await runWithFeedbackToolFallback(
+        detected.tools,
+        preferredTool.name,
+        (tool) => generateFeedback(targetSession, tool),
+      );
+      const fb = fallbackResult.result;
 
       const existingAnns = targetSession.annotations ?? [];
       const newAnnotations = [
@@ -2719,6 +2722,9 @@ export async function startServer(
         itemCount: fb.result.feedbackItems.length,
         outcome: fb.result.outcome,
         sessionGoal: fb.result.sessionGoal,
+        toolName: fallbackResult.tool.name,
+        attemptedTools: fallbackResult.attemptedTools,
+        fallbackUsed: fallbackResult.fallbackUsed,
       });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
@@ -2755,10 +2761,10 @@ export async function startServer(
         );
       }
       const toolName = typeof body.toolName === "string" ? body.toolName : undefined;
-      const tool = toolName
+      const preferredTool = toolName
         ? detected.tools.find((t) => t.name === toolName) || null
         : detected.defaultTool;
-      if (!tool) {
+      if (!preferredTool) {
         return c.json({ error: `Requested tool is not available: ${toolName}` }, 400);
       }
 
@@ -2773,13 +2779,12 @@ export async function startServer(
       const chainBase: SessionOverlays = { version: 1, overlays: nonTranslateOverlays };
       const effectiveSession = sessionWithEffectiveContent(targetSession, chainBase);
 
-      const translationResult = await generateTranslation(effectiveSession, tool, {
-        targetLang,
-        sourceLang,
-      });
-      if (!translationResult) {
-        return c.json({ error: "Could not generate translations (invalid AI output)" }, 500);
-      }
+      const fallbackResult = await runWithFeedbackToolFallback(
+        detected.tools,
+        preferredTool.name,
+        (tool) => generateTranslation(effectiveSession, tool, { targetLang, sourceLang }),
+      );
+      const translationResult = fallbackResult.result;
       // Restore true originalValue from the unmodified session
       fixOriginalValues(translationResult.overlays, targetSession);
       const merged: SessionOverlays = {
@@ -2791,6 +2796,9 @@ export async function startServer(
       return c.json({
         overlays: merged,
         stats: translationResult.stats,
+        toolName: fallbackResult.tool.name,
+        attemptedTools: fallbackResult.attemptedTools,
+        fallbackUsed: fallbackResult.fallbackUsed,
       });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);
@@ -2814,10 +2822,10 @@ export async function startServer(
         );
       }
       const toolName = typeof body.toolName === "string" ? body.toolName : undefined;
-      const tool = toolName
+      const preferredTool = toolName
         ? detected.tools.find((t) => t.name === toolName) || null
         : detected.defaultTool;
-      if (!tool) {
+      if (!preferredTool) {
         return c.json({ error: `Requested tool is not available: ${toolName}` }, 400);
       }
 
@@ -2835,10 +2843,12 @@ export async function startServer(
       const chainBase: SessionOverlays = { version: 1, overlays: nonToneOverlays };
       const effectiveSession = sessionWithEffectiveContent(targetSession, chainBase);
 
-      const toneResult = await generateToneAdjustment(effectiveSession, tool, { style });
-      if (!toneResult) {
-        return c.json({ error: "Could not adjust tone (invalid AI output)" }, 500);
-      }
+      const fallbackResult = await runWithFeedbackToolFallback(
+        detected.tools,
+        preferredTool.name,
+        (tool) => generateToneAdjustment(effectiveSession, tool, { style }),
+      );
+      const toneResult = fallbackResult.result;
       // Restore true originalValue from the unmodified session
       fixOriginalValues(toneResult.overlays, targetSession);
       const merged: SessionOverlays = {
@@ -2850,6 +2860,9 @@ export async function startServer(
       return c.json({
         overlays: merged,
         stats: toneResult.stats,
+        toolName: fallbackResult.tool.name,
+        attemptedTools: fallbackResult.attemptedTools,
+        fallbackUsed: fallbackResult.fallbackUsed,
       });
     } catch (err) {
       return c.json({ error: getErrorMessage(err) }, 500);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -2699,7 +2699,8 @@ export async function startServer(
       const fallbackResult = await runWithFeedbackToolFallback(
         detected.tools,
         preferredTool.name,
-        (tool) => generateFeedback(targetSession, tool),
+        (tool, signal) => generateFeedback(targetSession, tool, { signal }),
+        { signal: c.req.raw.signal },
       );
       const fb = fallbackResult.result;
 
@@ -2782,7 +2783,9 @@ export async function startServer(
       const fallbackResult = await runWithFeedbackToolFallback(
         detected.tools,
         preferredTool.name,
-        (tool) => generateTranslation(effectiveSession, tool, { targetLang, sourceLang }),
+        (tool, signal) =>
+          generateTranslation(effectiveSession, tool, { targetLang, sourceLang }, { signal }),
+        { signal: c.req.raw.signal },
       );
       const translationResult = fallbackResult.result;
       // Restore true originalValue from the unmodified session
@@ -2846,7 +2849,8 @@ export async function startServer(
       const fallbackResult = await runWithFeedbackToolFallback(
         detected.tools,
         preferredTool.name,
-        (tool) => generateToneAdjustment(effectiveSession, tool, { style }),
+        (tool, signal) => generateToneAdjustment(effectiveSession, tool, { style }, { signal }),
+        { signal: c.req.raw.signal },
       );
       const toneResult = fallbackResult.result;
       // Restore true originalValue from the unmodified session

--- a/packages/cli/test/feedback.test.ts
+++ b/packages/cli/test/feedback.test.ts
@@ -1,13 +1,19 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ReplaySession, Scene } from "@vibe-replay/types";
 import { describe, expect, it } from "vitest";
 import {
+  __testables,
   buildSessionDigest,
   extractJson,
+  type FeedbackTool,
   type FeedbackResult,
   feedbackToAnnotations,
   findBalancedJson,
   parseFeedbackResponse,
   repairTruncatedJson,
+  runWithFeedbackToolFallback,
   stripAnsi,
 } from "../src/feedback.js";
 
@@ -66,6 +72,91 @@ function makeValidFeedbackJson(overrides?: Record<string, any>): string {
     ...overrides,
   });
 }
+
+// ─── AI tool fallback ─────────────────────────────────────
+
+describe("runWithFeedbackToolFallback", () => {
+  const tools: FeedbackTool[] = [
+    { name: "agent", command: "/fake/agent" },
+    { name: "claude", command: "/fake/claude" },
+    { name: "opencode", command: "/fake/opencode" },
+  ];
+
+  it("falls back from Cursor Agent to the next available tool", async () => {
+    const calls: string[] = [];
+    const fallback = await runWithFeedbackToolFallback(tools, "agent", async (tool) => {
+      calls.push(tool.name);
+      if (tool.name === "agent") throw new Error("authentication required");
+      return { translated: 1 };
+    });
+
+    expect(calls).toEqual(["agent", "claude"]);
+    expect(fallback.result).toEqual({ translated: 1 });
+    expect(fallback.tool.name).toBe("claude");
+    expect(fallback.attemptedTools).toEqual(["agent", "claude"]);
+    expect(fallback.fallbackUsed).toBe(true);
+  });
+
+  it("falls back when a tool returns invalid output", async () => {
+    const fallback = await runWithFeedbackToolFallback(tools, "agent", async (tool) =>
+      tool.name === "agent" ? null : "valid output",
+    );
+
+    expect(fallback.result).toBe("valid output");
+    expect(fallback.tool.name).toBe("claude");
+  });
+
+  it("honors an explicitly preferred tool before priority order", async () => {
+    const calls: string[] = [];
+    const fallback = await runWithFeedbackToolFallback(tools, "opencode", async (tool) => {
+      calls.push(tool.name);
+      return "ok";
+    });
+
+    expect(calls).toEqual(["opencode"]);
+    expect(fallback.tool.name).toBe("opencode");
+    expect(fallback.fallbackUsed).toBe(false);
+  });
+
+  it("reports every attempted tool when all tools fail", async () => {
+    await expect(
+      runWithFeedbackToolFallback(tools, "agent", async (tool) => {
+        throw new Error(`${tool.name} failed`);
+      }),
+    ).rejects.toThrow(
+      "All available AI CLI tools failed (agent: agent failed; claude: claude failed; opencode: opencode failed)",
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "retries Claude with a positional prompt when a launcher drops stdin",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "vibe-feedback-test-"));
+      const fakeClaude = join(dir, "claude");
+      const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const promptIndex = args.indexOf("-p");
+if (args[promptIndex + 1] === "--output-format") {
+  process.stdout.write("Error: Input must be provided either through stdin or as a prompt argument when using --print\\n");
+  process.stderr.write("Session exited with code 1\\n");
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({ result: '{"ok":true}' }) + "\\u001B[?25h");
+`;
+
+      try {
+        await writeFile(fakeClaude, script, "utf-8");
+        await chmod(fakeClaude, 0o755);
+
+        await expect(__testables.runClaude("translate this", fakeClaude)).resolves.toBe(
+          '{"ok":true}',
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});
 
 // ─── extractJson ───────────────────────────────────────────
 
@@ -1033,6 +1124,10 @@ describe("stripAnsi", () => {
 
   it("strips OSC sequences", () => {
     expect(stripAnsi("\x1B]0;window title\x07text")).toBe("text");
+  });
+
+  it("strips private terminal mode sequences appended by managed launchers", () => {
+    expect(stripAnsi('{"result":"ok"}\x1B[?25h')).toBe('{"result":"ok"}');
   });
 
   it("handles mixed ANSI and OSC sequences", () => {

--- a/packages/cli/test/feedback.test.ts
+++ b/packages/cli/test/feedback.test.ts
@@ -128,6 +128,24 @@ describe("runWithFeedbackToolFallback", () => {
     );
   });
 
+  it("stops fallback attempts when the operation-wide deadline expires", async () => {
+    const calls: string[] = [];
+    await expect(
+      runWithFeedbackToolFallback(
+        tools,
+        "agent",
+        (tool, signal) => {
+          calls.push(tool.name);
+          return new Promise((_, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          });
+        },
+        { timeoutMs: 20 },
+      ),
+    ).rejects.toThrow("AI Studio operation timed out after 20ms");
+    expect(calls).toEqual(["agent"]);
+  });
+
   it.skipIf(process.platform === "win32")(
     "retries Claude with a positional prompt when a launcher drops stdin",
     async () => {
@@ -156,6 +174,68 @@ process.stdout.write(JSON.stringify({ result: '{"ok":true}' }) + "\\u001B[?25h")
       }
     },
   );
+
+  it.skipIf(process.platform === "win32")(
+    "detects the dropped-stdin diagnostic on Claude stderr",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "vibe-feedback-test-"));
+      const fakeClaude = join(dir, "claude");
+      const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const promptIndex = args.indexOf("-p");
+if (args[promptIndex + 1] === "--output-format") {
+  process.stderr.write("Error: Input must be provided either through stdin or as a prompt argument when using --print\\n");
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({ result: '{"ok":true}' }));
+`;
+
+      try {
+        await writeFile(fakeClaude, script, "utf-8");
+        await chmod(fakeClaude, 0o755);
+
+        await expect(__testables.runClaude("translate this", fakeClaude)).resolves.toBe(
+          '{"ok":true}',
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+describe("aggregateOverlayBatches", () => {
+  const batch = {
+    overlays: [
+      {
+        id: "overlay-1",
+        sceneIndex: 0,
+        field: "content" as const,
+        originalValue: "before",
+        modifiedValue: "after",
+        source: { type: "translate" as const, params: { from: "auto", to: "English" } },
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      },
+    ],
+    skipped: 0,
+  };
+
+  it("rejects an invalid single batch", () => {
+    expect(__testables.aggregateOverlayBatches([null])).toBeNull();
+  });
+
+  it("rejects incomplete results from a large multi-batch session", () => {
+    const results: Array<typeof batch | null> = Array.from({ length: 17 }, () => batch);
+    results[8] = null;
+    expect(__testables.aggregateOverlayBatches(results)).toBeNull();
+  });
+
+  it("combines complete batch results", () => {
+    const aggregate = __testables.aggregateOverlayBatches([batch, { overlays: [], skipped: 2 }]);
+    expect(aggregate?.overlays).toHaveLength(1);
+    expect(aggregate?.skipped).toBe(2);
+  });
 });
 
 // ─── extractJson ───────────────────────────────────────────
@@ -1124,6 +1204,10 @@ describe("stripAnsi", () => {
 
   it("strips OSC sequences", () => {
     expect(stripAnsi("\x1B]0;window title\x07text")).toBe("text");
+  });
+
+  it("strips OSC sequences terminated by ST", () => {
+    expect(stripAnsi("\x1B]0;window title\x1B\\text")).toBe("text");
   });
 
   it("strips private terminal mode sequences appended by managed launchers", () => {

--- a/packages/viewer/src/components/AiStudioPanel.tsx
+++ b/packages/viewer/src/components/AiStudioPanel.tsx
@@ -321,7 +321,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
                 cmd: 'Bundled with Cursor IDE (run "agent login")',
                 rec: true,
               },
-              { name: "Claude Code", cmd: "npm install -g @anthropic-ai/claude-code" },
+              { name: "Claude Code", cmd: "pnpm add --global @anthropic-ai/claude-code" },
               { name: "OpenCode", cmd: "go install github.com/opencode-ai/opencode@latest" },
             ].map((t) => (
               <div

--- a/packages/viewer/src/components/AiStudioPanel.tsx
+++ b/packages/viewer/src/components/AiStudioPanel.tsx
@@ -44,6 +44,25 @@ function Spinner({ className = "" }: { className?: string }) {
   );
 }
 
+function toolLabel(toolName: string): string {
+  if (toolName === "agent") return "Cursor Agent";
+  if (toolName === "claude") return "Claude Code";
+  if (toolName === "opencode") return "OpenCode";
+  if (toolName === "hermes") return "Hermes";
+  return toolName;
+}
+
+function toolRunSuffix(result: {
+  toolName: string;
+  attemptedTools: string[];
+  fallbackUsed: boolean;
+}): string {
+  if (!result.toolName) return "";
+  if (!result.fallbackUsed) return ` via ${toolLabel(result.toolName)}`;
+  const firstTool = result.attemptedTools[0];
+  return ` via ${toolLabel(result.toolName)} (fallback${firstTool ? ` from ${toolLabel(firstTool)}` : ""})`;
+}
+
 function ToolExplainer({ toolName }: { toolName: string | null }) {
   if (toolName === "claude") {
     return (
@@ -193,7 +212,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
       const result = await runAiCoach();
       setCoachStatus({
         type: "success",
-        text: `Score ${result.score}/10 \u2014 ${result.itemCount} comment(s)`,
+        text: `Score ${result.score}/10 \u2014 ${result.itemCount} comment(s)${toolRunSuffix(result)}`,
       });
     } catch (e) {
       if (e instanceof DOMException && e.name === "AbortError") return;
@@ -209,7 +228,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
       const result = await runTranslate({ targetLang });
       setTranslateStatus({
         type: "success",
-        text: `${result.translated} message(s) translated, ${result.skipped} unchanged`,
+        text: `${result.translated} message(s) translated, ${result.skipped} unchanged${toolRunSuffix(result)}`,
       });
     } catch (e) {
       if (e instanceof DOMException && e.name === "AbortError") return;
@@ -228,7 +247,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
       const result = await runTone({ style: toneStyle });
       setToneStatus({
         type: "success",
-        text: `${result.adjusted} prompt(s) adjusted, ${result.skipped} unchanged`,
+        text: `${result.adjusted} prompt(s) adjusted, ${result.skipped} unchanged${toolRunSuffix(result)}`,
       });
     } catch (e) {
       if (e instanceof DOMException && e.name === "AbortError") return;
@@ -297,8 +316,12 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
           </p>
           <div className="w-full space-y-2 text-left">
             {[
-              { name: "Claude Code", cmd: "npm install -g @anthropic-ai/claude-code", rec: true },
-              { name: "Cursor CLI", cmd: 'Bundled with Cursor IDE (run as "agent")' },
+              {
+                name: "Cursor Agent",
+                cmd: 'Bundled with Cursor IDE (run "agent login")',
+                rec: true,
+              },
+              { name: "Claude Code", cmd: "npm install -g @anthropic-ai/claude-code" },
               { name: "OpenCode", cmd: "go install github.com/opencode-ai/opencode@latest" },
             ].map((t) => (
               <div
@@ -362,13 +385,13 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
               >
                 {tools.map((t) => (
                   <option key={t.name} value={t.name}>
-                    {t.name}
+                    {toolLabel(t.name)}
                   </option>
                 ))}
               </select>
             ) : (
               <span className="text-xs font-mono font-medium text-terminal-text px-2 py-0.5 rounded-lg bg-terminal-surface border border-terminal-border">
-                {toolName}
+                {toolName ? toolLabel(toolName) : ""}
               </span>
             )}
           </div>

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -61,7 +61,15 @@ export interface AnnotationActions {
   /** Editor mode: update selected AI Coach tool */
   setAiCoachToolName: ((toolName: string) => void) | null;
   /** Editor mode: run AI Coach to generate feedback annotations */
-  runAiCoach: (() => Promise<{ score: number; itemCount: number }>) | null;
+  runAiCoach:
+    | (() => Promise<{
+        score: number;
+        itemCount: number;
+        toolName: string;
+        attemptedTools: string[];
+        fallbackUsed: boolean;
+      }>)
+    | null;
   /** Editor mode: cancel a running AI Coach operation */
   cancelAiCoach: (() => void) | null;
   aiCoachRunning: boolean;
@@ -356,7 +364,13 @@ export function useAnnotations(
             if (!resp.ok) throw new Error(data.error || "AI Coach failed");
             setAnnotations(data.annotations);
             setSavedSnapshot(data.annotations);
-            return { score: data.score as number, itemCount: data.itemCount as number };
+            return {
+              score: data.score as number,
+              itemCount: data.itemCount as number,
+              toolName: data.toolName as string,
+              attemptedTools: data.attemptedTools as string[],
+              fallbackUsed: data.fallbackUsed as boolean,
+            };
           } finally {
             aiCoachAbortRef.current = null;
             setAiCoachRunning(false);

--- a/packages/viewer/src/hooks/useOverlays.ts
+++ b/packages/viewer/src/hooks/useOverlays.ts
@@ -48,6 +48,9 @@ export interface OverlayActions {
     | ((opts: { targetLang: string; sourceLang?: string }) => Promise<{
         translated: number;
         skipped: number;
+        toolName: string;
+        attemptedTools: string[];
+        fallbackUsed: boolean;
       }>)
     | null;
   /** Run tone adjustment */
@@ -55,6 +58,9 @@ export interface OverlayActions {
     | ((opts: { style: "professional" | "neutral" | "friendly" }) => Promise<{
         adjusted: number;
         skipped: number;
+        toolName: string;
+        attemptedTools: string[];
+        fallbackUsed: boolean;
       }>)
     | null;
 }
@@ -282,7 +288,12 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
               const data = await resp.json();
               if (!resp.ok) throw new Error(data.error || "Translation failed");
               if (data.overlays) setOverlaysState(data.overlays as SessionOverlays);
-              return data.stats as { translated: number; skipped: number };
+              return {
+                ...(data.stats as { translated: number; skipped: number }),
+                toolName: data.toolName as string,
+                attemptedTools: data.attemptedTools as string[],
+                fallbackUsed: data.fallbackUsed as boolean,
+              };
             } finally {
               abortRef.current = null;
               setTranslating(false);
@@ -312,7 +323,12 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
               const data = await resp.json();
               if (!resp.ok) throw new Error(data.error || "Tone adjustment failed");
               if (data.overlays) setOverlaysState(data.overlays as SessionOverlays);
-              return data.stats as { adjusted: number; skipped: number };
+              return {
+                ...(data.stats as { adjusted: number; skipped: number }),
+                toolName: data.toolName as string,
+                attemptedTools: data.attemptedTools as string[],
+                fallbackUsed: data.fallbackUsed as boolean,
+              };
             } finally {
               abortRef.current = null;
               setToningDown(false);


### PR DESCRIPTION
## Summary

- make Cursor Agent (`agent`) the first-choice AI Studio tool
- automatically fall back across detected tools when the preferred tool errors or returns invalid output
- retry Claude with its positional prompt form on POSIX when a managed launcher drops stdin; Windows safely continues to the next tool
- strip private terminal-mode ANSI sequences before parsing Claude JSON output
- show the actual tool and fallback source in AI Studio results
- bump the CLI patch version to `0.2.6`

## Demo

Local tools were detected in this order:

```json
{
  "tools": ["agent", "claude", "opencode"],
  "defaultTool": "agent"
}
```

A real Cursor Agent translation completed successfully:

```text
这个修复现在可以发布了。
→ This fix is ready to be released now.
```

Fallback behavior is covered for both failure modes:

1. preferred tool failure or invalid output → next detected tool
2. Claude launcher drops stdin → retry with Claude's supported positional prompt form on POSIX; continue tool fallback on Windows

The UI reports results such as `via Cursor Agent` or `via Claude Code (fallback from Cursor Agent)`.

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`
- `pnpm test:e2e`
- `node packages/cli/dist/index.js --version` → `0.2.6`
- real Cursor Agent translation
- real Claude managed-launcher fallback translation

## Release plan

After approval and merge, publish GitHub release `v0.2.6`; the release workflow will publish the matching npm package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Coach, translation, and tone adjustments now retry available tools when the preferred tool fails.
  * Results identify the selected tool, attempted tools, and whether fallback was used.
  * Added cancellation and deadline support for AI operations.
  * Updated tool labels and installation guidance for Cursor Agent.

* **Bug Fixes**
  * Improved handling of invalid results, unsupported input methods, batch failures, and terminal formatting.

* **Chores**
  * Updated the CLI version to 0.2.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
