### PR TITLE
Fix npm release workflow engine compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '22.22.1'
           cache: pnpm
 
-      - run: npm install -g npm@11
+      - run: npm install -g npm@11.19.0
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '22.22.1'
           cache: pnpm
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- pin the release workflow to npm 11
- keep compatibility with the configured Node 22.22.1 runtime
- unblock the v0.2.6 npm publish

## Failure

`npm@latest` now resolves to npm 12, which requires Node 22.22.2 or newer. The release runner uses Node 22.22.1 and fails with `EBADENGINE` before install/build/publish.

## Validation

- npm 11 engine range: `^20.17.0 || >=22.9.0`
- workflow Node version: `22.22.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use npm version 11.19.0 for publishing, improving consistency and reliability between releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->