### PR TITLE
fix(scanner): preserve cached results when provider discovery fails

### DIFF
--- a/packages/cli/src/server-enrichment.ts
+++ b/packages/cli/src/server-enrichment.ts
@@ -193,6 +193,46 @@ export function prioritizeScanInputs(
   });
 }
 
+/**
+ * Keep the last successful scan for a provider whose discovery failed.
+ *
+ * Source discovery already preserves the provider's cached source records in
+ * this situation. The background insights scan must do the same; otherwise a
+ * transient provider/filesystem failure makes that provider disappear from
+ * the dashboard until the next successful scan.
+ */
+export function preserveFailedProviderScanResults(
+  currentResults: SessionScanResult[],
+  previousResults: SessionScanResult[],
+  failedProviders: readonly string[],
+): SessionScanResult[] {
+  if (failedProviders.length === 0 || previousResults.length === 0) return currentResults;
+
+  const failed = new Set(failedProviders);
+  const seen = new Set(
+    currentResults.map((result) => providerSessionKey(result.provider, result.sessionId)),
+  );
+  const staleResults: SessionScanResult[] = [];
+
+  for (const previous of previousResults) {
+    if (!failed.has(previous.provider)) continue;
+
+    const key = providerSessionKey(previous.provider, previous.sessionId);
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const note = `Provider discovery failed for ${previous.provider}; showing the last successful scan.`;
+    staleResults.push({
+      ...previous,
+      dataQualityNotes: previous.dataQualityNotes?.includes(note)
+        ? previous.dataQualityNotes
+        : [...(previous.dataQualityNotes || []), note],
+    });
+  }
+
+  return staleResults.length > 0 ? [...currentResults, ...staleResults] : currentResults;
+}
+
 function scanInputPriorityScore(
   input: ScanInput,
   previousSessionIds: Set<string>,

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -60,6 +60,7 @@ import {
   pickSourceRecordForSession,
   providerSessionKey,
   providerSlugKey,
+  preserveFailedProviderScanResults,
   prioritizeScanInputs,
   selectCursorEnrichmentCandidates,
   sourceSessionKey,
@@ -1230,7 +1231,7 @@ export async function startServer(
 
         scanState.total = scanInputs.length;
 
-        const results = await runBackgroundScan(scanInputs, (progress) => {
+        const freshResults = await runBackgroundScan(scanInputs, (progress) => {
           scanState = {
             ...scanState,
             phase: "scanning",
@@ -1239,11 +1240,16 @@ export async function startServer(
             currentSession: progress.currentSession,
           };
         });
+        const results = preserveFailedProviderScanResults(
+          freshResults,
+          previousResults,
+          discovery.failedProviders,
+        );
 
         scanState = {
           running: false,
           scanned: results.length,
-          total: scanInputs.length,
+          total: results.length,
           results,
           currentSession: undefined,
           phase: undefined,

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -2,11 +2,12 @@ import { mkdir, mkdtemp, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { ScanInput } from "../src/scanner.js";
+import type { ScanInput, SessionScanResult } from "../src/scanner.js";
 import type { SourceSummaryRecord } from "../src/server.js";
 import { __testables } from "../src/server.js";
 import {
   pickSourceRecordForSession,
+  preserveFailedProviderScanResults,
   prioritizeScanInputs,
   providerSessionKey,
   providerSlugKey,
@@ -41,6 +42,22 @@ function makeCursorSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     toolPaths: ["/tmp/tool-a.txt"],
     firstPrompt: "test prompt",
     ...overrides,
+  };
+}
+
+function makeScanResult(provider: string, sessionId: string): SessionScanResult {
+  return {
+    sessionId,
+    provider,
+    project: "~/project-a",
+    slug: sessionId,
+    promptCount: 1,
+    toolCallCount: 1,
+    editCount: 0,
+    filesModified: [],
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
   };
 }
 
@@ -500,6 +517,40 @@ describe("sources enrichment helpers", () => {
       "unscanned-old",
       "already-new",
     ]);
+  });
+
+  it("preserves previous scan results when a provider discovery fails", () => {
+    const fresh = makeScanResult("claude-code", "fresh");
+    const previousCursor = makeScanResult("cursor", "cursor-old");
+    const previousClaude = makeScanResult("claude-code", "fresh");
+
+    const merged = preserveFailedProviderScanResults(
+      [fresh],
+      [previousCursor, previousClaude],
+      ["cursor"],
+    );
+
+    expect(merged.map((result) => `${result.provider}:${result.sessionId}`)).toEqual([
+      "claude-code:fresh",
+      "cursor:cursor-old",
+    ]);
+    expect(merged[1]?.dataQualityNotes).toEqual([
+      "Provider discovery failed for cursor; showing the last successful scan.",
+    ]);
+  });
+
+  it("does not retain stale results from healthy providers or duplicate fresh results", () => {
+    const fresh = makeScanResult("cursor", "cursor-old");
+    const previousCursor = makeScanResult("cursor", "cursor-old");
+    const previousPi = makeScanResult("pi", "pi-old");
+
+    const merged = preserveFailedProviderScanResults(
+      [fresh],
+      [previousCursor, previousPi],
+      ["cursor"],
+    );
+
+    expect(merged).toEqual([fresh]);
   });
 
   it("does not cross-provider match by sessionId when picking cache records", () => {


### PR DESCRIPTION
## Summary

- Preserve the last successful `SessionScanResult` entries when a provider discovery fails during a background scan.
- Keep fresh results authoritative and avoid duplicate provider/session entries.
- Add a data-quality note to retained results so stale data is visible to the dashboard.
- Add regression coverage for failed-provider retention, healthy-provider filtering, and fresh-result precedence.

This keeps the background insights cache consistent with the existing source-catalog fallback behavior during transient provider or filesystem failures.

## Validation

- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`
- `pnpm test:e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previous scan results when provider discovery fails, reducing data loss in scan results.
  * Added a data-quality notice to restored results for transparency.
  * Prevented duplicate results and ensured current results remain authoritative for healthy providers.
  * Updated scan progress totals to reflect the final result set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->