### PR TITLE
chore(release): v0.2.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
Minimal release PR bumping the CLI version from `0.2.6` to `0.2.7`.

## Highlights since v0.2.6

- Hermes: multi-profile discovery — sessions are now found across `~/.hermes/state.db` and every `~/.hermes/profiles/<name>/state.db` (#444, thanks @ebolamerican!)
- Hermes: profile-aware parsing with per-DB marker paths; parsed sessions report the SQLite file that actually produced them
- Hermes: `HERMES_HOME` handling aligned with Hermes's own root resolution (profile mode + Docker layouts)
- Scanner: preserve cached scan results when provider discovery fails, so a transient failure no longer hides a provider from the dashboard
- Usage analytics index and dashboard facets (#446), harness compatibility and provider discovery resilience fixes

## Release validation completed

- full lint, typecheck, unit/provider/cloud, build, E2E suites green locally
- CI green on this PR: lint / test / windows-smoke / build / e2e / audit
- `node packages/cli/dist/index.js --version` reports `0.2.7`