### PR TITLE
feat: make Insights ranges exact and add project drilldowns

### DIFF
--- a/packages/cli/src/insights-rollup.ts
+++ b/packages/cli/src/insights-rollup.ts
@@ -1,0 +1,48 @@
+import type { ReplaySummary } from "./server-types.js";
+import type { SessionScanResult } from "./scanner.js";
+
+export interface InsightsRollupSession {
+  project: string;
+  startTime?: string;
+  durationMs?: number;
+  cost?: number;
+  prompts: number;
+  edits: number;
+  toolCalls: number;
+}
+
+export interface InsightsRollupReplay {
+  project: string;
+  startTime?: string;
+}
+
+export interface InsightsRollupPayload {
+  sessions: InsightsRollupSession[];
+  replays: InsightsRollupReplay[];
+}
+
+/**
+ * Project only the fields needed for exact time-range totals.
+ * Deliberately omit prompts, tool arguments/results, titles, file paths, and
+ * usage events: the Insights page only needs additive per-session metrics.
+ */
+export function buildInsightsRollup(
+  scans: readonly SessionScanResult[],
+  replays: readonly ReplaySummary[],
+): InsightsRollupPayload {
+  return {
+    sessions: scans.map((scan) => ({
+      project: scan.project,
+      startTime: scan.startTime,
+      durationMs: scan.durationMs,
+      cost: scan.costEstimate,
+      prompts: scan.promptCount,
+      edits: scan.editCount,
+      toolCalls: scan.toolCallCount,
+    })),
+    replays: replays.map((replay) => ({
+      project: replay.project,
+      startTime: replay.startTime,
+    })),
+  };
+}

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1524,6 +1524,10 @@ export interface BackgroundScanState {
   scanned: number;
   total: number;
   results: SessionScanResult[];
+  /** Increments whenever the result snapshot changes, including usage backfill. */
+  revision: number;
+  /** True when results represent a completed or persisted scan, even if empty. */
+  hasSnapshot: boolean;
   currentSession?: string;
   phase?: "discovering" | "scanning";
   startedAt?: string;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1635,12 +1635,38 @@ export async function runBackgroundScan(
 
 // ─── Aggregation ────────────────────────────────────────────────────
 
+const AGENT_WORKTREE_RE = /^(.+?)\/\.claude\/worktrees\/[^/]+(?:\/.*)?$/;
+const RUN_ID_SUFFIX_RE =
+  /(?:^|-)(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|(?=[0-9a-f]{12,}$)[0-9]*[a-f][0-9a-f]*)$/i;
+
+function agentWorktreeParent(project: string): string | null {
+  const normalized = project.replace(/\\/g, "/").replace(/\/+$/, "");
+  const match = normalized.match(AGENT_WORKTREE_RE);
+  return match ? match[1] : null;
+}
+
+function agentRunWorkspaceParent(project: string): string | null {
+  const clean = project.replace(/[\\/]+$/, "");
+  const slash = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\"));
+  if (slash <= 0 || !RUN_ID_SUFFIX_RE.test(clean.slice(slash + 1))) return null;
+  const parent = clean.slice(0, slash);
+  return /^[A-Za-z]:$/.test(parent) ? null : parent;
+}
+
+function projectMatches(project: string, requestedProject: string): boolean {
+  return (
+    project === requestedProject ||
+    agentWorktreeParent(project) === requestedProject ||
+    agentRunWorkspaceParent(project) === requestedProject
+  );
+}
+
 export function aggregateProjectInsights(
   project: string,
   scans: SessionScanResult[],
   memory?: ProjectMemory,
 ): ProjectInsights {
-  const projectScans = scans.filter((s) => s.project === project);
+  const projectScans = scans.filter((s) => projectMatches(s.project, project));
 
   let totalDurationMs = 0;
   let totalCost = 0;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -636,7 +636,7 @@ export async function startServer(
       ),
     );
   };
-  const refreshReplaysCache = async (): Promise<any[] | null> => {
+  const refreshReplaysCache = async (): Promise<ReplaySummary[] | null> => {
     try {
       const sessions = await scanSessions(baseDir);
       await writeFileCache(replaysCacheKey, sessions);
@@ -886,6 +886,8 @@ export async function startServer(
     scanned: persistedScanResults?.data.length || 0,
     total: persistedScanResults?.data.length || 0,
     results: persistedScanResults?.data || [],
+    revision: persistedScanResults ? 1 : 0,
+    hasSnapshot: persistedScanResults !== null,
     finishedAt: persistedScanResults?.updatedAt,
   };
   // Incremented per scan so a slower follow-up pass can tell it was superseded.
@@ -1146,6 +1148,8 @@ export async function startServer(
       scanState = {
         ...scanState,
         usageBackfill: { running: false, scanned: enriched.length, total: pending.length },
+        revision: scanState.revision + 1,
+        hasSnapshot: true,
       };
     } catch {
       if (!superseded()) {
@@ -1173,12 +1177,16 @@ export async function startServer(
     if (scanState.running || scanState.usageBackfill?.running) return;
     const generation = ++scanGeneration;
     const previousResults = scanState.results;
+    const previousRevision = scanState.revision;
+    const previousHasSnapshot = scanState.hasSnapshot;
     const previousFinishedAt = scanState.finishedAt;
     scanState = {
       running: true,
       scanned: 0,
       total: 0,
       results: previousResults,
+      revision: previousRevision,
+      hasSnapshot: previousHasSnapshot,
       phase: "discovering",
       startedAt: new Date().toISOString(),
       finishedAt: previousFinishedAt,
@@ -1252,6 +1260,8 @@ export async function startServer(
           scanned: results.length,
           total: results.length,
           results,
+          revision: scanState.revision + 1,
+          hasSnapshot: true,
           currentSession: undefined,
           phase: undefined,
           startedAt: scanState.startedAt,
@@ -2161,6 +2171,8 @@ export async function startServer(
       scanned: scanState.scanned,
       total: scanState.total,
       resultCount: scanState.results.length,
+      revision: scanState.revision,
+      hasSnapshot: scanState.hasSnapshot,
       currentSession: scanState.currentSession,
       phase: scanState.phase,
       startedAt: scanState.startedAt,
@@ -2182,6 +2194,7 @@ export async function startServer(
       running: scanState.running,
       scanned: scanState.scanned,
       total: scanState.total,
+      revision: scanState.revision,
       finishedAt: scanState.finishedAt,
       failedProviders: scanState.failedProviders || [],
     });
@@ -2229,15 +2242,16 @@ export async function startServer(
   // Conversation content and tool inputs/results intentionally never leave the
   // scanner here; the viewer only needs additive metrics and timestamps.
   app.get("/api/insights/rollup", async (c) => {
-    const cachedReplays = await readFileCache<ReplaySummary[]>(replaysCacheKey);
-    let replays = cachedReplays?.data;
+    if (!scanState.hasSnapshot) {
+      return c.json({ error: "No scan results available. Start a scan first." }, 503);
+    }
+    // Replay files can be created or deleted without a source scan, so refresh
+    // this small list instead of trusting a potentially stale dashboard cache.
+    const refreshedReplays = await refreshReplaysCache();
+    let replays = refreshedReplays;
     if (!replays) {
-      try {
-        replays = await scanSessions(baseDir);
-        await writeFileCache(replaysCacheKey, replays);
-      } catch {
-        replays = [];
-      }
+      const cachedReplays = await readFileCache<ReplaySummary[]>(replaysCacheKey);
+      replays = cachedReplays?.data || [];
     }
     return c.json(buildInsightsRollup(scanState.results, replays));
   });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -33,6 +33,7 @@ import {
 import { generateGitHubGif } from "./formatters/gif.js";
 import { generateGitHubMarkdown, generateGitHubSvg } from "./formatters/github.js";
 import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js";
+import { buildInsightsRollup } from "./insights-rollup.js";
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { loadOverlays, sessionWithEffectiveContent } from "./overlays.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
@@ -2222,6 +2223,23 @@ export async function startServer(
       totalSessions: scanState.results.length,
       scannedAt: scanState.finishedAt,
     });
+  });
+
+  // Compact per-session projection for exact 7d/30d/90d insight totals.
+  // Conversation content and tool inputs/results intentionally never leave the
+  // scanner here; the viewer only needs additive metrics and timestamps.
+  app.get("/api/insights/rollup", async (c) => {
+    const cachedReplays = await readFileCache<ReplaySummary[]>(replaysCacheKey);
+    let replays = cachedReplays?.data;
+    if (!replays) {
+      try {
+        replays = await scanSessions(baseDir);
+        await writeFileCache(replaysCacheKey, replays);
+      } catch {
+        replays = [];
+      }
+    }
+    return c.json(buildInsightsRollup(scanState.results, replays));
   });
 
   app.get("/api/insights", async (c) => {

--- a/packages/cli/test/insights-rollup.test.ts
+++ b/packages/cli/test/insights-rollup.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { buildInsightsRollup } from "../src/insights-rollup.js";
+import type { SessionScanResult } from "../src/scanner.js";
+import type { ReplaySummary } from "../src/server-types.js";
+
+function makeScan(overrides: Partial<SessionScanResult> = {}): SessionScanResult {
+  return {
+    sessionId: "session-a",
+    provider: "claude-code",
+    project: "~/Code/app",
+    slug: "session-a",
+    startTime: "2026-08-20T10:00:00.000Z",
+    durationMs: 60_000,
+    promptCount: 2,
+    toolCallCount: 5,
+    editCount: 1,
+    filesModified: [{ file: "src/app.ts", count: 1 }],
+    tokenUsage: {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheCreationTokens: 40,
+    },
+    costEstimate: 0.25,
+    firstPrompt: "private prompt content",
+    usageEvents: [
+      {
+        kind: "tool",
+        name: "Read",
+        status: "success",
+        attribution: "explicit",
+      },
+    ],
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeReplay(overrides: Partial<ReplaySummary> = {}): ReplaySummary {
+  return {
+    slug: "replay-a",
+    baseDir: "/tmp/vibe-replay",
+    sessionId: "session-a",
+    title: "private replay title",
+    provider: "claude-code",
+    project: "~/Code/app",
+    startTime: "2026-08-20T10:00:00.000Z",
+    stats: {
+      sceneCount: 4,
+      userPrompts: 2,
+      toolCalls: 5,
+      thinkingBlocks: 1,
+      durationMs: 60_000,
+      costEstimate: 0.25,
+    },
+    replaySize: 123,
+    replayOutdated: false,
+    hasAnnotations: false,
+    annotationCount: 0,
+    messages: ["private replay content"],
+    ...overrides,
+  };
+}
+
+describe("buildInsightsRollup", () => {
+  it("keeps only compact additive metrics and timestamps", () => {
+    const payload = buildInsightsRollup(
+      [makeScan()],
+      [makeReplay({ project: "~/Code/replay", startTime: "2026-08-19T10:00:00.000Z" })],
+    );
+
+    expect(payload).toEqual({
+      sessions: [
+        {
+          project: "~/Code/app",
+          startTime: "2026-08-20T10:00:00.000Z",
+          durationMs: 60_000,
+          cost: 0.25,
+          prompts: 2,
+          edits: 1,
+          toolCalls: 5,
+        },
+      ],
+      replays: [{ project: "~/Code/replay", startTime: "2026-08-19T10:00:00.000Z" }],
+    });
+    expect(JSON.stringify(payload)).not.toContain("private");
+  });
+});

--- a/packages/cli/test/insights-rollup.test.ts
+++ b/packages/cli/test/insights-rollup.test.ts
@@ -87,4 +87,34 @@ describe("buildInsightsRollup", () => {
     });
     expect(JSON.stringify(payload)).not.toContain("private");
   });
+
+  it.each([30, 500])("keeps a %d-session scan set compact", (sessionCount) => {
+    const scans = Array.from({ length: sessionCount }, (_, index) =>
+      makeScan({
+        sessionId: `session-${index}`,
+        slug: `session-${index}`,
+        project: `~/Code/app-${index % 3}`,
+        usageEvents: Array.from({ length: 30 }, (_, eventIndex) => ({
+          kind: "tool",
+          name: `tool-${eventIndex}`,
+          status: "success",
+          attribution: "explicit",
+        })),
+      }),
+    );
+
+    const payload = buildInsightsRollup(scans, []);
+
+    expect(payload.sessions).toHaveLength(sessionCount);
+    expect(payload.sessions[0]).toEqual({
+      project: "~/Code/app-0",
+      startTime: "2026-08-20T10:00:00.000Z",
+      durationMs: 60_000,
+      cost: 0.25,
+      prompts: 2,
+      edits: 1,
+      toolCalls: 5,
+    });
+    expect(JSON.stringify(payload)).not.toContain("tool-");
+  });
 });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -1207,6 +1207,22 @@ describe("aggregateProjectInsights", () => {
     expect(insights.apiErrorTotal).toBe(1);
   });
 
+  it("aggregates sessions from collapsed workspaces under their parent project", () => {
+    const worktreeScan = {
+      ...scans[0],
+      sessionId: "worktree-session",
+      project: "~/Code/proj-a/.claude/worktrees/feature",
+    };
+    const runWorkspaceScan = {
+      ...scans[0],
+      sessionId: "run-session",
+      project: "/tmp/review-abcdef123456",
+    };
+
+    expect(aggregateProjectInsights("~/Code/proj-a", [worktreeScan]).sessionCount).toBe(1);
+    expect(aggregateProjectInsights("/tmp", [runWorkspaceScan]).sessionCount).toBe(1);
+  });
+
   it("groups branches with session IDs", () => {
     const insights = aggregateProjectInsights("~/Code/proj-a", scans);
 

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -1,0 +1,172 @@
+export interface TurnDurationHistogramData {
+  buckets: Array<{ label: string; count: number; pct: number }>;
+  percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
+  totalTurns: number;
+}
+
+export interface TokenBreakdownData {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+function formatDurationShort(ms: number): string {
+  if (ms < 1000) return "<1s";
+  const totalSec = Math.round(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min < 60) return sec > 0 ? `${min}m ${sec}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
+}
+
+export function TurnDurationChart({ histogram }: { histogram: TurnDurationHistogramData }) {
+  const maxPct = Math.max(...histogram.buckets.map((bucket) => bucket.pct), 1);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2 h-32">
+        {histogram.buckets.map((bucket) => {
+          const heightPct = Math.max((bucket.pct / maxPct) * 100, bucket.count > 0 ? 6 : 0);
+          return (
+            <div
+              key={bucket.label}
+              className="flex-1 flex flex-col items-center justify-end h-full group relative"
+            >
+              <div className="absolute bottom-full mb-1 hidden group-hover:block z-10">
+                <div className="bg-terminal-surface-2 border border-terminal-border-subtle rounded-lg px-2 py-1 shadow-layer-md whitespace-nowrap">
+                  <div className="text-[10px] font-mono text-terminal-dim">{bucket.label}</div>
+                  <div className="text-[10px] font-mono text-terminal-green font-bold">
+                    {bucket.count} turn{bucket.count !== 1 ? "s" : ""} ({bucket.pct}%)
+                  </div>
+                </div>
+              </div>
+              {bucket.pct > 0 && (
+                <div className="text-[9px] font-mono text-terminal-dimmer tabular-nums mb-1">
+                  {bucket.pct >= 10 ? Math.round(bucket.pct) : bucket.pct.toFixed(1)}%
+                </div>
+              )}
+              <div
+                className="w-full rounded-md bg-terminal-green hover:opacity-90 transition-all"
+                style={{
+                  height: `${heightPct}%`,
+                  minHeight: bucket.count > 0 ? "4px" : "0",
+                  opacity: bucket.count > 0 ? 0.7 : 0.1,
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="flex gap-2">
+        {histogram.buckets.map((bucket) => (
+          <div
+            key={bucket.label}
+            className="flex-1 text-center text-[9px] font-mono text-terminal-dimmer"
+          >
+            {bucket.label}
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
+        <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dim">
+          <span>
+            P50{" "}
+            <span className="text-terminal-text font-bold">
+              {formatDurationShort(histogram.percentiles.p50Ms)}
+            </span>
+          </span>
+          <span className="text-terminal-dimmer">{"\u00b7"}</span>
+          <span>
+            P75{" "}
+            <span className="text-terminal-text font-bold">
+              {formatDurationShort(histogram.percentiles.p75Ms)}
+            </span>
+          </span>
+          <span className="text-terminal-dimmer">{"\u00b7"}</span>
+          <span>
+            P90{" "}
+            <span className="text-terminal-text font-bold">
+              {formatDurationShort(histogram.percentiles.p90Ms)}
+            </span>
+          </span>
+        </div>
+        <span className="text-[10px] font-mono text-terminal-dimmer">
+          {histogram.totalTurns.toLocaleString()} turns
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const TOKEN_COLORS = [
+  { key: "cacheRead", label: "Cache Read", color: "bg-terminal-purple" },
+  { key: "cacheCreation", label: "Cache Write", color: "bg-terminal-orange" },
+  { key: "output", label: "Output", color: "bg-terminal-green" },
+  { key: "input", label: "Input", color: "bg-terminal-blue" },
+] as const;
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${Math.floor(value / 1_000)}k`;
+  return value.toString();
+}
+
+export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownData }) {
+  const total = breakdown.input + breakdown.output + breakdown.cacheRead + breakdown.cacheCreation;
+  if (total === 0) return null;
+
+  const items = TOKEN_COLORS.map((token) => ({
+    ...token,
+    value: breakdown[token.key],
+    pct: (breakdown[token.key] / total) * 100,
+  }));
+  const visibleItems = items.filter((item) => item.value > 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="h-4 rounded-full bg-terminal-surface-2 overflow-hidden flex">
+        {visibleItems.map((item) => (
+          <div
+            key={item.key}
+            className={`h-full ${item.color} transition-all duration-500`}
+            style={{ width: `${item.pct}%`, opacity: 0.7 }}
+          />
+        ))}
+      </div>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div key={item.key} className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className={`w-2.5 h-2.5 rounded-sm ${item.color}`} style={{ opacity: 0.7 }} />
+              <span className="text-[11px] font-mono text-terminal-dim">{item.label}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="text-[11px] font-mono text-terminal-text tabular-nums">
+                {formatTokenCount(item.value)}
+              </span>
+              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums w-10 text-right">
+                {item.value === 0
+                  ? "0%"
+                  : item.pct < 0.1
+                    ? "<0.1%"
+                    : item.pct < 1
+                      ? `${item.pct.toFixed(1)}%`
+                      : `${Math.round(item.pct)}%`}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
+        <span className="text-[10px] font-mono text-terminal-dimmer">Total</span>
+        <span className="text-[11px] font-mono text-terminal-text font-bold tabular-nums">
+          {formatTokenCount(total)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -4,7 +4,8 @@
  * Shows a shareable stats card, GitHub-style activity heatmap, streak/highlights,
  * weekly trend, project breakdown, and model/provider usage.
  *
- * All data comes from the existing ScanInsightsProvider (UserInsights).
+ * Aggregate data comes from ScanInsightsProvider; exact range totals and usage
+ * facets use compact per-session rollups from the local dashboard API.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -13,13 +14,21 @@ import {
   type UsageRollupEntry,
   type UsageRollupSession,
 } from "../engine/usage-rollup";
+import {
+  rollupInsights,
+  type InsightsRangeStats,
+  type InsightsRollupPayload,
+  rangeSince as insightsRangeSince,
+} from "../engine/insights-rollup";
 import { AnimatedValue } from "../hooks/useAnimatedNumber";
 import type { SessionSummary, SourceSession } from "../types";
 import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
+import { TokenBreakdownChart, TurnDurationChart } from "./InsightCharts";
 import {
   formatCompactAge,
   formatCompactDuration,
+  navigateTo,
   parseCachedList,
   projectName,
   providerBarClass,
@@ -40,16 +49,7 @@ interface UsageRollupPayload {
   totalSessions: number;
 }
 
-interface ComputedStats {
-  sessions: number;
-  replays: number;
-  durationMs: number;
-  cost: number;
-  prompts: number;
-  edits: number;
-  toolCalls: number;
-  projects: number;
-}
+type ComputedStats = InsightsRangeStats;
 
 interface StreakInfo {
   current: number;
@@ -100,14 +100,7 @@ function rangeDays(range: TimeRange): number {
 }
 
 /** Start of the selected range as an instant, or undefined for "all". */
-function rangeSince(range: TimeRange): string | undefined {
-  const days = rangeDays(range);
-  if (days === 0) return undefined;
-  const cutoff = new Date();
-  cutoff.setHours(0, 0, 0, 0);
-  cutoff.setDate(cutoff.getDate() - days);
-  return cutoff.toISOString();
-}
+const rangeSince = insightsRangeSince;
 
 function filterSessionsByRange(
   sessionsPerDay: Record<string, number>,
@@ -117,55 +110,13 @@ function filterSessionsByRange(
   const days = rangeDays(range);
   const cutoff = new Date();
   cutoff.setHours(0, 0, 0, 0);
-  cutoff.setDate(cutoff.getDate() - days);
+  cutoff.setDate(cutoff.getDate() - (days - 1));
   const cutoffKey = dateKey(cutoff);
   const filtered: Record<string, number> = {};
   for (const [k, v] of Object.entries(sessionsPerDay)) {
     if (k >= cutoffKey) filtered[k] = v;
   }
   return filtered;
-}
-
-function computeStats(
-  sessionsPerDay: Record<string, number>,
-  totalStats: {
-    totalDurationMs: number;
-    totalCost: number;
-    totalPrompts: number;
-    totalEdits: number;
-    totalToolCalls: number;
-    totalSessions: number;
-    totalReplays: number;
-    totalProjects: number;
-  },
-  range: TimeRange,
-): ComputedStats {
-  if (range === "all") {
-    return {
-      sessions: totalStats.totalSessions,
-      replays: totalStats.totalReplays,
-      durationMs: totalStats.totalDurationMs,
-      cost: totalStats.totalCost,
-      prompts: totalStats.totalPrompts,
-      edits: totalStats.totalEdits,
-      toolCalls: totalStats.totalToolCalls,
-      projects: totalStats.totalProjects,
-    };
-  }
-  // For filtered ranges, count sessions from sessionsPerDay
-  const filtered = filterSessionsByRange(sessionsPerDay, range);
-  const sessions = Object.values(filtered).reduce((a, b) => a + b, 0);
-  const ratio = totalStats.totalSessions > 0 ? sessions / totalStats.totalSessions : 0;
-  return {
-    sessions,
-    replays: Math.round(totalStats.totalReplays * ratio),
-    durationMs: Math.round(totalStats.totalDurationMs * ratio),
-    cost: totalStats.totalCost * ratio,
-    prompts: Math.round(totalStats.totalPrompts * ratio),
-    edits: Math.round(totalStats.totalEdits * ratio),
-    toolCalls: Math.round(totalStats.totalToolCalls * ratio),
-    projects: totalStats.totalProjects,
-  };
 }
 
 function computeStreak(sessionsPerDay: Record<string, number>): StreakInfo {
@@ -303,12 +254,6 @@ function formatCost(cost: number): string {
 function formatCompactNum(n: number): string {
   if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
   return n.toLocaleString();
-}
-
-function fmtTokenCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.floor(n / 1_000)}k`;
-  return n.toString();
 }
 
 function buildAggregateMetricQuality(notes: string[] | undefined): {
@@ -697,176 +642,6 @@ function HighlightCard({
 }
 
 // ─── Weekly Trend Chart ─────────────────────────────────────────────
-
-function formatDurationShort(ms: number): string {
-  if (ms < 1000) return "<1s";
-  const totalSec = Math.round(ms / 1000);
-  if (totalSec < 60) return `${totalSec}s`;
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  if (min < 60) return sec > 0 ? `${min}m ${sec}s` : `${min}m`;
-  const hr = Math.floor(min / 60);
-  const remMin = min % 60;
-  return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
-}
-
-function TurnDurationChart({
-  histogram,
-}: {
-  histogram: {
-    buckets: Array<{ label: string; count: number; pct: number }>;
-    percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
-    totalTurns: number;
-  };
-}) {
-  const maxPct = Math.max(...histogram.buckets.map((b) => b.pct), 1);
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-end gap-2 h-32">
-        {histogram.buckets.map((bucket) => {
-          const heightPct = Math.max((bucket.pct / maxPct) * 100, bucket.count > 0 ? 6 : 0);
-          return (
-            <div
-              key={bucket.label}
-              className="flex-1 flex flex-col items-center justify-end h-full group relative"
-            >
-              {/* Tooltip */}
-              <div className="absolute bottom-full mb-1 hidden group-hover:block z-10">
-                <div className="bg-terminal-surface-2 border border-terminal-border-subtle rounded-lg px-2 py-1 shadow-layer-md whitespace-nowrap">
-                  <div className="text-[10px] font-mono text-terminal-dim">{bucket.label}</div>
-                  <div className="text-[10px] font-mono text-terminal-green font-bold">
-                    {bucket.count} turn{bucket.count !== 1 ? "s" : ""} ({bucket.pct}%)
-                  </div>
-                </div>
-              </div>
-              {/* Percentage label above bar */}
-              {bucket.pct > 0 && (
-                <div className="text-[9px] font-mono text-terminal-dimmer tabular-nums mb-1">
-                  {bucket.pct >= 10 ? Math.round(bucket.pct) : bucket.pct.toFixed(1)}%
-                </div>
-              )}
-              <div
-                className="w-full rounded-md bg-terminal-green hover:opacity-90 transition-all"
-                style={{
-                  height: `${heightPct}%`,
-                  minHeight: bucket.count > 0 ? "4px" : "0",
-                  opacity: bucket.count > 0 ? 0.7 : 0.1,
-                }}
-              />
-            </div>
-          );
-        })}
-      </div>
-      {/* X-axis labels */}
-      <div className="flex gap-2">
-        {histogram.buckets.map((b) => (
-          <div
-            key={b.label}
-            className="flex-1 text-center text-[9px] font-mono text-terminal-dimmer"
-          >
-            {b.label}
-          </div>
-        ))}
-      </div>
-      {/* Percentiles + total */}
-      <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
-        <div className="flex items-center gap-3 text-[10px] font-mono text-terminal-dim">
-          <span>
-            P50{" "}
-            <span className="text-terminal-text font-bold">
-              {formatDurationShort(histogram.percentiles.p50Ms)}
-            </span>
-          </span>
-          <span className="text-terminal-dimmer">{"\u00b7"}</span>
-          <span>
-            P75{" "}
-            <span className="text-terminal-text font-bold">
-              {formatDurationShort(histogram.percentiles.p75Ms)}
-            </span>
-          </span>
-          <span className="text-terminal-dimmer">{"\u00b7"}</span>
-          <span>
-            P90{" "}
-            <span className="text-terminal-text font-bold">
-              {formatDurationShort(histogram.percentiles.p90Ms)}
-            </span>
-          </span>
-        </div>
-        <span className="text-[10px] font-mono text-terminal-dimmer">
-          {histogram.totalTurns.toLocaleString()} turns
-        </span>
-      </div>
-    </div>
-  );
-}
-
-const TOKEN_COLORS = [
-  { key: "cacheRead", label: "Cache Read", color: "bg-terminal-purple" },
-  { key: "cacheCreation", label: "Cache Write", color: "bg-terminal-orange" },
-  { key: "output", label: "Output", color: "bg-terminal-green" },
-  { key: "input", label: "Input", color: "bg-terminal-blue" },
-] as const;
-
-function TokenBreakdownChart({
-  breakdown,
-}: {
-  breakdown: { input: number; output: number; cacheRead: number; cacheCreation: number };
-}) {
-  const total = breakdown.input + breakdown.output + breakdown.cacheRead + breakdown.cacheCreation;
-  if (total === 0) return null;
-
-  const items = TOKEN_COLORS.map((t) => ({
-    ...t,
-    value: breakdown[t.key],
-    pct: (breakdown[t.key] / total) * 100,
-  })).filter((t) => t.value > 0);
-
-  return (
-    <div className="space-y-4">
-      {/* Stacked bar */}
-      <div className="h-4 rounded-full bg-terminal-surface-2 overflow-hidden flex">
-        {items.map((item) => (
-          <div
-            key={item.key}
-            className={`h-full ${item.color} transition-all duration-500`}
-            style={{ width: `${item.pct}%`, opacity: 0.7 }}
-          />
-        ))}
-      </div>
-      {/* Legend rows */}
-      <div className="space-y-2">
-        {items.map((item) => (
-          <div key={item.key} className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className={`w-2.5 h-2.5 rounded-sm ${item.color}`} style={{ opacity: 0.7 }} />
-              <span className="text-[11px] font-mono text-terminal-dim">{item.label}</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-[11px] font-mono text-terminal-text tabular-nums">
-                {fmtTokenCount(item.value)}
-              </span>
-              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums w-10 text-right">
-                {item.pct < 0.1
-                  ? "<0.1%"
-                  : item.pct < 1
-                    ? `${item.pct.toFixed(1)}%`
-                    : `${Math.round(item.pct)}%`}
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
-      {/* Total */}
-      <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
-        <span className="text-[10px] font-mono text-terminal-dimmer">Total</span>
-        <span className="text-[11px] font-mono text-terminal-text font-bold tabular-nums">
-          {fmtTokenCount(total)}
-        </span>
-      </div>
-    </div>
-  );
-}
 
 function WeeklyTrendChart({ data }: { data: WeeklyData[] }) {
   const maxVal = Math.max(...data.map((d) => d.sessions), 1);
@@ -1263,6 +1038,58 @@ function InsightsLoadingState({
   );
 }
 
+function InsightsRangeLoadingState({
+  range,
+  onRangeChange,
+  loading,
+  error,
+}: {
+  range: TimeRange;
+  onRangeChange: (range: TimeRange) => void;
+  loading: boolean;
+  error: boolean;
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-4 md:px-6 py-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-sans font-bold text-terminal-text">Your Insights</h1>
+          <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-terminal-surface">
+            {(["7d", "30d", "90d", "all"] as TimeRange[]).map((value) => (
+              <button
+                key={value}
+                onClick={() => onRangeChange(value)}
+                className={`px-3 py-1.5 text-xs font-sans rounded-md transition-all ${
+                  range === value
+                    ? "bg-terminal-green-subtle text-terminal-green font-bold"
+                    : "text-terminal-dim hover:text-terminal-text"
+                }`}
+              >
+                {value === "all" ? "All" : value}
+              </button>
+            ))}
+          </div>
+        </div>
+        <output className="block rounded-xl border border-terminal-purple/20 bg-terminal-surface px-4 py-5 text-sm font-sans text-terminal-text">
+          <div className="flex items-center gap-2">
+            {!error && <span className="w-2 h-2 rounded-full bg-terminal-purple animate-pulse" />}
+            <span>
+              {loading
+                ? `Loading exact ${range} per-session totals...`
+                : "Exact range totals are unavailable."}
+            </span>
+          </div>
+          {error && (
+            <p className="mt-2 text-xs font-mono text-terminal-dim">
+              Refresh the dashboard to retry. All-time totals remain available.
+            </p>
+          )}
+        </output>
+      </div>
+    </div>
+  );
+}
+
 // ─── Source/Replay counts (consistent with homepage) ────────────────
 
 /** Fetch same source + replay data as homepage to ensure consistent totals. */
@@ -1331,6 +1158,48 @@ function useHomePageCounts() {
 }
 
 /**
+ * Compact per-session metrics used to compute exact time-range totals locally.
+ * Refetch after a background scan finishes; changing the selected range itself
+ * remains request-free.
+ */
+function useInsightsRollup(scanFinishedAt?: string) {
+  const [payload, setPayload] = useState<InsightsRollupPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let stopped = false;
+    setLoading(true);
+    setError(false);
+    fetch("/api/insights/rollup")
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`Insights rollup request failed: ${r.status}`);
+        return (await r.json()) as InsightsRollupPayload;
+      })
+      .then((data) => {
+        if (!Array.isArray(data.sessions) || !Array.isArray(data.replays)) {
+          throw new Error("Invalid insights rollup payload");
+        }
+        if (!stopped) setPayload(data);
+      })
+      .catch(() => {
+        if (!stopped) {
+          setPayload(null);
+          setError(true);
+        }
+      })
+      .finally(() => {
+        if (!stopped) setLoading(false);
+      });
+    return () => {
+      stopped = true;
+    };
+  }, [scanFinishedAt]);
+
+  return { payload, loading, error };
+}
+
+/**
  * Per-session usage counters for the whole scan. Fetched once and aggregated
  * locally so switching time range costs no request, and refetched when a scan
  * finishes so the section isn't stuck on a stale snapshot.
@@ -1356,14 +1225,36 @@ function useUsageRollupSessions(scanFinishedAt?: string, usageBackfillRunning = 
 
 // ─── Tool & MCP Usage ───────────────────────────────────────────────
 
-function UsageBarList({
+export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "skill", name: string) {
+  navigateTo({
+    view: "dashboard",
+    session: null,
+    tab: "sessions",
+    project: null,
+    q: null,
+    provider: null,
+    repo: null,
+    tool: null,
+    mcp: null,
+    mcpTool: null,
+    skill: null,
+    archived: null,
+    agentRuns: null,
+    replay: null,
+    [facet]: encodeURIComponent(name),
+  });
+}
+
+export function UsageBarList({
   entries,
   emptyLabel,
   unit,
+  onSelect,
 }: {
   entries: UsageRollupEntry[];
   emptyLabel: string;
   unit: string;
+  onSelect?: (name: string) => void;
 }) {
   if (entries.length === 0) {
     return (
@@ -1376,7 +1267,21 @@ function UsageBarList({
   return (
     <div className="space-y-2">
       {entries.map((entry) => (
-        <div key={entry.name} className="space-y-1">
+        <button
+          key={entry.name}
+          type="button"
+          disabled={!onSelect}
+          onClick={() => onSelect?.(entry.name)}
+          title={onSelect ? `View sessions using ${entry.name}` : undefined}
+          aria-label={`${entry.name}: ${entry.calls} ${unit} across ${entry.sessions} session${
+            entry.sessions === 1 ? "" : "s"
+          }${onSelect ? ". View matching sessions" : ""}`}
+          className={`w-full text-left space-y-1 rounded-md ${
+            onSelect
+              ? "cursor-pointer hover:bg-terminal-surface-2/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-terminal-green/50"
+              : ""
+          }`}
+        >
           <div className="flex items-center justify-between gap-2">
             <span
               className="text-xs font-sans font-medium text-terminal-text truncate max-w-[55%]"
@@ -1395,7 +1300,7 @@ function UsageBarList({
               style={{ width: `${Math.max((entry.calls / max) * 100, 3)}%`, opacity: 0.65 }}
             />
           </div>
-        </div>
+        </button>
       ))}
     </div>
   );
@@ -1407,6 +1312,11 @@ export default function InsightsPage() {
   const { userInsights, loading, scanStatus } = useScanInsightsContext();
   const homePageCounts = useHomePageCounts();
   const [range, setRange] = useState<TimeRange>("all");
+  const {
+    payload: insightsRollupPayload,
+    loading: insightsRollupLoading,
+    error: insightsRollupError,
+  } = useInsightsRollup(scanStatus?.finishedAt);
 
   const isInitialScan = scanStatus?.running && !userInsights;
 
@@ -1436,14 +1346,18 @@ export default function InsightsPage() {
 
       const spd = userInsights.sessionsPerDay || {};
       const filtered = filterSessionsByRange(spd, range);
-      const scanSnapshotTotals = {
-        ...userInsights,
-        // Replays come from generated artifacts rather than the scan snapshot, so
-        // keep using the homepage cache here while the rest of the stats stay on
-        // the single insights-scan timeline.
-        totalReplays: homePageCounts?.replays ?? 0,
-      };
-      const s = computeStats(filtered, scanSnapshotTotals, range);
+      const s = insightsRollupPayload
+        ? rollupInsights(insightsRollupPayload, { since: rangeSince(range) })
+        : {
+            sessions: userInsights.totalSessions,
+            replays: homePageCounts?.replays ?? 0,
+            durationMs: userInsights.totalDurationMs,
+            cost: userInsights.totalCost,
+            prompts: userInsights.totalPrompts,
+            edits: userInsights.totalEdits,
+            toolCalls: userInsights.totalToolCalls,
+            projects: userInsights.totalProjects,
+          };
       const sk = computeStreak(spd); // always compute streak from all data
       const dow = computeDayOfWeek(filtered);
       const best = [...dow].sort((a, b) => b.count - a.count)[0] || null;
@@ -1462,7 +1376,7 @@ export default function InsightsPage() {
         activeDays: ad,
         firstSessionDate: first,
       };
-    }, [userInsights, range, homePageCounts]);
+    }, [userInsights, range, homePageCounts, insightsRollupPayload]);
 
   const rolledTopProjects = useMemo(
     () => rollupTopProjects(userInsights?.topProjects || []),
@@ -1489,6 +1403,17 @@ export default function InsightsPage() {
 
   if (!userInsights) {
     return <InsightsPageSkeleton />;
+  }
+
+  if (range !== "all" && !insightsRollupPayload) {
+    return (
+      <InsightsRangeLoadingState
+        range={range}
+        onRangeChange={setRange}
+        loading={insightsRollupLoading}
+        error={insightsRollupError}
+      />
+    );
   }
 
   const avgPerActiveDay = activeDays > 0 ? (stats.sessions / activeDays).toFixed(1) : "0";
@@ -1671,17 +1596,32 @@ export default function InsightsPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
               <div>
                 <h4 className="ui-section-title mb-3">Top tools</h4>
-                <UsageBarList entries={usage.tools} emptyLabel="No tool data" unit="calls" />
+                <UsageBarList
+                  entries={usage.tools}
+                  emptyLabel="No tool data"
+                  unit="calls"
+                  onSelect={(name) => navigateToUsageSessions("tool", name)}
+                />
               </div>
               <div>
                 <h4 className="ui-section-title mb-3">Top MCP servers</h4>
-                <UsageBarList entries={usage.mcpServers} emptyLabel="No MCP data" unit="calls" />
+                <UsageBarList
+                  entries={usage.mcpServers}
+                  emptyLabel="No MCP data"
+                  unit="calls"
+                  onSelect={(name) => navigateToUsageSessions("mcp", name)}
+                />
               </div>
             </div>
             {usage.mcpTools.length > 0 && (
               <div>
                 <h4 className="ui-section-title mb-3">Top MCP tools</h4>
-                <UsageBarList entries={usage.mcpTools} emptyLabel="No MCP data" unit="calls" />
+                <UsageBarList
+                  entries={usage.mcpTools}
+                  emptyLabel="No MCP data"
+                  unit="calls"
+                  onSelect={(name) => navigateToUsageSessions("mcpTool", name)}
+                />
               </div>
             )}
             {usage.skills.length > 0 && (
@@ -1691,6 +1631,7 @@ export default function InsightsPage() {
                   entries={usage.skills}
                   emptyLabel="No skill data"
                   unit="activations"
+                  onSelect={(name) => navigateToUsageSessions("skill", name)}
                 />
               </div>
             )}

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -1159,10 +1159,10 @@ function useHomePageCounts() {
 
 /**
  * Compact per-session metrics used to compute exact time-range totals locally.
- * Refetch after a background scan finishes; changing the selected range itself
- * remains request-free.
+ * Refetch when the background scan snapshot changes, including deferred usage
+ * backfill; changing the selected range itself remains request-free.
  */
-function useInsightsRollup(scanFinishedAt?: string) {
+function useInsightsRollup(scanFinishedAt?: string, scanRevision?: number) {
   const [payload, setPayload] = useState<InsightsRollupPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -1194,17 +1194,21 @@ function useInsightsRollup(scanFinishedAt?: string) {
     return () => {
       stopped = true;
     };
-  }, [scanFinishedAt]);
+  }, [scanFinishedAt, scanRevision]);
 
   return { payload, loading, error };
 }
 
 /**
  * Per-session usage counters for the whole scan. Fetched once and aggregated
- * locally so switching time range costs no request, and refetched when a scan
- * finishes so the section isn't stuck on a stale snapshot.
+ * locally so switching time range costs no request, and refetched when the scan
+ * snapshot changes so the section isn't stuck on a stale snapshot.
  */
-function useUsageRollupSessions(scanFinishedAt?: string, usageBackfillRunning = false) {
+function useUsageRollupSessions(
+  scanFinishedAt?: string,
+  usageBackfillRunning = false,
+  scanRevision?: number,
+) {
   const [payload, setPayload] = useState<UsageRollupPayload | null>(null);
 
   useEffect(() => {
@@ -1218,7 +1222,7 @@ function useUsageRollupSessions(scanFinishedAt?: string, usageBackfillRunning = 
     return () => {
       stopped = true;
     };
-  }, [scanFinishedAt, usageBackfillRunning]);
+  }, [scanFinishedAt, usageBackfillRunning, scanRevision]);
 
   return payload;
 }
@@ -1238,10 +1242,10 @@ export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "ski
     mcp: null,
     mcpTool: null,
     skill: null,
-    archived: null,
-    agentRuns: null,
+    archived: "true",
+    agentRuns: "true",
     replay: null,
-    [facet]: name,
+    [facet]: [name],
   });
 }
 
@@ -1316,7 +1320,7 @@ export default function InsightsPage() {
     payload: insightsRollupPayload,
     loading: insightsRollupLoading,
     error: insightsRollupError,
-  } = useInsightsRollup(scanStatus?.finishedAt);
+  } = useInsightsRollup(scanStatus?.finishedAt, scanStatus?.revision);
 
   const isInitialScan = scanStatus?.running && !userInsights;
 
@@ -1386,6 +1390,7 @@ export default function InsightsPage() {
   const usagePayload = useUsageRollupSessions(
     scanStatus?.finishedAt,
     scanStatus?.usageBackfill?.running === true,
+    scanStatus?.revision,
   );
   const usage = useMemo(
     () => rollupUsage(usagePayload?.sessions || [], { since: rangeSince(range), limit: 8 }),

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -1081,7 +1081,7 @@ function InsightsRangeLoadingState({
           </div>
           {error && (
             <p className="mt-2 text-xs font-mono text-terminal-dim">
-              Refresh the dashboard to retry. All-time totals remain available.
+              Refresh the dashboard to retry, or select All to view available all-time totals.
             </p>
           )}
         </output>
@@ -1225,13 +1225,6 @@ function useUsageRollupSessions(scanFinishedAt?: string, usageBackfillRunning = 
 
 // ─── Tool & MCP Usage ───────────────────────────────────────────────
 
-function encodeUsageFacetValue(name: string): string {
-  // URLSearchParams performs the URL encoding. Keep MCP's conventional
-  // server/tool slash readable so the resulting query is a normal single
-  // facet value rather than a doubly encoded `%252F` sequence.
-  return encodeURIComponent(name).replace(/%2F/gi, "/");
-}
-
 export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "skill", name: string) {
   navigateTo({
     view: "dashboard",
@@ -1248,7 +1241,7 @@ export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "ski
     archived: null,
     agentRuns: null,
     replay: null,
-    [facet]: encodeUsageFacetValue(name),
+    [facet]: name,
   });
 }
 

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -1225,6 +1225,13 @@ function useUsageRollupSessions(scanFinishedAt?: string, usageBackfillRunning = 
 
 // ─── Tool & MCP Usage ───────────────────────────────────────────────
 
+function encodeUsageFacetValue(name: string): string {
+  // URLSearchParams performs the URL encoding. Keep MCP's conventional
+  // server/tool slash readable so the resulting query is a normal single
+  // facet value rather than a doubly encoded `%252F` sequence.
+  return encodeURIComponent(name).replace(/%2F/gi, "/");
+}
+
 export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "skill", name: string) {
   navigateTo({
     view: "dashboard",
@@ -1241,7 +1248,7 @@ export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "ski
     archived: null,
     agentRuns: null,
     replay: null,
-    [facet]: encodeURIComponent(name),
+    [facet]: encodeUsageFacetValue(name),
   });
 }
 

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -145,6 +145,8 @@ interface ScanStatus {
   scanned: number;
   total: number;
   resultCount: number;
+  revision?: number;
+  hasSnapshot?: boolean;
   currentSession?: string;
   phase?: "discovering" | "scanning";
   startedAt?: string;
@@ -207,7 +209,8 @@ export function ScanInsightsProvider({ children }: { children: ReactNode }) {
         setScanStatus(status);
 
         if (status.running || status.usageBackfill?.running) return;
-        if (!status.hasCachedResults || !isCacheFresh(status.cachedAt, CACHE_REFRESH_TTL_MS)) {
+        const hasSnapshot = status.hasSnapshot ?? status.hasCachedResults;
+        if (!hasSnapshot || !isCacheFresh(status.cachedAt, CACHE_REFRESH_TTL_MS)) {
           startScan();
           return;
         }

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -62,13 +62,13 @@ interface TurnDurationBucket {
   pct: number;
 }
 
-interface TurnDurationHistogram {
+export interface TurnDurationHistogram {
   buckets: TurnDurationBucket[];
   percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
   totalTurns: number;
 }
 
-interface ProjectInsights {
+export interface ProjectInsights {
   project: string;
   sessionCount: number;
   totalDurationMs: number;
@@ -91,7 +91,6 @@ interface ProjectInsights {
     cacheRead: number;
     cacheCreation: number;
   };
-  // TODO: render in project-level panel (currently only rendered in user-level InsightsPage)
   turnDurationHistogram?: TurnDurationHistogram;
   memory?: ProjectMemory;
   dataQuality?: {

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -447,8 +447,8 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
 
   // Scratch workspaces from automated runs are their own project each, so on a
   // machine that runs agents on a schedule they crowd out everything the user
-  // actually worked in. They have to be dropped before the rollup, which folds
-  // them into a parent that no longer looks like a run workspace.
+  // actually worked in. Keep them in the source set so the default rollup can
+  // add their activity to the parent project.
   const agentRunCount = useMemo(
     () => (userInsights?.topProjects || []).filter((p) => isAgentRunWorkspace(p.project)).length,
     [userInsights],
@@ -456,14 +456,11 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
 
   const projects = useMemo(() => {
     if (!userInsights) return [];
-    const source = showAgentRuns
-      ? userInsights.topProjects
-      : userInsights.topProjects.filter((p) => !isAgentRunWorkspace(p.project));
-    // When the toggle is on, preserve each run workspace as its own project.
-    // When it is off, those entries were already removed above, so parent
-    // totals exclude run-workspace activity; agentRunCount reports it
-    // separately.
-    const sorted = rollupTopProjects(source, { rollupAgentRuns: !showAgentRuns });
+    // When the toggle is on, preserve each run workspace as its own project;
+    // otherwise roll its activity into the parent project.
+    const sorted = rollupTopProjects(userInsights.topProjects, {
+      rollupAgentRuns: !showAgentRuns,
+    });
     sorted.sort((a, b) => (b.lastActivity || "").localeCompare(a.lastActivity || ""));
     return sorted;
   }, [userInsights, showAgentRuns]);
@@ -477,7 +474,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
 
   useEffect(() => {
     if (selectedProject !== ALL_PROJECTS) fetchProjectInsights(selectedProject);
-  }, [selectedProject, fetchProjectInsights, scanStatus?.finishedAt]);
+  }, [selectedProject, fetchProjectInsights, scanStatus?.finishedAt, scanStatus?.revision]);
 
   const isScanning = scanStatus?.running && scanStatus.total > 0;
 

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -7,13 +7,15 @@
  * project is selected or "All projects".
  */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ALL_PROJECTS } from "../hooks/usePanelFilters";
 import { localDayKey } from "../utils/date";
 import { plural, timeAgo } from "../utils/format";
 import type { Tab } from "./Dashboard";
+import { DataQualityIndicator } from "./DataQualityIndicator";
 import { isAgentRunWorkspace, navigateTo, projectName, rollupTopProjects } from "./dashboard-utils";
-import { useScanInsightsContext } from "./InsightsPanel";
+import { TokenBreakdownChart, TurnDurationChart } from "./InsightCharts";
+import { type ProjectInsights, useScanInsightsContext } from "./InsightsPanel";
 import SessionRelationshipsView from "./SessionRelationshipsView";
 import { fmtNum, formatDuration } from "./StatsPanel";
 
@@ -268,6 +270,52 @@ function ProjectOverview({
   );
 }
 
+export function ProjectPerformance({
+  insights,
+  loading,
+}: {
+  insights?: ProjectInsights;
+  loading: boolean;
+}) {
+  if (!insights && loading) {
+    return (
+      <div className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm animate-pulse">
+        <div className="h-4 w-28 skeleton rounded" />
+        <div className="mt-4 h-24 skeleton rounded-lg" />
+      </div>
+    );
+  }
+  if (!insights || (!insights.turnDurationHistogram && !insights.tokenBreakdown)) return null;
+
+  const dataQualityNotes = insights.dataQuality?.notes || [];
+  return (
+    <section className="space-y-3" aria-labelledby="project-performance-title">
+      <div className="flex items-center gap-2">
+        <h3 id="project-performance-title" className="ui-section-title-strong">
+          Performance
+        </h3>
+        {dataQualityNotes.length > 0 && (
+          <DataQualityIndicator title={dataQualityNotes.join("\n")} />
+        )}
+      </div>
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+        {insights.turnDurationHistogram && (
+          <div className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm">
+            <h4 className="ui-section-title-strong mb-4">Turn Duration</h4>
+            <TurnDurationChart histogram={insights.turnDurationHistogram} />
+          </div>
+        )}
+        {insights.tokenBreakdown && (
+          <div className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm">
+            <h4 className="ui-section-title-strong mb-4">Token Usage</h4>
+            <TokenBreakdownChart breakdown={insights.tokenBreakdown} />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function Stat({
   label,
   value,
@@ -384,7 +432,13 @@ function ProjectsGrid({
 // ─── Main Component ─────────────────────────────────────────────────
 
 export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
-  const { userInsights, scanStatus } = useScanInsightsContext();
+  const {
+    userInsights,
+    scanStatus,
+    projectInsightsCache,
+    fetchProjectInsights,
+    loading: insightsLoading,
+  } = useScanInsightsContext();
   const [selectedProject, setSelectedProject] = useState<string>(ALL_PROJECTS);
   const [mode, setMode] = useState<PanelMode>("overview");
   const [showAgentRuns, setShowAgentRuns] = useState(
@@ -418,6 +472,12 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     selectedProject === ALL_PROJECTS
       ? null
       : (projects.find((p) => p.project === selectedProject) ?? null);
+  const detailedInsight =
+    selectedProject === ALL_PROJECTS ? undefined : projectInsightsCache.get(selectedProject);
+
+  useEffect(() => {
+    if (selectedProject !== ALL_PROJECTS) fetchProjectInsights(selectedProject);
+  }, [selectedProject, fetchProjectInsights, scanStatus?.finishedAt]);
 
   const isScanning = scanStatus?.running && scanStatus.total > 0;
 
@@ -560,6 +620,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 insight={selectedInsight}
                 onOpenSessions={() => openSessionsForProject(selectedProject)}
               />
+              <ProjectPerformance insights={detailedInsight} loading={insightsLoading} />
               <SessionRelationshipsView view="timeline" projectFilter={projectFilterArg} />
             </>
           )}

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import { matchesProjectFacet } from "../engine/dashboard-filtering";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
 import { plural } from "../utils/format";
 import { isAutomated, sessionScore } from "../utils/sessionSignals";
@@ -1192,7 +1193,9 @@ export default function SessionRelationshipsView({
   // session rows still expose the original path when it matters.
   const filteredSessions = useMemo(
     () =>
-      projectFilter ? sessions.filter((s) => rollupProject(s.project) === projectFilter) : sessions,
+      projectFilter
+        ? sessions.filter((s) => matchesProjectFacet(s, projectFilter, "__all__", rollupProject))
+        : sessions,
     [sessions, projectFilter],
   );
   const groups = useMemo(

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -51,6 +51,7 @@ describe("UsageBarList", () => {
       expect(params.get(key), `${key} should be cleared`).toBeNull();
     }
     expect(decodeURIComponent(params.get("mcpTool")!)).toBe("sourcegraph/search");
+    expect(params.get("mcpTool")).toBe("sourcegraph/search");
   });
 
   it.each([

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { navigateToUsageSessions, UsageBarList } from "../InsightsPage";
+import { getMultiFromUrl } from "../../hooks/usePanelFilters";
 
 afterEach(() => {
   cleanup();
@@ -36,20 +37,11 @@ describe("UsageBarList", () => {
 
     const params = new URLSearchParams(window.location.search);
     expect(params.get("tab")).toBe("sessions");
-    for (const key of [
-      "project",
-      "q",
-      "provider",
-      "repo",
-      "tool",
-      "mcp",
-      "skill",
-      "archived",
-      "agentRuns",
-      "replay",
-    ]) {
+    for (const key of ["project", "q", "provider", "repo", "tool", "mcp", "skill", "replay"]) {
       expect(params.get(key), `${key} should be cleared`).toBeNull();
     }
+    expect(params.get("archived")).toBe("true");
+    expect(params.get("agentRuns")).toBe("true");
     expect(params.get("mcpTool")).toBe("sourcegraph/search");
   });
 
@@ -67,11 +59,12 @@ describe("UsageBarList", () => {
   });
 
   it("round-trips facet names with URL-sensitive characters exactly once", () => {
-    const value = "sourcegraph/search?query=foo bar&scope=100%";
+    const value = "sourcegraph/search?query=foo bar&scope=100%,comma";
 
     navigateToUsageSessions("mcpTool", value);
 
     const params = new URLSearchParams(window.location.search);
     expect(params.get("mcpTool")).toBe(value);
+    expect(getMultiFromUrl("mcpTool")).toEqual([value]);
   });
 });

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { navigateToUsageSessions, UsageBarList } from "../InsightsPage";
+
+afterEach(() => {
+  cleanup();
+  sessionStorage.clear();
+});
+
+describe("UsageBarList", () => {
+  it("opens matching sessions when an entry is selected", () => {
+    const onSelect = vi.fn();
+    render(
+      <UsageBarList
+        entries={[{ name: "sourcegraph/search", calls: 12, sessions: 3 }]}
+        emptyLabel="No MCP data"
+        unit="calls"
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /sourcegraph\/search/i }));
+
+    expect(onSelect).toHaveBeenCalledWith("sourcegraph/search");
+  });
+
+  it("navigates to Sessions with only the selected usage facet", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?view=dashboard&tab=insights&project=old&tool=Read&archived=true&agentRuns=true&replay=old",
+    );
+
+    navigateToUsageSessions("mcpTool", "sourcegraph/search");
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("tab")).toBe("sessions");
+    for (const key of [
+      "project",
+      "q",
+      "provider",
+      "repo",
+      "tool",
+      "mcp",
+      "skill",
+      "archived",
+      "agentRuns",
+      "replay",
+    ]) {
+      expect(params.get(key), `${key} should be cleared`).toBeNull();
+    }
+    expect(decodeURIComponent(params.get("mcpTool")!)).toBe("sourcegraph/search");
+  });
+
+  it.each([
+    ["tool", "Read"],
+    ["mcp", "sourcegraph"],
+    ["mcpTool", "sourcegraph/search"],
+    ["skill", "replay"],
+  ] as const)("supports the %s URL facet", (facet, value) => {
+    navigateToUsageSessions(facet, value);
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("tab")).toBe("sessions");
+    expect(decodeURIComponent(params.get(facet)!)).toBe(value);
+  });
+});

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -50,7 +50,6 @@ describe("UsageBarList", () => {
     ]) {
       expect(params.get(key), `${key} should be cleared`).toBeNull();
     }
-    expect(decodeURIComponent(params.get("mcpTool")!)).toBe("sourcegraph/search");
     expect(params.get("mcpTool")).toBe("sourcegraph/search");
   });
 
@@ -64,6 +63,15 @@ describe("UsageBarList", () => {
 
     const params = new URLSearchParams(window.location.search);
     expect(params.get("tab")).toBe("sessions");
-    expect(decodeURIComponent(params.get(facet)!)).toBe(value);
+    expect(params.get(facet)).toBe(value);
+  });
+
+  it("round-trips facet names with URL-sensitive characters exactly once", () => {
+    const value = "sourcegraph/search?query=foo bar&scope=100%";
+
+    navigateToUsageSessions("mcpTool", value);
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("mcpTool")).toBe(value);
   });
 });

--- a/packages/viewer/src/components/__tests__/project-performance.test.tsx
+++ b/packages/viewer/src/components/__tests__/project-performance.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProjectPerformance } from "../ProjectsPanel";
+import type { ProjectInsights } from "../InsightsPanel";
+
+afterEach(() => cleanup());
+
+function projectInsights(): ProjectInsights {
+  return {
+    project: "~/code/example",
+    sessionCount: 2,
+    totalDurationMs: 30_000,
+    totalCost: 1,
+    totalPrompts: 4,
+    totalToolCalls: 8,
+    totalEdits: 2,
+    models: {},
+    branches: [],
+    hotFiles: [],
+    subAgentTotal: 0,
+    apiErrorTotal: 0,
+    timeRange: {
+      first: "2026-08-01T00:00:00Z",
+      last: "2026-08-02T00:00:00Z",
+    },
+    sessionsPerDay: {},
+    avgSessionDurationMs: 15_000,
+    turnDurationHistogram: {
+      buckets: [
+        { label: "<10s", minMs: 0, maxMs: 10_000, count: 1, pct: 50 },
+        { label: "10–30s", minMs: 10_000, maxMs: 30_000, count: 1, pct: 50 },
+      ],
+      percentiles: { p50Ms: 8_000, p75Ms: 15_000, p90Ms: 20_000 },
+      totalTurns: 2,
+    },
+    tokenBreakdown: {
+      input: 100,
+      output: 50,
+      cacheRead: 1_000,
+      cacheCreation: 200,
+    },
+  };
+}
+
+describe("ProjectPerformance", () => {
+  it("renders project turn percentiles and token breakdown", () => {
+    render(<ProjectPerformance insights={projectInsights()} loading={false} />);
+
+    expect(screen.getByRole("heading", { name: "Performance" })).toBeDefined();
+    expect(screen.getByText("P50")).toBeDefined();
+    expect(screen.getByText("P75")).toBeDefined();
+    expect(screen.getByText("P90")).toBeDefined();
+    expect(screen.getByText("8s")).toBeDefined();
+    expect(screen.getByText("Cache Read")).toBeDefined();
+    expect(screen.getAllByText("1k")).toHaveLength(2);
+  });
+
+  it("keeps zero token categories visible", () => {
+    render(
+      <ProjectPerformance
+        loading={false}
+        insights={{
+          ...projectInsights(),
+          turnDurationHistogram: undefined,
+          tokenBreakdown: { input: 100, output: 0, cacheRead: 0, cacheCreation: 0 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Input")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("Cache Read")).toBeDefined();
+    expect(screen.getByText("Cache Write")).toBeDefined();
+  });
+
+  it("renders a loading state while detailed insights are fetched", () => {
+    const { container } = render(<ProjectPerformance loading={true} />);
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+  });
+});

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -70,4 +70,24 @@ describe("ProjectsPanel project insights", () => {
     expect(context.fetchProjectInsights).toHaveBeenCalledTimes(1);
     expect(context.fetchProjectInsights).toHaveBeenCalledWith("~/code/example");
   });
+
+  it("keeps hidden agent-run activity in the default parent rollup", () => {
+    const context = contextValue();
+    context.userInsights!.topProjects.push({
+      ...context.userInsights!.topProjects[0],
+      project: "~/code/example/run-abcdef123456",
+      sessions: 1,
+      cost: 0.5,
+      prompts: 1,
+      durationMs: 1_000,
+      toolCalls: 1,
+      edits: 0,
+      lastActivity: "2026-08-21T00:00:00Z",
+    });
+    vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);
+
+    render(<ProjectsPanel onNavigate={vi.fn()} />);
+
+    expect(screen.getAllByRole("button", { name: /example/i })[0]?.textContent).toContain("3");
+  });
 });

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProjectsPanel from "../ProjectsPanel";
+import * as InsightsPanel from "../InsightsPanel";
+
+vi.mock("../SessionRelationshipsView", () => ({ default: () => null }));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function contextValue(): ReturnType<typeof InsightsPanel.useScanInsightsContext> {
+  return {
+    scanStatus: {
+      running: false,
+      scanned: 2,
+      total: 2,
+      resultCount: 2,
+    },
+    userInsights: {
+      totalSessions: 2,
+      totalProjects: 1,
+      totalDurationMs: 30_000,
+      totalCost: 1,
+      totalPrompts: 4,
+      totalToolCalls: 8,
+      totalEdits: 2,
+      providers: {},
+      topProjects: [
+        {
+          project: "~/code/example",
+          sessions: 2,
+          cost: 1,
+          prompts: 4,
+          durationMs: 30_000,
+          toolCalls: 8,
+          edits: 2,
+          branchCount: 0,
+          prCount: 0,
+          memoryFileCount: 0,
+          lastActivity: "2026-08-20T00:00:00Z",
+          sessionsPerDay: {},
+        },
+      ],
+      models: {},
+      timeRange: { first: "2026-08-19T00:00:00Z", last: "2026-08-20T00:00:00Z" },
+      sessionsPerDay: {},
+      subAgentTotal: 0,
+      apiErrorTotal: 0,
+      avgSessionDurationMs: 15_000,
+    },
+    projectInsightsCache: new Map(),
+    fetchProjectInsights: vi.fn(),
+    loading: false,
+  };
+}
+
+describe("ProjectsPanel project insights", () => {
+  it("fetches detailed insights only after selecting a project", () => {
+    const context = contextValue();
+    vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);
+
+    render(<ProjectsPanel onNavigate={vi.fn()} />);
+    expect(context.fetchProjectInsights).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);
+
+    expect(context.fetchProjectInsights).toHaveBeenCalledTimes(1);
+    expect(context.fetchProjectInsights).toHaveBeenCalledWith("~/code/example");
+  });
+});

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -350,8 +350,10 @@ export function replaySuggestedTitle(s: SessionSummary): string {
 
 // ─── Navigation ──────────────────────────────────────────────────────
 
+export type NavigationValue = string | readonly string[] | null;
+
 export function navigateTo(
-  params: Record<string, string | null>,
+  params: Record<string, NavigationValue>,
   options: { replace?: boolean; notify?: boolean } = {},
 ) {
   const url = new URL(window.location.href);
@@ -363,10 +365,11 @@ export function navigateTo(
       !url.searchParams.has("gist") &&
       !url.searchParams.has("url"));
   if (isCurrentlyDashboard) {
-    const dashboardState: Record<string, string> = {};
+    const dashboardState: Record<string, string | string[]> = {};
     DASHBOARD_PARAMS.forEach((p) => {
-      const v = url.searchParams.get(p);
-      if (v) dashboardState[p] = v;
+      const values = url.searchParams.getAll(p);
+      if (values.length === 1) dashboardState[p] = values[0]!;
+      else if (values.length > 1) dashboardState[p] = values;
     });
     if (Object.keys(dashboardState).length > 0) {
       safeStorageSet(sessionStorage, "vibe_dashboard_state", JSON.stringify(dashboardState));
@@ -397,7 +400,13 @@ export function navigateTo(
         const state = JSON.parse(saved);
         Object.entries(state).forEach(([k, v]) => {
           if (params[k] === undefined && !url.searchParams.has(k)) {
-            url.searchParams.set(k, v as string);
+            if (Array.isArray(v)) {
+              for (const value of v) {
+                if (typeof value === "string") url.searchParams.append(k, value);
+              }
+            } else if (typeof v === "string") {
+              url.searchParams.set(k, v);
+            }
           }
         });
       } catch (e) {
@@ -411,7 +420,12 @@ export function navigateTo(
 
   for (const [key, value] of Object.entries(params)) {
     if (value === null) url.searchParams.delete(key);
-    else url.searchParams.set(key, value);
+    else if (Array.isArray(value)) {
+      url.searchParams.delete(key);
+      for (const item of value) url.searchParams.append(key, item);
+    } else if (typeof value === "string") {
+      url.searchParams.set(key, value);
+    }
   }
   const changed = url.toString() !== window.location.href;
   if (options.replace) {

--- a/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
+++ b/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyDashboardFacetFilters } from "../dashboard-filtering";
+import { applyDashboardFacetFilters, matchesProjectFacet } from "../dashboard-filtering";
 
 const ALL_PROJECTS = "__all__";
 const identityRollup = (project: string) => project;
@@ -78,5 +78,20 @@ describe("dashboard facet filtering", () => {
     });
 
     expect(filtered.map((session) => session.slug)).toEqual(["cursor-1"]);
+  });
+
+  it("matches both canonical projects and explicitly shown run workspaces", () => {
+    const parent = "~/code/example";
+    const runWorkspace = `${parent}/run-abcdef123456`;
+    const rollup = (project: string) => (project === runWorkspace ? parent : project);
+
+    expect(matchesProjectFacet({ project: parent }, parent, ALL_PROJECTS, rollup)).toBe(true);
+    expect(matchesProjectFacet({ project: runWorkspace }, parent, ALL_PROJECTS, rollup)).toBe(true);
+    expect(matchesProjectFacet({ project: runWorkspace }, runWorkspace, ALL_PROJECTS, rollup)).toBe(
+      true,
+    );
+    expect(matchesProjectFacet({ project: parent }, runWorkspace, ALL_PROJECTS, rollup)).toBe(
+      false,
+    );
   });
 });

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -167,4 +167,30 @@ describe("rollupInsights", () => {
       projects: 2,
     });
   });
+
+  it("counts collapsed worktrees as one canonical project", () => {
+    const project = "~/code/example";
+    const worktree = `${project}/.claude/worktrees/feature`;
+    const payload: InsightsRollupPayload = {
+      sessions: [
+        {
+          project,
+          startTime: "2026-08-20T12:00:00Z",
+          prompts: 1,
+          edits: 0,
+          toolCalls: 0,
+        },
+        {
+          project: worktree,
+          startTime: "2026-08-20T13:00:00Z",
+          prompts: 1,
+          edits: 0,
+          toolCalls: 0,
+        },
+      ],
+      replays: [{ project: worktree, startTime: "2026-08-20T14:00:00Z" }],
+    };
+
+    expect(rollupInsights(payload).projects).toBe(1);
+  });
 });

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -143,4 +143,28 @@ describe("rollupInsights", () => {
 
     expect(result).toMatchObject({ sessions: 1, prompts: 1, edits: 0, toolCalls: 0 });
   });
+
+  it.each([30, 500])("aggregates exact bounded totals for %d sessions", (sessionCount) => {
+    const sessions = Array.from({ length: sessionCount }, (_, index) => ({
+      project: `~/code/project-${index % 2}`,
+      startTime: "2026-08-20T12:00:00Z",
+      durationMs: 1_000,
+      cost: 0.25,
+      prompts: 2,
+      edits: 1,
+      toolCalls: 3,
+    }));
+    const replays = sessions.map(({ project, startTime }) => ({ project, startTime }));
+
+    expect(rollupInsights({ sessions, replays }, { since: "2026-08-20T00:00:00Z" })).toEqual({
+      sessions: sessionCount,
+      replays: sessionCount,
+      durationMs: sessionCount * 1_000,
+      cost: sessionCount * 0.25,
+      prompts: sessionCount * 2,
+      edits: sessionCount,
+      toolCalls: sessionCount * 3,
+      projects: 2,
+    });
+  });
 });

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { rangeSince, rollupInsights, type InsightsRollupPayload } from "../insights-rollup";
+
+const payload: InsightsRollupPayload = {
+  sessions: [
+    {
+      project: "~/code/recent",
+      startTime: "2026-08-20T12:00:00-07:00",
+      durationMs: 60_000,
+      cost: 3,
+      prompts: 10,
+      edits: 8,
+      toolCalls: 40,
+    },
+    {
+      project: "~/code/recent",
+      startTime: "2026-08-19T10:00:00Z",
+      durationMs: 5_000,
+      cost: 0.25,
+      prompts: 2,
+      edits: 1,
+      toolCalls: 3,
+    },
+    {
+      project: "~/code/old",
+      startTime: "2026-01-01T00:00:00Z",
+      durationMs: 600_000,
+      cost: 20,
+      prompts: 100,
+      edits: 70,
+      toolCalls: 400,
+    },
+    {
+      project: "~/code/unknown",
+      durationMs: 1_000,
+      cost: 0.1,
+      prompts: 1,
+      edits: 0,
+      toolCalls: 1,
+    },
+  ],
+  replays: [
+    {
+      project: "~/code/recent",
+      startTime: "2026-08-20T12:00:00-07:00",
+    },
+    {
+      project: "~/code/old",
+      startTime: "2026-01-01T00:00:00Z",
+    },
+    {
+      project: "~/code/replay-only",
+      startTime: "2026-08-18T09:00:00Z",
+    },
+    {
+      project: "~/code/unknown",
+    },
+  ],
+};
+
+describe("rollupInsights", () => {
+  it("sums exact metrics instead of scaling all-time totals", () => {
+    expect(rollupInsights(payload, { since: "2026-08-15T00:00:00Z" })).toEqual({
+      sessions: 2,
+      replays: 2,
+      durationMs: 65_000,
+      cost: 3.25,
+      prompts: 12,
+      edits: 9,
+      toolCalls: 43,
+      projects: 2,
+    });
+  });
+
+  it("keeps undated sessions and replays only in all-time totals", () => {
+    expect(rollupInsights(payload)).toEqual({
+      sessions: 4,
+      replays: 4,
+      durationMs: 666_000,
+      cost: 23.35,
+      prompts: 113,
+      edits: 79,
+      toolCalls: 444,
+      projects: 4,
+    });
+  });
+
+  it("compares offset timestamps as instants", () => {
+    const result = rollupInsights(payload, { since: "2026-08-20T18:30:00Z" });
+    expect(result.sessions).toBe(1);
+    expect(result.prompts).toBe(10);
+  });
+
+  it("includes sessions exactly on the cutoff instant", () => {
+    const result = rollupInsights(payload, { since: "2026-08-20T19:00:00Z" });
+    expect(result.sessions).toBe(1);
+    expect(result.durationMs).toBe(60_000);
+  });
+
+  it("starts each bounded range at local midnight", () => {
+    const now = new Date(2026, 7, 20, 15, 30, 45, 123);
+    const expected = new Date(now.getTime());
+    expected.setHours(0, 0, 0, 0);
+    expected.setDate(expected.getDate() - 6);
+
+    expect(rangeSince("7d", now)).toBe(expected.toISOString());
+    expect(rangeSince("30d", now)).toBe(
+      (() => {
+        const cutoff = new Date(now.getTime());
+        cutoff.setHours(0, 0, 0, 0);
+        cutoff.setDate(cutoff.getDate() - 29);
+        return cutoff.toISOString();
+      })(),
+    );
+    expect(rangeSince("all", now)).toBeUndefined();
+  });
+
+  it("keeps the local-day boundary inclusive across timestamp offsets", () => {
+    const now = new Date(2026, 7, 20, 12);
+    const since = rangeSince("7d", now)!;
+    const result = rollupInsights(
+      {
+        sessions: [
+          {
+            project: "~/code/boundary",
+            startTime: since,
+            prompts: 1,
+            edits: 0,
+            toolCalls: 0,
+          },
+          {
+            project: "~/code/boundary",
+            startTime: new Date(Date.parse(since) - 1).toISOString(),
+            prompts: 99,
+            edits: 99,
+            toolCalls: 99,
+          },
+        ],
+        replays: [],
+      },
+      { since },
+    );
+
+    expect(result).toMatchObject({ sessions: 1, prompts: 1, edits: 0, toolCalls: 0 });
+  });
+});

--- a/packages/viewer/src/engine/dashboard-filtering.ts
+++ b/packages/viewer/src/engine/dashboard-filtering.ts
@@ -34,7 +34,11 @@ export function matchesProjectFacet(
   allProjectsKey: string,
   rollupProject: (project: string) => string,
 ): boolean {
-  return selectedProjectKey === allProjectsKey || rollupProject(s.project) === selectedProjectKey;
+  return (
+    selectedProjectKey === allProjectsKey ||
+    s.project === selectedProjectKey ||
+    rollupProject(s.project) === selectedProjectKey
+  );
 }
 
 function matchesMultiValueFacet(

--- a/packages/viewer/src/engine/insights-rollup.ts
+++ b/packages/viewer/src/engine/insights-rollup.ts
@@ -1,3 +1,5 @@
+import { rollupProject } from "../components/dashboard-utils";
+
 export interface InsightsMetricSession {
   project: string;
   startTime?: string;
@@ -82,7 +84,7 @@ export function rollupInsights(
   let toolCalls = 0;
 
   for (const session of sessions) {
-    if (session.project) projects.add(session.project);
+    if (session.project) projects.add(rollupProject(session.project));
     durationMs += session.durationMs || 0;
     cost += session.cost || 0;
     prompts += session.prompts;
@@ -90,7 +92,7 @@ export function rollupInsights(
     toolCalls += session.toolCalls;
   }
   for (const replay of replays) {
-    if (replay.project) projects.add(replay.project);
+    if (replay.project) projects.add(rollupProject(replay.project));
   }
 
   return {

--- a/packages/viewer/src/engine/insights-rollup.ts
+++ b/packages/viewer/src/engine/insights-rollup.ts
@@ -1,0 +1,106 @@
+export interface InsightsMetricSession {
+  project: string;
+  startTime?: string;
+  durationMs?: number;
+  cost?: number;
+  prompts: number;
+  edits: number;
+  toolCalls: number;
+}
+
+export interface InsightsReplayRef {
+  project: string;
+  startTime?: string;
+}
+
+export interface InsightsRollupPayload {
+  sessions: InsightsMetricSession[];
+  replays: InsightsReplayRef[];
+}
+
+export interface InsightsRangeStats {
+  sessions: number;
+  replays: number;
+  durationMs: number;
+  cost: number;
+  prompts: number;
+  edits: number;
+  toolCalls: number;
+  projects: number;
+}
+
+export type InsightsRange = "7d" | "30d" | "90d" | "all";
+
+export function rangeDays(range: InsightsRange): number {
+  if (range === "7d") return 7;
+  if (range === "30d") return 30;
+  if (range === "90d") return 90;
+  return 0;
+}
+
+/**
+ * Return the instant for the first local calendar day in a range.
+ * A 7d range is today plus the six preceding local calendar days, including
+ * the full local day even when the viewer's timezone is west of UTC or crosses
+ * a daylight-saving transition.
+ */
+export function rangeSince(range: InsightsRange, now = new Date()): string | undefined {
+  const days = rangeDays(range);
+  if (days === 0) return undefined;
+  const cutoff = new Date(now.getTime());
+  cutoff.setHours(0, 0, 0, 0);
+  cutoff.setDate(cutoff.getDate() - (days - 1));
+  return cutoff.toISOString();
+}
+
+function isInRange(startTime: string | undefined, cutoffMs: number): boolean {
+  if (Number.isNaN(cutoffMs)) return true;
+  if (!Number.isFinite(cutoffMs)) return false;
+  if (!startTime) return false;
+  const startedMs = Date.parse(startTime);
+  return Number.isFinite(startedMs) && startedMs >= cutoffMs;
+}
+
+/**
+ * Aggregate exact per-session metrics for a selected time range.
+ *
+ * Unknown timestamps stay in all-time totals but are excluded from bounded
+ * ranges so a value labelled "last 30 days" never includes undated history.
+ */
+export function rollupInsights(
+  payload: InsightsRollupPayload,
+  { since }: { since?: string } = {},
+): InsightsRangeStats {
+  const cutoffMs = since ? Date.parse(since) : Number.NaN;
+  const sessions = payload.sessions.filter((session) => isInRange(session.startTime, cutoffMs));
+  const replays = payload.replays.filter((replay) => isInRange(replay.startTime, cutoffMs));
+  const projects = new Set<string>();
+  let durationMs = 0;
+  let cost = 0;
+  let prompts = 0;
+  let edits = 0;
+  let toolCalls = 0;
+
+  for (const session of sessions) {
+    if (session.project) projects.add(session.project);
+    durationMs += session.durationMs || 0;
+    cost += session.cost || 0;
+    prompts += session.prompts;
+    edits += session.edits;
+    toolCalls += session.toolCalls;
+  }
+  for (const replay of replays) {
+    if (replay.project) projects.add(replay.project);
+  }
+
+  return {
+    sessions: sessions.length,
+    replays: replays.length,
+    durationMs,
+    cost,
+    prompts,
+    edits,
+    toolCalls,
+    projects: projects.size,
+  };
+}

--- a/packages/viewer/src/hooks/usePanelFilters.ts
+++ b/packages/viewer/src/hooks/usePanelFilters.ts
@@ -3,23 +3,14 @@ import { navigateTo } from "../components/dashboard-utils";
 
 export const ALL_PROJECTS = "__all__";
 
-function getMultiFromUrl(param: string): string[] {
-  const raw = new URLSearchParams(window.location.search).get(param);
-  if (!raw) return [];
-  return raw
-    .split(",")
-    .map((v) => {
-      try {
-        return decodeURIComponent(v.trim());
-      } catch {
-        return v.trim();
-      }
-    })
-    .filter(Boolean);
+export function getMultiFromUrl(param: string): string[] {
+  return new URLSearchParams(window.location.search)
+    .getAll(param)
+    .filter((value) => value.length > 0);
 }
 
-function multiParam(values: readonly string[]): string | null {
-  return values.length > 0 ? values.map(encodeURIComponent).join(",") : null;
+function multiParam(values: readonly string[]): readonly string[] | null {
+  return values.length > 0 ? [...values] : null;
 }
 
 function getProjectFromUrl(): string {


### PR DESCRIPTION
## Summary
- replace proportional 7d/30d/90d Insights estimates with exact per-session rollups using local-calendar boundaries
- add a compact `/api/insights/rollup` projection that excludes conversation and tool content
- make tool, MCP server/tool, and skill usage facets link to filtered Sessions views
- lazily fetch selected-project insights and render turn-duration percentiles/histograms plus token breakdowns

## Validation
- `pnpm test`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm build`
- validated the local dataset: 2,435 scanned sessions, 102 replay summaries, compact rollup response, and selected-project performance data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Insights charts for turn durations and token usage, including percentages, totals, and percentile summaries.
  - Added project-specific performance insights with data-quality indicators and loading states.
  - Added clickable usage metrics that open filtered session views.
  - Added accurate 7-, 30-, and 90-day Insights ranges, plus all-time totals.
  - Added automatic refresh of Insights after scans complete.

- **Bug Fixes**
  - Corrected date-range filtering, inclusive boundaries, timezone handling, and treatment of undated records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->