### PR TITLE
fix(insights): scope metrics and drilldowns to selected ranges

### DIFF
--- a/packages/cli/src/insights-rollup.ts
+++ b/packages/cli/src/insights-rollup.ts
@@ -9,6 +9,16 @@ export interface InsightsRollupSession {
   prompts: number;
   edits: number;
   toolCalls: number;
+  /** Included by the dashboard endpoint for range-scoped secondary charts. */
+  provider?: string;
+  model?: string;
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  };
+  turnDurations?: number[];
 }
 
 export interface InsightsRollupReplay {
@@ -23,23 +33,35 @@ export interface InsightsRollupPayload {
 
 /**
  * Project only the fields needed for exact time-range totals.
- * Deliberately omit prompts, tool arguments/results, titles, file paths, and
- * usage events: the Insights page only needs additive per-session metrics.
+ * Deliberately omit tool arguments/results, titles, file paths, and usage
+ * events: the Insights page only needs additive per-session metrics. The
+ * dashboard requests the optional detail fields for range-scoped breakdowns.
  */
 export function buildInsightsRollup(
   scans: readonly SessionScanResult[],
   replays: readonly ReplaySummary[],
+  options: { includeDetails?: boolean } = {},
 ): InsightsRollupPayload {
+  const includeDetails = options.includeDetails === true;
   return {
-    sessions: scans.map((scan) => ({
-      project: scan.project,
-      startTime: scan.startTime,
-      durationMs: scan.durationMs,
-      cost: scan.costEstimate,
-      prompts: scan.promptCount,
-      edits: scan.editCount,
-      toolCalls: scan.toolCallCount,
-    })),
+    sessions: scans.map((scan) => {
+      const session: InsightsRollupSession = {
+        project: scan.project,
+        startTime: scan.startTime,
+        durationMs: scan.durationMs,
+        cost: scan.costEstimate,
+        prompts: scan.promptCount,
+        edits: scan.editCount,
+        toolCalls: scan.toolCallCount,
+      };
+      if (includeDetails) {
+        session.provider = scan.provider;
+        session.model = scan.model;
+        session.tokenUsage = scan.tokenUsage;
+        session.turnDurations = scan.turnDurations;
+      }
+      return session;
+    }),
     replays: replays.map((replay) => ({
       project: replay.project,
       startTime: replay.startTime,

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -41,7 +41,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v19: the usage index distinguishes sessions that were scanned and found to
 // have no usage from sessions whose rich usage scan was deferred. Cached v18
 // results cannot make that distinction.
-export const SCANNER_VERSION = 19;
+// v20: normalize placeholder MCP server names in cached usage summaries.
+export const SCANNER_VERSION = 20;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -135,6 +136,11 @@ function stripCursorServerScope(server: string): string {
   const scopeIndex = server.indexOf("::mcpScope:");
   const base = scopeIndex > 0 ? server.slice(0, scopeIndex) : server;
   return base.startsWith("user-") ? base.slice("user-".length) : base;
+}
+
+function normalizeMcpServerName(server: string): string {
+  const normalized = server.trim();
+  return normalized === "" || normalized === "-" ? "Unknown" : normalized;
 }
 
 /** Cursor tools that manage MCP itself rather than call a server. */
@@ -267,7 +273,9 @@ function toolUsageEvent(
         attribution: "explicit" as const,
       }
     : parseMcpUsage(name, options.input);
-  const serverName = mcp && (options.mcpServerNames?.[mcp.server] || mcp.server);
+  const serverName = mcp
+    ? normalizeMcpServerName(options.mcpServerNames?.[mcp.server] || mcp.server)
+    : undefined;
   return {
     kind: "tool",
     name,
@@ -288,7 +296,7 @@ function summarizeUsage(
   mcpServersUsed?: Iterable<string>,
 ): SessionUsageSummary | undefined {
   const skills = skillsUsed ? [...skillsUsed] : [];
-  const mcpServers = mcpServersUsed ? [...mcpServersUsed] : [];
+  const mcpServers = mcpServersUsed ? [...mcpServersUsed].map(normalizeMcpServerName) : [];
   if (events.length === 0 && skills.length === 0 && mcpServers.length === 0) return undefined;
   const summary: SessionUsageSummary = {
     tools: {},
@@ -821,7 +829,9 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
       if (!model && obj.message.model && obj.message.model !== "<synthetic>") {
         model = obj.message.model;
       }
-      if (obj.attributionMcpServer) mcpServersUsed.add(obj.attributionMcpServer);
+      if (obj.attributionMcpServer) {
+        mcpServersUsed.add(normalizeMcpServerName(obj.attributionMcpServer));
+      }
       if (obj.attributionSkill) skillsUsed.add(obj.attributionSkill);
 
       // Tool results carry the outcome of an earlier tool_use block, which is
@@ -1355,7 +1365,9 @@ function buildScanResultFromParsed(
     });
   }
   const derivedMcpServers = new Set(
-    (parsed.mcpServersUsed || []).map((server) => parsed.mcpServerNames?.[server] || server),
+    (parsed.mcpServersUsed || []).map((server) =>
+      normalizeMcpServerName(parsed.mcpServerNames?.[server] || server),
+    ),
   );
   for (const event of usageEvents) {
     if (event.mcpServer) derivedMcpServers.add(event.mcpServer);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -2238,9 +2238,9 @@ export async function startServer(
     });
   });
 
-  // Compact per-session projection for exact 7d/30d/90d insight totals.
-  // Conversation content and tool inputs/results intentionally never leave the
-  // scanner here; the viewer only needs additive metrics and timestamps.
+  // Compact per-session projection for exact 7d/30d/90d insight totals and
+  // range-scoped secondary breakdowns. Conversation content and tool
+  // inputs/results intentionally never leave the scanner here.
   app.get("/api/insights/rollup", async (c) => {
     if (!scanState.hasSnapshot) {
       return c.json({ error: "No scan results available. Start a scan first." }, 503);
@@ -2253,7 +2253,7 @@ export async function startServer(
       const cachedReplays = await readFileCache<ReplaySummary[]>(replaysCacheKey);
       replays = cachedReplays?.data || [];
     }
-    return c.json(buildInsightsRollup(scanState.results, replays));
+    return c.json(buildInsightsRollup(scanState.results, replays, { includeDetails: true }));
   });
 
   app.get("/api/insights", async (c) => {

--- a/packages/cli/test/insights-rollup.test.ts
+++ b/packages/cli/test/insights-rollup.test.ts
@@ -65,6 +65,32 @@ function makeReplay(overrides: Partial<ReplaySummary> = {}): ReplaySummary {
 }
 
 describe("buildInsightsRollup", () => {
+  it("can include secondary range fields without conversation content", () => {
+    const payload = buildInsightsRollup(
+      [
+        makeScan({
+          model: "claude-sonnet-4",
+          turnDurations: [10_000, 45_000],
+        }),
+      ],
+      [],
+      { includeDetails: true },
+    );
+
+    expect(payload.sessions[0]).toMatchObject({
+      provider: "claude-code",
+      model: "claude-sonnet-4",
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 30,
+        cacheCreationTokens: 40,
+      },
+      turnDurations: [10_000, 45_000],
+    });
+    expect(JSON.stringify(payload)).not.toContain("private");
+  });
+
   it("keeps only compact additive metrics and timestamps", () => {
     const payload = buildInsightsRollup(
       [makeScan()],

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -436,6 +436,35 @@ describe("scanSession", () => {
     expect(result.usageSummary?.skills).toEqual({ "browser-skill": 1 });
   });
 
+  it("normalizes placeholder MCP server names to Unknown", async () => {
+    const path = join(tmpDir, "usage-unknown-mcp.jsonl");
+    await writeFile(
+      path,
+      makeLine({
+        type: "assistant",
+        attributionMcpServer: "-",
+        attributionMcpTool: "search",
+        timestamp: "2025-03-20T10:00:00Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "unknown-mcp", name: "Browser", input: {} }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "usage-unknown-mcp",
+      provider: "claude-code",
+      project: "~/test/project",
+      slug: "usage-unknown-mcp",
+      filePaths: [path],
+    });
+
+    expect(result.usageSummary?.mcpServers).toEqual({ Unknown: 1 });
+    expect(result.usageSummary?.mcpTools).toEqual({ "Unknown/search": 1 });
+  });
+
   it("resolves MCP server and tool from Cursor's dashed tool naming", async () => {
     const path = join(tmpDir, "usage-cursor-mcp.jsonl");
     await writeFile(

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useOutsideClick } from "../hooks/useOutsideClick";
 import { ALL_PROJECTS, usePanelFilters } from "../hooks/usePanelFilters";
 import type { SessionSummary, SessionUsageSummary, SourceSession } from "../types";
 import DashboardHome from "./DashboardHome";
+import { isInInsightsRange, rangeSince as insightsRangeSince } from "../engine/insights-rollup";
 import {
   applyDashboardFacetFilters,
   matchesProjectFacet,
@@ -32,6 +33,8 @@ import {
   navigateToLive,
   nonDefaultBranch,
   normalizeTitleText,
+  normalizeMcpServerName,
+  normalizeMcpToolName,
   parseCachedList,
   projectName,
   providerDisplayName,
@@ -152,6 +155,14 @@ export interface SessionScanData {
   gitBranches?: string[];
   dataSource?: string;
   dataQualityNotes?: string[];
+}
+
+/** Use the scanner's session start when range filtering, with discovery as a fallback. */
+export function getSessionRangeTimestamp(
+  source: SourceSession,
+  scanData?: SessionScanData | null,
+): string | undefined {
+  return scanData?.startTime || source.timestamp;
 }
 
 interface RawJsonItem {
@@ -631,10 +642,10 @@ export function SessionDetailPopup({
             ))}
             {scanData?.mcpServersUsed?.map((server) => (
               <span
-                key={server}
+                key={normalizeMcpServerName(server)}
                 className="text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-purple-500/10 text-purple-400"
               >
-                {server}
+                {normalizeMcpServerName(server)}
               </span>
             ))}
             {s.replay?.replayOutdated && (
@@ -717,7 +728,10 @@ export function SessionDetailPopup({
                 <InfoRow label="Skills" value={scanData.skillsUsed.join(", ")} />
               )}
               {scanData?.mcpServersUsed && scanData.mcpServersUsed.length > 0 && (
-                <InfoRow label="MCP Servers" value={scanData.mcpServersUsed.join(", ")} />
+                <InfoRow
+                  label="MCP Servers"
+                  value={scanData.mcpServersUsed.map(normalizeMcpServerName).join(", ")}
+                />
               )}
               <InfoRow label="Started" value={`${formatDate(startedAt)} (${timeAgo(startedAt)})`} />
               {scanData?.endTime && <InfoRow label="Ended" value={formatDate(scanData.endTime)} />}
@@ -1562,8 +1576,8 @@ function multiFacetCountMap<T>(
 function usageFacetValues(scanData?: SessionScanData) {
   return {
     tools: Object.keys(scanData?.usageSummary?.tools || {}),
-    mcpServers: Object.keys(scanData?.usageSummary?.mcpServers || {}),
-    mcpTools: Object.keys(scanData?.usageSummary?.mcpTools || {}),
+    mcpServers: Object.keys(scanData?.usageSummary?.mcpServers || {}).map(normalizeMcpServerName),
+    mcpTools: Object.keys(scanData?.usageSummary?.mcpTools || {}).map(normalizeMcpToolName),
     skills: Object.keys(scanData?.usageSummary?.skills || {}),
   };
 }
@@ -1901,6 +1915,7 @@ function SessionsPanel() {
     filter,
     showArchived,
     showAgentRuns,
+    insightsRange,
     selectedProviders,
     selectedRepos,
     selectedTools,
@@ -1919,6 +1934,7 @@ function SessionsPanel() {
     handleSkillToggle,
     handleToggleArchived,
     handleToggleAgentRuns,
+    handleClearInsightsRange,
     handleClearAllFilters,
   } = usePanelFilters();
 
@@ -2200,18 +2216,29 @@ function SessionsPanel() {
     () => (showArchived ? sources : sources.filter((s) => !archivedSlugs.has(s.slug))),
     [archivedSlugs, showArchived, sources],
   );
+  const selectedRangeSince = insightsRangeSince(insightsRange);
+  const rangeUnarchivedSources = useMemo(
+    () =>
+      unarchivedSources.filter((source) =>
+        isInInsightsRange(
+          getSessionRangeTimestamp(source, scanResultsBySlug[source.slug]),
+          selectedRangeSince,
+        ),
+      ),
+    [scanResultsBySlug, selectedRangeSince, unarchivedSources],
+  );
   // One-off scratch workspaces are hidden by default: a machine that reviews
   // PRs or triages alerts on a schedule accumulates far more of them than real
   // projects, and each one is a single session the user never opened by hand.
   const agentRunCount = new Set(
-    unarchivedSources.filter((s) => isAgentRunWorkspace(s.project)).map((s) => s.project),
+    rangeUnarchivedSources.filter((s) => isAgentRunWorkspace(s.project)).map((s) => s.project),
   ).size;
   const visibleSources = useMemo(
     () =>
       showAgentRuns
-        ? unarchivedSources
-        : unarchivedSources.filter((s) => !isAgentRunWorkspace(s.project)),
-    [showAgentRuns, unarchivedSources],
+        ? rangeUnarchivedSources
+        : rangeUnarchivedSources.filter((s) => !isAgentRunWorkspace(s.project)),
+    [rangeUnarchivedSources, showAgentRuns],
   );
 
   const selectedProviderSet = new Set(selectedProviders);
@@ -2370,7 +2397,8 @@ function SessionsPanel() {
     selectedMcpServers.length > 0 ||
     selectedMcpTools.length > 0 ||
     selectedSkills.length > 0 ||
-    selectedProjectKey !== ALL_PROJECTS;
+    selectedProjectKey !== ALL_PROJECTS ||
+    insightsRange !== "all";
   const [renderLimit, setRenderLimit] = useState(SESSION_RENDER_BATCH_SIZE);
   const providerFilterKey = selectedProviders.join("\0");
   const repoFilterKey = selectedRepos.join("\0");
@@ -2383,6 +2411,7 @@ function SessionsPanel() {
     selectedMcpTools.join("\0"),
     selectedSkills.join("\0"),
     selectedProjectKey,
+    insightsRange,
     showArchived ? "archived" : "active",
     showAgentRuns ? "agent-runs" : "no-agent-runs",
   ].join("\0");
@@ -2397,6 +2426,7 @@ function SessionsPanel() {
     selectedMcpTools,
     selectedSkills,
     selectedProjectKey,
+    insightsRange,
     showArchived,
     showAgentRuns,
   ]);
@@ -2814,6 +2844,13 @@ function SessionsPanel() {
                     onRemove={() => handleFilterChange("")}
                   />
                 )}
+                {insightsRange !== "all" && (
+                  <ActiveFilterChip
+                    label="Range"
+                    value={insightsRange}
+                    onRemove={handleClearInsightsRange}
+                  />
+                )}
                 {selectedProviders.map((provider) => (
                   <ActiveFilterChip
                     key={provider}
@@ -2923,6 +2960,13 @@ function SessionsPanel() {
                   label="Search"
                   value={filter}
                   onRemove={() => handleFilterChange("")}
+                />
+              )}
+              {insightsRange !== "all" && (
+                <ActiveFilterChip
+                  label="Range"
+                  value={insightsRange}
+                  onRemove={handleClearInsightsRange}
                 />
               )}
               {selectedProviders.map((provider) => (
@@ -4483,6 +4527,7 @@ export default function Dashboard({
         archived: null,
         provider: null,
         repo: null,
+        insightsRange: null,
         replay: null,
       });
     };
@@ -4500,6 +4545,7 @@ export default function Dashboard({
       archived: null,
       provider: null,
       repo: null,
+      insightsRange: null,
       replay: null,
     });
   };

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -2240,6 +2240,13 @@ function SessionsPanel() {
         : rangeUnarchivedSources.filter((s) => !isAgentRunWorkspace(s.project)),
     [rangeUnarchivedSources, showAgentRuns],
   );
+  const baseSourceCount = useMemo(
+    () =>
+      showAgentRuns
+        ? unarchivedSources.length
+        : unarchivedSources.filter((s) => !isAgentRunWorkspace(s.project)).length,
+    [showAgentRuns, unarchivedSources],
+  );
 
   const selectedProviderSet = new Set(selectedProviders);
   const selectedRepoSet = new Set(selectedRepos);
@@ -2811,12 +2818,12 @@ function SessionsPanel() {
                   <span className="text-xs font-mono text-terminal-dimmer shrink-0">
                     {hasActiveFilters
                       ? `${filtered.length.toLocaleString()} matching`
-                      : `${visibleSources.length.toLocaleString()} local sessions`}
+                      : `${baseSourceCount.toLocaleString()} local sessions`}
                   </span>
                 </div>
                 <div className="mt-0.5 text-xs font-mono text-terminal-dimmer">
                   {hasActiveFilters
-                    ? `Filtered from ${visibleSources.length.toLocaleString()} local sessions`
+                    ? `Filtered from ${baseSourceCount.toLocaleString()} local sessions`
                     : "Use sidebar facets or search to narrow the list"}
                   {showArchived && " · including archived"}
                 </div>

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -16,11 +16,15 @@ import {
 } from "../engine/usage-rollup";
 import {
   rollupInsights,
+  rollupInsightsBreakdown,
+  type InsightsRange,
+  type InsightsRangeBreakdown,
   type InsightsRangeStats,
   type InsightsRollupPayload,
   rangeSince as insightsRangeSince,
 } from "../engine/insights-rollup";
 import { AnimatedValue } from "../hooks/useAnimatedNumber";
+import { getInsightsRangeFromUrl, INSIGHTS_RANGE_PARAM } from "../hooks/usePanelFilters";
 import type { SessionSummary, SourceSession } from "../types";
 import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
@@ -29,8 +33,8 @@ import {
   formatCompactAge,
   formatCompactDuration,
   navigateTo,
+  computeProjectLabels,
   parseCachedList,
-  projectName,
   providerBarClass,
   providerDisplayName,
   rollupTopProjects,
@@ -41,7 +45,7 @@ import { formatDuration } from "./StatsPanel";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
-type TimeRange = "7d" | "30d" | "90d" | "all";
+type TimeRange = InsightsRange;
 
 interface UsageRollupPayload {
   sessions: UsageRollupSession[];
@@ -749,7 +753,7 @@ function DayOfWeekChart({ data }: { data: DayOfWeekStats[] }) {
 
 // ─── Top Projects ───────────────────────────────────────────────────
 
-function TopProjectsList({
+export function TopProjectsList({
   projects,
 }: {
   projects: Array<{
@@ -768,16 +772,20 @@ function TopProjectsList({
   }
 
   const maxSessions = Math.max(...projects.map((p) => p.sessions), 1);
+  const projectLabels = computeProjectLabels(projects.map((p) => p.project));
 
   return (
     <div className="space-y-2">
       {projects.slice(0, 8).map((p) => {
-        const name = projectName(p.project);
+        const name = projectLabels.get(p.project) || p.project;
         const pct = (p.sessions / maxSessions) * 100;
         return (
           <div key={p.project} className="space-y-1">
             <div className="flex items-center justify-between">
-              <span className="text-xs font-sans font-medium text-terminal-text truncate max-w-[60%]">
+              <span
+                className="text-xs font-sans font-medium text-terminal-text truncate max-w-[60%]"
+                title={p.project}
+              >
                 {name}
               </span>
               <span className="text-[10px] font-mono text-terminal-dim tabular-nums">
@@ -1229,7 +1237,11 @@ function useUsageRollupSessions(
 
 // ─── Tool & MCP Usage ───────────────────────────────────────────────
 
-export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "skill", name: string) {
+export function navigateToUsageSessions(
+  facet: "tool" | "mcp" | "mcpTool" | "skill",
+  name: string,
+  range: TimeRange = "all",
+) {
   navigateTo({
     view: "dashboard",
     session: null,
@@ -1245,6 +1257,7 @@ export function navigateToUsageSessions(facet: "tool" | "mcp" | "mcpTool" | "ski
     archived: "true",
     agentRuns: "true",
     replay: null,
+    [INSIGHTS_RANGE_PARAM]: range === "all" ? null : range,
     [facet]: [name],
   });
 }
@@ -1315,7 +1328,16 @@ export function UsageBarList({
 export default function InsightsPage() {
   const { userInsights, loading, scanStatus } = useScanInsightsContext();
   const homePageCounts = useHomePageCounts();
-  const [range, setRange] = useState<TimeRange>("all");
+  const [range, setRange] = useState<TimeRange>(getInsightsRangeFromUrl);
+  const handleRangeChange = useCallback((next: TimeRange) => {
+    setRange(next);
+    navigateTo({ [INSIGHTS_RANGE_PARAM]: next === "all" ? null : next }, { notify: false });
+  }, []);
+  useEffect(() => {
+    const handlePopState = () => setRange(getInsightsRangeFromUrl());
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
   const {
     payload: insightsRollupPayload,
     loading: insightsRollupLoading,
@@ -1324,68 +1346,92 @@ export default function InsightsPage() {
 
   const isInitialScan = scanStatus?.running && !userInsights;
 
-  const { stats, streak, dayOfWeek, bestDay, peak, weeklyTrend, activeDays, firstSessionDate } =
-    useMemo(() => {
-      if (!userInsights) {
-        return {
-          stats: {
-            sessions: 0,
-            replays: 0,
-            durationMs: 0,
-            cost: 0,
-            prompts: 0,
-            edits: 0,
-            toolCalls: 0,
-            projects: 0,
-          },
-          streak: { current: 0, longest: 0 },
-          dayOfWeek: [],
-          bestDay: null,
-          peak: null,
-          weeklyTrend: [],
-          activeDays: 0,
-          firstSessionDate: null,
-        };
-      }
-
-      const spd = userInsights.sessionsPerDay || {};
-      const filtered = filterSessionsByRange(spd, range);
-      const s = insightsRollupPayload
-        ? rollupInsights(insightsRollupPayload, { since: rangeSince(range) })
-        : {
-            sessions: userInsights.totalSessions,
-            replays: homePageCounts?.replays ?? 0,
-            durationMs: userInsights.totalDurationMs,
-            cost: userInsights.totalCost,
-            prompts: userInsights.totalPrompts,
-            edits: userInsights.totalEdits,
-            toolCalls: userInsights.totalToolCalls,
-            projects: userInsights.totalProjects,
-          };
-      const sk = computeStreak(spd); // always compute streak from all data
-      const dow = computeDayOfWeek(filtered);
-      const best = [...dow].sort((a, b) => b.count - a.count)[0] || null;
-      const pk = peakDay(filtered);
-      const wt = computeWeeklyTrend(spd, 12);
-      const ad = Object.values(filtered).filter((v) => v > 0).length;
-      const first = userInsights.timeRange?.first || null;
-
+  const {
+    stats,
+    streak,
+    dayOfWeek,
+    bestDay,
+    peak,
+    weeklyTrend,
+    activeDays,
+    firstSessionDate,
+    sessionsPerDay,
+  } = useMemo(() => {
+    if (!userInsights) {
       return {
-        stats: s,
-        streak: sk,
-        dayOfWeek: dow,
-        bestDay: best,
-        peak: pk,
-        weeklyTrend: wt,
-        activeDays: ad,
-        firstSessionDate: first,
+        stats: {
+          sessions: 0,
+          replays: 0,
+          durationMs: 0,
+          cost: 0,
+          prompts: 0,
+          edits: 0,
+          toolCalls: 0,
+          projects: 0,
+        },
+        streak: { current: 0, longest: 0 },
+        dayOfWeek: [],
+        bestDay: null,
+        peak: null,
+        weeklyTrend: [],
+        activeDays: 0,
+        firstSessionDate: null,
+        sessionsPerDay: {},
       };
-    }, [userInsights, range, homePageCounts, insightsRollupPayload]);
+    }
+
+    const spd = userInsights.sessionsPerDay || {};
+    const filtered = filterSessionsByRange(spd, range);
+    const s = insightsRollupPayload
+      ? rollupInsights(insightsRollupPayload, { since: rangeSince(range) })
+      : {
+          sessions: userInsights.totalSessions,
+          replays: homePageCounts?.replays ?? 0,
+          durationMs: userInsights.totalDurationMs,
+          cost: userInsights.totalCost,
+          prompts: userInsights.totalPrompts,
+          edits: userInsights.totalEdits,
+          toolCalls: userInsights.totalToolCalls,
+          projects: userInsights.totalProjects,
+        };
+    const sk = computeStreak(spd); // always compute streak from all data
+    const dow = computeDayOfWeek(filtered);
+    const best = [...dow].sort((a, b) => b.count - a.count)[0] || null;
+    const pk = peakDay(filtered);
+    const wt = computeWeeklyTrend(filtered, 12);
+    const ad = Object.values(filtered).filter((v) => v > 0).length;
+    const first = userInsights.timeRange?.first || null;
+
+    return {
+      stats: s,
+      streak: sk,
+      dayOfWeek: dow,
+      bestDay: best,
+      peak: pk,
+      weeklyTrend: wt,
+      activeDays: ad,
+      firstSessionDate: first,
+      sessionsPerDay: filtered,
+    };
+  }, [userInsights, range, homePageCounts, insightsRollupPayload]);
+
+  const rangeBreakdown = useMemo<InsightsRangeBreakdown | null>(() => {
+    if (range === "all" || !insightsRollupPayload) return null;
+    return rollupInsightsBreakdown(insightsRollupPayload, { since: rangeSince(range) });
+  }, [insightsRollupPayload, range]);
 
   const rolledTopProjects = useMemo(
     () => rollupTopProjects(userInsights?.topProjects || []),
     [userInsights?.topProjects],
   );
+  const topProjects = range === "all" ? rolledTopProjects : (rangeBreakdown?.projects ?? []);
+  const models = range === "all" ? userInsights?.models || {} : (rangeBreakdown?.models ?? {});
+  const providers =
+    range === "all" ? userInsights?.providers || {} : (rangeBreakdown?.providers ?? {});
+  const tokenBreakdown =
+    range === "all" ? userInsights?.tokenBreakdown : rangeBreakdown?.tokenBreakdown;
+  const turnDurationHistogram =
+    range === "all" ? userInsights?.turnDurationHistogram : rangeBreakdown?.turnDurationHistogram;
 
   const usagePayload = useUsageRollupSessions(
     scanStatus?.finishedAt,
@@ -1414,7 +1460,7 @@ export default function InsightsPage() {
     return (
       <InsightsRangeLoadingState
         range={range}
-        onRangeChange={setRange}
+        onRangeChange={handleRangeChange}
         loading={insightsRollupLoading}
         error={insightsRollupError}
       />
@@ -1445,7 +1491,7 @@ export default function InsightsPage() {
             {(["7d", "30d", "90d", "all"] as TimeRange[]).map((r) => (
               <button
                 key={r}
-                onClick={() => setRange(r)}
+                onClick={() => handleRangeChange(r)}
                 className={`px-3 py-1.5 text-xs font-sans rounded-md transition-all ${
                   range === r
                     ? "bg-terminal-green-subtle text-terminal-green font-bold"
@@ -1493,9 +1539,9 @@ export default function InsightsPage() {
           stats={stats}
           streak={streak}
           bestDay={bestDay}
-          sessionsPerDay={userInsights.sessionsPerDay || {}}
+          sessionsPerDay={sessionsPerDay}
           range={range}
-          providers={userInsights.providers || {}}
+          providers={providers}
           dataQualityNotes={userInsights.dataQuality?.notes}
         />
 
@@ -1570,18 +1616,18 @@ export default function InsightsPage() {
         </div>
 
         {/* Turn Duration Distribution + Token Breakdown */}
-        {(userInsights.turnDurationHistogram || userInsights.tokenBreakdown) && (
+        {(turnDurationHistogram || tokenBreakdown) && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {userInsights.turnDurationHistogram && (
+            {turnDurationHistogram && (
               <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
                 <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
-                <TurnDurationChart histogram={userInsights.turnDurationHistogram} />
+                <TurnDurationChart histogram={turnDurationHistogram} />
               </div>
             )}
-            {userInsights.tokenBreakdown && (
+            {tokenBreakdown && (
               <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
                 <h3 className="ui-section-title-strong mb-4">Token Usage</h3>
-                <TokenBreakdownChart breakdown={userInsights.tokenBreakdown} />
+                <TokenBreakdownChart breakdown={tokenBreakdown} />
               </div>
             )}
           </div>
@@ -1605,7 +1651,7 @@ export default function InsightsPage() {
                   entries={usage.tools}
                   emptyLabel="No tool data"
                   unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("tool", name)}
+                  onSelect={(name) => navigateToUsageSessions("tool", name, range)}
                 />
               </div>
               <div>
@@ -1614,7 +1660,7 @@ export default function InsightsPage() {
                   entries={usage.mcpServers}
                   emptyLabel="No MCP data"
                   unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("mcp", name)}
+                  onSelect={(name) => navigateToUsageSessions("mcp", name, range)}
                 />
               </div>
             </div>
@@ -1625,7 +1671,7 @@ export default function InsightsPage() {
                   entries={usage.mcpTools}
                   emptyLabel="No MCP data"
                   unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("mcpTool", name)}
+                  onSelect={(name) => navigateToUsageSessions("mcpTool", name, range)}
                 />
               </div>
             )}
@@ -1636,7 +1682,7 @@ export default function InsightsPage() {
                   entries={usage.skills}
                   emptyLabel="No skill data"
                   unit="activations"
-                  onSelect={(name) => navigateToUsageSessions("skill", name)}
+                  onSelect={(name) => navigateToUsageSessions("skill", name, range)}
                 />
               </div>
             )}
@@ -1665,26 +1711,17 @@ export default function InsightsPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
             <h3 className="ui-section-title-strong mb-4">Top Projects</h3>
-            <TopProjectsList
-              projects={rolledTopProjects.map((p) => ({
-                project: p.project,
-                sessions: p.sessions,
-                cost: p.cost,
-                prompts: p.prompts,
-                durationMs: p.durationMs,
-                edits: p.edits,
-              }))}
-            />
+            <TopProjectsList projects={topProjects} />
           </div>
           <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-5">
             <div>
               <h3 className="ui-section-title-strong mb-4">Models</h3>
-              <ModelBreakdown models={userInsights.models || {}} />
+              <ModelBreakdown models={models} />
             </div>
-            {Object.keys(userInsights.providers || {}).length > 1 && (
+            {Object.keys(providers).length > 1 && (
               <div>
                 <h3 className="ui-section-title-strong mb-4">Providers</h3>
-                <ProviderBreakdown providers={userInsights.providers || {}} />
+                <ProviderBreakdown providers={providers} />
               </div>
             )}
           </div>

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stubBrowserAPIs } from "../../test-utils/jsdom-stubs";
-import Dashboard from "../Dashboard";
+import Dashboard, { getSessionRangeTimestamp } from "../Dashboard";
 
 beforeEach(() => {
   stubBrowserAPIs();
@@ -38,5 +38,35 @@ describe("Dashboard (smoke)", () => {
     // (The post-fetch view depends on each endpoint's exact response shape, so
     // asserting it is out of scope for this smoke test — the mount + load path
     // not throwing is the signal.)
+  });
+});
+
+describe("session range timestamps", () => {
+  it("prefers the scanned start time over discovery activity time", () => {
+    const source = {
+      provider: "cursor",
+      slug: "session",
+      project: "~/code/project",
+      timestamp: "2026-08-23T12:00:00Z",
+      fileSize: 0,
+      lineCount: 0,
+      firstPrompt: "",
+      filePaths: [],
+      existingReplay: null,
+    };
+
+    expect(
+      getSessionRangeTimestamp(source, {
+        startTime: "2026-08-01T12:00:00Z",
+        subAgentCount: 0,
+        apiErrorCount: 0,
+        compactionCount: 0,
+        editCount: 0,
+        filesModified: [],
+        promptCount: 0,
+        toolCallCount: 0,
+      }),
+    ).toBe("2026-08-01T12:00:00Z");
+    expect(getSessionRangeTimestamp(source)).toBe("2026-08-23T12:00:00Z");
   });
 });

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { navigateToUsageSessions, UsageBarList } from "../InsightsPage";
-import { getMultiFromUrl } from "../../hooks/usePanelFilters";
+import { navigateToUsageSessions, TopProjectsList, UsageBarList } from "../InsightsPage";
+import { getInsightsRangeFromUrl, getMultiFromUrl } from "../../hooks/usePanelFilters";
 
 afterEach(() => {
   cleanup();
@@ -58,6 +58,20 @@ describe("UsageBarList", () => {
     expect(params.get(facet)).toBe(value);
   });
 
+  it("preserves the selected Insights range in the Sessions URL", () => {
+    navigateToUsageSessions("tool", "Read", "7d");
+
+    expect(new URLSearchParams(window.location.search).get("insightsRange")).toBe("7d");
+  });
+
+  it("reads only supported Insights ranges from the URL", () => {
+    window.history.replaceState({}, "", "/?insightsRange=30d");
+    expect(getInsightsRangeFromUrl()).toBe("30d");
+
+    window.history.replaceState({}, "", "/?insightsRange=invalid");
+    expect(getInsightsRangeFromUrl()).toBe("all");
+  });
+
   it("round-trips facet names with URL-sensitive characters exactly once", () => {
     const value = "sourcegraph/search?query=foo bar&scope=100%,comma";
 
@@ -66,5 +80,35 @@ describe("UsageBarList", () => {
     const params = new URLSearchParams(window.location.search);
     expect(params.get("mcpTool")).toBe(value);
     expect(getMultiFromUrl("mcpTool")).toEqual([value]);
+  });
+});
+
+describe("TopProjectsList", () => {
+  it("keeps projects with the same basename distinguishable", () => {
+    render(
+      <TopProjectsList
+        projects={[
+          {
+            project: "~/git/roblox/ros-2",
+            sessions: 2,
+            cost: 1,
+            prompts: 2,
+            durationMs: 1_000,
+            edits: 1,
+          },
+          {
+            project: "~/Code/ros-2",
+            sessions: 1,
+            cost: 0,
+            prompts: 1,
+            durationMs: 500,
+            edits: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("~/git/roblox/ros-2")).toBeDefined();
+    expect(screen.getByText("~/Code/ros-2")).toBeDefined();
   });
 });

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -174,6 +174,17 @@ export function projectName(project: string): string {
   return parts[parts.length - 1] || project;
 }
 
+export function normalizeMcpServerName(server: string): string {
+  const normalized = server.trim();
+  return normalized === "" || normalized === "-" ? "Unknown" : normalized;
+}
+
+export function normalizeMcpToolName(tool: string): string {
+  if (tool === "-") return "Unknown";
+  if (tool.startsWith("-/")) return `Unknown${tool.slice(1)}`;
+  return tool;
+}
+
 // ─── Text helpers ────────────────────────────────────────────────────
 
 export const TITLE_MAX_CHARS = 120;
@@ -453,6 +464,7 @@ export const DASHBOARD_PARAMS = [
   "mcpTool",
   "skill",
   "agentRuns",
+  "insightsRange",
   "replay",
 ] as const;
 
@@ -721,8 +733,22 @@ export function shortenPath(path: string): string {
 
 export function computeProjectLabels(projects: string[]): Map<string, string> {
   const labels = new Map<string, string>();
+  const projectsByLabel = new Map<string, string[]>();
   for (const p of projects) {
-    labels.set(p, specialProjectLabel(p) || shortenPath(p));
+    const label = specialProjectLabel(p) || shortenPath(p);
+    labels.set(p, label);
+    const matchingProjects = projectsByLabel.get(label) || [];
+    matchingProjects.push(p);
+    projectsByLabel.set(label, matchingProjects);
+  }
+  for (const matchingProjects of projectsByLabel.values()) {
+    if (matchingProjects.length < 2) continue;
+    for (const project of matchingProjects) {
+      // The compact path can still collide for long projects that share their
+      // first and last segments. Fall back to the full path rather than
+      // showing two indistinguishable project rows.
+      labels.set(project, project);
+    }
   }
   return labels;
 }

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { rangeSince, rollupInsights, type InsightsRollupPayload } from "../insights-rollup";
+import {
+  isInInsightsRange,
+  rangeSince,
+  rollupInsights,
+  rollupInsightsBreakdown,
+  type InsightsRollupPayload,
+} from "../insights-rollup";
 
 const payload: InsightsRollupPayload = {
   sessions: [
@@ -192,5 +198,89 @@ describe("rollupInsights", () => {
     };
 
     expect(rollupInsights(payload).projects).toBe(1);
+  });
+
+  it("filters secondary breakdowns by the same session boundary", () => {
+    const result = rollupInsightsBreakdown(
+      {
+        sessions: [
+          {
+            project: "~/code/recent",
+            startTime: "2026-08-20T12:00:00Z",
+            durationMs: 60_000,
+            cost: 3,
+            prompts: 10,
+            edits: 8,
+            toolCalls: 40,
+            provider: "claude-code",
+            model: "claude-sonnet-4",
+            tokenUsage: {
+              inputTokens: 100,
+              outputTokens: 20,
+              cacheReadTokens: 30,
+              cacheCreationTokens: 40,
+            },
+            turnDurations: [10_000, 45_000],
+          },
+          {
+            project: "~/code/old",
+            startTime: "2026-01-01T00:00:00Z",
+            durationMs: 600_000,
+            cost: 20,
+            prompts: 100,
+            edits: 70,
+            toolCalls: 400,
+            provider: "cursor",
+            model: "gpt-4",
+            tokenUsage: {
+              inputTokens: 1_000,
+              outputTokens: 2_000,
+              cacheReadTokens: 3_000,
+              cacheCreationTokens: 4_000,
+            },
+            turnDurations: [720_000],
+          },
+        ],
+        replays: [],
+      },
+      { since: "2026-08-15T00:00:00Z" },
+    );
+
+    expect(result.projects).toEqual([
+      {
+        project: "~/code/recent",
+        sessions: 1,
+        cost: 3,
+        prompts: 10,
+        durationMs: 60_000,
+        toolCalls: 40,
+        edits: 8,
+      },
+    ]);
+    expect(result.models).toEqual({ "claude-sonnet-4": 1 });
+    expect(result.providers).toEqual({ "claude-code": 1 });
+    expect(result.tokenBreakdown).toEqual({
+      input: 100,
+      output: 20,
+      cacheRead: 30,
+      cacheCreation: 40,
+    });
+    expect(result.turnDurationHistogram).toMatchObject({
+      totalTurns: 2,
+      buckets: [
+        { label: "<30s", count: 1, pct: 50 },
+        { label: "30s-1m", count: 1, pct: 50 },
+        { label: "1-2m", count: 0, pct: 0 },
+        { label: "2-5m", count: 0, pct: 0 },
+        { label: "5-10m", count: 0, pct: 0 },
+        { label: "10m+", count: 0, pct: 0 },
+      ],
+      percentiles: { p50Ms: 27_500, p75Ms: 36_250, p90Ms: 41_500 },
+    });
+  });
+
+  it("excludes undated sessions from bounded secondary breakdowns", () => {
+    expect(isInInsightsRange(undefined, "2026-08-15T00:00:00Z")).toBe(false);
+    expect(isInInsightsRange(undefined)).toBe(true);
   });
 });

--- a/packages/viewer/src/engine/__tests__/session-usage.test.ts
+++ b/packages/viewer/src/engine/__tests__/session-usage.test.ts
@@ -39,6 +39,18 @@ describe("summarizeSessionUsage", () => {
     expect(breakdown?.totalCalls).toBe(7);
   });
 
+  it("normalizes placeholder MCP names in session details", () => {
+    const breakdown = summarizeSessionUsage(
+      makeSummary({
+        mcpServers: { "-": 2 },
+        mcpTools: { "-/search": 2 },
+      }),
+    );
+
+    expect(breakdown?.mcpServerCount).toBe(1);
+    expect(breakdown?.mcpTools).toEqual([{ name: "Unknown/search", count: 2 }]);
+  });
+
   it("limits each list and counts distinct MCP servers", () => {
     const breakdown = summarizeSessionUsage(
       makeSummary({

--- a/packages/viewer/src/engine/__tests__/usage-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/usage-rollup.test.ts
@@ -64,6 +64,18 @@ describe("rollupUsage", () => {
     expect(rollup.mcpTools).toEqual([{ name: "Unknown/search", calls: 2, sessions: 1 }]);
   });
 
+  it("counts a session once when legacy and normalized MCP names merge", () => {
+    const rollup = rollupUsage([
+      makeSession("mixed-names", {
+        mcpServers: { "-": 2, Unknown: 3 },
+        mcpTools: { "-/search": 2, "Unknown/search": 3 },
+      }),
+    ]);
+
+    expect(rollup.mcpServers).toEqual([{ name: "Unknown", calls: 5, sessions: 1 }]);
+    expect(rollup.mcpTools).toEqual([{ name: "Unknown/search", calls: 5, sessions: 1 }]);
+  });
+
   it("keeps only sessions inside the requested range", () => {
     const rollup = rollupUsage(
       [

--- a/packages/viewer/src/engine/__tests__/usage-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/usage-rollup.test.ts
@@ -52,6 +52,18 @@ describe("rollupUsage", () => {
     expect(rollup.mcpTools).toEqual([{ name: "sourcegraph/search", calls: 2, sessions: 1 }]);
   });
 
+  it("normalizes placeholder MCP names from cached summaries", () => {
+    const rollup = rollupUsage([
+      makeSession("unknown", {
+        mcpServers: { "-": 2 },
+        mcpTools: { "-/search": 2 },
+      }),
+    ]);
+
+    expect(rollup.mcpServers).toEqual([{ name: "Unknown", calls: 2, sessions: 1 }]);
+    expect(rollup.mcpTools).toEqual([{ name: "Unknown/search", calls: 2, sessions: 1 }]);
+  });
+
   it("keeps only sessions inside the requested range", () => {
     const rollup = rollupUsage(
       [

--- a/packages/viewer/src/engine/insights-rollup.ts
+++ b/packages/viewer/src/engine/insights-rollup.ts
@@ -8,6 +8,15 @@ export interface InsightsMetricSession {
   prompts: number;
   edits: number;
   toolCalls: number;
+  provider?: string;
+  model?: string;
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  };
+  turnDurations?: number[];
 }
 
 export interface InsightsReplayRef {
@@ -29,6 +38,37 @@ export interface InsightsRangeStats {
   edits: number;
   toolCalls: number;
   projects: number;
+}
+
+export interface InsightsRangeProject {
+  project: string;
+  sessions: number;
+  cost: number;
+  prompts: number;
+  durationMs: number;
+  toolCalls: number;
+  edits: number;
+}
+
+export interface InsightsRangeTokenBreakdown {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+export interface InsightsRangeTurnDurationHistogram {
+  buckets: Array<{ label: string; count: number; pct: number }>;
+  percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
+  totalTurns: number;
+}
+
+export interface InsightsRangeBreakdown {
+  projects: InsightsRangeProject[];
+  models: Record<string, number>;
+  providers: Record<string, number>;
+  tokenBreakdown?: InsightsRangeTokenBreakdown;
+  turnDurationHistogram?: InsightsRangeTurnDurationHistogram;
 }
 
 export type InsightsRange = "7d" | "30d" | "90d" | "all";
@@ -61,6 +101,15 @@ function isInRange(startTime: string | undefined, cutoffMs: number): boolean {
   if (!startTime) return false;
   const startedMs = Date.parse(startTime);
   return Number.isFinite(startedMs) && startedMs >= cutoffMs;
+}
+
+export function isInInsightsRange(startTime: string | undefined, since?: string): boolean {
+  return isInRange(startTime, since ? Date.parse(since) : Number.NaN);
+}
+
+function sessionsInRange(payload: InsightsRollupPayload, since?: string): InsightsMetricSession[] {
+  const cutoffMs = since ? Date.parse(since) : Number.NaN;
+  return payload.sessions.filter((session) => isInRange(session.startTime, cutoffMs));
 }
 
 /**
@@ -104,5 +153,127 @@ export function rollupInsights(
     edits,
     toolCalls,
     projects: projects.size,
+  };
+}
+
+const DURATION_BUCKETS: Array<{ label: string; minMs: number; maxMs: number }> = [
+  { label: "<30s", minMs: 0, maxMs: 30_000 },
+  { label: "30s-1m", minMs: 30_000, maxMs: 60_000 },
+  { label: "1-2m", minMs: 60_000, maxMs: 120_000 },
+  { label: "2-5m", minMs: 120_000, maxMs: 300_000 },
+  { label: "5-10m", minMs: 300_000, maxMs: 600_000 },
+  { label: "10m+", minMs: 600_000, maxMs: Number.POSITIVE_INFINITY },
+];
+
+function percentile(sorted: number[], p: number): number {
+  const index = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower]!;
+  return sorted[lower]! + (sorted[upper]! - sorted[lower]!) * (index - lower);
+}
+
+function buildTurnDurationHistogram(
+  durations: readonly number[],
+): InsightsRangeTurnDurationHistogram | undefined {
+  const sorted = durations.filter(Number.isFinite).sort((a, b) => a - b);
+  if (sorted.length === 0) return undefined;
+
+  const counts = DURATION_BUCKETS.map(() => 0);
+  for (const duration of sorted) {
+    const bucketIndex = DURATION_BUCKETS.findIndex((bucket) => duration < bucket.maxMs);
+    if (bucketIndex >= 0) counts[bucketIndex]!++;
+  }
+
+  return {
+    buckets: DURATION_BUCKETS.map((bucket, index) => ({
+      label: bucket.label,
+      count: counts[index]!,
+      pct: Math.round((counts[index]! / sorted.length) * 1000) / 10,
+    })),
+    percentiles: {
+      p50Ms: Math.round(percentile(sorted, 50)),
+      p75Ms: Math.round(percentile(sorted, 75)),
+      p90Ms: Math.round(percentile(sorted, 90)),
+    },
+    totalTurns: sorted.length,
+  };
+}
+
+/**
+ * Aggregate the non-additive Insights sections for a selected time range.
+ * These fields are carried per session by the optional detail projection so
+ * changing the range does not require another request.
+ */
+export function rollupInsightsBreakdown(
+  payload: InsightsRollupPayload,
+  { since }: { since?: string } = {},
+): InsightsRangeBreakdown {
+  const sessions = sessionsInRange(payload, since);
+  const projects = new Map<string, InsightsRangeProject>();
+  const models: Record<string, number> = {};
+  const providers: Record<string, number> = {};
+  const durations: number[] = [];
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheCreation = 0;
+
+  for (const session of sessions) {
+    if (session.project) {
+      const project = rollupProject(session.project);
+      const existing = projects.get(project);
+      if (existing) {
+        existing.sessions++;
+        existing.cost += session.cost || 0;
+        existing.prompts += session.prompts;
+        existing.durationMs += session.durationMs || 0;
+        existing.toolCalls += session.toolCalls;
+        existing.edits += session.edits;
+      } else {
+        projects.set(project, {
+          project,
+          sessions: 1,
+          cost: session.cost || 0,
+          prompts: session.prompts,
+          durationMs: session.durationMs || 0,
+          toolCalls: session.toolCalls,
+          edits: session.edits,
+        });
+      }
+    }
+
+    if (session.model) models[session.model] = (models[session.model] || 0) + 1;
+    if (session.provider) providers[session.provider] = (providers[session.provider] || 0) + 1;
+
+    if (session.tokenUsage) {
+      input += session.tokenUsage.inputTokens;
+      output += session.tokenUsage.outputTokens;
+      cacheRead += session.tokenUsage.cacheReadTokens;
+      cacheCreation += session.tokenUsage.cacheCreationTokens;
+    }
+    if (session.turnDurations) durations.push(...session.turnDurations);
+  }
+
+  const tokenTotal = input + output + cacheRead + cacheCreation;
+  return {
+    projects: [...projects.values()].sort(
+      (a, b) =>
+        b.sessions - a.sessions ||
+        b.durationMs - a.durationMs ||
+        a.project.localeCompare(b.project),
+    ),
+    models,
+    providers,
+    tokenBreakdown:
+      tokenTotal > 0
+        ? {
+            input,
+            output,
+            cacheRead,
+            cacheCreation,
+          }
+        : undefined,
+    turnDurationHistogram: buildTurnDurationHistogram(durations),
   };
 }

--- a/packages/viewer/src/engine/session-usage.ts
+++ b/packages/viewer/src/engine/session-usage.ts
@@ -1,4 +1,5 @@
 import type { SessionUsageSummary } from "@vibe-replay/types";
+import { normalizeMcpServerName, normalizeMcpToolName } from "../components/dashboard-utils";
 
 export interface UsageEntry {
   name: string;
@@ -19,9 +20,18 @@ export interface SessionUsageBreakdown {
   avgDurationMs?: number;
 }
 
-function rank(counts: Record<string, number>, limit: number): UsageEntry[] {
+function rank(
+  counts: Record<string, number>,
+  limit: number,
+  normalizeName: (name: string) => string = (name) => name,
+): UsageEntry[] {
+  const normalized = new Map<string, number>();
+  for (const [name, count] of Object.entries(counts)) {
+    const normalizedName = normalizeName(name);
+    normalized.set(normalizedName, (normalized.get(normalizedName) || 0) + count);
+  }
   return (
-    Object.entries(counts)
+    [...normalized.entries()]
       .map(([name, count]) => ({ name, count }))
       // Ties break alphabetically so the list is stable across re-renders.
       .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
@@ -47,13 +57,14 @@ export function summarizeSessionUsage(
   // MCP call total without double-counting calls that never named a tool.
   const totalCalls = sum(summary.tools) + sum(summary.mcpServers);
   const skills = rank(summary.skills, limit);
+  const mcpServers = new Set(Object.keys(summary.mcpServers).map(normalizeMcpServerName));
   if (totalCalls === 0 && skills.length === 0) return undefined;
 
   return {
     tools: rank(summary.tools, limit),
-    mcpTools: rank(summary.mcpTools, limit),
+    mcpTools: rank(summary.mcpTools, limit, normalizeMcpToolName),
     skills,
-    mcpServerCount: Object.keys(summary.mcpServers).length,
+    mcpServerCount: mcpServers.size,
     totalCalls,
     successCount: summary.successCount,
     errorCount: summary.errorCount,

--- a/packages/viewer/src/engine/usage-rollup.ts
+++ b/packages/viewer/src/engine/usage-rollup.ts
@@ -41,9 +41,13 @@ function add(
   counts: Record<string, number>,
   normalizeName: (name: string) => string = (name) => name,
 ): void {
+  const normalizedCounts = new Map<string, number>();
   for (const [name, calls] of Object.entries(counts)) {
     if (calls <= 0) continue;
     const normalizedName = normalizeName(name);
+    normalizedCounts.set(normalizedName, (normalizedCounts.get(normalizedName) || 0) + calls);
+  }
+  for (const [normalizedName, calls] of normalizedCounts) {
     const entry = into.get(normalizedName);
     if (entry) {
       entry.calls += calls;

--- a/packages/viewer/src/engine/usage-rollup.ts
+++ b/packages/viewer/src/engine/usage-rollup.ts
@@ -1,4 +1,5 @@
 import type { SessionUsageSummary } from "@vibe-replay/types";
+import { normalizeMcpServerName, normalizeMcpToolName } from "../components/dashboard-utils";
 
 /** One scanned session's usage, as served by `/api/usage/rollup`. */
 export interface UsageRollupSession {
@@ -35,15 +36,20 @@ interface Accumulator {
   sessions: number;
 }
 
-function add(into: Map<string, Accumulator>, counts: Record<string, number>): void {
+function add(
+  into: Map<string, Accumulator>,
+  counts: Record<string, number>,
+  normalizeName: (name: string) => string = (name) => name,
+): void {
   for (const [name, calls] of Object.entries(counts)) {
     if (calls <= 0) continue;
-    const entry = into.get(name);
+    const normalizedName = normalizeName(name);
+    const entry = into.get(normalizedName);
     if (entry) {
       entry.calls += calls;
       entry.sessions += 1;
     } else {
-      into.set(name, { calls, sessions: 1 });
+      into.set(normalizedName, { calls, sessions: 1 });
     }
   }
 }
@@ -110,8 +116,8 @@ export function rollupUsage(
     successCount += usage.successCount;
     errorCount += usage.errorCount;
     add(tools, usage.tools);
-    add(mcpServers, usage.mcpServers);
-    add(mcpTools, usage.mcpTools);
+    add(mcpServers, usage.mcpServers, normalizeMcpServerName);
+    add(mcpTools, usage.mcpTools, normalizeMcpToolName);
     add(skills, usage.skills);
   }
 

--- a/packages/viewer/src/hooks/usePanelFilters.ts
+++ b/packages/viewer/src/hooks/usePanelFilters.ts
@@ -1,7 +1,15 @@
 import { useEffect, useRef, useState } from "react";
-import { navigateTo } from "../components/dashboard-utils";
+import {
+  navigateTo,
+  normalizeMcpServerName,
+  normalizeMcpToolName,
+} from "../components/dashboard-utils";
+import type { InsightsRange } from "../engine/insights-rollup";
 
 export const ALL_PROJECTS = "__all__";
+export const INSIGHTS_RANGE_PARAM = "insightsRange";
+
+const INSIGHTS_RANGES = new Set<InsightsRange>(["7d", "30d", "90d", "all"]);
 
 export function getMultiFromUrl(param: string): string[] {
   return new URLSearchParams(window.location.search)
@@ -25,6 +33,10 @@ function getShowArchivedFromUrl(): boolean {
 function getShowAgentRunsFromUrl(): boolean {
   return new URLSearchParams(window.location.search).get("agentRuns") === "true";
 }
+export function getInsightsRangeFromUrl(): InsightsRange {
+  const value = new URLSearchParams(window.location.search).get(INSIGHTS_RANGE_PARAM);
+  return INSIGHTS_RANGES.has(value as InsightsRange) ? (value as InsightsRange) : "all";
+}
 
 function getProvidersFromUrl(): string[] {
   return getMultiFromUrl("provider");
@@ -39,11 +51,11 @@ function getToolsFromUrl(): string[] {
 }
 
 function getMcpServersFromUrl(): string[] {
-  return getMultiFromUrl("mcp");
+  return getMultiFromUrl("mcp").map(normalizeMcpServerName);
 }
 
 function getMcpToolsFromUrl(): string[] {
-  return getMultiFromUrl("mcpTool");
+  return getMultiFromUrl("mcpTool").map(normalizeMcpToolName);
 }
 
 function getSkillsFromUrl(): string[] {
@@ -56,6 +68,7 @@ export function usePanelFilters() {
   const [filter, setFilter] = useState(getFilterFromUrl);
   const [showArchived, setShowArchived] = useState(getShowArchivedFromUrl);
   const [showAgentRuns, setShowAgentRuns] = useState(getShowAgentRunsFromUrl);
+  const [insightsRange, setInsightsRange] = useState(getInsightsRangeFromUrl);
   const [selectedProviders, setSelectedProviders] = useState(getProvidersFromUrl);
   const [selectedRepos, setSelectedRepos] = useState(getReposFromUrl);
   const [selectedTools, setSelectedTools] = useState(getToolsFromUrl);
@@ -99,6 +112,7 @@ export function usePanelFilters() {
       setFilter(getFilterFromUrl());
       setShowArchived(getShowArchivedFromUrl());
       setShowAgentRuns(getShowAgentRunsFromUrl());
+      setInsightsRange(getInsightsRangeFromUrl());
       const providers = getProvidersFromUrl();
       const repos = getReposFromUrl();
       const tools = getToolsFromUrl();
@@ -202,6 +216,11 @@ export function usePanelFilters() {
     navigateTo({ agentRuns: next ? "true" : null }, { notify: false });
   };
 
+  const handleClearInsightsRange = () => {
+    setInsightsRange("all");
+    navigateTo({ [INSIGHTS_RANGE_PARAM]: null }, { notify: false });
+  };
+
   const handleClearAllFilters = () => {
     // Archive and agent-run visibility are display modes, not content facets,
     // so Clear all only resets the explorer dimensions shown as active chips.
@@ -219,6 +238,7 @@ export function usePanelFilters() {
     setSelectedMcpServers([]);
     setSelectedMcpTools([]);
     setSelectedSkills([]);
+    setInsightsRange("all");
     navigateTo(
       {
         project: null,
@@ -229,6 +249,7 @@ export function usePanelFilters() {
         mcp: null,
         mcpTool: null,
         skill: null,
+        [INSIGHTS_RANGE_PARAM]: null,
         replay: null,
       },
       { notify: false },
@@ -240,6 +261,7 @@ export function usePanelFilters() {
     filter,
     showArchived,
     showAgentRuns,
+    insightsRange,
     selectedProviders,
     selectedRepos,
     selectedTools,
@@ -258,6 +280,7 @@ export function usePanelFilters() {
     handleSkillToggle,
     handleToggleArchived,
     handleToggleAgentRuns,
+    handleClearInsightsRange,
     handleClearAllFilters,
   };
 }


### PR DESCRIPTION
## Summary
- Scope Insights totals and secondary breakdowns to the selected 7d/30d/90d range using compact per-session rollups.
- Persist the selected range through URL navigation and usage drilldowns, and apply the same session-start boundary in Sessions.
- Disambiguate colliding project labels and normalize legacy MCP placeholder names to `Unknown`.

## Test plan
- [x] `pnpm test`
- [x] `pnpm lint:check`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Manual dashboard verification of range changes, reload persistence, Read drilldown filtering, project labels, and MCP normalization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 7-day, 30-day, 90-day, and all-time filtering for Insights.
  * Insights now provide range-specific breakdowns for projects, models, providers, tokens, and turn durations.
  * Selected ranges stay synchronized with URLs and navigation.
  * Session details can include provider, model, token usage, and turn durations without exposing conversation content.
* **Bug Fixes**
  * Standardized blank or placeholder MCP server and tool names as “Unknown.”
  * Prevented duplicate shortened project labels from obscuring distinct projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->