### PR TITLE
fix(dashboard): distinguish automation workflows in project labels

### DIFF
--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -1345,7 +1345,7 @@ describe("aggregateUserInsights", () => {
       key: "cursor-sdk:github-pr-review:Roblox/ros",
       kind: "cursor-sdk-automation" as const,
       isAutomated: true,
-      displayName: "Automated · Roblox/ros",
+      displayName: "Automated · Roblox/ros · GitHub PR review",
       workflowId: "github-pr-review",
       repository: "Roblox/ros",
     };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,6 +28,7 @@ export {
   agentRunWorkspaceParent,
   agentWorktreeParent,
   classifyProject,
+  cursorSdkWorkflowLabel,
   isAutomatedProject,
   isCursorSdkAutomationPath,
   mergeProjectIdentities,

--- a/packages/types/src/project-identity.ts
+++ b/packages/types/src/project-identity.ts
@@ -62,6 +62,26 @@ const CURSOR_SDK_WORKFLOWS: Array<{ id: string; pattern: RegExp }> = [
   { id: "slack-inbox", pattern: /slack[-_]inbox/i },
 ];
 
+const CURSOR_SDK_WORKFLOW_LABELS: Record<string, string> = {
+  "github-pr-review": "GitHub PR review",
+  "google-drive-search": "Google Drive search",
+  "google-doc-review": "Google Doc review",
+  "source-extraction-sentry": "Source extraction · Sentry",
+  "source-extraction-slack-inbox": "Source extraction · Slack inbox",
+  "sentry-triage": "Sentry triage",
+  "slack-inbox": "Slack inbox",
+};
+
+export function cursorSdkWorkflowLabel(workflowId: string): string {
+  const knownLabel = CURSOR_SDK_WORKFLOW_LABELS[workflowId];
+  if (knownLabel) return knownLabel;
+  return workflowId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+    .replace(/\bPr\b/g, "PR");
+}
+
 function normalizePath(value: string): string {
   return value.replace(/\\/g, "/").replace(/\/+$/, "");
 }
@@ -192,14 +212,15 @@ export function classifyProject(
     const group = repository || target || cursorSdkGroupParent(projectValue, hints.sdkWorkspaceRef);
     const key = `cursor-sdk:${resolvedWorkflow}:${group || "unknown"}`;
     const displayTarget = repository || target;
+    const workflowLabel = cursorSdkWorkflowLabel(resolvedWorkflow);
 
     return {
       key,
       kind: "cursor-sdk-automation",
       isAutomated: true,
       displayName: displayTarget
-        ? `Automated · ${displayTarget}`
-        : `Automated · ${resolvedWorkflow}`,
+        ? `Automated · ${displayTarget} · ${workflowLabel}`
+        : `Automated · ${workflowLabel}`,
       workflowId: resolvedWorkflow,
       repository,
       prNumber,

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -143,7 +143,7 @@ describe("Cursor SDK project identity", () => {
       key: "cursor-sdk:github-pr-review:Roblox/ros",
       kind: "cursor-sdk-automation",
       isAutomated: true,
-      displayName: "Automated · Roblox/ros",
+      displayName: "Automated · Roblox/ros · GitHub PR review",
       repository: "Roblox/ros",
       prNumber: 13473,
     });

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -1,6 +1,7 @@
 import {
   agentRunWorkspaceParent as sharedAgentRunWorkspaceParent,
   agentWorktreeParent as sharedAgentWorktreeParent,
+  cursorSdkWorkflowLabel,
   isAutomatedProject,
   mergeProjectIdentities,
   projectIdentityKey,
@@ -898,8 +899,9 @@ function specialProjectLabel(project: string): string | null {
   if (normalized === "~") return "Home";
   const cursorAutomation = normalized.match(/^cursor-sdk:([^:]+):(.+)$/);
   if (cursorAutomation) {
-    const target = cursorAutomation[2].replace(/^all$/, cursorAutomation[1]);
-    return `Automated · ${target}`;
+    const workflowLabel = cursorSdkWorkflowLabel(cursorAutomation[1]);
+    if (cursorAutomation[2] === "all") return `Automated · ${workflowLabel}`;
+    return `Automated · ${cursorAutomation[2]} · ${workflowLabel}`;
   }
   if (/\/\.cursor\/projects\/.+\/terminals$/.test(normalized)) return "Cursor Terminals";
   if (/\/\.cursor\/extensions\//.test(normalized)) return "Cursor Extension";

--- a/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
+++ b/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
@@ -100,7 +100,7 @@ describe("dashboard facet filtering", () => {
       key: "cursor-sdk:github-pr-review:Roblox/ros",
       kind: "cursor-sdk-automation" as const,
       isAutomated: true,
-      displayName: "Automated · Roblox/ros",
+      displayName: "Automated · Roblox/ros · GitHub PR review",
     };
 
     expect(

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -205,7 +205,7 @@ describe("rollupInsights", () => {
       key: "cursor-sdk:github-pr-review:Roblox/ros",
       kind: "cursor-sdk-automation" as const,
       isAutomated: true,
-      displayName: "Automated · Roblox/ros",
+      displayName: "Automated · Roblox/ros · GitHub PR review",
     };
     const result = rollupInsights({
       sessions: [


### PR DESCRIPTION
## Summary
- Include the Cursor SDK workflow in generated automation project labels.
- Keep same-repository workflows distinguishable in Projects, Sessions, Insights, and fallback labels.

## Validation
- Targeted viewer identity/filter/rollup tests: 70 passed.
- CLI scanner identity tests: 44 passed.
- `pnpm lint:check`, `pnpm typecheck`, and `pnpm build` passed.
- Local Projects inspection now distinguishes PR review from Google Drive search for the same repository.
