### PR TITLE
fix(dashboard): invalidate stale project label caches

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -46,7 +46,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v20: normalize placeholder MCP server names in cached usage summaries.
 // v21: persist canonical project identity alongside scan results.
 // v22: refine Cursor SDK context-worktree classification and fallback keys.
-export const SCANNER_VERSION = 22;
+// v23: disambiguate Cursor SDK workflow display labels.
+export const SCANNER_VERSION = 23;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -597,13 +597,15 @@ export async function startServer(
   // v5 → v6: source records carry canonical project identity and corrected
   // Cursor SDK worktree paths.
   // v6 → v7: refine Cursor SDK context-worktree identity grouping.
-  const sourcesCacheKey = `dashboard-sources-v7-${cacheKeySuffix}`;
+  // v7 → v8: disambiguate Cursor SDK workflow display labels.
+  const sourcesCacheKey = `dashboard-sources-v8-${cacheKeySuffix}`;
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
   // Keyed by scanner version too: a bump changes the shape of what a scan
   // extracts, so serving the previous run's results would show stale facets
   // until the next scan happened to finish.
   const scanResultsCacheKey = `dashboard-scan-results-v${SCANNER_VERSION}-${cacheKeySuffix}`;
-  const insightsCacheKey = `dashboard-insights-v4-${cacheKeySuffix}`;
+  // v4 → v5: invalidate persisted project labels after workflow disambiguation.
+  const insightsCacheKey = `dashboard-insights-v5-${cacheKeySuffix}`;
   const readSourcesCatalogCache = async (): Promise<NormalizedSourceSessionCatalogCache | null> =>
     normalizeSourceSessionCatalogCache(
       await readFileCache<SourceSessionCatalogCache | CachedSourceRecord[]>(sourcesCacheKey),


### PR DESCRIPTION
## Summary
- Bump source, scan, and Insights cache keys after changing automation project labels.
- Ensure existing installations rebuild cached identities and do not keep duplicate old display names.

## Validation
- Targeted scanner identity tests: 44 passed.
- Targeted viewer identity/filter/rollup tests: 70 passed.
- `pnpm lint:check`, `pnpm typecheck`, and `pnpm build` passed.
