### PR TITLE
fix(cursor): unify session duration accounting

### DIFF
--- a/packages/cli/test/duration.test.ts
+++ b/packages/cli/test/duration.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
+import {
+  buildTurnDurationIntervals,
+  estimateActiveDuration,
+  sumDurationIntervals,
+} from "@vibe-replay/provider-core/duration";
 
 describe("estimateActiveDuration", () => {
   it("returns undefined for empty array", () => {
@@ -75,5 +79,63 @@ describe("estimateActiveDuration", () => {
     expect(result).toBe(31 * 60 * 1000);
     // NOT 52 hours of wall clock time
     expect(result).toBeLessThan(60 * 60 * 1000); // under 1 hour
+  });
+});
+
+describe("buildTurnDurationIntervals", () => {
+  it("uses the last assistant event as the turn end", () => {
+    expect(
+      buildTurnDurationIntervals([
+        { role: "user", startMs: 0 },
+        { role: "assistant", endMs: 1_000 },
+        { role: "assistant", endMs: 4_000 },
+      ]),
+    ).toEqual([{ startMs: 0, endMs: 4_000 }]);
+  });
+
+  it("keeps missing or incomplete turns unavailable", () => {
+    expect(
+      buildTurnDurationIntervals([
+        { role: "user" },
+        { role: "assistant", endMs: 1_000 },
+        { role: "user", startMs: 2_000 },
+      ]),
+    ).toEqual([undefined, undefined]);
+  });
+
+  it("builds separate intervals for multiple user prompts", () => {
+    expect(
+      buildTurnDurationIntervals([
+        { role: "user", startMs: 0 },
+        { role: "assistant", endMs: 10_000 },
+        { role: "user", startMs: 5_000 },
+        { role: "assistant", endMs: 15_000 },
+      ]),
+    ).toEqual([
+      { startMs: 0, endMs: 10_000 },
+      { startMs: 5_000, endMs: 15_000 },
+    ]);
+  });
+});
+
+describe("sumDurationIntervals", () => {
+  it("merges overlapping intervals before summing", () => {
+    expect(
+      sumDurationIntervals([
+        { startMs: 0, endMs: 10_000 },
+        { startMs: 5_000, endMs: 15_000 },
+        { startMs: 20_000, endMs: 25_000 },
+      ]),
+    ).toBe(20_000);
+  });
+
+  it("ignores invalid and missing intervals", () => {
+    expect(
+      sumDurationIntervals([
+        undefined,
+        { startMs: 1_000, endMs: 1_000 },
+        { startMs: Number.NaN, endMs: 2_000 },
+      ]),
+    ).toBeUndefined();
   });
 });

--- a/packages/cli/test/scanner-cursor-duration.test.ts
+++ b/packages/cli/test/scanner-cursor-duration.test.ts
@@ -44,6 +44,46 @@ describe("scanSession cursor duration", () => {
     expect(result.durationMs).toBeUndefined();
   });
 
+  it("uses parser-provided turn duration when Cursor timestamps are available", async () => {
+    mockedParseCursorSession.mockResolvedValueOnce({
+      sessionId: "cursor-session",
+      slug: "cursor-slug",
+      title: "Cursor session",
+      cwd: "/repo",
+      turns: [
+        {
+          role: "user",
+          timestamp: "2025-01-01T00:00:00.000Z",
+          blocks: [{ type: "text", text: "hello" }],
+        },
+        {
+          role: "assistant",
+          timestamp: "2025-01-01T00:00:05.000Z",
+          blocks: [{ type: "text", text: "hi" }],
+        },
+      ],
+      startTime: "2025-01-01T00:00:00.000Z",
+      endTime: "2025-01-01T00:00:05.000Z",
+      totalDurationMs: 5_000,
+      turnStats: [{ turnIndex: 0, durationMs: 5_000 }],
+      dataSource: "jsonl",
+    });
+
+    const result = await scanSession({
+      sessionId: "cursor-session",
+      provider: "cursor",
+      project: "~/Code/project",
+      slug: "cursor-slug",
+      filePaths: ["/tmp/session.jsonl"],
+      timestamp: "2025-01-01T00:00:00.000Z",
+    });
+
+    expect(result.startTime).toBe("2025-01-01T00:00:00.000Z");
+    expect(result.endTime).toBe("2025-01-01T00:00:05.000Z");
+    expect(result.durationMs).toBe(5_000);
+    expect(result.turnDurations).toEqual([5_000]);
+  });
+
   it("does not double-count subagents when parser summary already exists", async () => {
     mockedParseCursorSession.mockResolvedValueOnce({
       sessionId: "cursor-session",

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -215,6 +215,8 @@ export type ContentBlock =
       name: string;
       input: Record<string, any>;
       _result?: string;
+      /** Internal source timestamp for the tool result; omitted from replay scenes. */
+      _resultTimestamp?: string;
       _images?: string[];
       _isError?: boolean;
       _subAgent?: SubAgent;

--- a/packages/provider-core/src/duration.ts
+++ b/packages/provider-core/src/duration.ts
@@ -9,6 +9,115 @@
 
 const DEFAULT_MAX_GAP_MS = 5 * 60 * 1000; // 5 minutes
 
+export interface DurationInterval {
+  startMs: number;
+  endMs: number;
+}
+
+export interface TurnTimingEvent {
+  role: "user" | "assistant";
+  /** Timestamp at which a user turn starts. */
+  startMs?: number;
+  /** Latest timestamp observed while an assistant turn is completing. */
+  endMs?: number;
+}
+
+/**
+ * Build one interval per user turn from ordered user/assistant events.
+ *
+ * An assistant response can be split across several records, so its end is
+ * the latest assistant timestamp observed before the next user turn. Missing
+ * timestamps intentionally produce no interval instead of a guessed duration.
+ */
+export function buildTurnDurationIntervals(
+  events: readonly TurnTimingEvent[],
+): Array<DurationInterval | undefined> {
+  const intervals: Array<DurationInterval | undefined> = [];
+  let hasCurrentTurn = false;
+  let startMs: number | undefined;
+  let endMs: number | undefined;
+
+  const finalize = () => {
+    intervals.push(toDurationInterval(startMs, endMs));
+  };
+
+  for (const event of events) {
+    if (event.role === "user") {
+      if (hasCurrentTurn) finalize();
+      hasCurrentTurn = true;
+      startMs = finiteTimestamp(event.startMs);
+      endMs = undefined;
+      continue;
+    }
+
+    if (startMs === undefined) continue;
+    const candidateEndMs = finiteTimestamp(event.endMs);
+    if (candidateEndMs !== undefined && (endMs === undefined || candidateEndMs > endMs)) {
+      endMs = candidateEndMs;
+    }
+  }
+
+  if (hasCurrentTurn) finalize();
+  return intervals;
+}
+
+/** Return a valid interval only when both endpoints are finite and ordered. */
+export function toDurationInterval(
+  startMs: number | undefined,
+  endMs: number | undefined,
+): DurationInterval | undefined {
+  if (startMs === undefined || endMs === undefined) return undefined;
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
+  return { startMs, endMs };
+}
+
+/**
+ * Sum the union of intervals rather than summing each interval independently.
+ *
+ * Parallel tool calls and nested agents can cover the same wall-clock range.
+ * Merging first prevents those overlapping activities from inflating the
+ * session's active duration.
+ */
+export function sumDurationIntervals(
+  intervals: readonly (DurationInterval | undefined)[],
+): number | undefined {
+  const sorted = intervals
+    .filter((interval): interval is DurationInterval => {
+      return (
+        interval !== undefined &&
+        Number.isFinite(interval.startMs) &&
+        Number.isFinite(interval.endMs) &&
+        interval.endMs > interval.startMs
+      );
+    })
+    .map((interval) => ({ ...interval }))
+    .sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs);
+
+  if (sorted.length === 0) return undefined;
+
+  let active = 0;
+  let currentStart = sorted[0].startMs;
+  let currentEnd = sorted[0].endMs;
+
+  for (let i = 1; i < sorted.length; i++) {
+    const next = sorted[i];
+    if (next.startMs <= currentEnd) {
+      currentEnd = Math.max(currentEnd, next.endMs);
+      continue;
+    }
+    active += currentEnd - currentStart;
+    currentStart = next.startMs;
+    currentEnd = next.endMs;
+  }
+  active += currentEnd - currentStart;
+
+  return active > 0 ? active : undefined;
+}
+
+function finiteTimestamp(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value) ? value : undefined;
+}
+
 export function estimateActiveDuration(
   timestamps: string[],
   maxGapMs = DEFAULT_MAX_GAP_MS,

--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -9,12 +9,17 @@ import {
   type SessionInfo,
 } from "@vibe-replay/provider-contract";
 import type { DataSourceInfo, ProviderParseResult } from "@vibe-replay/provider-contract";
-import type { Scene, SubAgent } from "@vibe-replay/types";
+import type { Scene, SubAgent, TurnStat } from "@vibe-replay/types";
 import {
   sanitizeCursorAssistantText,
+  extractCursorTimestamp,
   sanitizeCursorReasoningText,
   sanitizeCursorUserText,
 } from "./sanitize.js";
+import {
+  buildTurnDurationIntervals,
+  sumDurationIntervals,
+} from "@vibe-replay/provider-core/duration";
 import {
   applySdkEnrichmentToTurns,
   findSdkAgentById,
@@ -99,6 +104,7 @@ async function parseCursorSessionWithDependencies(
       if (transcriptPaths.length > 0) {
         const thinkingBefore = countThinkingBlocks(sqliteResult.turns);
         const userImagesBefore = countUserImages(sqliteResult.turns);
+        const timestampsBefore = countTurnTimestamps(sqliteResult.turns);
         const jsonlThinking = await parseCursorJsonl(
           transcriptPaths,
           [],
@@ -115,13 +121,16 @@ async function parseCursorSessionWithDependencies(
           sqliteResult.turns,
           jsonlThinking.turns,
         );
+        mergeJsonlTimingIntoCursorResult(sqliteResult, jsonlThinking);
         const thinkingAfter = countThinkingBlocks(sqliteResult.turns);
         const userImagesAfter = countUserImages(sqliteResult.turns);
+        const timestampsAfter = countTurnTimestamps(sqliteResult.turns);
         const supplementedThinkingBlocks = Math.max(0, thinkingAfter - thinkingBefore);
         const supplementedUserImages = Math.max(0, userImagesAfter - userImagesBefore);
+        const supplementedTimestamps = Math.max(0, timestampsAfter - timestampsBefore);
         sqliteResult.dataSourceInfo = withSupplement(
           sqliteResult.dataSourceInfo || defaultDataSourceInfo(sqliteResult.dataSource),
-          `cursor/projects/agent-transcripts/*.jsonl (thinking +${supplementedThinkingBlocks}, images +${supplementedUserImages})`,
+          `cursor/projects/agent-transcripts/*.jsonl (thinking +${supplementedThinkingBlocks}, images +${supplementedUserImages}${supplementedTimestamps > 0 ? `, timestamps +${supplementedTimestamps}` : ""})`,
         );
       }
       await attachCursorSubagents(sqliteResult, transcriptPaths, deps);
@@ -194,8 +203,13 @@ async function parseCursorSessionWithDependencies(
       if (enrichment.finishedAt && !jsonlResult.endTime) {
         jsonlResult.endTime = enrichment.finishedAt;
       }
-      if (enrichment.totalDurationMs && !jsonlResult.totalDurationMs) {
+      if (enrichment.totalDurationMs !== undefined) {
         jsonlResult.totalDurationMs = enrichment.totalDurationMs;
+        jsonlResult.turnStats = mergeSdkTurnStats(jsonlResult.turnStats, enrichment.turnStats);
+        jsonlResult.dataSourceInfo = withSupplement(
+          jsonlResult.dataSourceInfo || defaultDataSourceInfo(jsonlResult.dataSource),
+          "cursor-sdk index.db (union of run intervals)",
+        );
       }
       // SDK transcripts carry no usage of their own, so the index.db totals are
       // the only token accounting available for these sessions.
@@ -330,6 +344,67 @@ function withNote(info: DataSourceInfo | undefined, note: string): DataSourceInf
   return { ...info, notes };
 }
 
+interface CursorTurnTiming {
+  startTime?: string;
+  endTime?: string;
+  totalDurationMs?: number;
+  turnStats?: TurnStat[];
+}
+
+function buildCursorTurnTiming(turns: ParsedTurn[]): CursorTurnTiming {
+  const events = turns.map((turn) => ({
+    role: turn.role,
+    startMs: turn.role === "user" ? timestampMs(turn.timestamp) : undefined,
+    endMs: turn.role === "assistant" ? assistantTurnEndMs(turn) : undefined,
+  }));
+  const intervals = buildTurnDurationIntervals(events);
+  const hasDuration = intervals.some((interval) => interval !== undefined);
+  const turnStats = hasDuration
+    ? intervals.map((interval, turnIndex) => ({
+        turnIndex,
+        ...(interval ? { durationMs: interval.endMs - interval.startMs } : {}),
+      }))
+    : undefined;
+
+  const userTimestamps = turns
+    .filter((turn) => turn.role === "user")
+    .map((turn) => timestampMs(turn.timestamp))
+    .filter((timestamp): timestamp is number => timestamp !== undefined);
+  const endTimestamps = turns
+    .filter((turn) => turn.role === "assistant")
+    .map(assistantTurnEndMs)
+    .filter((timestamp): timestamp is number => timestamp !== undefined);
+
+  return {
+    ...(userTimestamps.length > 0
+      ? { startTime: new Date(Math.min(...userTimestamps)).toISOString() }
+      : {}),
+    ...(endTimestamps.length > 0
+      ? { endTime: new Date(Math.max(...endTimestamps)).toISOString() }
+      : {}),
+    ...(hasDuration ? { totalDurationMs: sumDurationIntervals(intervals) } : {}),
+    ...(turnStats ? { turnStats } : {}),
+  };
+}
+
+function assistantTurnEndMs(turn: ParsedTurn): number | undefined {
+  let latest = timestampMs(turn.timestamp);
+  for (const block of turn.blocks) {
+    if (block.type !== "tool_use") continue;
+    const resultTimestamp = timestampMs(block._resultTimestamp);
+    if (resultTimestamp !== undefined && (latest === undefined || resultTimestamp > latest)) {
+      latest = resultTimestamp;
+    }
+  }
+  return latest;
+}
+
+function timestampMs(timestamp: string | undefined): number | undefined {
+  if (!timestamp) return undefined;
+  const value = Date.parse(timestamp);
+  return Number.isFinite(value) ? value : undefined;
+}
+
 async function parseCursorJsonl(
   transcriptPaths: string[],
   explicitToolPaths: string[],
@@ -382,19 +457,23 @@ async function parseCursorJsonl(
       const textParts: string[] = [];
       const userImages: string[] = [];
       const imageFilePaths = new Set<string>();
+      let recordTimestamp = typeof obj.timestamp === "string" ? obj.timestamp : undefined;
       for (const block of contentBlocks) {
         if (block.type === "tool_result") {
           const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
           if (toolUseId) {
             toolResults.set(toolUseId, {
               result: extractToolResultText(block),
-              timestamp: typeof obj.timestamp === "string" ? obj.timestamp : undefined,
+              timestamp: recordTimestamp,
             });
             if (block.is_error) toolErrors.set(toolUseId, true);
             const images = extractToolResultImages(block);
             if (images.length > 0) toolImages.set(toolUseId, images);
           }
         } else if (block.type === "text" && block.text) {
+          if (role === "user" && !recordTimestamp && typeof block.text === "string") {
+            recordTimestamp = extractCursorTimestamp(block.text);
+          }
           let text = stripUserQueryWrapper(block.text);
           if (role === "user" && deps.isSystemContextText(text)) continue;
           const extracted = extractImageFilePathsFromText(text);
@@ -437,7 +516,7 @@ async function parseCursorJsonl(
         if (blocks.length > 0) {
           allTurns.push({
             role,
-            ...(typeof obj.timestamp === "string" ? { timestamp: obj.timestamp } : {}),
+            ...(recordTimestamp ? { timestamp: recordTimestamp } : {}),
             blocks,
           });
         }
@@ -493,7 +572,7 @@ async function parseCursorJsonl(
       if (blocks.length > 0) {
         allTurns.push({
           role,
-          ...(typeof obj.timestamp === "string" ? { timestamp: obj.timestamp } : {}),
+          ...(recordTimestamp ? { timestamp: recordTimestamp } : {}),
           blocks,
         });
       }
@@ -509,6 +588,7 @@ async function parseCursorJsonl(
   const toolEvents = await loadToolEvents(toolPaths);
   attachToolResults(allTurns, toolResults, toolErrors, toolImages, deps);
   attachToolEvents(allTurns, toolEvents, deps);
+  const timing = buildCursorTurnTiming(allTurns);
 
   // Derive slug from session ID
   const slug = sessionId.slice(0, 8);
@@ -519,12 +599,22 @@ async function parseCursorJsonl(
   const firstText = firstBlock?.type === "text" ? firstBlock.text?.slice(0, 80) : undefined;
 
   const hasToolData = toolPaths.length > 0;
+  const dataSourceNotes: string[] = [];
+  if (duplicateTranscriptRecords > 0) {
+    dataSourceNotes.push(
+      `${duplicateTranscriptRecords} duplicate Cursor transcript records were omitted.`,
+    );
+  }
   return {
     sessionId,
     slug,
     title: firstText,
     cwd: "",
     turns: allTurns,
+    ...(timing.startTime ? { startTime: timing.startTime } : {}),
+    ...(timing.endTime ? { endTime: timing.endTime } : {}),
+    ...(timing.totalDurationMs !== undefined ? { totalDurationMs: timing.totalDurationMs } : {}),
+    ...(timing.turnStats ? { turnStats: timing.turnStats } : {}),
     dataSource: hasToolData ? "jsonl+tools" : "jsonl",
     dataSourceInfo: {
       primary: hasToolData ? "jsonl+tools" : "jsonl",
@@ -532,13 +622,7 @@ async function parseCursorJsonl(
         "cursor/projects/agent-transcripts/*.jsonl",
         ...(hasToolData ? ["cursor/projects/agent-tools/*.txt"] : []),
       ],
-      ...(duplicateTranscriptRecords > 0
-        ? {
-            notes: [
-              `${duplicateTranscriptRecords} duplicate Cursor transcript records were omitted.`,
-            ],
-          }
-        : {}),
+      ...(dataSourceNotes.length > 0 ? { notes: dataSourceNotes } : {}),
     },
     parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
   };
@@ -1009,6 +1093,105 @@ function countUserImages(turns: ParsedTurn[]): number {
   return count;
 }
 
+function countTurnTimestamps(turns: ParsedTurn[]): number {
+  return turns.filter((turn) => typeof turn.timestamp === "string" && turn.timestamp.length > 0)
+    .length;
+}
+
+function mergeJsonlTimingIntoCursorResult(
+  primary: ProviderParseResult,
+  enrichment: ProviderParseResult,
+): void {
+  const enrichmentStartMs = timestampMs(enrichment.startTime);
+  const primaryStartMs = timestampMs(primary.startTime);
+  if (
+    enrichment.startTime &&
+    enrichmentStartMs !== undefined &&
+    (primaryStartMs === undefined || enrichmentStartMs < primaryStartMs)
+  ) {
+    primary.startTime = enrichment.startTime;
+  }
+  const enrichmentEndMs = timestampMs(enrichment.endTime);
+  const primaryEndMs = timestampMs(primary.endTime);
+  if (
+    enrichment.endTime &&
+    enrichmentEndMs !== undefined &&
+    (primaryEndMs === undefined || enrichmentEndMs > primaryEndMs)
+  ) {
+    primary.endTime = enrichment.endTime;
+  }
+  if (enrichment.totalDurationMs === undefined) return;
+
+  const enrichmentDurations = new Map(
+    (enrichment.turnStats || [])
+      .filter((stat): stat is typeof stat & { durationMs: number } => stat.durationMs !== undefined)
+      .map((stat) => [stat.turnIndex, stat.durationMs]),
+  );
+  const primaryStats = primary.turnStats || [];
+  const mergedStats = [...primaryStats];
+  for (const stat of enrichment.turnStats || []) {
+    const current = mergedStats.find((candidate) => candidate.turnIndex === stat.turnIndex);
+    if (!current) {
+      mergedStats.push(stat);
+      continue;
+    }
+    const durationMs = enrichmentDurations.get(stat.turnIndex);
+    if (durationMs !== undefined) current.durationMs = durationMs;
+  }
+  mergedStats.sort((a, b) => a.turnIndex - b.turnIndex);
+  if (mergedStats.length > 0) primary.turnStats = mergedStats;
+
+  const fallbackDurationMs =
+    primaryStats.length > 0
+      ? primaryStats.reduce(
+          (sum, stat) =>
+            sum + (enrichmentDurations.has(stat.turnIndex) ? 0 : (stat.durationMs ?? 0)),
+          0,
+        )
+      : (primary.totalDurationMs ?? 0);
+  const mergedDurationMs = enrichment.totalDurationMs + fallbackDurationMs;
+  primary.totalDurationMs = mergedDurationMs > 0 ? mergedDurationMs : undefined;
+  primary.dataSourceInfo = replaceDurationNote(
+    primary.dataSourceInfo,
+    "Per-turn duration is inferred from Cursor transcript timestamps (user prompt to final assistant or tool result).",
+  );
+}
+
+function mergeSdkTurnStats(
+  primary: TurnStat[] | undefined,
+  sdk: TurnStat[] | undefined,
+): TurnStat[] | undefined {
+  if (!primary?.length) return sdk;
+  if (!sdk?.length) return primary;
+
+  const byIndex = new Map(primary.map((stat) => [stat.turnIndex, { ...stat }]));
+  for (const stat of sdk) {
+    const current = byIndex.get(stat.turnIndex);
+    byIndex.set(stat.turnIndex, {
+      ...current,
+      ...stat,
+      ...(current?.model && !stat.model ? { model: current.model } : {}),
+      ...(current?.tokenUsage && !stat.tokenUsage ? { tokenUsage: current.tokenUsage } : {}),
+      ...(current?.contextTokens !== undefined && stat.contextTokens === undefined
+        ? { contextTokens: current.contextTokens }
+        : {}),
+    });
+  }
+  return [...byIndex.values()].sort((a, b) => a.turnIndex - b.turnIndex);
+}
+
+function replaceDurationNote(
+  info: DataSourceInfo | undefined,
+  note: string,
+): DataSourceInfo | undefined {
+  if (!info) return undefined;
+  const notes = (info.notes || []).filter(
+    (existing) => !/duration/i.test(existing) || existing === note,
+  );
+  if (!notes.includes(note)) notes.push(note);
+  return { ...info, notes };
+}
+
 function extractToolResultText(block: Extract<ContentBlock, { type: "tool_result" }>): string {
   if (typeof block.content === "string") return block.content;
   if (!Array.isArray(block.content)) return "";
@@ -1051,6 +1234,7 @@ function attachToolResults(
         block.input = deps.mapToolArgs(block.name, block.input, result.result);
         const durationMs = durationBetween(turn.timestamp, result.timestamp);
         if (durationMs !== undefined) block._durationMs = durationMs;
+        if (result.timestamp) block._resultTimestamp = result.timestamp;
       }
       const images = toolImages.get(block.id);
       if (images?.length) block._images = images;
@@ -1142,11 +1326,41 @@ function mergeJsonlUserImagesIntoCursorTurns(
   return merged;
 }
 
+function mergeJsonlTimestampsIntoCursorTurns(
+  primaryTurns: ParsedTurn[],
+  jsonlTurns: ParsedTurn[],
+): ParsedTurn[] {
+  if (primaryTurns.length === 0 || jsonlTurns.length === 0) return primaryTurns;
+
+  const merged = primaryTurns.map((turn) => ({
+    ...turn,
+    blocks: [...turn.blocks],
+  }));
+
+  for (const role of ["user", "assistant"] as const) {
+    const primaryIndices = merged
+      .map((turn, index) => ({ turn, index }))
+      .filter(({ turn }) => turn.role === role)
+      .map(({ index }) => index);
+    const jsonlTurnsForRole = jsonlTurns.filter((turn) => turn.role === role);
+    const paired = Math.min(primaryIndices.length, jsonlTurnsForRole.length);
+
+    for (let i = 0; i < paired; i++) {
+      const target = merged[primaryIndices[i]];
+      const candidate = jsonlTurnsForRole[i];
+      if (!target.timestamp && candidate.timestamp) target.timestamp = candidate.timestamp;
+    }
+  }
+
+  return merged;
+}
+
 export function mergeJsonlSupplementsIntoCursorTurns(
   primaryTurns: ParsedTurn[],
   jsonlTurns: ParsedTurn[],
 ): ParsedTurn[] {
-  const withThinking = mergeJsonlThinkingIntoCursorTurns(primaryTurns, jsonlTurns);
+  const withTimestamps = mergeJsonlTimestampsIntoCursorTurns(primaryTurns, jsonlTurns);
+  const withThinking = mergeJsonlThinkingIntoCursorTurns(withTimestamps, jsonlTurns);
   return mergeJsonlUserImagesIntoCursorTurns(withThinking, jsonlTurns);
 }
 
@@ -1321,6 +1535,7 @@ function attachToolEvents(
       ...tool.input,
     };
     marker.block._result = tool.result;
+    if (tool.timestamp) marker.block._resultTimestamp = tool.timestamp;
     const durationMs = durationBetween(marker.turn.timestamp, tool.timestamp);
     if (durationMs !== undefined) marker.block._durationMs = durationMs;
     marker.block._isPendingMarker = undefined;
@@ -1354,6 +1569,7 @@ function attachToolEvents(
     // sidecar result when the later call is still unresolved.
     if (typeof block._result === "string") continue;
     block._result = tool.result;
+    if (tool.timestamp) block._resultTimestamp = tool.timestamp;
     block.input = { ...block.input, ...tool.input };
     try {
       block.input = deps.mapToolArgs(block.name, block.input, tool.result);
@@ -1395,6 +1611,7 @@ function toToolUseBlock(tool: ToolEvent): ContentBlock {
     name: tool.name,
     input: tool.input,
     _result: tool.result,
+    ...(tool.timestamp ? { _resultTimestamp: tool.timestamp } : {}),
   };
 }
 

--- a/packages/provider-cursor/src/cursor/sanitize.ts
+++ b/packages/provider-cursor/src/cursor/sanitize.ts
@@ -31,6 +31,93 @@ export function sanitizeCursorUserText(value: string): string {
     .trim();
 }
 
+/** Read Cursor's leading human-readable prompt timestamp and normalize it to ISO. */
+export function extractCursorTimestamp(value: string): string | undefined {
+  const match = /^\s*<timestamp>([^<]*?)<\/timestamp>/i.exec(value);
+  if (!match?.[1]) return undefined;
+  const rawTimestamp = match[1].trim();
+  const timestampMs =
+    parseCursorTimestamp(rawTimestamp) ??
+    (/^(?:[A-Za-z]+,\s+)?[A-Za-z]+\s+\d{1,2},\s+\d{4},/i.test(rawTimestamp)
+      ? undefined
+      : Date.parse(rawTimestamp));
+  return timestampMs !== undefined && Number.isFinite(timestampMs)
+    ? new Date(timestampMs).toISOString()
+    : undefined;
+}
+
+function parseCursorTimestamp(value: string): number | undefined {
+  const match =
+    /^(?:[A-Za-z]+,\s+)?([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4}),\s+(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(AM|PM)\s+\(UTC([+-]\d{1,2})(?::?(\d{2}))?\)$/i.exec(
+      value.trim(),
+    );
+  if (!match) return undefined;
+
+  const [
+    ,
+    monthName,
+    dayText,
+    yearText,
+    hourText,
+    minuteText,
+    secondText,
+    meridiem,
+    offsetText,
+    offsetMinuteText,
+  ] = match;
+  const month = [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+  ].indexOf(monthName.toLowerCase().slice(0, 3));
+  const day = Number(dayText);
+  const year = Number(yearText);
+  const minute = Number(minuteText);
+  const second = secondText ? Number(secondText) : 0;
+  let hour = Number(hourText);
+  if (month < 0 || day < 1 || year < 1 || hour < 1 || hour > 12 || minute > 59 || second > 59) {
+    return undefined;
+  }
+  if (meridiem.toLowerCase() === "pm" && hour !== 12) hour += 12;
+  if (meridiem.toLowerCase() === "am" && hour === 12) hour = 0;
+
+  const localMs = Date.UTC(year, month, day, hour, minute, second);
+  const localDate = new Date(localMs);
+  if (
+    localDate.getUTCFullYear() !== year ||
+    localDate.getUTCMonth() !== month ||
+    localDate.getUTCDate() !== day ||
+    localDate.getUTCHours() !== hour ||
+    localDate.getUTCMinutes() !== minute ||
+    localDate.getUTCSeconds() !== second
+  ) {
+    return undefined;
+  }
+
+  const offsetHours = Number(offsetText);
+  const offsetMinutes = offsetMinuteText ? Number(offsetMinuteText) : 0;
+  if (
+    !Number.isFinite(offsetHours) ||
+    Math.abs(offsetHours) > 23 ||
+    offsetMinutes < 0 ||
+    offsetMinutes > 59
+  ) {
+    return undefined;
+  }
+  const signedOffsetMinutes =
+    (offsetText.startsWith("-") ? -1 : 1) * (Math.abs(offsetHours) * 60 + offsetMinutes);
+  return localMs - signedOffsetMinutes * 60_000;
+}
+
 export function sanitizeCursorReasoningText(value: string): string {
   return trimInternalPlanningTail(value);
 }

--- a/packages/provider-cursor/src/cursor/sdk-reader.ts
+++ b/packages/provider-cursor/src/cursor/sdk-reader.ts
@@ -4,7 +4,9 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { sumDurationIntervals, toDurationInterval } from "@vibe-replay/provider-core/duration";
 import type { ContentBlock, ParsedTurn, TokenUsage } from "@vibe-replay/provider-contract";
+import type { TurnStat } from "@vibe-replay/types";
 import { mapCursorToolName, mapToolArgs, sqlJsRows, sqlString } from "./sqlite-reader.js";
 
 /**
@@ -100,8 +102,10 @@ export interface SdkAgentEnrichment {
   startedAt?: string;
   /** Latest finished_at across runs. */
   finishedAt?: string;
-  /** Sum of per-run durations (ms). */
+  /** Union of per-run durations (ms), so parallel runs are counted once. */
   totalDurationMs?: number;
+  /** Per-turn duration union, indexed from the SDK run's 1-based turn number. */
+  turnStats?: TurnStat[];
   /** Most-recent model seen across runs. */
   latestModel?: string;
   /** Sum of per-run token usage. Absent on older SDK schemas. */
@@ -310,11 +314,11 @@ function finalizeEnrichment(
 ): SdkAgentEnrichment {
   let startedAt: string | undefined;
   let finishedAt: string | undefined;
-  let totalDurationMs = 0;
-  let totalDurationSeen = false;
   let latestModel: string | undefined;
   let tokenUsage: TokenUsage | undefined;
   const tokenUsageByModel: Record<string, TokenUsage> = {};
+  const runIntervals: Array<ReturnType<typeof toDurationInterval>> = [];
+  const intervalsByTurn = new Map<number, NonNullable<ReturnType<typeof toDurationInterval>>[]>();
 
   for (const run of runs) {
     if (run.tokenUsage) {
@@ -340,16 +344,29 @@ function finalizeEnrichment(
     }
     if (run.startedAt && (!startedAt || run.startedAt < startedAt)) startedAt = run.startedAt;
     if (run.finishedAt && (!finishedAt || run.finishedAt > finishedAt)) finishedAt = run.finishedAt;
-    if (run.startedAt && run.finishedAt) {
-      const startMs = Date.parse(run.startedAt);
-      const endMs = Date.parse(run.finishedAt);
-      if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs >= startMs) {
-        totalDurationMs += endMs - startMs;
-        totalDurationSeen = true;
+    const interval = toDurationInterval(
+      run.startedAt ? eventTimeMs(run.startedAt) : undefined,
+      run.finishedAt ? eventTimeMs(run.finishedAt) : undefined,
+    );
+    if (interval) {
+      runIntervals.push(interval);
+      if (Number.isFinite(run.turnNumber)) {
+        const turnIndex = Math.max(0, Math.floor(run.turnNumber) - 1);
+        const turnIntervals = intervalsByTurn.get(turnIndex) || [];
+        turnIntervals.push(interval);
+        intervalsByTurn.set(turnIndex, turnIntervals);
       }
     }
     if (run.model) latestModel = run.model;
   }
+
+  const turnStats = [...intervalsByTurn.entries()]
+    .sort(([a], [b]) => a - b)
+    .flatMap(([turnIndex, intervals]) => {
+      const durationMs = sumDurationIntervals(intervals);
+      return durationMs === undefined ? [] : [{ turnIndex, durationMs }];
+    });
+  const totalDurationMs = sumDurationIntervals(runIntervals);
 
   return {
     agent,
@@ -357,7 +374,8 @@ function finalizeEnrichment(
     toolCallsByRun,
     startedAt,
     finishedAt,
-    totalDurationMs: totalDurationSeen ? totalDurationMs : undefined,
+    ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
+    ...(turnStats.length > 0 ? { turnStats } : {}),
     latestModel,
     ...(tokenUsage ? { tokenUsage } : {}),
     ...(Object.keys(tokenUsageByModel).length > 0 ? { tokenUsageByModel } : {}),

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -8,6 +8,10 @@ import { basename, dirname, join, posix } from "node:path";
 import { promisify } from "node:util";
 import type { CursorSidecars, PrLink, TokenUsage, TurnStat } from "@vibe-replay/types";
 import { readFileCache, writeFileCache } from "@vibe-replay/provider-core/cache";
+import {
+  buildTurnDurationIntervals,
+  sumDurationIntervals,
+} from "@vibe-replay/provider-core/duration";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "@vibe-replay/provider-contract";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import type { ProviderParseResult } from "@vibe-replay/provider-contract";
@@ -2906,37 +2910,18 @@ function applyGlobalStateWallClockDurations(
     return { turnStats, usedWallClock: false };
   }
 
-  const durationsByTurn = new Map<number, number>();
-  let currentTurnIndex = -1;
-  let currentUserAt: number | undefined;
-  let currentAssistantAt: number | undefined;
-
-  const finalizeTurn = () => {
-    if (
-      currentTurnIndex >= 0 &&
-      currentUserAt !== undefined &&
-      currentAssistantAt !== undefined &&
-      currentAssistantAt > currentUserAt
-    ) {
-      durationsByTurn.set(currentTurnIndex, currentAssistantAt - currentUserAt);
-    }
-  };
-
-  for (const entry of entries) {
-    if (entry.turn.role === "user") {
-      finalizeTurn();
-      currentTurnIndex++;
-      currentUserAt = bubbleWallClockStartMs(entry.bubble);
-      currentAssistantAt = undefined;
-      continue;
-    }
-    const bubbleTimestamp = bubbleWallClockEndMs(entry.bubble);
-    if (currentTurnIndex < 0 || bubbleTimestamp === undefined) continue;
-    if (currentAssistantAt === undefined || bubbleTimestamp > currentAssistantAt) {
-      currentAssistantAt = bubbleTimestamp;
-    }
-  }
-  finalizeTurn();
+  const intervals = buildTurnDurationIntervals(
+    entries.map((entry) => ({
+      role: entry.turn.role,
+      startMs: entry.turn.role === "user" ? bubbleWallClockStartMs(entry.bubble) : undefined,
+      endMs: entry.turn.role === "assistant" ? bubbleWallClockEndMs(entry.bubble) : undefined,
+    })),
+  );
+  const durationsByTurn = new Map(
+    intervals.flatMap((interval, turnIndex) =>
+      interval ? [[turnIndex, interval.endMs - interval.startMs] as const] : [],
+    ),
+  );
 
   if (durationsByTurn.size === 0) {
     return {
@@ -2951,11 +2936,16 @@ function applyGlobalStateWallClockDurations(
     const wallClockDuration = durationsByTurn.get(stat.turnIndex);
     return wallClockDuration !== undefined ? { ...stat, durationMs: wallClockDuration } : stat;
   });
+  const fallbackDurationMs = turnStats.reduce(
+    (sum, stat) => sum + (durationsByTurn.has(stat.turnIndex) ? 0 : stat.durationMs || 0),
+    0,
+  );
+  const wallClockDurationMs = sumDurationIntervals(intervals);
+  const totalDurationMs = (wallClockDurationMs || 0) + fallbackDurationMs || undefined;
 
   return {
     turnStats: mergedTurnStats,
-    totalDurationMs:
-      mergedTurnStats.reduce((sum, stat) => sum + (stat.durationMs || 0), 0) || undefined,
+    totalDurationMs,
     usedWallClock: true,
   };
 }

--- a/packages/provider-cursor/test/jsonl-parser.test.ts
+++ b/packages/provider-cursor/test/jsonl-parser.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseCursorSession } from "../src/cursor/parser.js";
+import { extractCursorTimestamp } from "../src/cursor/sanitize.js";
 import { transformToReplay } from "./helpers/transform.js";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
 
@@ -97,6 +98,15 @@ describe("Cursor parser", () => {
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("rejects malformed Cursor timestamp wrappers", () => {
+    expect(
+      extractCursorTimestamp("<timestamp>Thursday, Feb 31, 2026, 4:43 PM (UTC-7)</timestamp>"),
+    ).toBeUndefined();
+    expect(
+      extractCursorTimestamp("<timestamp>Tuesday, Apr 28, 2026, 4:43 PM (UTC-99)</timestamp>"),
+    ).toBeUndefined();
   });
 
   it("extracts <image_files> into _user_images and removes image markers", async () => {
@@ -322,6 +332,86 @@ describe("Cursor parser — tool outputs", () => {
       expect(toolScenes).toHaveLength(1);
       expect(toolScenes[0].durationMs).toBe(2500);
       expect(toolScenes[0].resultTokens).toBeGreaterThan(0);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives turn and session duration from user and assistant timestamps", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "vibe-replay-cursor-turn-duration-"));
+    const jsonlPath = join(tempDir, "turn-duration.jsonl");
+    await writeFile(
+      jsonlPath,
+      [
+        JSON.stringify({
+          role: "user",
+          message: {
+            content: [
+              {
+                type: "text",
+                text: "<timestamp>Thursday, Jan 1, 2026, 12:00 AM (UTC-7)</timestamp>\n<user_query>\nFirst prompt\n</user_query>",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          timestamp: "2026-01-01T07:00:01.000Z",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_duration",
+                name: "run_terminal_cmd",
+                input: { command: "pnpm test" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "user",
+          timestamp: "2026-01-01T07:00:04.000Z",
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: "toolu_duration", content: "tests passed" },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          timestamp: "2026-01-01T07:00:07.000Z",
+          message: { content: [{ type: "text", text: "The tests pass." }] },
+        }),
+        JSON.stringify({
+          role: "user",
+          message: {
+            content: [
+              {
+                type: "text",
+                text: "<timestamp>Thursday, Jan 1, 2026, 12:00:08 AM (UTC-7)</timestamp>\n<user_query>\nSecond prompt\n</user_query>",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          timestamp: "2026-01-01T07:00:10.000Z",
+          message: { content: [{ type: "text", text: "Done." }] },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      const parsed = await parseCursorSession(jsonlPath);
+
+      expect(parsed.startTime).toBe("2026-01-01T07:00:00.000Z");
+      expect(parsed.endTime).toBe("2026-01-01T07:00:10.000Z");
+      expect(parsed.totalDurationMs).toBe(9_000);
+      expect(parsed.turnStats).toEqual([
+        { turnIndex: 0, durationMs: 7_000 },
+        { turnIndex: 1, durationMs: 2_000 },
+      ]);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/provider-cursor/test/sdk-reader.test.ts
+++ b/packages/provider-cursor/test/sdk-reader.test.ts
@@ -710,6 +710,55 @@ describe("applySdkEnrichmentToTurns", () => {
   });
 });
 
+describe("Cursor SDK duration aggregation", () => {
+  it("unions overlapping runs and exposes per-turn durations", () => {
+    const agent: SdkAgent = {
+      agentId: "agent-overlap",
+      workspaceRef: "/tmp/ws",
+      status: "FINISHED",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:20.000Z",
+      dbPath: "/tmp/ws/sdk/index.db",
+    };
+    const enrichment = __testables.finalizeEnrichment(
+      agent,
+      [
+        {
+          runId: "run-1",
+          agentId: agent.agentId,
+          turnNumber: 1,
+          status: "FINISHED",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:00:10.000Z",
+        },
+        {
+          runId: "run-2",
+          agentId: agent.agentId,
+          turnNumber: 2,
+          status: "FINISHED",
+          startedAt: "2026-01-01T00:00:05.000Z",
+          finishedAt: "2026-01-01T00:00:15.000Z",
+        },
+        {
+          runId: "run-3",
+          agentId: agent.agentId,
+          turnNumber: 2,
+          status: "FINISHED",
+          startedAt: "2026-01-01T00:00:12.000Z",
+          finishedAt: "2026-01-01T00:00:20.000Z",
+        },
+      ],
+      new Map(),
+    );
+
+    expect(enrichment.totalDurationMs).toBe(20_000);
+    expect(enrichment.turnStats).toEqual([
+      { turnIndex: 0, durationMs: 10_000 },
+      { turnIndex: 1, durationMs: 15_000 },
+    ]);
+  });
+});
+
 describe("loadSdkAgentEnrichment + listSdkIndexDbPaths (integration with synthetic db)", () => {
   let tempRoot: string;
   let dbPath: string;

--- a/packages/provider-cursor/test/sqlite-reader.test.ts
+++ b/packages/provider-cursor/test/sqlite-reader.test.ts
@@ -515,6 +515,58 @@ describe("cursor sqlite metrics helpers", () => {
     expect(metrics.usedWallClock).toBe(false);
   });
 
+  it("unions overlapping wall-clock turn intervals", () => {
+    const metrics = __testables.buildGlobalStateMetrics(
+      [
+        {
+          turn: {
+            role: "user",
+            blocks: [{ type: "text", text: "first prompt" }],
+          },
+          bubble: {
+            type: 1,
+            timingInfo: { clientStartTime: Date.parse("2026-01-01T00:00:00.000Z") },
+          },
+        },
+        {
+          turn: {
+            role: "assistant",
+            blocks: [{ type: "text", text: "first reply" }],
+          },
+          bubble: {
+            type: 2,
+            timingInfo: { clientEndTime: Date.parse("2026-01-01T00:00:10.000Z") },
+          },
+        },
+        {
+          turn: {
+            role: "user",
+            blocks: [{ type: "text", text: "second prompt" }],
+          },
+          bubble: {
+            type: 1,
+            timingInfo: { clientStartTime: Date.parse("2026-01-01T00:00:05.000Z") },
+          },
+        },
+        {
+          turn: {
+            role: "assistant",
+            blocks: [{ type: "text", text: "second reply" }],
+          },
+          bubble: {
+            type: 2,
+            timingInfo: { clientEndTime: Date.parse("2026-01-01T00:00:15.000Z") },
+          },
+        },
+      ],
+      undefined,
+    );
+
+    expect(metrics.turnStats?.map((stat) => stat.durationMs)).toEqual([10_000, 10_000]);
+    expect(metrics.totalDurationMs).toBe(15_000);
+    expect(metrics.usedWallClock).toBe(true);
+  });
+
   it("does not use clustered createdAt values as wall-clock durations", () => {
     const metrics = __testables.buildGlobalStateMetrics(
       [


### PR DESCRIPTION
## Summary
- Derive Cursor JSONL turn duration from the user prompt through the final assistant or tool-result timestamp.
- Union overlapping global-state and SDK intervals so parallel work is counted once.
- Supplement SQLite sessions with transcript timestamps while retaining execution-metadata fallback when completion timestamps are unavailable.

## Test plan
- [x] `pnpm test`
- [x] `pnpm lint:check`
- [x] `pnpm typecheck`
- [x] `pnpm --filter vibe-replay build`
- [x] `git diff --check`
- [x] Read-only parse of a real local Cursor session

## Notes
- Cost accounting is intentionally unchanged; Cursor local session files do not expose authoritative charged usage.
- The real session had prompt timestamps but no reliable assistant completion timestamp, so the parser correctly kept its SQLite tool-execution estimate instead of inventing a session span.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cursor session parsing now captures timestamps from transcript data when available.
  * Session start/end times and individual turn durations are calculated more accurately.
  * Tool-result timestamps are preserved to improve timing details.
* **Bug Fixes**
  * Overlapping activities are merged when calculating total duration, preventing double-counting.
  * Invalid or incomplete timestamps no longer produce misleading duration estimates.
  * Duplicate transcript records are surfaced as data-source notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->