### PR TITLE
fix(insights): harden cost and duration accounting

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -2117,7 +2117,13 @@ function buildAggregateDataQuality(scans: SessionScanResult[]): { notes: string[
   const missingDurationCount = cursorScans.filter((s) => !s.durationMs).length;
   const missingTokenCount = cursorScans.filter((s) => !s.tokenUsage).length;
   const missingTurnStatsCount = cursorScans.filter((s) => !s.turnStatCount).length;
-  const sessionsWithTokens = scans.filter((s) => s.tokenUsage);
+  const sessionsWithTokens = scans.filter((s) => {
+    const usage = s.tokenUsage;
+    return (
+      usage !== undefined &&
+      usage.inputTokens + usage.outputTokens + usage.cacheCreationTokens + usage.cacheReadTokens > 0
+    );
+  });
   const missingCostCount = sessionsWithTokens.filter((s) => s.costEstimate === undefined).length;
 
   const notes: string[] = [];

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -52,10 +52,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v24: persist session location so local and SSH scan results stay isolated.
 // v25: persist transcript availability so metadata-only sources do not look
 // like ordinary sessions that simply have not been scanned yet.
-export const SCANNER_VERSION = 25;
-// v26 briefly existed during development for a title-only change. Its result
-// shape is identical to v25, so accepting it avoids a second full local rescan.
-const COMPATIBLE_SCANNER_VERSIONS = new Set([SCANNER_VERSION, 26]);
+// v27: normalize end times, ignore zero Pi usage, and use active OpenCode duration.
+export const SCANNER_VERSION = 27;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -1064,6 +1062,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     model ||= input.discoveryModel;
     durationMs ||= input.discoveryDurationMs;
   }
+  const normalizedEndTime = ensureEndCoversDuration(startTime, endTime, durationMs);
   const qualityNotes = [...(costDataQualityNotes(undefined, tokenUsage, costEstimate) || [])];
   if (richFallbackProvider) {
     qualityNotes.push(
@@ -1082,7 +1081,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     title,
     firstPrompt,
     startTime,
-    endTime,
+    endTime: normalizedEndTime,
     durationMs,
     gitBranch,
     gitBranches: gitBranches.length > 1 ? gitBranches : undefined,
@@ -1118,6 +1117,22 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
 function scanFallbackPrompt(input: ScanInput, placeholder = ""): string {
   if (input.transcriptStatus) return "";
   return input.firstPrompt || input.title || placeholder;
+}
+
+/** Keep persisted timing internally consistent without discarding active-time evidence. */
+function ensureEndCoversDuration(
+  startTime: string | undefined,
+  endTime: string | undefined,
+  durationMs: number | undefined,
+): string | undefined {
+  if (!startTime) return endTime;
+  const startMs = Date.parse(startTime);
+  if (!Number.isFinite(startMs)) return endTime;
+  const minimumEndMs = startMs + Math.max(0, durationMs || 0);
+  const endMs = endTime ? Date.parse(endTime) : Number.NaN;
+  return Number.isFinite(endMs) && endMs >= minimumEndMs
+    ? endTime
+    : new Date(minimumEndMs).toISOString();
 }
 
 async function scanClaudeCoworkSession(input: ScanInput): Promise<SessionScanResult> {
@@ -1421,6 +1436,7 @@ function buildScanResultFromParsed(
   const costEstimate = estimateParsedCost(parsed);
   const fallbackStart = parsed.startTime || input.timestamp;
   const durationMs = parsed.totalDurationMs;
+  const normalizedEndTime = ensureEndCoversDuration(fallbackStart, parsed.endTime, durationMs);
   const firstPrompt = input.transcriptStatus
     ? ""
     : firstUserPrompt(parsed.turns) || input.firstPrompt || parsed.title;
@@ -1453,7 +1469,7 @@ function buildScanResultFromParsed(
     title: parsed.title || input.title,
     firstPrompt,
     startTime: fallbackStart,
-    endTime: parsed.endTime,
+    endTime: normalizedEndTime,
     durationMs,
     gitBranch: parsed.gitBranch,
     gitBranches: parsed.gitBranches,
@@ -1544,8 +1560,8 @@ const SCAN_CONCURRENCY = 4;
 async function readScanCache(): Promise<ScanCacheData | null> {
   const cached = await readFileCache<ScanCacheData>(SCAN_CACHE_KEY);
   if (!cached) return null;
-  if (!COMPATIBLE_SCANNER_VERSIONS.has(cached.data.scannerVersion)) return null;
-  return { ...cached.data, scannerVersion: SCANNER_VERSION };
+  if (cached.data.scannerVersion !== SCANNER_VERSION) return null;
+  return cached.data;
 }
 
 async function writeScanCache(data: ScanCacheData): Promise<void> {
@@ -2094,8 +2110,6 @@ export function aggregateUserInsights(scans: SessionScanResult[]): UserInsights 
 
 function buildAggregateDataQuality(scans: SessionScanResult[]): { notes: string[] } | undefined {
   const cursorScans = scans.filter((s) => s.provider === "cursor");
-  if (cursorScans.length === 0) return undefined;
-
   const total = cursorScans.length;
   const estimatedDurationCount = cursorScans.filter((s) =>
     s.dataQualityNotes?.some((note) => /duration.*estimated|estimated.*duration/i.test(note)),
@@ -2103,25 +2117,32 @@ function buildAggregateDataQuality(scans: SessionScanResult[]): { notes: string[
   const missingDurationCount = cursorScans.filter((s) => !s.durationMs).length;
   const missingTokenCount = cursorScans.filter((s) => !s.tokenUsage).length;
   const missingTurnStatsCount = cursorScans.filter((s) => !s.turnStatCount).length;
+  const sessionsWithTokens = scans.filter((s) => s.tokenUsage);
+  const missingCostCount = sessionsWithTokens.filter((s) => s.costEstimate === undefined).length;
 
   const notes: string[] = [];
-  if (estimatedDurationCount > 0) {
+  if (total > 0 && estimatedDurationCount > 0) {
     notes.push(
       `${estimatedDurationCount}/${total} Cursor sessions use best-effort duration estimates.`,
     );
   }
-  if (missingDurationCount > 0) {
+  if (total > 0 && missingDurationCount > 0) {
     notes.push(
       `${missingDurationCount}/${total} Cursor sessions do not have enough timing data to compute duration.`,
     );
   }
-  if (missingTokenCount > 0) {
+  if (total > 0 && missingTokenCount > 0) {
     notes.push(
       `${missingTokenCount}/${total} Cursor sessions do not include token snapshots, so token and cost totals are partial.`,
     );
   }
-  if (missingTurnStatsCount > 0) {
+  if (total > 0 && missingTurnStatsCount > 0) {
     notes.push(`${missingTurnStatsCount}/${total} Cursor sessions do not include per-turn stats.`);
+  }
+  if (missingCostCount > 0) {
+    notes.push(
+      `${missingCostCount}/${sessionsWithTokens.length} sessions with token usage have unknown model pricing or attribution, so displayed cost is a partial lower bound.`,
+    );
   }
 
   return notes.length > 0 ? { notes } : undefined;

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -863,6 +863,39 @@ describe("scanSession", () => {
     expect(result.durationMs).toBe(9000);
   });
 
+  it("extends endTime when active duration outlasts the final event timestamp", async () => {
+    const path = join(tmpDir, "duration-after-final-event.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "user",
+          timestamp: "2025-03-20T10:00:00.000Z",
+          message: { role: "user", content: "Run a timed task" },
+        }),
+        makeLine({
+          type: "system",
+          subtype: "turn_duration",
+          timestamp: "2025-03-20T10:00:01.000Z",
+          durationMs: 10_000,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "duration-after-final-event",
+      provider: "claude-code",
+      project: "~/project",
+      slug: "duration-after-final-event",
+      filePaths: [path],
+    });
+
+    expect(result.startTime).toBe("2025-03-20T10:00:00.000Z");
+    expect(result.durationMs).toBe(10_000);
+    expect(result.endTime).toBe("2025-03-20T10:00:10.000Z");
+  });
+
   it("counts synthetic assistant API error messages", async () => {
     const path = join(tmpDir, "api-error-message.jsonl");
     await writeFile(
@@ -1203,6 +1236,41 @@ describe("scanSession", () => {
     expect(result.dataQualityNotes).toContain(
       "Partial Pi scan: the rich parser failed, so available generic and discovery metadata was used.",
     );
+  });
+
+  it("normalizes parsed duration from the discovery start fallback", async () => {
+    const path = join(tmpDir, "codex-duration-without-timestamps.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "session_meta",
+          payload: { id: "codex-duration-fallback", cwd: "/tmp/project" },
+        }),
+        makeLine({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Run the task" },
+        }),
+        makeLine({
+          type: "event_msg",
+          payload: { type: "task_complete", duration_ms: 15_000 },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "codex-duration-fallback",
+      provider: "codex",
+      project: "~/project",
+      slug: "codex-duration-fallback",
+      filePaths: [path],
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(result.startTime).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.durationMs).toBe(15_000);
+    expect(result.endTime).toBe("2026-01-01T00:00:15.000Z");
   });
 
   it("recognizes multi-word provider names in partial scan notes", () => {
@@ -1585,6 +1653,30 @@ describe("aggregateUserInsights", () => {
     );
     expect(insights.dataQuality?.notes).toContain(
       "2/2 Cursor sessions do not include per-turn stats.",
+    );
+  });
+
+  it("reports when aggregate cost is only a priced lower bound", () => {
+    const tokenUsage = {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+    };
+    const insights = aggregateUserInsights([
+      { ...scans[0], sessionId: "priced", tokenUsage, costEstimate: 0.01 },
+      {
+        ...scans[0],
+        sessionId: "unknown-price",
+        model: "future-model",
+        tokenUsage,
+        costEstimate: undefined,
+      },
+    ]);
+
+    expect(insights.totalCost).toBe(0.01);
+    expect(insights.dataQuality?.notes).toContain(
+      "1/2 sessions with token usage have unknown model pricing or attribution, so displayed cost is a partial lower bound.",
     );
   });
 

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -1672,6 +1672,18 @@ describe("aggregateUserInsights", () => {
         tokenUsage,
         costEstimate: undefined,
       },
+      {
+        ...scans[0],
+        sessionId: "empty-usage",
+        model: "future-model",
+        tokenUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheCreationTokens: 0,
+          cacheReadTokens: 0,
+        },
+        costEstimate: undefined,
+      },
     ]);
 
     expect(insights.totalCost).toBe(0.01);

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -913,6 +913,18 @@ function maxIsoTimestamp(values: Array<unknown>): string | undefined {
   return maxMs === undefined ? undefined : new Date(maxMs).toISOString();
 }
 
+function minIsoTimestamp(values: Array<unknown>): string | undefined {
+  let minMs: number | undefined;
+  for (const value of values) {
+    const iso = toIsoTimestamp(value);
+    if (!iso) continue;
+    const ms = Date.parse(iso);
+    if (!Number.isFinite(ms)) continue;
+    if (minMs === undefined || ms < minMs) minMs = ms;
+  }
+  return minMs === undefined ? undefined : new Date(minMs).toISOString();
+}
+
 function bubbleTimestamp(bubble: Record<string, any>): string | undefined {
   const timingInfo =
     bubble.timingInfo && typeof bubble.timingInfo === "object"
@@ -3184,11 +3196,12 @@ async function parseCursorGlobalStateDb(
     );
     const requestContexts = await loadCursorRequestContexts(resolvedGlobalStateDb, sessionId);
 
-    const startTime = toIsoTimestamp(composer.createdAt);
+    const turnTimestamps = turns.map((turn) => turn.timestamp).filter(Boolean);
+    const startTime = minIsoTimestamp([composer.createdAt, ...turnTimestamps]);
     const endTime = maxIsoTimestamp([
       composer.lastUpdatedAt,
       composer.conversationCheckpointLastUpdatedAt,
-      ...turns.map((turn) => turn.timestamp).filter(Boolean),
+      ...turnTimestamps,
     ]);
     const sessionTokenUsage = tokenUsageFromCursorTokenCount(composer.tokenCount);
     const metrics = buildGlobalStateMetrics(entries, modelName, sessionTokenUsage);
@@ -3485,6 +3498,7 @@ export const __testables = {
   mapCursorToolName,
   mapToolArgs,
   maxIsoTimestamp,
+  minIsoTimestamp,
   mergeCursorParseResults,
   messagesToTurns,
   mergeTurnStats,

--- a/packages/provider-cursor/test/sqlite-reader.test.ts
+++ b/packages/provider-cursor/test/sqlite-reader.test.ts
@@ -610,6 +610,12 @@ describe("cursor sqlite metrics helpers", () => {
     ).toBe("2026-04-28T20:25:48.085Z");
   });
 
+  it("keeps global-state start time at least as early as turn timestamps", () => {
+    expect(
+      __testables.minIsoTimestamp(["2026-04-28T20:25:48.109Z", "2026-04-28T20:24:48.085Z"]),
+    ).toBe("2026-04-28T20:24:48.085Z");
+  });
+
   it("extracts new Cursor composerData sidecar metadata", () => {
     expect(
       __testables.cursorComposerSidecarMetadata({

--- a/packages/provider-opencode/src/opencode/discover.ts
+++ b/packages/provider-opencode/src/opencode/discover.ts
@@ -1,6 +1,7 @@
 /// <reference path="../sql-js.d.ts" />
 import type { Database } from "sql.js";
 import { cleanPromptText } from "@vibe-replay/provider-core/clean-prompt";
+import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
 import type { SessionInfo } from "@vibe-replay/provider-contract";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import { openOpencodeDb, opencodeDataDir, opencodeDbPath } from "./sqlite.js";
@@ -110,6 +111,7 @@ interface SessionStats {
   toolCallCount: number;
   editCountEst: number;
   firstPrompt: string;
+  durationMs?: number;
 }
 
 function buildSessionStats(db: Database): Map<string, SessionStats> {
@@ -148,6 +150,7 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
     `,
   );
   const firstPrompts = firstUserPrompts(db);
+  const durations = activeDurationsBySession(db);
 
   const map = new Map<string, SessionStats>();
   for (const row of messageCounts) {
@@ -159,9 +162,33 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
       toolCallCount: toolCounts.get(sessionId) ?? 0,
       editCountEst: editToolCounts.get(sessionId) ?? 0,
       firstPrompt: firstPrompts.get(sessionId) ?? "",
+      durationMs: durations.get(sessionId),
     });
   }
   return map;
+}
+
+/** Estimate active time from message activity, capping long idle gaps. */
+function activeDurationsBySession(db: Database): Map<string, number> {
+  const timestamps = new Map<string, string[]>();
+  for (const row of rowValues(
+    db,
+    `SELECT session_id, time_created FROM message ORDER BY session_id ASC, time_created ASC`,
+  )) {
+    const sessionId = String(row.session_id ?? "");
+    const timestamp = toIsoMs(Number(row.time_created));
+    if (!sessionId || !timestamp) continue;
+    const values = timestamps.get(sessionId) || [];
+    values.push(timestamp);
+    timestamps.set(sessionId, values);
+  }
+
+  const durations = new Map<string, number>();
+  for (const [sessionId, values] of timestamps) {
+    const durationMs = estimateActiveDuration(values);
+    if (durationMs !== undefined) durations.set(sessionId, durationMs);
+  }
+  return durations;
 }
 
 /** Map session_id → aggregate count for a `GROUP BY session_id` query. */
@@ -236,10 +263,7 @@ function sessionInfoFromRow(row: OpencodeSessionRow, stats: SessionStats): Sessi
     promptCount: stats.promptCount,
     toolCallCount: stats.toolCallCount,
     model,
-    durationMsEst:
-      row.time_created > 0 && row.time_updated > row.time_created
-        ? row.time_updated - row.time_created
-        : undefined,
+    durationMsEst: stats.durationMs,
     editCountEst: stats.editCountEst,
   };
 }

--- a/packages/provider-opencode/test/discover.test.ts
+++ b/packages/provider-opencode/test/discover.test.ts
@@ -84,7 +84,7 @@ describe("opencode discover", () => {
         hasSqlite: true,
       });
       expect(main?.filePath).toContain("#session:ses_main");
-      expect(main?.durationMsEst).toBe(100_000);
+      expect(main?.durationMsEst).toBe(20_000);
     } finally {
       db.close();
     }

--- a/packages/provider-pi/src/pi/parser.ts
+++ b/packages/provider-pi/src/pi/parser.ts
@@ -280,13 +280,15 @@ export function parsePiLines(
           model = model || msgModel;
           currentModel = msgModel;
         }
-        if (message.usage && entry.id) {
+        if (message.usage && entry.id && hasValidUsageValues(message.usage)) {
           const usage = normalizeUsage(message.usage);
-          usageByMessageId.set(entry.id, {
-            usage,
-            model: msgModel,
-            contextTokens: usage.inputTokens + usage.cacheCreationTokens + usage.cacheReadTokens,
-          });
+          if (tokenUsageTotal(usage) > 0) {
+            usageByMessageId.set(entry.id, {
+              usage,
+              model: msgModel,
+              contextTokens: usage.inputTokens + usage.cacheCreationTokens + usage.cacheReadTokens,
+            });
+          }
         }
         turns.push({
           role: "assistant",
@@ -657,12 +659,7 @@ function collectSummaryUsage(
   const rawUsage = usage as PiUsage;
   if (!hasValidUsageValues(rawUsage)) return;
   const normalized = normalizeUsage(rawUsage);
-  const total =
-    normalized.inputTokens +
-    normalized.outputTokens +
-    normalized.cacheCreationTokens +
-    normalized.cacheReadTokens;
-  if (total === 0) return;
+  if (tokenUsageTotal(normalized) === 0) return;
   target.push({ usage: normalized, ...(model ? { model } : {}) });
 }
 
@@ -677,6 +674,10 @@ function normalizeUsage(usage: PiUsage): TokenUsage {
 
 function tokenCount(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function tokenUsageTotal(usage: TokenUsage): number {
+  return usage.inputTokens + usage.outputTokens + usage.cacheCreationTokens + usage.cacheReadTokens;
 }
 
 function hasValidUsageValues(usage: PiUsage): boolean {

--- a/packages/provider-pi/test/parser.test.ts
+++ b/packages/provider-pi/test/parser.test.ts
@@ -968,6 +968,45 @@ describe("Pi parser", () => {
     });
   });
 
+  it("ignores all-zero assistant usage snapshots", async () => {
+    await withPiFixture(
+      [
+        {
+          type: "session",
+          version: 3,
+          id: "pi-zero-usage",
+          timestamp: "2026-01-01T00:00:00.000Z",
+          cwd: "/Users/test/project",
+        },
+        {
+          type: "message",
+          id: "user1",
+          parentId: null,
+          timestamp: "2026-01-01T00:00:01.000Z",
+          message: { role: "user", content: [{ type: "text", text: "Inspect usage" }] },
+        },
+        {
+          type: "message",
+          id: "assistant1",
+          parentId: "user1",
+          timestamp: "2026-01-01T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            model: "gpt-5.5",
+            content: [{ type: "text", text: "Done" }],
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          },
+        },
+      ],
+      async (path) => {
+        const parsed = await parsePiSession(path);
+        expect(parsed.tokenUsage).toBeUndefined();
+        expect(parsed.tokenUsageByModel).toBeUndefined();
+        expect(parsed.turnStats?.[0]?.tokenUsage).toBeUndefined();
+      },
+    );
+  });
+
   it.each([
     { pairs: 15, expectedScenes: 30 },
     { pairs: 250, expectedScenes: 500 },

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -15,6 +15,24 @@ interface ModelPricing {
 // - Claude: LiteLLM model pricing data (used by ccusage).
 // - GPT-5.x: OpenAI API pricing page (standard rates for context lengths under 270K).
 const MODEL_PRICING: Record<string, ModelPricing> = {
+  "gpt-5.6-sol": {
+    inputRate: 4,
+    outputRate: 20,
+    cacheCreateRate: 5,
+    cacheReadRate: 0.4,
+  },
+  "gpt-5.6-terra": {
+    inputRate: 2,
+    outputRate: 12,
+    cacheCreateRate: 2.5,
+    cacheReadRate: 0.2,
+  },
+  "gpt-5.6-luna": {
+    inputRate: 0.2,
+    outputRate: 1.2,
+    cacheCreateRate: 0.25,
+    cacheReadRate: 0.02,
+  },
   "gpt-5.5": {
     inputRate: 5,
     outputRate: 30,
@@ -33,7 +51,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheCreateRate: 0.75,
     cacheReadRate: 0.075,
   },
-  // Opus 4.6/4.5
+  // Opus 5 and 4.8–4.5
   "opus-4-new": {
     inputRate: 5,
     outputRate: 25,
@@ -98,15 +116,25 @@ export function getModelPricing(model: string): ModelPricing {
 export function getKnownModelPricing(model: string): ModelPricing | undefined {
   const lower = model.toLowerCase();
   // GPT-5.x prices from OpenAI's public API pricing table.
+  if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
+  if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
+  if (lower.includes("gpt-5.6-luna")) return MODEL_PRICING["gpt-5.6-luna"];
   // Check mini before gpt-5.4 so "gpt-5.4-mini" is not shadowed.
   if (lower.includes("gpt-5.4-mini")) return MODEL_PRICING["gpt-5.4-mini"];
   if (lower.includes("gpt-5.5")) return MODEL_PRICING["gpt-5.5"];
   if (lower.includes("gpt-5.4")) return MODEL_PRICING["gpt-5.4"];
-  // Opus: 4.6/4.5 → new pricing, 4.1 and earlier → legacy
+  // Opus: 5 and 4.8–4.5 → current pricing, 4.1 and earlier → legacy
   const opusVersion = parseClaudeVersion(lower, "opus");
-  if (isUnsupportedClaudeVersion(opusVersion)) return undefined;
-  if (opusVersion?.major === 4 && (opusVersion.minor === 5 || opusVersion.minor === 6))
+  if (
+    opusVersion?.major === 5 ||
+    (opusVersion?.major === 4 &&
+      opusVersion.minor !== undefined &&
+      opusVersion.minor >= 5 &&
+      opusVersion.minor <= 8)
+  ) {
     return MODEL_PRICING["opus-4-new"];
+  }
+  if (isUnsupportedClaudeVersion(opusVersion)) return undefined;
   if (lower.includes("opus")) return MODEL_PRICING.opus;
   // Sonnet: 4.6/4.5 → new pricing, Sonnet 4 → explicit, earlier → standard
   const sonnetVersion = parseClaudeVersion(lower, "sonnet");
@@ -155,6 +183,7 @@ function isUnsupportedClaudeVersion(version: ClaudeVersion | undefined): boolean
 
 // Non-Claude context window limits. Claude models are handled by name detection below.
 const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  "gpt-5.6": 272_000,
   "gpt-5.5": 270_000,
   "gpt-5.4-mini": 270_000,
   "gpt-5.4": 270_000,

--- a/packages/replay-core/src/pricing.ts
+++ b/packages/replay-core/src/pricing.ts
@@ -115,6 +115,7 @@ export function getModelPricing(model: string): ModelPricing {
 /** Resolve pricing only when the model family/version is known. */
 export function getKnownModelPricing(model: string): ModelPricing | undefined {
   const lower = model.toLowerCase();
+  if (lower === "gpt-5.6") return MODEL_PRICING["gpt-5.6-sol"];
   // GPT-5.x prices from OpenAI's public API pricing table.
   if (lower.includes("gpt-5.6-sol")) return MODEL_PRICING["gpt-5.6-sol"];
   if (lower.includes("gpt-5.6-terra")) return MODEL_PRICING["gpt-5.6-terra"];
@@ -183,7 +184,7 @@ function isUnsupportedClaudeVersion(version: ClaudeVersion | undefined): boolean
 
 // Non-Claude context window limits. Claude models are handled by name detection below.
 const MODEL_CONTEXT_LIMITS: Record<string, number> = {
-  "gpt-5.6": 272_000,
+  "gpt-5.6": 1_050_000,
   "gpt-5.5": 270_000,
   "gpt-5.4-mini": 270_000,
   "gpt-5.4": 270_000,

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -28,6 +28,16 @@ describe("getModelPricing — model family detection", () => {
     expect(p.outputRate).toBe(25);
   });
 
+  it("returns current Opus pricing for Opus 4.8 and Opus 5", () => {
+    expect(getKnownModelPricing("claude-opus-4-8")).toMatchObject({
+      inputRate: 5,
+      outputRate: 25,
+      cacheCreateRate: 6.25,
+      cacheReadRate: 0.5,
+    });
+    expect(getKnownModelPricing("claude-opus-5")).toEqual(getKnownModelPricing("claude-opus-4-8"));
+  });
+
   it("returns legacy Opus pricing for opus-4-20250514 (4.1)", () => {
     const p = getModelPricing("claude-opus-4-20250514");
     expect(p.inputRate).toBe(15);
@@ -70,6 +80,23 @@ describe("getModelPricing — model family detection", () => {
     expect(p.cacheReadRate).toBe(0.5);
   });
 
+  it("returns GPT-5.6 family pricing for effort-suffixed model IDs", () => {
+    expect(getKnownModelPricing("gpt-5.6-sol-xhigh")).toMatchObject({
+      inputRate: 4,
+      outputRate: 20,
+      cacheCreateRate: 5,
+      cacheReadRate: 0.4,
+    });
+    expect(getKnownModelPricing("gpt-5.6-terra-medium")).toMatchObject({
+      inputRate: 2,
+      outputRate: 12,
+    });
+    expect(getKnownModelPricing("gpt-5.6-luna")).toMatchObject({
+      inputRate: 0.2,
+      outputRate: 1.2,
+    });
+  });
+
   it("returns GPT-5.4 pricing for Codex model IDs", () => {
     const p = getModelPricing("gpt-5.4-high");
     expect(p.inputRate).toBe(2.5);
@@ -106,17 +133,16 @@ describe("getModelPricing — model family detection", () => {
 
   it("distinguishes unknown pricing without changing the legacy fallback", () => {
     expect(getKnownModelPricing("some-unknown-model")).toBeUndefined();
-    expect(getKnownModelPricing("claude-opus-4-8")).toBeUndefined();
     expect(getKnownModelPricing("claude-opus-4-10")).toBeUndefined();
     expect(getKnownModelPricing("claude-sonnet-4-8")).toBeUndefined();
     expect(getKnownModelPricing("claude-haiku-4-8")).toBeUndefined();
-    expect(getKnownModelPricing("claude-opus-5")).toBeUndefined();
     expect(getKnownModelPricing("claude-sonnet-5")).toBeUndefined();
     expect(getKnownModelPricing("claude-haiku-5")).toBeUndefined();
-    for (const family of ["opus", "sonnet", "haiku"]) {
+    for (const family of ["sonnet", "haiku"]) {
       expect(getKnownModelPricing(`claude-${family}-4-60`)).toBeUndefined();
       expect(getKnownModelPricing(`claude-4-8-${family}`)).toBeUndefined();
     }
+    expect(getKnownModelPricing("claude-opus-4-60")).toBeUndefined();
     expect(getKnownModelPricing("claude-opus-4-100")).toBeUndefined();
     expect(getKnownModelPricing("claude-4-600-haiku")).toBeUndefined();
     expect(getKnownModelPricing("claude-4-1-sonnet")).toBe(
@@ -135,6 +161,7 @@ describe("getModelPricing — model family detection", () => {
 describe("getModelContextLimit", () => {
   it("returns GPT-5.x public pricing threshold as fallback context limit", () => {
     expect(getModelContextLimit("gpt-5.5")).toBe(270_000);
+    expect(getModelContextLimit("gpt-5.6-sol")).toBe(272_000);
     expect(getModelContextLimit("gpt-5.4-high")).toBe(270_000);
     expect(getModelContextLimit("gpt-5.4-mini")).toBe(270_000);
   });

--- a/packages/replay-core/test/pricing.test.ts
+++ b/packages/replay-core/test/pricing.test.ts
@@ -81,6 +81,7 @@ describe("getModelPricing — model family detection", () => {
   });
 
   it("returns GPT-5.6 family pricing for effort-suffixed model IDs", () => {
+    expect(getKnownModelPricing("gpt-5.6")).toEqual(getKnownModelPricing("gpt-5.6-sol"));
     expect(getKnownModelPricing("gpt-5.6-sol-xhigh")).toMatchObject({
       inputRate: 4,
       outputRate: 20,
@@ -161,7 +162,7 @@ describe("getModelPricing — model family detection", () => {
 describe("getModelContextLimit", () => {
   it("returns GPT-5.x public pricing threshold as fallback context limit", () => {
     expect(getModelContextLimit("gpt-5.5")).toBe(270_000);
-    expect(getModelContextLimit("gpt-5.6-sol")).toBe(272_000);
+    expect(getModelContextLimit("gpt-5.6-sol")).toBe(1_050_000);
     expect(getModelContextLimit("gpt-5.4-high")).toBe(270_000);
     expect(getModelContextLimit("gpt-5.4-mini")).toBe(270_000);
   });


### PR DESCRIPTION
## Summary
- replace OpenCode wall-clock lifespan with active message duration and normalize scan timestamp bounds
- ignore empty Pi usage snapshots and expose partial aggregate cost coverage instead of implying completeness
- add official GPT-5.6 and Claude Opus 4.8/5 rates while leaving ambiguous Cursor pricing unknown

## Test plan
- [x] `pnpm lint:check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] re-scan 2,578 local sessions and verify zero negative/inconsistent timing rows
- [x] verify OpenCode active duration, Pi non-zero usage coverage, and Claude/Pi pricing coverage against real local data

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session timelines now better reflect recorded activity across supported providers.
  * Aggregate cost reports include sessions with usage but incomplete pricing or attribution, showing priced amounts as lower bounds.
  * Zero-value usage records are no longer included in usage summaries.
  * Session discovery now provides more accurate active-duration estimates.

* **Pricing**
  * Added pricing and context-window support for GPT-5.6 models.
  * Expanded pricing recognition for newer Opus model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->