### PR TITLE
feat(insights): redesign workspace and audit invocation counts

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -26,7 +26,10 @@ import { classifyProject, mergeProjectIdentities, projectIdentityKey } from "@vi
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseClaudeCoworkSession } from "@vibe-replay/provider-claude-code/claude-cowork/parser";
 import { parseCursorSession } from "./providers/cursor/parser.js";
+import { parseHermesSession } from "@vibe-replay/provider-hermes/parser";
+import { parseOpencodeSession } from "@vibe-replay/provider-opencode/parser";
 import { parsePiSession } from "./providers/pi/parser.js";
+import type { ContentBlock } from "@vibe-replay/provider-contract";
 import type { ProviderParseResult } from "./providers/types.js";
 import type {
   DataSource,
@@ -57,7 +60,9 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v29: expand generic Cursor/Pi MCP name parsing so MCP calls cannot fall into
 // the ordinary tool facet merely because Cursor used an uppercase or opaque
 // MCP entrypoint name.
-export const SCANNER_VERSION = 29;
+// v30: preserve repeated rich-provider skill activations and MCP attribution.
+// v31: deduplicate streamed skill attribution and index OpenCode/Hermes usage.
+export const SCANNER_VERSION = 31;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -192,6 +197,21 @@ function parseMcpUsage(rawName: string, input?: Record<string, unknown>): McpUsa
     }
   }
 
+  // Cursor's generic MCP bridge uses `mcp--` for calls that could not be
+  // represented by a stable server/tool name. Authentication failures still
+  // carry the concrete server identifier in the input, so retain that server
+  // instead of collapsing the event into Unknown.
+  if (
+    normalizedRawName === "mcp--" &&
+    typeof input?.serverIdentifier === "string" &&
+    input.serverIdentifier
+  ) {
+    return {
+      server: stripCursorServerScope(input.serverIdentifier),
+      attribution: "explicit",
+    };
+  }
+
   if (normalizedRawName.startsWith("mcp__")) {
     const [, server, ...toolParts] = rawName.split("__");
     const tool = toolParts.join("__");
@@ -297,6 +317,17 @@ function parseMcpUsage(rawName: string, input?: Record<string, unknown>): McpUsa
   return undefined;
 }
 
+function skillNameFromTool(block: Extract<ContentBlock, { type: "tool_use" }>): string | undefined {
+  if (block._skillName?.trim()) return block._skillName.trim();
+  const normalizedName = block.name.trim().toLowerCase();
+  if (normalizedName !== "skill" && normalizedName !== "skill_view") return undefined;
+  for (const key of ["name", "skill", "skillName", "skill_name", "slug"]) {
+    const value = block.input?.[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
 /** Results that still need the rich Cursor pass before usage facets are complete. */
 export function isPendingCursorUsageIndex(
   result: Pick<SessionScanResult, "provider" | "usageIndexed" | "transcriptStatus">,
@@ -334,7 +365,7 @@ function toolUsageEvent(
   const name = typeof rawName === "string" && rawName.trim() ? rawName : "Unknown";
   const mcp = options.mcpServer
     ? {
-        server: options.mcpServer,
+        server: stripCursorServerScope(options.mcpServer),
         tool: options.mcpTool,
         attribution: "explicit" as const,
       }
@@ -356,14 +387,8 @@ function toolUsageEvent(
   };
 }
 
-function summarizeUsage(
-  events: UsageEvent[],
-  skillsUsed?: Iterable<string>,
-  mcpServersUsed?: Iterable<string>,
-): SessionUsageSummary | undefined {
-  const skills = skillsUsed ? [...skillsUsed] : [];
-  const mcpServers = mcpServersUsed ? [...mcpServersUsed].map(normalizeMcpServerName) : [];
-  if (events.length === 0 && skills.length === 0 && mcpServers.length === 0) return undefined;
+function summarizeUsage(events: UsageEvent[]): SessionUsageSummary | undefined {
+  if (events.length === 0) return undefined;
   const summary: SessionUsageSummary = {
     tools: {},
     mcpServers: {},
@@ -393,13 +418,6 @@ function summarizeUsage(
       summary.totalDurationMs += event.durationMs;
       summary.durationCount++;
     }
-  }
-
-  for (const skill of skills) {
-    if (!summary.skills[skill]) summary.skills[skill] = 1;
-  }
-  for (const server of mcpServers) {
-    if (!summary.mcpServers[server]) summary.mcpServers[server] = 1;
   }
 
   return summary;
@@ -663,6 +681,7 @@ interface ScanLinePrLink {
  * field. Replaces an untyped `JSON.parse(...)` result.
  */
 interface ScanLine extends ScanLinePrLink {
+  uuid?: string;
   gitBranch?: string;
   entrypoint?: string;
   permissionMode?: string;
@@ -744,9 +763,24 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     }
   }
   if (input.provider === "opencode") {
+    if (hasSqliteSessionMarker(input)) {
+      try {
+        return await scanOpencodeSession(input);
+      } catch {
+        // Keep discovery visible when a database is replaced or a session is
+        // removed between discovery and the rich pass.
+      }
+    }
     return buildLightweightOpencodeScanResult(input);
   }
   if (input.provider === "hermes") {
+    if (hasSqliteSessionMarker(input)) {
+      try {
+        return await scanHermesSession(input);
+      } catch {
+        // Fall back to the discovery summary for unavailable SQLite sources.
+      }
+    }
     return buildLightweightHermesScanResult(input);
   }
 
@@ -920,9 +954,17 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         model = obj.message.model;
       }
       if (obj.attributionMcpServer) {
-        mcpServersUsed.add(normalizeMcpServerName(obj.attributionMcpServer));
+        mcpServersUsed.add(
+          normalizeMcpServerName(stripCursorServerScope(obj.attributionMcpServer)),
+        );
       }
-      if (obj.attributionSkill) skillsUsed.add(obj.attributionSkill);
+      if (obj.attributionSkill) {
+        const skillName = obj.attributionSkill.trim();
+        // attributionSkill is repeated response provenance, not a skill
+        // invocation. Keep it in the distinct vocabulary, but only concrete
+        // injection/Skill records contribute to usageSummary.skills.
+        if (skillName) skillsUsed.add(skillName);
+      }
 
       // Tool results carry the outcome of an earlier tool_use block, which is
       // the only place this raw path can learn whether a call actually failed.
@@ -981,6 +1023,29 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         for (const block of msgContent) {
           if (block.type === "tool_use") {
             toolCallCount++;
+            const skillName = skillNameFromTool({
+              type: "tool_use",
+              name: typeof block.name === "string" ? block.name : "Unknown",
+              input:
+                block.input && typeof block.input === "object" && !Array.isArray(block.input)
+                  ? block.input
+                  : {},
+              id: typeof block.id === "string" ? block.id : `skill-${toolCallCount}`,
+            });
+            if (skillName) {
+              const event: UsageEvent = {
+                kind: "skill",
+                name: skillName,
+                skillName,
+                timestamp: obj.timestamp,
+                status: "unknown",
+                attribution: "explicit",
+              };
+              if (typeof block.id === "string") eventByToolUseId.set(block.id, event);
+              usageEvents.push(event);
+              skillsUsed.add(skillName);
+              continue;
+            }
             const event = toolUsageEvent(block.name, {
               input: block.input,
               timestamp: obj.timestamp,
@@ -1157,7 +1222,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
     permissionMode,
     skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
-    usageSummary: summarizeUsage(usageEvents, skillsUsed, mcpServersUsed),
+    usageSummary: summarizeUsage(usageEvents),
     usageEvents: retainedUsageEvents(usageEvents),
     // A normal generic scan is the usage-aware path even when a source file
     // disappeared between discovery and reading. Rich-parser fallbacks need a
@@ -1255,6 +1320,63 @@ async function scanPiSession(input: ScanInput): Promise<SessionScanResult> {
   };
 
   const parsed = await parsePiSession(input.filePaths, sessionInfo);
+  return buildScanResultFromParsed(input, parsed);
+}
+
+function hasSqliteSessionMarker(
+  input: Pick<ScanInput, "filePaths" | "sourceFilePath" | "sessionId">,
+): boolean {
+  const paths = [...input.filePaths, input.sourceFilePath || ""];
+  return (
+    paths.some((path) => path.includes("#session:")) ||
+    input.sessionId.startsWith("ses_") ||
+    input.sessionId.startsWith("session_")
+  );
+}
+
+async function scanOpencodeSession(input: ScanInput): Promise<SessionScanResult> {
+  const sessionInfo: SessionInfo = {
+    provider: "opencode",
+    sessionId: input.sessionId,
+    slug: input.slug,
+    location: input.location,
+    transcriptStatus: input.transcriptStatus,
+    title: input.title,
+    project: input.project,
+    cwd: input.workspacePath || input.project,
+    version: "",
+    timestamp: input.timestamp || new Date().toISOString(),
+    lineCount: input.sourceLineCount || 0,
+    fileSize: input.sourceFileSize || 0,
+    filePath: input.filePaths[0] || input.sourceFilePath || "",
+    filePaths: input.filePaths,
+    firstPrompt: scanFallbackPrompt(input, "(OpenCode session)"),
+    model: input.discoveryModel,
+  };
+  const parsed = await parseOpencodeSession(input.filePaths, sessionInfo);
+  return buildScanResultFromParsed(input, parsed);
+}
+
+async function scanHermesSession(input: ScanInput): Promise<SessionScanResult> {
+  const sessionInfo: SessionInfo = {
+    provider: "hermes",
+    sessionId: input.sessionId,
+    slug: input.slug,
+    location: input.location,
+    transcriptStatus: input.transcriptStatus,
+    title: input.title,
+    project: input.project,
+    cwd: input.workspacePath || input.project,
+    version: "",
+    timestamp: input.timestamp || new Date().toISOString(),
+    lineCount: input.sourceLineCount || 0,
+    fileSize: input.sourceFileSize || 0,
+    filePath: input.filePaths[0] || input.sourceFilePath || "",
+    filePaths: input.filePaths,
+    firstPrompt: scanFallbackPrompt(input, "(Hermes session)"),
+    model: input.discoveryModel,
+  };
+  const parsed = await parseHermesSession(input.filePaths, sessionInfo);
   return buildScanResultFromParsed(input, parsed);
 }
 
@@ -1413,6 +1535,20 @@ function buildScanResultFromParsed(
   let derivedSubAgentCount = 0;
   const fileEditCounts = new Map<string, number>();
   const usageEvents: UsageEvent[] = [];
+  const skillActivations =
+    parsed.skillActivations && parsed.skillActivations.length > 0 ? parsed.skillActivations : [];
+  const pendingSkillActivations = new Map<string, number>();
+  for (const skill of skillActivations) {
+    const normalized = skill.trim();
+    if (normalized) {
+      pendingSkillActivations.set(normalized, (pendingSkillActivations.get(normalized) || 0) + 1);
+    }
+  }
+  const skillsUsed = new Set(
+    [...(parsed.skillsUsed || []), ...skillActivations]
+      .map((skill) => skill.trim())
+      .filter(Boolean),
+  );
 
   for (const [turnIndex, turn] of parsed.turns.entries()) {
     if (turn.role === "user" && !turn.subtype) {
@@ -1429,6 +1565,31 @@ function buildScanResultFromParsed(
     for (const block of turn.blocks) {
       if (block.type !== "tool_use") continue;
       toolCallCount++;
+      const skillName = skillNameFromTool(block);
+      if (skillName) {
+        const knownCount = pendingSkillActivations.get(skillName) || 0;
+        if (knownCount > 0) {
+          // Provider parsers report these activations separately so their
+          // repeated activation list remains available. Do not also count the
+          // underlying Skill tool as an ordinary tool call.
+          pendingSkillActivations.set(skillName, knownCount - 1);
+        } else {
+          // Some providers expose a canonical Skill tool but do not populate
+          // skillActivations. The tool block itself is still concrete evidence
+          // of one activation.
+          usageEvents.push({
+            kind: "skill",
+            name: skillName,
+            skillName,
+            turnIndex,
+            timestamp: turn.timestamp,
+            status: "unknown",
+            attribution: "explicit",
+          });
+          skillsUsed.add(skillName);
+        }
+        continue;
+      }
       usageEvents.push(
         toolUsageEvent(block.name, {
           input: block.input,
@@ -1436,7 +1597,9 @@ function buildScanResultFromParsed(
           timestamp: turn.timestamp,
           durationMs: block._durationMs,
           isError: block._isError,
-          hasResult: block._result !== undefined,
+          hasResult: block._hasResult ?? block._result !== undefined,
+          mcpServer: block._mcpServer,
+          mcpTool: block._mcpTool,
           mcpServerNames: parsed.mcpServerNames,
         }),
       );
@@ -1454,13 +1617,34 @@ function buildScanResultFromParsed(
       if (block.name === "Agent" && block._subAgent?.scenes) {
         for (const saScene of block._subAgent.scenes) {
           if (saScene.type !== "tool-call") continue;
+          toolCallCount++;
+          const saToolBlock = {
+            name: saScene.toolName || "Unknown",
+            input: saScene.input,
+            _skillName: undefined,
+          } as Extract<ContentBlock, { type: "tool_use" }>;
+          const saSkillName = skillNameFromTool(saToolBlock);
+          if (saSkillName) {
+            usageEvents.push({
+              kind: "skill",
+              name: saSkillName,
+              skillName: saSkillName,
+              timestamp: saScene.timestamp,
+              status: "unknown",
+              attribution: "explicit",
+            });
+            skillsUsed.add(saSkillName);
+            continue;
+          }
           usageEvents.push(
             toolUsageEvent(saScene.toolName, {
               input: saScene.input,
               timestamp: saScene.timestamp,
               durationMs: saScene.durationMs,
               isError: saScene.isError,
-              hasResult: saScene.result !== "",
+              hasResult:
+                (saScene as typeof saScene & { hasResult?: boolean }).hasResult ??
+                (saScene.result !== undefined && saScene.result !== ""),
               parentAgentId: block._subAgent.agentId,
               mcpServerNames: parsed.mcpServerNames,
             }),
@@ -1494,18 +1678,20 @@ function buildScanResultFromParsed(
   const firstPrompt = input.transcriptStatus
     ? ""
     : firstUserPrompt(parsed.turns) || input.firstPrompt || parsed.title;
-  for (const skill of parsed.skillsUsed || []) {
+  for (const skill of skillActivations) {
+    const normalized = skill.trim();
+    if (!normalized) continue;
     usageEvents.push({
       kind: "skill",
-      name: skill,
-      skillName: skill,
+      name: normalized,
+      skillName: normalized,
       status: "unknown",
       attribution: "session-metadata",
     });
   }
   const derivedMcpServers = new Set(
     (parsed.mcpServersUsed || []).map((server) =>
-      normalizeMcpServerName(parsed.mcpServerNames?.[server] || server),
+      normalizeMcpServerName(stripCursorServerScope(parsed.mcpServerNames?.[server] || server)),
     ),
   );
   for (const event of usageEvents) {
@@ -1543,9 +1729,9 @@ function buildScanResultFromParsed(
     compactionCount: parsed.compactions?.length || 0,
     entrypoint: parsed.entrypoint,
     permissionMode: parsed.permissionMode,
-    skillsUsed: parsed.skillsUsed,
+    skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: derivedMcpServers.size > 0 ? [...derivedMcpServers].sort() : undefined,
-    usageSummary: summarizeUsage(usageEvents, parsed.skillsUsed, derivedMcpServers),
+    usageSummary: summarizeUsage(usageEvents),
     usageEvents: retainedUsageEvents(usageEvents),
     usageIndexed: true,
     dataSource: parsed.dataSource,

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -344,6 +344,62 @@ describe("scanSession", () => {
     expect(JSON.stringify(result.usageEvents)).not.toContain("/secret/path.ts");
   });
 
+  it("preserves repeated rich-provider skill activations and MCP attribution", async () => {
+    const path = join(tmpDir, "usage-rich-attribution.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "user",
+          isMeta: true,
+          timestamp: "2025-03-20T10:00:00Z",
+          message: {
+            role: "user",
+            content: "Base directory for this skill: /Users/test/.claude/skills/review\n",
+          },
+        }),
+        makeLine({
+          type: "user",
+          isMeta: true,
+          timestamp: "2025-03-20T10:00:01Z",
+          message: {
+            role: "user",
+            content: "Base directory for this skill: /Users/test/.claude/skills/review\n",
+          },
+        }),
+        makeLine({
+          type: "assistant",
+          timestamp: "2025-03-20T10:00:02Z",
+          attributionMcpServer: "sourcegraph",
+          attributionMcpTool: "search",
+          message: {
+            role: "assistant",
+            id: "rich-mcp-call",
+            content: [{ type: "tool_use", id: "mcp-1", name: "tool", input: {} }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "usage-rich-attribution",
+      provider: "claude-cowork",
+      project: "~/test/project",
+      slug: "usage-rich-attribution",
+      filePaths: [path],
+    });
+
+    expect(result.toolCallCount).toBe(1);
+    expect(result.usageSummary).toMatchObject({
+      tools: {},
+      mcpServers: { sourcegraph: 1 },
+      mcpTools: { "sourcegraph/search": 1 },
+      skills: { review: 2 },
+    });
+    expect(result.usageEvents?.filter((event) => event.kind === "skill")).toHaveLength(2);
+  });
+
   it("keeps usage summaries complete while bounding retained invocation details", async () => {
     const path = join(tmpDir, "usage-events-bounded.jsonl");
     const toolUses = Array.from({ length: 120 }, (_unused, index) => ({
@@ -456,7 +512,61 @@ describe("scanSession", () => {
     expect(result.usageSummary?.tools).toEqual({});
     expect(result.usageSummary?.mcpServers).toEqual({ "claude-in-chrome": 1 });
     expect(result.usageSummary?.mcpTools).toEqual({ "claude-in-chrome/browser_open": 1 });
-    expect(result.usageSummary?.skills).toEqual({ "browser-skill": 1 });
+    expect(result.usageSummary?.skills).toEqual({});
+    expect(result.skillsUsed).toEqual(["browser-skill"]);
+  });
+
+  it("does not count repeated streamed attributionSkill records as activations", async () => {
+    const path = join(tmpDir, "usage-repeated-attribution-skill.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "assistant",
+          attributionSkill: "mcp-adaptor",
+          timestamp: "2025-03-20T10:00:00Z",
+          message: {
+            role: "assistant",
+            id: "streamed-message",
+            content: [{ type: "thinking", thinking: "one" }],
+          },
+        }),
+        makeLine({
+          type: "assistant",
+          attributionSkill: "mcp-adaptor",
+          timestamp: "2025-03-20T10:00:00Z",
+          message: {
+            role: "assistant",
+            id: "streamed-message",
+            content: [{ type: "text", text: "two" }],
+          },
+        }),
+        makeLine({
+          type: "assistant",
+          attributionSkill: "mcp-adaptor",
+          timestamp: "2025-03-20T10:00:00Z",
+          message: {
+            role: "assistant",
+            id: "streamed-message",
+            content: [{ type: "tool_use", id: "streamed-tool", name: "Read", input: {} }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "usage-repeated-attribution-skill",
+      provider: "claude-code",
+      project: "~/test/project",
+      slug: "usage-repeated-attribution-skill",
+      filePaths: [path],
+    });
+
+    expect(result.skillsUsed).toEqual(["mcp-adaptor"]);
+    expect(result.usageSummary?.skills).toEqual({});
+    expect(result.usageEvents?.filter((event) => event.kind === "skill")).toHaveLength(0);
+    expect(result.usageSummary?.tools).toEqual({ Read: 1 });
   });
 
   it("normalizes placeholder MCP server names to Unknown", async () => {

--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -106,6 +106,14 @@ export async function parseClaudeCodeLines(
 
   // Skills used in the session (extracted from isMeta skill injection messages and attribution fields)
   const skillsUsed = new Set<string>();
+  const skillActivations: string[] = [];
+
+  const recordSkillActivation = (skillName: string) => {
+    const normalized = skillName.trim();
+    if (!normalized) return;
+    skillsUsed.add(normalized);
+    skillActivations.push(normalized);
+  };
 
   // MCP servers used (extracted from mcp__server__tool naming convention and attribution fields)
   const mcpServersUsed = new Set<string>();
@@ -118,6 +126,7 @@ export async function parseClaudeCodeLines(
 
   // Collect tool results by tool_use_id
   const toolResults = new Map<string, string>();
+  const toolResultIds = new Set<string>();
   // Collect tool error flags by tool_use_id
   const toolErrors = new Map<string, boolean>();
   // Collect tool result timestamps by tool_use_id (for duration calculation)
@@ -310,12 +319,12 @@ export async function parseClaudeCodeLines(
             .replace("Base directory for this skill: ", "")
             .trim();
           const skillName = skillPath.split("/").pop() || skillPath;
-          skillsUsed.add(skillName);
+          recordSkillActivation(skillName);
         }
         // Extract slash command name from command output
         if (text.startsWith("The user just ran /")) {
           const cmd = text.split("/")[1]?.split(/[\s\n]/)[0];
-          if (cmd) skillsUsed.add(`/${cmd}`);
+          if (cmd) recordSkillActivation(`/${cmd}`);
         }
         // Only emit context-injection scenes for content with real information value.
         // Skip local-command caveats (just a wrapper telling the model to ignore) and
@@ -366,6 +375,7 @@ export async function parseClaudeCodeLines(
         if (block.type === "tool_result") {
           const resultText = extractToolResultText(block);
           toolResults.set(block.tool_use_id, resultText);
+          toolResultIds.add(block.tool_use_id);
           if (obj.timestamp) toolResultTimestamps.set(block.tool_use_id, obj.timestamp);
           if (block.is_error) {
             toolErrors.set(block.tool_use_id, true);
@@ -408,7 +418,13 @@ export async function parseClaudeCodeLines(
     if (role === "assistant" && msgId && Array.isArray(msgContent)) {
       if (!model && obj.message.model) model = obj.message.model;
       if (obj.attributionMcpServer) mcpServersUsed.add(obj.attributionMcpServer);
-      if (obj.attributionSkill) skillsUsed.add(obj.attributionSkill);
+      if (obj.attributionSkill) {
+        const skillName = obj.attributionSkill.trim();
+        // attributionSkill describes which skill supplied an assistant
+        // response. It is repeated on streamed fragments and across follow-up
+        // assistant messages, so it is vocabulary evidence, not an activation.
+        if (skillName) skillsUsed.add(skillName);
+      }
       // attributionMcpTool is tool-level detail; the replay metadata currently
       // summarizes MCP usage by server only, so keep the typed field for
       // forward compatibility without surfacing another aggregate today.
@@ -441,13 +457,37 @@ export async function parseClaudeCodeLines(
       }
 
       const blocks = assistantBlocks.get(msgId)!;
+      const seenToolIds = new Set(
+        blocks
+          .filter(
+            (candidate): candidate is Extract<ContentBlock, { type: "tool_use" }> =>
+              candidate.type === "tool_use",
+          )
+          .map((candidate) => candidate.id),
+      );
       for (const block of msgContent as ContentBlock[]) {
         if (block.type === "thinking") {
           blocks.push({ type: "thinking", thinking: block.thinking });
         } else if (block.type === "text") {
           blocks.push(block);
         } else if (block.type === "tool_use") {
-          blocks.push(block);
+          if (seenToolIds.has(block.id)) continue;
+          seenToolIds.add(block.id);
+          const skillName =
+            block.name.toLowerCase() === "skill"
+              ? typeof block.input?.name === "string"
+                ? block.input.name.trim()
+                : typeof block.input?.skill === "string"
+                  ? block.input.skill.trim()
+                  : undefined
+              : undefined;
+          blocks.push({
+            ...block,
+            ...(obj.attributionMcpServer ? { _mcpServer: obj.attributionMcpServer } : {}),
+            ...(obj.attributionMcpTool ? { _mcpTool: obj.attributionMcpTool } : {}),
+            ...(skillName ? { _skillName: skillName } : {}),
+          });
+          if (skillName) recordSkillActivation(skillName);
           // Track MCP server usage from mcp__server__tool naming convention
           if (block.name.startsWith("mcp__")) {
             const server = block.name.split("__")[1];
@@ -474,6 +514,7 @@ export async function parseClaudeCodeLines(
     let prevToolEndTs = assistantTimestamps.get(msgId);
     const enrichedBlocks = blocks.map((block) => {
       if (block.type === "tool_use") {
+        const hasResult = toolResultIds.has(block.id);
         const result = toolResults.get(block.id) || "";
         const images = toolImages.get(block.id);
         const isError = toolErrors.get(block.id);
@@ -490,6 +531,7 @@ export async function parseClaudeCodeLines(
         if (resultTs) prevToolEndTs = resultTs;
         return {
           ...block,
+          _hasResult: hasResult,
           _result: result,
           _images: images,
           ...(isError ? { _isError: true } : {}),
@@ -643,6 +685,7 @@ export async function parseClaudeCodeLines(
     serviceTier,
     truncatedResponses: truncatedCount > 0 ? truncatedCount : undefined,
     skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
+    skillActivations: skillActivations.length > 0 ? skillActivations : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
     agentName,
     worktree,
@@ -884,6 +927,7 @@ interface SubAgentParsed {
     toolName?: string;
     input?: Record<string, any>;
     result?: string;
+    hasResult?: boolean;
     isError?: boolean;
     timestamp?: string;
   }>;
@@ -954,6 +998,7 @@ async function readSubagents(
 
     // Track tool results for enrichment
     const saToolResults = new Map<string, string>();
+    const saToolResultIds = new Set<string>();
     const saToolErrors = new Map<string, boolean>();
 
     // Collect assistant blocks by message ID (same dedup as main parser)
@@ -1003,6 +1048,7 @@ async function readSubagents(
           if (block.type === "tool_result") {
             const resultText = extractToolResultText(block as ContentBlock);
             saToolResults.set(block.tool_use_id, resultText.slice(0, 1000));
+            saToolResultIds.add(block.tool_use_id);
             if (block.is_error) saToolErrors.set(block.tool_use_id, true);
           }
         }
@@ -1032,7 +1078,17 @@ async function readSubagents(
         }
 
         const blocks = saAssistantBlocks.get(msgId)!;
+        const seenToolIds = new Set(
+          blocks
+            .filter(
+              (candidate): candidate is Extract<ContentBlock, { type: "tool_use" }> =>
+                candidate.type === "tool_use",
+            )
+            .map((candidate) => candidate.id),
+        );
         for (const block of msgContent) {
+          if (block.type === "tool_use" && seenToolIds.has(block.id)) continue;
+          if (block.type === "tool_use") seenToolIds.add(block.id);
           if (block.type === "thinking" || block.type === "text" || block.type === "tool_use") {
             blocks.push(block);
           }
@@ -1061,12 +1117,14 @@ async function readSubagents(
           }
         } else if (block.type === "tool_use") {
           const toolResult = saToolResults.get(block.id) || "";
+          const hasResult = saToolResultIds.has(block.id);
           const isError = saToolErrors.get(block.id);
           scenes.push({
             type: "tool-call",
             toolName: block.name,
             input: block.input,
             result: toolResult,
+            hasResult,
             isError: isError || false,
             timestamp: ts,
           });

--- a/packages/provider-claude-code/test/claude-code-source-insights.test.ts
+++ b/packages/provider-claude-code/test/claude-code-source-insights.test.ts
@@ -7,7 +7,7 @@
  */
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseClaudeCodeSession } from "../src/claude-code/parser.js";
+import { parseClaudeCodeLines, parseClaudeCodeSession } from "../src/claude-code/parser.js";
 import { transformToReplay } from "./helpers/transform.js";
 import type { ContentBlock } from "@vibe-replay/provider-contract";
 
@@ -67,6 +67,34 @@ describe("Claude Code source insights: isMeta as context-injection", () => {
   it("extracts skillsUsed from isMeta skill injections", async () => {
     const result = await parseClaudeCodeSession(FIXTURE);
     expect(result.skillsUsed).toEqual(["auth-skill"]);
+  });
+
+  it("preserves repeated skill activations separately from distinct skill names", async () => {
+    const result = await parseClaudeCodeLines(
+      [
+        {
+          type: "user",
+          isMeta: true,
+          timestamp: "2026-03-31T10:05:01Z",
+          message: {
+            role: "user",
+            content: "Base directory for this skill: /Users/test/skills/auth-skill",
+          },
+        },
+        {
+          type: "user",
+          isMeta: true,
+          timestamp: "2026-03-31T10:06:01Z",
+          message: {
+            role: "user",
+            content: "Base directory for this skill: /Users/test/skills/auth-skill",
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.skillsUsed).toEqual(["auth-skill"]);
+    expect(result.skillActivations).toEqual(["auth-skill", "auth-skill"]);
   });
 
   it("passes skillsUsed through to ReplaySession", async () => {
@@ -187,5 +215,32 @@ describe("Claude Code source insights: MCP server detection", () => {
     expect(mcpScene!.type === "tool-call" && mcpScene!.toolName).toBe(
       "mcp__claude-in-chrome__tabs_context_mcp",
     );
+  });
+
+  it("preserves message-level MCP attribution on generic tool blocks", async () => {
+    const result = await parseClaudeCodeLines(
+      [
+        {
+          type: "assistant",
+          timestamp: "2026-03-31T10:05:03Z",
+          attributionMcpServer: "sourcegraph",
+          attributionMcpTool: "search",
+          message: {
+            role: "assistant",
+            id: "msg_attributed_mcp",
+            content: [{ type: "tool_use", id: "tool_attributed", name: "tool", input: {} }],
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      _mcpServer: "sourcegraph",
+      _mcpTool: "search",
+    });
   });
 });

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -211,15 +211,16 @@ export function parseCodexLines(
         continue;
       }
       if (p.type === "patch_apply_end" && p.call_id) {
-        const tool = tools.get(p.call_id);
+        let tool = tools.get(p.call_id);
         const changedFiles = patchApplyChangedFiles(p);
         if (!tool) {
-          tools.set(p.call_id, {
+          tool = {
             id: p.call_id,
             name: "apply_patch",
             input: {},
             timestamp: obj.timestamp,
-          });
+          };
+          tools.set(p.call_id, tool);
         }
         if (tool && changedFiles.length > 0) {
           tool.input = mergeToolFilePaths(tool.input, changedFiles);

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -82,7 +82,6 @@ export function parseCodexLines(
   const tokenSnapshots: CodexTokenSnapshot[] = [];
   const taskDurations: number[] = [];
   const mcpServersUsed = new Set<string>();
-  const skillsUsed = new Set<string>();
   const gitBranches: string[] = [];
   const seenUserMessages = new Map<string, number[]>();
   const seenAssistantMessages = new Map<string, number[]>();
@@ -175,6 +174,14 @@ export function parseCodexLines(
         continue;
       }
       if (p.type === "exec_command_end" && p.call_id) {
+        if (!tools.has(p.call_id)) {
+          tools.set(p.call_id, {
+            id: p.call_id,
+            name: "exec_command",
+            input: p.command || p.action || {},
+            timestamp: obj.timestamp,
+          });
+        }
         mergeToolResult(toolResults, p.call_id, {
           result: formatExecResult(p),
           isError: typeof p.exit_code === "number" ? p.exit_code !== 0 : undefined,
@@ -206,6 +213,14 @@ export function parseCodexLines(
       if (p.type === "patch_apply_end" && p.call_id) {
         const tool = tools.get(p.call_id);
         const changedFiles = patchApplyChangedFiles(p);
+        if (!tool) {
+          tools.set(p.call_id, {
+            id: p.call_id,
+            name: "apply_patch",
+            input: {},
+            timestamp: obj.timestamp,
+          });
+        }
         if (tool && changedFiles.length > 0) {
           tool.input = mergeToolFilePaths(tool.input, changedFiles);
         }
@@ -239,10 +254,33 @@ export function parseCodexLines(
         const invocation = p.invocation || {};
         const server = typeof invocation.server === "string" ? invocation.server : "";
         const toolName = typeof invocation.tool === "string" ? invocation.tool : "";
-        const tool = tools.get(p.call_id);
-        if (tool && server && toolName) {
-          tool.name = `mcp__${server}__${toolName}`;
+        let tool = tools.get(p.call_id);
+        if (server) {
           mcpServersUsed.add(server);
+          if (!tool) {
+            tool = {
+              id: p.call_id,
+              name: toolName ? `mcp__${server}__${toolName}` : "mcp",
+              input: toolName
+                ? invocation.arguments || {}
+                : {
+                    server,
+                  },
+              timestamp: obj.timestamp,
+            };
+            tools.set(p.call_id, tool);
+          } else if (toolName) {
+            tool.name = `mcp__${server}__${toolName}`;
+          }
+        } else if (!tool) {
+          // The completion event itself proves that Codex attempted an MCP
+          // invocation, even when the start payload omitted server metadata.
+          tools.set(p.call_id, {
+            id: p.call_id,
+            name: "mcp",
+            input: {},
+            timestamp: obj.timestamp,
+          });
         }
         mergeToolResult(toolResults, p.call_id, {
           result: formatMcpToolResult(p),
@@ -343,7 +381,6 @@ export function parseCodexLines(
         const server = name.split("__")[1];
         if (server) mcpServersUsed.add(server);
       }
-      if (name === "tool_search") skillsUsed.add("tool_search");
       continue;
     }
 
@@ -353,6 +390,16 @@ export function parseCodexLines(
       p.type === "tool_search_output"
     ) {
       if (p.call_id) {
+        if (!tools.has(p.call_id)) {
+          // Preserve orphan completions as an unknown ordinary tool rather
+          // than silently losing a concrete provider event.
+          tools.set(p.call_id, {
+            id: p.call_id,
+            name: "Unknown",
+            input: {},
+            timestamp: obj.timestamp,
+          });
+        }
         mergeToolResult(
           toolResults,
           p.call_id,
@@ -378,6 +425,7 @@ export function parseCodexLines(
           id: tool.id,
           name: normalizeToolName(tool.name),
           input: normalizeToolInput(tool.name, tool.input),
+          _hasResult: toolResults.has(tool.id),
           _result: tr?.result || "",
           ...(tr?.isError ? { _isError: true } : {}),
           ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
@@ -424,7 +472,6 @@ export function parseCodexLines(
     entrypoint,
     permissionMode: approvalPolicy || permissionMode,
     memoryMode,
-    skillsUsed: skillsUsed.size > 0 ? [...skillsUsed].sort() : undefined,
     mcpServersUsed: mcpServersUsed.size > 0 ? [...mcpServersUsed].sort() : undefined,
     dataSource: "jsonl",
     dataSourceInfo: {

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -96,6 +96,32 @@ const lines = [
 ].map((line) => JSON.stringify(line));
 
 describe("Codex parser", () => {
+  it("keeps tool search as a tool invocation rather than a skill activation", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T06:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-tool-search", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T06:00:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "tool_search_call",
+            call_id: "search-1",
+            arguments: { query: "github" },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.skillsUsed).toBeUndefined();
+    expect(
+      result.turns.flatMap((turn) => turn.blocks).filter((block) => block.type === "tool_use"),
+    ).toHaveLength(1);
+  });
+
   it("parses Codex rollout JSONL into replay turns", () => {
     const result = parseCodexLines(lines);
 
@@ -1148,6 +1174,46 @@ describe("Codex parser", () => {
       _isError: true,
       _result: "rate limited",
       _durationMs: 3000,
+    });
+  });
+
+  it("retains an MCP invocation when only the end event is present", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-05-03T06:50:00.000Z",
+          type: "session_meta",
+          payload: {
+            id: "codex-session-mcp-orphan",
+            cwd: "/Users/test/project",
+            source: "codex-app",
+          },
+        },
+        {
+          timestamp: "2026-05-03T06:50:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "mcp_tool_call_end",
+            call_id: "mcp_orphan",
+            invocation: {
+              server: "codex_apps",
+              tool: "github_search",
+              arguments: { query: "vibe-replay" },
+            },
+            result: { Ok: { content: [{ type: "text", text: "one result" }] } },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(result.mcpServersUsed).toEqual(["codex_apps"]);
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "mcp__codex_apps__github_search",
+      _result: "one result",
     });
   });
 

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -810,6 +810,43 @@ describe("Codex parser", () => {
     });
   });
 
+  it("preserves changed files when patch_apply_end is the only patch event", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:21:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-orphan-patch", cwd: "/Users/test/project", source: "cli" },
+        },
+        {
+          timestamp: "2026-04-26T10:21:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "patch_apply_end",
+            call_id: "patch_orphan",
+            status: "completed",
+            success: true,
+            changes: {
+              "/Users/test/project/src/app.ts": { status: "modified" },
+              "/Users/test/project/src/auth.ts": { status: "added" },
+            },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "Edit",
+      input: {
+        file_paths: ["/Users/test/project/src/app.ts", "/Users/test/project/src/auth.ts"],
+      },
+    });
+  });
+
   it("preserves multi-file apply_patch contents through replay transform", () => {
     const patch = `*** Begin Patch
 *** Update File: src/app.ts

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -222,6 +222,11 @@ export type ContentBlock =
       name: string;
       input: Record<string, any>;
       _result?: string;
+      /**
+       * Whether the provider recorded a result for this call. This is separate
+       * from `_result` because an empty string can be a valid completed result.
+       */
+      _hasResult?: boolean;
       /** Internal source timestamp for the tool result; omitted from replay scenes. */
       _resultTimestamp?: string;
       _images?: string[];
@@ -229,6 +234,11 @@ export type ContentBlock =
       _subAgent?: SubAgent;
       _durationMs?: number;
       _isPendingMarker?: boolean;
+      /** Provider attribution retained for usage indexing; omitted from replay output. */
+      _mcpServer?: string;
+      _mcpTool?: string;
+      /** Canonical skill name for provider-native skill invocation records. */
+      _skillName?: string;
     }
   | {
       type: "tool_result";
@@ -316,6 +326,11 @@ export interface ProviderParseResult {
   serviceTier?: string;
   /** Skills / slash commands used in the session (e.g. ["playwright-cli", "/insights"]) */
   skillsUsed?: string[];
+  /**
+   * One entry per skill activation, preserving repeated activations. `skillsUsed`
+   * remains the distinct display/filter vocabulary.
+   */
+  skillActivations?: string[];
   /** MCP servers used in the session (e.g. ["claude-in-chrome", "playwright"]) */
   mcpServersUsed?: string[];
   /**

--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -837,6 +837,7 @@ async function parseCursorSubagentTranscript(
   const toolErrors = new Set<string>();
   const toolImages = new Map<string, string[]>();
   const pendingTools: PendingCursorSubagentTool[] = [];
+  const seenToolIds = new Set<string>();
 
   const lines = content.split("\n");
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
@@ -915,6 +916,9 @@ async function parseCursorSubagentTranscript(
       if (block?.type !== "tool_use") continue;
       const rawName =
         typeof block.name === "string" && block.name.trim() ? block.name.trim() : "Tool";
+      const id = typeof block.id === "string" && block.id.trim() ? block.id : undefined;
+      if (id && seenToolIds.has(id)) continue;
+      if (id) seenToolIds.add(id);
       const scene: Extract<Scene, { type: "tool-call" }> = {
         type: "tool-call",
         toolName: deps.mapCursorToolName(rawName),
@@ -926,7 +930,7 @@ async function parseCursorSubagentTranscript(
       scenes.push(scene);
       pendingTools.push({
         scene,
-        ...(typeof block.id === "string" && block.id.trim() ? { id: block.id } : {}),
+        ...(id ? { id } : {}),
         rawName,
         rawInput: block.input,
         timestamp,

--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -422,6 +422,7 @@ async function parseCursorJsonl(
   const toolResults = new Map<string, CursorToolResult>();
   const toolErrors = new Map<string, boolean>();
   const toolImages = new Map<string, string[]>();
+  const seenToolUseIds = new Set<string>();
   const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
   const sortedTranscriptPaths = await sortByMtime(transcriptPaths);
   const sessionId = basename(sortedTranscriptPaths[sortedTranscriptPaths.length - 1], ".jsonl");
@@ -543,6 +544,7 @@ async function parseCursorJsonl(
               id: `cursor-marker-${syntheticToolId++}`,
               name: markerParsed.markerName,
               input: { marker: markerParsed.markerName },
+              _hasResult: false,
               _isPendingMarker: true,
             });
           } else {
@@ -561,16 +563,30 @@ async function parseCursorJsonl(
           const rawName =
             typeof block.name === "string" && block.name.trim() ? block.name.trim() : "Tool";
           const name = deps.mapCursorToolName(rawName);
+          const id =
+            typeof block.id === "string" && block.id.trim()
+              ? block.id
+              : `cursor-inline-${syntheticToolId++}`;
+          if (seenToolUseIds.has(id)) continue;
+          seenToolUseIds.add(id);
+          const mappedInput = deps.mapToolArgs(rawName, block.input);
+          const skillName =
+            rawName.toLowerCase() === "skill"
+              ? ["name", "skill", "skillName", "skill_name"]
+                  .map((key) => mappedInput?.[key])
+                  .find(
+                    (value): value is string =>
+                      typeof value === "string" && value.trim().length > 0,
+                  )
+              : undefined;
           blocks.push({
             type: "tool_use",
-            id:
-              typeof block.id === "string" && block.id.trim()
-                ? block.id
-                : `cursor-inline-${syntheticToolId++}`,
+            id,
             name,
             // Keep the raw name here because Cursor raw tools carry different arg
             // schemas even when they map to the same canonical replay tool.
-            input: deps.mapToolArgs(rawName, block.input),
+            input: mappedInput,
+            ...(skillName ? { _skillName: skillName.trim() } : {}),
           });
         }
       }
@@ -1236,6 +1252,7 @@ function attachToolResults(
       if (block.type !== "tool_use" || typeof block.id !== "string") continue;
       const result = toolResults.get(block.id);
       if (result !== undefined) {
+        block._hasResult = true;
         block._result = result.result;
         block.input = deps.mapToolArgs(block.name, block.input, result.result);
         const durationMs = durationBetween(turn.timestamp, result.timestamp);
@@ -1541,6 +1558,7 @@ function attachToolEvents(
       ...tool.input,
     };
     marker.block._result = tool.result;
+    marker.block._hasResult = true;
     if (tool.timestamp) marker.block._resultTimestamp = tool.timestamp;
     const durationMs = durationBetween(marker.turn.timestamp, tool.timestamp);
     if (durationMs !== undefined) marker.block._durationMs = durationMs;
@@ -1573,8 +1591,14 @@ function attachToolEvents(
     // Consume the sidecar belonging to an inline-resolved call as well. Without
     // advancing here, consecutive same-name calls can reuse the first call's
     // sidecar result when the later call is still unresolved.
-    if (typeof block._result === "string") continue;
+    if (
+      block._hasResult === true ||
+      (block._hasResult === undefined && typeof block._result === "string")
+    ) {
+      continue;
+    }
     block._result = tool.result;
+    block._hasResult = true;
     if (tool.timestamp) block._resultTimestamp = tool.timestamp;
     block.input = { ...block.input, ...tool.input };
     try {
@@ -1616,6 +1640,7 @@ function toToolUseBlock(tool: ToolEvent): ContentBlock {
     id: tool.id,
     name: tool.name,
     input: tool.input,
+    _hasResult: true,
     _result: tool.result,
     ...(tool.timestamp ? { _resultTimestamp: tool.timestamp } : {}),
   };

--- a/packages/provider-cursor/src/cursor/sdk-reader.ts
+++ b/packages/provider-cursor/src/cursor/sdk-reader.ts
@@ -595,7 +595,12 @@ export function applySdkEnrichmentToTurns(
       if (block.type !== "tool_use") continue;
       // Only enrich when the JSONL block lacks a result. Empty-string results
       // are valid tool outputs, so any string `_result` counts as already resolved.
-      if (typeof block._result === "string") continue;
+      if (
+        block._hasResult === true ||
+        (block._hasResult === undefined && typeof block._result === "string")
+      ) {
+        continue;
+      }
 
       // Positional pairing only holds while both streams agree. When they drift
       // (SDK-only calls, renamed tools), find the next compatible call instead of
@@ -610,6 +615,7 @@ export function applySdkEnrichmentToTurns(
       if (sdkCall.result === undefined) continue;
 
       block._result = sdkCall.result;
+      block._hasResult = true;
       if (sdkCall.isError) block._isError = true;
       if (sdkCall.durationMs !== undefined && block._durationMs === undefined) {
         block._durationMs = sdkCall.durationMs;

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -236,6 +236,7 @@ function projectedCursorBubbleSelectSql(): string {
     `json_extract(${value}, '$.toolFormerData.name') AS toolName`,
     `json_extract(${value}, '$.toolFormerData.params') AS toolParams`,
     `${truncatedToolResult} AS toolResult`,
+    `json_extract(${value}, '$.toolFormerData.result') IS NOT NULL AS toolHasResult`,
     `length(${toolResult}) AS toolResultLength`,
     `json_extract(${value}, '$.toolFormerData.toolCallId') AS toolCallId`,
     `json_extract(${value}, '$.pullRequests') AS pullRequests`,
@@ -851,15 +852,23 @@ function projectedCursorBubbleRowToBubble(row: Record<string, any>): Record<stri
       typeof row.toolResult === "string" ? row.toolResult : valueToString(row.toolResult);
     const parsedResultLength = Number(row.toolResultLength);
     const resultLength = Number.isFinite(parsedResultLength) ? parsedResultLength : result.length;
+    const hasResult =
+      row.toolHasResult === undefined
+        ? row.toolResult !== null && row.toolResult !== undefined
+        : Number(row.toolHasResult) !== 0;
     bubble.toolFormerData = {
       name: valueToString(row.toolName),
       ...(row.toolParams !== null && row.toolParams !== undefined
         ? { params: optionalJsonColumn(row.toolParams) ?? row.toolParams }
         : {}),
-      result:
-        resultLength > MAX_CURSOR_GLOBAL_STATE_TOOL_RESULT_CHARS
-          ? `${result}\n... (truncated by vibe-replay, ${resultLength} chars total)`
-          : result,
+      ...(hasResult
+        ? {
+            result:
+              resultLength > MAX_CURSOR_GLOBAL_STATE_TOOL_RESULT_CHARS
+                ? `${result}\n... (truncated by vibe-replay, ${resultLength} chars total)`
+                : result,
+          }
+        : {}),
       ...(row.toolCallId ? { toolCallId: valueToString(row.toolCallId) } : {}),
     };
   }
@@ -2109,6 +2118,7 @@ function parseToolFormerBlock(
   const parsedParams = parseJson<Record<string, any>>(toolFormerData.params);
   const paramsRaw = parsedParams ?? toolFormerData.params ?? {};
   const result = extractToolResultText(toolFormerData.result);
+  const hasResult = Object.prototype.hasOwnProperty.call(toolFormerData, "result");
 
   return {
     type: "tool_use",
@@ -2117,7 +2127,8 @@ function parseToolFormerBlock(
       `cursor-bubble-${bubbleId}`,
     name: mapCursorToolName(name),
     input: mapToolArgs(name, paramsRaw, result),
-    _result: result,
+    _hasResult: hasResult,
+    ...(hasResult ? { _result: result } : {}),
     ...(hasToolError(toolFormerData.result) ? { _isError: true } : {}),
   };
 }
@@ -3429,7 +3440,8 @@ function parseAssistantContent(
         id: b.toolCallId,
         name: mapCursorToolName(b.toolName),
         input: mapToolArgs(b.toolName, b.args || {}, result?.result || ""),
-        _result: result?.result || "",
+        _hasResult: result !== undefined,
+        ...(result !== undefined ? { _result: result.result } : {}),
         ...(result?.isError ? { _isError: true } : {}),
         ...(result?.executionTimeMs ? { _durationMs: result.executionTimeMs } : {}),
       };

--- a/packages/provider-cursor/test/sqlite-reader.test.ts
+++ b/packages/provider-cursor/test/sqlite-reader.test.ts
@@ -1016,7 +1016,7 @@ describe("cursor sqlite metrics helpers", () => {
         id: "tool-1",
         name: "Read",
         input: { file_path: "/tmp/demo.ts" },
-        _result: "",
+        _hasResult: false,
       },
     ]);
   });

--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -218,6 +218,7 @@ export function parseSessionFromDb(
   const compactions: Compaction[] = [];
   const summaryCompactions: Compaction[] = [];
   const skillsUsed = new Set<string>();
+  const skillActivations: string[] = [];
   let totalTokens: TokenUsage | undefined;
   let startTime: string | undefined;
   let endTime: string | undefined;
@@ -278,13 +279,21 @@ export function parseSessionFromDb(
           id: call.call_id || call.id || `hermes-${rawName}-${message.id}`,
           name,
           input: mappedInput,
+          ...(rawName === "skill_view" &&
+          typeof mappedInput.name === "string" &&
+          mappedInput.name.trim()
+            ? { _skillName: mappedInput.name.trim() }
+            : {}),
         };
         blocks.push(block);
         pendingResults.set(block.id, block);
 
         if (rawName === "skill_view") {
           const skillName = typeof mappedInput.name === "string" ? mappedInput.name : "";
-          if (skillName) skillsUsed.add(skillName);
+          if (skillName) {
+            skillsUsed.add(skillName);
+            skillActivations.push(skillName);
+          }
         }
       }
 
@@ -304,9 +313,32 @@ export function parseSessionFromDb(
 
     if (message.role === "tool") {
       const block = message.tool_call_id ? pendingResults.get(message.tool_call_id) : undefined;
-      if (!block) continue; // orphan result (no matching tool_use) — drop
       const result = (message.content || "").trim();
+      if (!block) {
+        // A persisted tool result is concrete evidence of an invocation even
+        // when its assistant start record was lost during compaction/export.
+        // Keep it as a synthetic assistant tool block instead of undercounting.
+        const rawName = message.tool_name || "Unknown";
+        turns.push({
+          role: "assistant",
+          timestamp,
+          blocks: [
+            {
+              type: "tool_use",
+              id: message.tool_call_id || `hermes-orphan-${message.id}`,
+              name: mapHermesToolName(rawName),
+              input: mapHermesToolArgs(rawName, {}),
+              _hasResult: true,
+              _result: result,
+            },
+          ],
+          ...(model ? { model } : {}),
+        });
+        continue;
+      }
+      block._hasResult = true;
       if (result) block._result = result;
+      else block._result = "";
       pendingResults.delete(block.id);
       continue;
     }
@@ -365,6 +397,7 @@ export function parseSessionFromDb(
     compactions: compactions.length > 0 ? compactions : undefined,
     gitBranch: session?.git_branch || undefined,
     ...(skillsUsed.size > 0 ? { skillsUsed: Array.from(skillsUsed) } : {}),
+    ...(skillActivations.length > 0 ? { skillActivations } : {}),
     parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
     ...(truncatedResponses > 0 ? { truncatedResponses } : {}),
   };

--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -289,7 +289,7 @@ export function parseSessionFromDb(
         pendingResults.set(block.id, block);
 
         if (rawName === "skill_view") {
-          const skillName = typeof mappedInput.name === "string" ? mappedInput.name : "";
+          const skillName = typeof mappedInput.name === "string" ? mappedInput.name.trim() : "";
           if (skillName) {
             skillsUsed.add(skillName);
             skillActivations.push(skillName);

--- a/packages/provider-hermes/test/parser.test.ts
+++ b/packages/provider-hermes/test/parser.test.ts
@@ -523,7 +523,9 @@ describe("hermes parser", () => {
           id: 2,
           sessionId: baseSession.id,
           role: "assistant",
-          toolCalls: toolCallsFor([{ id: "call_s", name: "skill_view", args: { name: "replay" } }]),
+          toolCalls: toolCallsFor([
+            { id: "call_s", name: "skill_view", args: { name: " replay " } },
+          ]),
           finishReason: "tool_calls",
           timestamp: 1_800_000_002,
         },

--- a/packages/provider-hermes/test/parser.test.ts
+++ b/packages/provider-hermes/test/parser.test.ts
@@ -361,7 +361,7 @@ describe("hermes parser", () => {
     });
   });
 
-  it("skips session_meta and empty user rows, drops orphan tool results", async () => {
+  it("skips session_meta and empty user rows, preserves orphan tool results", async () => {
     const db = await buildHermesDb({
       sessions: [baseSession],
       messages: [
@@ -388,10 +388,22 @@ describe("hermes parser", () => {
 
     try {
       const result = parseSessionFromDb(db, baseSession.id);
-      expect(result.turns).toHaveLength(1);
+      expect(result.turns).toHaveLength(2);
       expect(result.turns[0]).toMatchObject({
         role: "user",
         blocks: [{ type: "text", text: "real prompt" }],
+      });
+      expect(result.turns[1]).toMatchObject({
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            id: "missing_call",
+            name: "Bash",
+            _hasResult: true,
+            _result: "orphan",
+          },
+        ],
       });
     } finally {
       db.close();

--- a/packages/provider-opencode/src/opencode/parser.ts
+++ b/packages/provider-opencode/src/opencode/parser.ts
@@ -118,7 +118,7 @@ export async function parseOpencodeSession(
     );
   }
 
-  const opened = await openOpencodeDb(hintedDbPath(paths) || undefined);
+  const opened = await openOpencodeDb(hintedDbPath(paths, sessionInfo) || undefined);
   if (!opened) {
     throw new Error(`opencode database not found at ${opencodeDbPath()}`);
   }

--- a/packages/provider-opencode/src/opencode/parser.ts
+++ b/packages/provider-opencode/src/opencode/parser.ts
@@ -118,7 +118,7 @@ export async function parseOpencodeSession(
     );
   }
 
-  const opened = await openOpencodeDb();
+  const opened = await openOpencodeDb(hintedDbPath(paths) || undefined);
   if (!opened) {
     throw new Error(`opencode database not found at ${opencodeDbPath()}`);
   }
@@ -152,6 +152,19 @@ export function resolveSessionId(paths: string[], sessionInfo?: SessionInfo): st
   return undefined;
 }
 
+function hintedDbPath(paths: string[], sessionInfo?: SessionInfo): string | undefined {
+  for (const path of paths) {
+    const markerIndex = path.indexOf("#session:");
+    if (markerIndex >= 0) {
+      const dbPath = path.slice(0, markerIndex);
+      if (dbPath) return dbPath;
+    }
+  }
+  const filePath = sessionInfo?.filePath;
+  if (filePath?.includes("#session:")) return filePath.split("#session:", 1)[0];
+  return undefined;
+}
+
 export function parseSessionFromDb(
   db: Database,
   sessionId: string,
@@ -176,6 +189,8 @@ export function parseSessionFromDb(
   const allTimestamps: string[] = [];
   const compactions: Compaction[] = [];
   const tokenByModel = new Map<string, TokenUsage>();
+  const skillsUsed = new Set<string>();
+  const skillActivations: string[] = [];
   let totalTokens: TokenUsage | undefined;
   let startTime: string | undefined;
   let endTime: string | undefined;
@@ -261,6 +276,11 @@ export function parseSessionFromDb(
 
       const blocks = assistantBlocksFromParts(db, message.id, parseWarnings);
       if (blocks.length === 0) continue;
+      for (const block of blocks) {
+        if (block.type !== "tool_use" || !block._skillName) continue;
+        skillsUsed.add(block._skillName);
+        skillActivations.push(block._skillName);
+      }
       if (meta.finish === "max_tokens") truncatedResponses++;
 
       const modelForTurn = meta.modelID || model;
@@ -304,6 +324,8 @@ export function parseSessionFromDb(
     ...(tokenUsageByModel ? { tokenUsageByModel } : {}),
     ...(Number.isFinite(reportedCostUsd) && reportedCostUsd > 0 ? { reportedCostUsd } : {}),
     compactions: compactions.length > 0 ? compactions : undefined,
+    ...(skillsUsed.size > 0 ? { skillsUsed: [...skillsUsed] } : {}),
+    ...(skillActivations.length > 0 ? { skillActivations } : {}),
     parseWarnings: parseWarnings.length > 0 ? parseWarnings : undefined,
     ...(truncatedResponses > 0 ? { truncatedResponses } : {}),
   };
@@ -357,7 +379,11 @@ function assistantBlocksFromParts(
         const input = mapOpencodeToolArgs(toolName, state.input);
         const result = toolResultText(part);
         const isError = state.status === "error";
-        const isPending = state.status === "running";
+        const isPending = state.status === "running" || state.status === "pending";
+        const hasResult =
+          state.status === "completed" ||
+          state.status === "error" ||
+          (state.status !== "running" && state.status !== "pending" && result.length > 0);
         const durationMs = durationFromState(state.time);
 
         // A completed tool part supersedes its earlier pending marker: drop the
@@ -374,10 +400,15 @@ function assistantBlocksFromParts(
           id: callID,
           name: mapOpencodeToolName(toolName),
           input,
-          ...(result ? { _result: result } : {}),
+          ...(hasResult ? { _hasResult: true, _result: result } : { _hasResult: false }),
           ...(isError ? { _isError: true } : {}),
           ...(isPending ? { _isPendingMarker: true } : {}),
           ...(durationMs ? { _durationMs: durationMs } : {}),
+          ...(toolName.toLowerCase() === "skill" &&
+          typeof input.name === "string" &&
+          input.name.trim()
+            ? { _skillName: input.name.trim() }
+            : {}),
         };
         blocks.push(block);
         if (isPending) {

--- a/packages/provider-pi/src/pi/parser.ts
+++ b/packages/provider-pi/src/pi/parser.ts
@@ -453,14 +453,25 @@ function buildAssistantBlocks(
     } else if (block.type === "toolCall") {
       const result = toolResults.get(block.id);
       const rawInput = block.arguments || {};
+      const normalizedName = block.name.toLowerCase();
+      const skillName =
+        normalizedName === "skill" || normalizedName === "skill_view"
+          ? ["name", "skill", "skillName", "skill_name", "slug"]
+              .map((key) => rawInput[key])
+              .find(
+                (value): value is string => typeof value === "string" && value.trim().length > 0,
+              )
+          : undefined;
       blocks.push({
         type: "tool_use",
         id: block.id,
         name: mapToolName(block.name, rawInput),
         input: normalizeToolInput(block.name, rawInput),
-        _result: result?.text || "",
+        _hasResult: result !== undefined,
+        ...(result !== undefined ? { _result: result.text } : {}),
         ...(result?.images.length ? { _images: result.images } : {}),
         ...(result?.isError ? { _isError: true } : {}),
+        ...(skillName ? { _skillName: skillName.trim() } : {}),
         ...(assistantTimestamp && result?.timestamp
           ? { _durationMs: toolDurationMs(assistantTimestamp, result.timestamp) }
           : {}),
@@ -489,6 +500,7 @@ function buildBashExecutionBlock(
     id: fallbackId,
     name: "Bash",
     input: { command: message.command || "" },
+    _hasResult: true,
     _result: outputParts.join(""),
     ...(message.exitCode !== undefined && message.exitCode !== 0 ? { _isError: true } : {}),
   };

--- a/packages/provider-pi/test/parser.test.ts
+++ b/packages/provider-pi/test/parser.test.ts
@@ -218,6 +218,67 @@ describe("Pi parser", () => {
     });
   });
 
+  it("distinguishes missing tool results from completed empty results", async () => {
+    const lines = [
+      {
+        type: "session",
+        version: 3,
+        id: "pi-result-presence",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd: "/Users/test/project",
+      },
+      {
+        type: "message",
+        id: "user1",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        message: { role: "user", content: "Check results" },
+      },
+      {
+        type: "message",
+        id: "assistant1",
+        parentId: "user1",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "missing", name: "read", arguments: { path: "a.ts" } },
+            { type: "toolCall", id: "empty", name: "read", arguments: { path: "b.ts" } },
+          ],
+        },
+      },
+      {
+        type: "message",
+        id: "result1",
+        parentId: "assistant1",
+        timestamp: "2026-01-01T00:00:03.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "empty",
+          content: "",
+          isError: false,
+        },
+      },
+    ];
+
+    await withPiFixture(lines, async (path) => {
+      const parsed = await parsePiSession(path);
+      const tools = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .filter((block) => block.type === "tool_use");
+      expect(tools).toHaveLength(2);
+      expect(tools.find((tool) => tool.type === "tool_use" && tool.id === "missing")).toMatchObject(
+        {
+          _hasResult: false,
+        },
+      );
+      expect(tools.find((tool) => tool.type === "tool_use" && tool.id === "empty")).toMatchObject({
+        _hasResult: true,
+        _result: "",
+      });
+    });
+  });
+
   it("maps harness exec_command and apply_patch tools into replay-native scenes", async () => {
     const patch = `*** Begin Patch
 *** Update File: src/auth.ts

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -308,6 +308,176 @@ function rangeLabel(range: TimeRange): string {
   return "All Time";
 }
 
+type InsightsSectionId = "overview" | "activity" | "usage" | "workspace";
+
+const INSIGHTS_SECTIONS: Array<{
+  id: InsightsSectionId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "overview",
+    label: "Overview",
+    description: "Your coding pulse",
+  },
+  {
+    id: "activity",
+    label: "Activity",
+    description: "When you show up",
+  },
+  {
+    id: "usage",
+    label: "Usage",
+    description: "Tools, MCP, and tokens",
+  },
+  {
+    id: "workspace",
+    label: "Workspace",
+    description: "Projects and models",
+  },
+];
+
+const INSIGHTS_CARD_CLASS =
+  "rounded-xl bg-terminal-surface border border-terminal-border-subtle shadow-layer-sm";
+
+function InsightsSectionIcon({ section }: { section: InsightsSectionId }) {
+  const paths: Record<InsightsSectionId, string> = {
+    overview: "M3 3h6v6H3zM15 3h6v6h-6zM3 15h6v6H3zM15 15h6v6h-6z",
+    activity: "M3 12h4l2-7 4 14 2-7h6",
+    usage: "M4 5h16M4 12h16M4 19h16",
+    workspace: "M4 5h6v6H4zM14 5h6v6h-6zM4 15h6v6H4zM14 15h6v6h-6z",
+  };
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={paths[section]} />
+    </svg>
+  );
+}
+
+export function InsightsSectionNav({
+  activeSection,
+  onSelect,
+}: {
+  activeSection: InsightsSectionId;
+  onSelect: (section: InsightsSectionId) => void;
+}) {
+  return (
+    <aside className="shrink-0 border-b border-terminal-border-subtle bg-terminal-bg/70 md:w-56 md:border-b-0 md:border-r">
+      <div className="flex gap-3 overflow-x-auto p-3 md:sticky md:top-0 md:flex-col md:gap-6 md:p-5">
+        <div className="hidden md:block">
+          <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-dimmer">
+            Insights
+          </div>
+          <p className="mt-2 text-xs font-sans leading-relaxed text-terminal-dim">
+            A focused view of how you build with agents.
+          </p>
+        </div>
+
+        <nav aria-label="Insights sections" className="flex min-w-max gap-1 md:min-w-0 md:flex-col">
+          {INSIGHTS_SECTIONS.map((section, index) => {
+            const selected = activeSection === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                aria-current={selected ? "location" : undefined}
+                aria-controls={`insights-${section.id}`}
+                onClick={() => onSelect(section.id)}
+                className={`group flex min-w-[118px] items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition-colors md:min-w-0 ${
+                  selected
+                    ? "bg-terminal-green-subtle text-terminal-green"
+                    : "text-terminal-dim hover:bg-terminal-surface hover:text-terminal-text"
+                }`}
+              >
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${
+                    selected
+                      ? "bg-terminal-green/15"
+                      : "bg-terminal-surface-2 text-terminal-dimmer group-hover:text-terminal-dim"
+                  }`}
+                >
+                  <InsightsSectionIcon section={section.id} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-xs font-sans font-semibold">{section.label}</span>
+                  <span className="hidden truncate text-[10px] font-mono text-terminal-dimmer md:block">
+                    {section.description}
+                  </span>
+                </span>
+                <span className="ml-auto hidden text-[10px] font-mono tabular-nums text-terminal-dimmer md:block">
+                  0{index + 1}
+                </span>
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="hidden border-t border-terminal-border-subtle pt-4 md:block">
+          <div className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+            Tip
+          </div>
+          <p className="mt-2 text-[11px] font-sans leading-relaxed text-terminal-dimmer">
+            Select a tool or MCP entry to open the matching sessions.
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export function InsightsSection({
+  id,
+  eyebrow,
+  title,
+  description,
+  meta,
+  children,
+}: {
+  id: InsightsSectionId;
+  eyebrow: string;
+  title: string;
+  description: string;
+  meta?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      id={`insights-${id}`}
+      aria-labelledby={`insights-${id}-heading`}
+      className="scroll-mt-5"
+    >
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-green">
+            {eyebrow}
+          </div>
+          <h2
+            id={`insights-${id}-heading`}
+            className="mt-1 text-base font-sans font-semibold text-terminal-text"
+          >
+            {title}
+          </h2>
+          <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
+            {description}
+          </p>
+        </div>
+        {meta ? <div className="shrink-0">{meta}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
 // ─── GitHub-style Contribution Heatmap ──────────────────────────────
 
 export function ContributionHeatmap({
@@ -511,15 +681,15 @@ function ShareCard({
   return (
     <div
       ref={cardRef}
-      className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-terminal-surface via-terminal-bg to-terminal-surface border border-terminal-border p-6 md:p-8 shadow-layer-xl"
+      className="relative overflow-hidden rounded-xl border border-terminal-border-subtle bg-terminal-surface p-5 shadow-layer-sm md:p-6"
     >
       {/* Gradient glow */}
-      <div className="absolute -top-20 -right-20 w-64 h-64 bg-terminal-green/5 rounded-full blur-3xl pointer-events-none" />
-      <div className="absolute -bottom-20 -left-20 w-48 h-48 bg-terminal-blue/5 rounded-full blur-3xl pointer-events-none" />
+      <div className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-terminal-green/5 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-20 -left-20 h-48 w-48 rounded-full bg-terminal-blue/5 blur-3xl" />
 
       <div className="relative z-10">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="mb-5 flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">
             <span className="text-sm font-sans font-bold bg-gradient-to-r from-terminal-green to-terminal-blue bg-clip-text text-transparent">
               vibe-replay
@@ -537,7 +707,7 @@ function ShareCard({
         </div>
 
         {/* Stats grid — 4 columns matching homepage cards */}
-        <div className="grid grid-cols-4 gap-x-6 gap-y-5 mb-6">
+        <div className="mb-5 grid grid-cols-2 gap-x-4 gap-y-5 sm:grid-cols-4 xl:grid-cols-8">
           <div>
             <div className="text-2xl md:text-3xl font-mono font-bold text-terminal-green tabular-nums">
               <AnimatedValue durationMs={500} value={stats.sessions} formatter={formatCompactNum} />
@@ -601,12 +771,12 @@ function ShareCard({
         </div>
 
         {/* Mini heatmap */}
-        <div className="mb-4">
+        <div className="mb-3">
           <MiniHeatmap sessionsPerDay={sessionsPerDay} />
         </div>
 
         {/* Footer highlights */}
-        <div className="flex items-center justify-between pt-4 border-t border-terminal-border/30">
+        <div className="flex items-center justify-between border-t border-terminal-border/30 pt-3">
           <div className="flex items-center gap-4">
             {streak.current > 0 && <span className="ui-caption">{streak.current} day streak</span>}
             {bestDay && bestDay.count > 0 && (
@@ -634,7 +804,7 @@ function HighlightCard({
   sub?: string;
 }) {
   return (
-    <div className="bg-terminal-surface rounded-xl px-4 py-3.5 shadow-layer-sm hover:bg-terminal-surface-hover transition-colors group">
+    <div className="group rounded-xl border border-terminal-border-subtle bg-terminal-surface px-4 py-3.5 shadow-layer-sm transition-colors hover:bg-terminal-surface-hover">
       <div className="flex items-start gap-3">
         <span className="text-lg leading-none mt-0.5">{icon}</span>
         <div className="min-w-0">
@@ -937,84 +1107,79 @@ function ProviderBreakdown({ providers }: { providers: Record<string, number> })
 
 function InsightsPageSkeleton() {
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 md:px-6 py-6 space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div className="h-6 w-32 skeleton rounded" />
-          <div className="flex gap-1">
-            {Array.from({ length: 4 }, (_, i) => (
-              <div key={i} className="h-7 w-10 skeleton rounded-md" />
-            ))}
-          </div>
-        </div>
-        {/* Share card skeleton */}
-        <div className="rounded-2xl bg-terminal-surface border border-terminal-border/30 p-6 space-y-5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="h-4 w-20 skeleton rounded" />
-              <div className="h-5 w-12 skeleton rounded-md" />
-            </div>
-            <div className="h-3 w-28 skeleton rounded" />
-          </div>
-          <div className="grid grid-cols-4 gap-6">
-            {Array.from({ length: 8 }, (_, i) => (
-              <div key={i} className="space-y-2">
-                <div
-                  className="h-7 skeleton rounded"
-                  style={{ width: `${45 + ((i * 13) % 40)}%` }}
-                />
-                <div className="h-3 w-16 skeleton rounded" />
-              </div>
-            ))}
-          </div>
-          <div className="h-2.5 w-full skeleton rounded" />
-          <div className="flex justify-between">
-            <div className="h-3 w-40 skeleton rounded" />
-            <div className="h-3 w-24 skeleton rounded" />
-          </div>
-        </div>
-        {/* Activity heatmap skeleton */}
-        <div className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm space-y-4">
-          <div className="h-3 w-16 skeleton rounded" />
-          <div className="space-y-1.5">
-            {Array.from({ length: 3 }, (_, i) => (
-              <div key={i} className="h-3 skeleton rounded" />
-            ))}
-          </div>
-        </div>
-        {/* Highlight cards skeleton */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div className="mx-auto w-full max-w-[1600px] px-4 py-6 sm:px-6 xl:px-8 2xl:px-10 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="h-6 w-32 skeleton rounded" />
+        <div className="flex gap-1">
           {Array.from({ length: 4 }, (_, i) => (
-            <div key={i} className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm space-y-2.5">
-              <div className="flex items-center gap-2">
-                <div className="h-5 w-5 skeleton rounded" />
-                <div className="h-3 w-20 skeleton rounded" />
-              </div>
-              <div className="h-6 w-24 skeleton rounded" />
-              <div className="h-2.5 w-16 skeleton rounded" />
+            <div key={i} className="h-7 w-10 skeleton rounded-md" />
+          ))}
+        </div>
+      </div>
+      {/* Share card skeleton */}
+      <div className="rounded-2xl bg-terminal-surface border border-terminal-border/30 p-6 space-y-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="h-4 w-20 skeleton rounded" />
+            <div className="h-5 w-12 skeleton rounded-md" />
+          </div>
+          <div className="h-3 w-28 skeleton rounded" />
+        </div>
+        <div className="grid grid-cols-4 gap-6">
+          {Array.from({ length: 8 }, (_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="h-7 skeleton rounded" style={{ width: `${45 + ((i * 13) % 40)}%` }} />
+              <div className="h-3 w-16 skeleton rounded" />
             </div>
           ))}
         </div>
-        {/* Weekly Trend + Day of Week skeleton */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {Array.from({ length: 2 }, (_, col) => (
-            <div key={col} className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm space-y-4">
-              <div className="h-3 w-24 skeleton rounded" />
-              <div className="space-y-2">
-                {Array.from({ length: 5 }, (_, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <div className="h-3 w-8 skeleton rounded shrink-0" />
-                    <div
-                      className="h-5 skeleton rounded"
-                      style={{ width: `${25 + ((i * 17 + col * 31) % 60)}%` }}
-                    />
-                  </div>
-                ))}
-              </div>
-            </div>
+        <div className="h-2.5 w-full skeleton rounded" />
+        <div className="flex justify-between">
+          <div className="h-3 w-40 skeleton rounded" />
+          <div className="h-3 w-24 skeleton rounded" />
+        </div>
+      </div>
+      {/* Activity heatmap skeleton */}
+      <div className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm space-y-4">
+        <div className="h-3 w-16 skeleton rounded" />
+        <div className="space-y-1.5">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="h-3 skeleton rounded" />
           ))}
         </div>
+      </div>
+      {/* Highlight cards skeleton */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm space-y-2.5">
+            <div className="flex items-center gap-2">
+              <div className="h-5 w-5 skeleton rounded" />
+              <div className="h-3 w-20 skeleton rounded" />
+            </div>
+            <div className="h-6 w-24 skeleton rounded" />
+            <div className="h-2.5 w-16 skeleton rounded" />
+          </div>
+        ))}
+      </div>
+      {/* Weekly Trend + Day of Week skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {Array.from({ length: 2 }, (_, col) => (
+          <div key={col} className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm space-y-4">
+            <div className="h-3 w-24 skeleton rounded" />
+            <div className="space-y-2">
+              {Array.from({ length: 5 }, (_, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <div className="h-3 w-8 skeleton rounded shrink-0" />
+                  <div
+                    className="h-5 skeleton rounded"
+                    style={{ width: `${25 + ((i * 17 + col * 31) % 60)}%` }}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -1046,7 +1211,7 @@ function InsightsLoadingState({
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 md:px-6 py-8 space-y-4">
+      <div className="mx-auto w-full max-w-[1600px] px-4 py-8 sm:px-6 xl:px-8 2xl:px-10 space-y-4">
         <div className="rounded-xl border border-terminal-purple/20 bg-terminal-surface px-4 py-3">
           <div className="flex items-center gap-2 text-sm font-sans text-terminal-text">
             <span className="w-2 h-2 rounded-full bg-terminal-purple animate-pulse" />
@@ -1076,7 +1241,7 @@ function InsightsRangeLoadingState({
 }) {
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 md:px-6 py-6 space-y-6">
+      <div className="mx-auto w-full max-w-[1600px] px-4 py-6 sm:px-6 xl:px-8 2xl:px-10 space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-lg font-sans font-bold text-terminal-text">Your Insights</h1>
           <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-terminal-surface">
@@ -1350,15 +1515,43 @@ export function UsageBarList({
   );
 }
 
+export function UsageCoverage({ payload }: { payload: UsageRollupPayload | null }) {
+  if (!payload || payload.totalSessions <= 0) return null;
+  const indexed = Math.min(payload.indexedSessions, payload.totalSessions);
+  const coverage = Math.round((indexed / payload.totalSessions) * 100);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-terminal-border-subtle pt-3 text-[10px] font-mono text-terminal-dimmer">
+      <span className="uppercase tracking-widest">Invocation index</span>
+      <span className="text-terminal-dim">
+        {indexed.toLocaleString()} / {payload.totalSessions.toLocaleString()} sessions
+      </span>
+      <span className={coverage === 100 ? "text-terminal-green" : "text-terminal-orange"}>
+        {coverage}% covered
+      </span>
+      {coverage < 100 && <span>Counts will grow as provider details finish indexing.</span>}
+    </div>
+  );
+}
+
 // ─── Main Component ─────────────────────────────────────────────────
 
 export default function InsightsPage() {
   const { userInsights, loading, scanStatus } = useScanInsightsContext();
   const homePageCounts = useHomePageCounts();
   const [range, setRange] = useState<TimeRange>(getInsightsRangeFromUrl);
+  const [activeSection, setActiveSection] = useState<InsightsSectionId>("overview");
+  const contentRef = useRef<HTMLElement>(null);
   const handleRangeChange = useCallback((next: TimeRange) => {
     setRange(next);
     navigateTo({ [INSIGHTS_RANGE_PARAM]: next === "all" ? null : next }, { notify: false });
+  }, []);
+  const handleSectionSelect = useCallback((section: InsightsSectionId) => {
+    setActiveSection(section);
+    const target = document.getElementById(`insights-${section}`);
+    if (target && typeof target.scrollIntoView === "function") {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
   }, []);
   useEffect(() => {
     const handlePopState = () => setRange(getInsightsRangeFromUrl());
@@ -1470,6 +1663,27 @@ export default function InsightsPage() {
     [usagePayload, range],
   );
 
+  useEffect(() => {
+    const root = contentRef.current;
+    if (!root || !userInsights) return;
+
+    const updateActiveSection = () => {
+      const rootTop = root.getBoundingClientRect().top;
+      let next: InsightsSectionId = "overview";
+      for (const section of INSIGHTS_SECTIONS) {
+        const element = document.getElementById(`insights-${section.id}`);
+        if (element && element.getBoundingClientRect().top - rootTop <= 144) {
+          next = section.id;
+        }
+      }
+      setActiveSection((current) => (current === next ? current : next));
+    };
+
+    updateActiveSection();
+    root.addEventListener("scroll", updateActiveSection, { passive: true });
+    return () => root.removeEventListener("scroll", updateActiveSection);
+  }, [userInsights, range, usage.sessionCount, turnDurationHistogram, tokenBreakdown]);
+
   if (!userInsights && (loading || isInitialScan || scanStatus?.phase === "discovering")) {
     return (
       <InsightsLoadingState
@@ -1509,262 +1723,323 @@ export default function InsightsPage() {
       : undefined;
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 md:px-6 py-6 space-y-6">
-        {/* Header with time range selector */}
-        <div className="flex items-center justify-between">
-          <h1 className="text-lg font-sans font-bold text-terminal-text">Your Insights</h1>
-          <div className="flex items-center gap-0.5 p-0.5 rounded-lg bg-terminal-surface">
-            {(["7d", "30d", "90d", "all"] as TimeRange[]).map((r) => (
-              <button
-                key={r}
-                onClick={() => handleRangeChange(r)}
-                className={`px-3 py-1.5 text-xs font-sans rounded-md transition-all ${
-                  range === r
-                    ? "bg-terminal-green-subtle text-terminal-green font-bold"
-                    : "text-terminal-dim hover:text-terminal-text"
-                }`}
-              >
-                {r === "all" ? "All" : r}
-              </button>
-            ))}
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
+      <InsightsSectionNav activeSection={activeSection} onSelect={handleSectionSelect} />
+      <main ref={contentRef} className="min-w-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-[1600px] px-4 py-6 sm:px-6 xl:px-8 2xl:px-10">
+          {/* Page header and range selector */}
+          <div className="mb-8 flex flex-col gap-4 border-b border-terminal-border-subtle pb-5 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-green">
+                Personal analytics
+              </div>
+              <h1 className="mt-1 text-xl font-sans font-bold text-terminal-text">Your Insights</h1>
+              <p className="mt-1 text-xs font-sans text-terminal-dim">
+                A wider view of your sessions, activity, and agent usage.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 self-start sm:self-auto">
+              <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                Range
+              </span>
+              <div className="flex items-center gap-0.5 rounded-lg border border-terminal-border-subtle bg-terminal-surface p-0.5">
+                {(["7d", "30d", "90d", "all"] as TimeRange[]).map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => handleRangeChange(r)}
+                    className={`rounded-md px-3 py-1.5 text-xs font-sans transition-all ${
+                      range === r
+                        ? "bg-terminal-green-subtle font-bold text-terminal-green"
+                        : "text-terminal-dim hover:text-terminal-text"
+                    }`}
+                  >
+                    {r === "all" ? "All" : r}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
 
-        {showSnapshotNotice && (
-          <div className="rounded-xl border border-terminal-blue/30 bg-terminal-blue/10 px-4 py-3">
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-terminal-blue" />
-              <div className="space-y-1">
-                <div className="text-xs font-sans font-semibold text-terminal-text">
-                  Showing cached insights snapshot while the background refresh runs
-                </div>
-                <div className="text-xs font-mono text-terminal-dim">
-                  {snapshotAge
-                    ? `Snapshot from ${snapshotAge} ago.`
-                    : "Using the latest cached scan."}{" "}
-                  {refreshProgress
-                    ? `Refreshing ${refreshProgress} sessions now.`
-                    : "Refreshing now."}
-                </div>
-                {pendingSessionDelta > 0 && (
+          {showSnapshotNotice && (
+            <div className="rounded-xl border border-terminal-blue/30 bg-terminal-blue/10 px-4 py-3">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-terminal-blue" />
+                <div className="space-y-1">
+                  <div className="text-xs font-sans font-semibold text-terminal-text">
+                    Showing cached insights snapshot while the background refresh runs
+                  </div>
                   <div className="text-xs font-mono text-terminal-dim">
-                    Insights currently cover {userInsights.totalSessions} scanned sessions;{" "}
-                    {pendingSessionDelta} additional session
-                    {pendingSessionDelta === 1 ? "" : "s"} will appear after the refresh completes.
+                    {snapshotAge
+                      ? `Snapshot from ${snapshotAge} ago.`
+                      : "Using the latest cached scan."}{" "}
+                    {refreshProgress
+                      ? `Refreshing ${refreshProgress} sessions now.`
+                      : "Refreshing now."}
+                  </div>
+                  {pendingSessionDelta > 0 && (
+                    <div className="text-xs font-mono text-terminal-dim">
+                      Insights currently cover {userInsights.totalSessions} scanned sessions;{" "}
+                      {pendingSessionDelta} additional session
+                      {pendingSessionDelta === 1 ? "" : "s"} will appear after the refresh
+                      completes.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <ScanFailureNotice failedProviders={scanStatus?.failedProviders} />
+
+          <div className="space-y-10">
+            <InsightsSection
+              id="overview"
+              eyebrow="01 / Overview"
+              title="Your coding pulse"
+              description="The high-level picture for the selected range, with the all-time streak kept in view."
+              meta={
+                <span className="ui-pill-compact bg-terminal-green-subtle text-terminal-green">
+                  {formatCompactNum(stats.sessions)} sessions
+                </span>
+              }
+            >
+              <div className="space-y-4">
+                <ShareCard
+                  stats={stats}
+                  streak={streak}
+                  bestDay={bestDay}
+                  sessionsPerDay={sessionsPerDay}
+                  range={range}
+                  providers={providers}
+                  dataQualityNotes={userInsights.dataQuality?.notes}
+                />
+
+                {/* Highlights */}
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  <HighlightCard
+                    icon={"\u{1F525}"}
+                    label="Current Streak"
+                    value={`${streak.current} day${streak.current !== 1 ? "s" : ""}`}
+                    sub={
+                      streak.longest > streak.current
+                        ? `Best: ${streak.longest} days`
+                        : streak.current > 0
+                          ? "Personal best!"
+                          : undefined
+                    }
+                  />
+                  <HighlightCard
+                    icon={"\u26A1"}
+                    label="Avg / Active Day"
+                    value={`${avgPerActiveDay} sessions`}
+                    sub={`${activeDays} active day${activeDays !== 1 ? "s" : ""}`}
+                  />
+                  <HighlightCard
+                    icon={"\u{1F4AC}"}
+                    label="Avg / Session"
+                    value={`${avgPromptsPerSession} prompts`}
+                    sub={
+                      stats.sessions > 0
+                        ? `~${formatCompactDuration(stats.durationMs / stats.sessions)} each`
+                        : undefined
+                    }
+                  />
+                  {peak ? (
+                    <HighlightCard
+                      icon={"\u{1F3C6}"}
+                      label="Peak Day"
+                      value={`${peak.count} sessions`}
+                      sub={new Date(`${peak.date}T00:00:00`).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    />
+                  ) : (
+                    <HighlightCard
+                      icon={"\u{1F4C5}"}
+                      label="Vibe Coding Since"
+                      value={daysSinceFirst > 0 ? `${daysSinceFirst} days` : "Today"}
+                      sub={
+                        firstSessionDate
+                          ? new Date(firstSessionDate).toLocaleDateString("en-US", {
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                            })
+                          : undefined
+                      }
+                    />
+                  )}
+                </div>
+              </div>
+            </InsightsSection>
+
+            <InsightsSection
+              id="activity"
+              eyebrow="02 / Activity"
+              title="When you show up"
+              description="See your working rhythm over the full history, then compare recent weeks and weekdays."
+              meta={
+                <span className="text-[10px] font-mono text-terminal-dimmer">Last 52 weeks</span>
+              }
+            >
+              <div className="space-y-4">
+                {/* Activity Heatmap — always shows full history regardless of range filter */}
+                <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                  <div className="mb-4 flex items-center justify-between">
+                    <h3 className="ui-section-title-strong">Contribution activity</h3>
+                    <span className="text-[10px] font-mono text-terminal-dimmer">
+                      {activeDays} active day{activeDays !== 1 ? "s" : ""} in range
+                    </span>
+                  </div>
+                  <ContributionHeatmap sessionsPerDay={userInsights.sessionsPerDay || {}} />
+                </div>
+                <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                  <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                    <h3 className="ui-section-title-strong mb-4">Weekly Trend</h3>
+                    <WeeklyTrendChart data={weeklyTrend} />
+                  </div>
+                  <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                    <h3 className="ui-section-title-strong mb-4">Day of Week</h3>
+                    <DayOfWeekChart data={dayOfWeek} />
+                  </div>
+                </div>
+              </div>
+            </InsightsSection>
+
+            <InsightsSection
+              id="usage"
+              eyebrow="03 / Usage"
+              title="How your agents work"
+              description="Invocation counts are kept separate: ordinary tools, MCP servers and tools, and skill activations."
+              meta={
+                usage.sessionCount > 0 ? (
+                  <span className="text-[10px] font-mono tabular-nums text-terminal-dimmer">
+                    {formatCompactNum(usage.toolCalls)} tools · {formatCompactNum(usage.mcpCalls)}{" "}
+                    MCP
+                  </span>
+                ) : null
+              }
+            >
+              <div className="space-y-4">
+                {/* Turn Duration Distribution + Token Breakdown */}
+                {(turnDurationHistogram || tokenBreakdown) && (
+                  <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                    {turnDurationHistogram && (
+                      <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                        <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
+                        <TurnDurationChart histogram={turnDurationHistogram} />
+                      </div>
+                    )}
+                    {tokenBreakdown && (
+                      <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                        <h3 className="ui-section-title-strong mb-4">Token Usage</h3>
+                        <TokenBreakdownChart breakdown={tokenBreakdown} />
+                      </div>
+                    )}
                   </div>
                 )}
-              </div>
-            </div>
-          </div>
-        )}
 
-        <ScanFailureNotice failedProviders={scanStatus?.failedProviders} />
-
-        {/* Share Card */}
-        <ShareCard
-          stats={stats}
-          streak={streak}
-          bestDay={bestDay}
-          sessionsPerDay={sessionsPerDay}
-          range={range}
-          providers={providers}
-          dataQualityNotes={userInsights.dataQuality?.notes}
-        />
-
-        {/* Activity Heatmap — always shows full history regardless of range filter */}
-        <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="ui-section-title-strong">Activity</h3>
-            {range !== "all" && (
-              <span className="text-[9px] font-mono text-terminal-dimmer">Last 52 weeks</span>
-            )}
-          </div>
-          <ContributionHeatmap sessionsPerDay={userInsights.sessionsPerDay || {}} />
-        </div>
-
-        {/* Highlights */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <HighlightCard
-            icon={"\u{1F525}"}
-            label="Current Streak"
-            value={`${streak.current} day${streak.current !== 1 ? "s" : ""}`}
-            sub={
-              streak.longest > streak.current
-                ? `Best: ${streak.longest} days`
-                : streak.current > 0
-                  ? "Personal best!"
-                  : undefined
-            }
-          />
-          <HighlightCard
-            icon={"\u26A1"}
-            label="Avg / Active Day"
-            value={`${avgPerActiveDay} sessions`}
-            sub={`${activeDays} active day${activeDays !== 1 ? "s" : ""}`}
-          />
-          <HighlightCard
-            icon={"\u{1F4AC}"}
-            label="Avg / Session"
-            value={`${avgPromptsPerSession} prompts`}
-            sub={
-              stats.sessions > 0
-                ? `~${formatCompactDuration(stats.durationMs / stats.sessions)} each`
-                : undefined
-            }
-          />
-          {peak ? (
-            <HighlightCard
-              icon={"\u{1F3C6}"}
-              label="Peak Day"
-              value={`${peak.count} sessions`}
-              sub={new Date(`${peak.date}T00:00:00`).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })}
-            />
-          ) : (
-            <HighlightCard
-              icon={"\u{1F4C5}"}
-              label="Vibe Coding Since"
-              value={daysSinceFirst > 0 ? `${daysSinceFirst} days` : "Today"}
-              sub={
-                firstSessionDate
-                  ? new Date(firstSessionDate).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })
-                  : undefined
-              }
-            />
-          )}
-        </div>
-
-        {/* Turn Duration Distribution + Token Breakdown */}
-        {(turnDurationHistogram || tokenBreakdown) && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {turnDurationHistogram && (
-              <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-                <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
-                <TurnDurationChart histogram={turnDurationHistogram} />
+                {/* Tool & MCP usage — aggregated from per-session usage counters */}
+                {usage.sessionCount > 0 && (
+                  <div className={`${INSIGHTS_CARD_CLASS} space-y-5 p-5 md:p-6`}>
+                    <div className="flex items-baseline justify-between gap-3">
+                      <h3 className="ui-section-title-strong">Tools &amp; MCP</h3>
+                      <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
+                        {formatCompactNum(usage.toolCalls)} tool ·{" "}
+                        {formatCompactNum(usage.mcpCalls)} MCP calls
+                        {usage.errorCount > 0 && ` · ${formatCompactNum(usage.errorCount)} failed`}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                      <div>
+                        <h4 className="ui-section-title mb-3">Top tools</h4>
+                        <UsageBarList
+                          entries={usage.tools}
+                          emptyLabel="No tool data"
+                          unit="calls"
+                          onSelect={(name) => navigateToUsageSessions("tool", name, range)}
+                        />
+                      </div>
+                      <div>
+                        <h4 className="ui-section-title mb-3">Top MCP servers</h4>
+                        <UsageBarList
+                          entries={usage.mcpServers}
+                          emptyLabel="No MCP data"
+                          unit="calls"
+                          onSelect={(name) => navigateToUsageSessions("mcp", name, range)}
+                        />
+                      </div>
+                    </div>
+                    {usage.mcpTools.length > 0 && (
+                      <div>
+                        <h4 className="ui-section-title mb-3">Top MCP tools</h4>
+                        <UsageBarList
+                          entries={usage.mcpTools}
+                          emptyLabel="No MCP data"
+                          unit="calls"
+                          onSelect={(name) => navigateToUsageSessions("mcpTool", name, range)}
+                        />
+                      </div>
+                    )}
+                    {usage.skills.length > 0 && (
+                      <div>
+                        <h4 className="ui-section-title mb-3">Top skills</h4>
+                        <UsageBarList
+                          entries={usage.skills}
+                          emptyLabel="No skill data"
+                          unit="activations"
+                          onSelect={(name) => navigateToUsageSessions("skill", name, range)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+                <UsageCoverage payload={usagePayload} />
               </div>
-            )}
-            {tokenBreakdown && (
-              <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-                <h3 className="ui-section-title-strong mb-4">Token Usage</h3>
-                <TokenBreakdownChart breakdown={tokenBreakdown} />
-              </div>
-            )}
-          </div>
-        )}
+            </InsightsSection>
 
-        {/* Tool & MCP usage — aggregated from per-session usage counters */}
-        {usage.sessionCount > 0 && (
-          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-5">
-            <div className="flex items-baseline justify-between gap-3">
-              <h3 className="ui-section-title-strong">Tools &amp; MCP</h3>
-              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums">
-                {formatCompactNum(usage.toolCalls)} tool · {formatCompactNum(usage.mcpCalls)} MCP
-                calls
-                {usage.errorCount > 0 && ` · ${formatCompactNum(usage.errorCount)} failed`}
-              </span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-              <div>
-                <h4 className="ui-section-title mb-3">Top tools</h4>
-                <UsageBarList
-                  entries={usage.tools}
-                  emptyLabel="No tool data"
-                  unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("tool", name, range)}
-                />
+            <InsightsSection
+              id="workspace"
+              eyebrow="04 / Workspace"
+              title="Your working set"
+              description="The projects, models, and providers that shaped your sessions in this range."
+            >
+              <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                  <h3 className="ui-section-title-strong mb-4">Top Projects</h3>
+                  <TopProjectsList projects={topProjects} />
+                </div>
+                <div className={`${INSIGHTS_CARD_CLASS} space-y-5 p-5 md:p-6`}>
+                  <div>
+                    <h3 className="ui-section-title-strong mb-4">Models</h3>
+                    <ModelBreakdown models={models} />
+                  </div>
+                  {Object.keys(providers).length > 1 && (
+                    <div>
+                      <h3 className="ui-section-title-strong mb-4">Providers</h3>
+                      <ProviderBreakdown providers={providers} />
+                    </div>
+                  )}
+                </div>
               </div>
-              <div>
-                <h4 className="ui-section-title mb-3">Top MCP servers</h4>
-                <UsageBarList
-                  entries={usage.mcpServers}
-                  emptyLabel="No MCP data"
-                  unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("mcp", name, range)}
-                />
-              </div>
-            </div>
-            {usage.mcpTools.length > 0 && (
-              <div>
-                <h4 className="ui-section-title mb-3">Top MCP tools</h4>
-                <UsageBarList
-                  entries={usage.mcpTools}
-                  emptyLabel="No MCP data"
-                  unit="calls"
-                  onSelect={(name) => navigateToUsageSessions("mcpTool", name, range)}
-                />
-              </div>
-            )}
-            {usage.skills.length > 0 && (
-              <div>
-                <h4 className="ui-section-title mb-3">Top skills</h4>
-                <UsageBarList
-                  entries={usage.skills}
-                  emptyLabel="No skill data"
-                  unit="activations"
-                  onSelect={(name) => navigateToUsageSessions("skill", name, range)}
-                />
-              </div>
-            )}
-            {usagePayload && usagePayload.indexedSessions < usagePayload.totalSessions && (
-              <div className="text-[10px] font-mono text-terminal-dimmer">
-                Based on {usagePayload.indexedSessions} of {usagePayload.totalSessions} scanned
-                sessions — the rest have no usage index yet.
-              </div>
-            )}
-          </div>
-        )}
+            </InsightsSection>
 
-        {/* Two-column: Weekly Trend + Day of Week */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="ui-section-title-strong mb-4">Weekly Trend</h3>
-            <WeeklyTrendChart data={weeklyTrend} />
-          </div>
-          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="ui-section-title-strong mb-4">Day of Week</h3>
-            <DayOfWeekChart data={dayOfWeek} />
-          </div>
-        </div>
-
-        {/* Two-column: Top Projects + Models & Providers */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm">
-            <h3 className="ui-section-title-strong mb-4">Top Projects</h3>
-            <TopProjectsList projects={topProjects} />
-          </div>
-          <div className="bg-terminal-surface rounded-xl p-5 shadow-layer-sm space-y-5">
-            <div>
-              <h3 className="ui-section-title-strong mb-4">Models</h3>
-              <ModelBreakdown models={models} />
-            </div>
-            {Object.keys(providers).length > 1 && (
-              <div>
-                <h3 className="ui-section-title-strong mb-4">Providers</h3>
-                <ProviderBreakdown providers={providers} />
+            {/* Vibe coding since banner */}
+            {daysSinceFirst > 0 && (
+              <div className="text-center py-4">
+                <span className="text-[11px] font-mono text-terminal-dimmer">
+                  You've been vibe coding for {daysSinceFirst} day{daysSinceFirst !== 1 ? "s" : ""}{" "}
+                  · {formatDuration(stats.durationMs)} total · {formatCompactNum(stats.toolCalls)}{" "}
+                  tool calls
+                </span>
               </div>
             )}
           </div>
         </div>
-
-        {/* Vibe coding since banner */}
-        {daysSinceFirst > 0 && (
-          <div className="text-center py-4">
-            <span className="text-[11px] font-mono text-terminal-dimmer">
-              You've been vibe coding for {daysSinceFirst} day{daysSinceFirst !== 1 ? "s" : ""} ·{" "}
-              {formatDuration(stats.durationMs)} total · {formatCompactNum(stats.toolCalls)} tool
-              calls
-            </span>
-          </div>
-        )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { navigateToUsageSessions, TopProjectsList, UsageBarList } from "../InsightsPage";
+import {
+  InsightsSection,
+  InsightsSectionNav,
+  navigateToUsageSessions,
+  TopProjectsList,
+  UsageBarList,
+  UsageCoverage,
+} from "../InsightsPage";
 import { getInsightsRangeFromUrl, getMultiFromUrl } from "../../hooks/usePanelFilters";
 
 afterEach(() => {
@@ -80,6 +87,49 @@ describe("UsageBarList", () => {
     const params = new URLSearchParams(window.location.search);
     expect(params.get("mcpTool")).toBe(value);
     expect(getMultiFromUrl("mcpTool")).toEqual([value]);
+  });
+});
+
+describe("Insights sections", () => {
+  it("exposes section anchors and navigates from the sidebar", () => {
+    const onSelect = vi.fn();
+    render(
+      <>
+        <InsightsSectionNav activeSection="overview" onSelect={onSelect} />
+        <InsightsSection
+          id="usage"
+          eyebrow="03 / Usage"
+          title="How your agents work"
+          description="Invocation counts"
+        >
+          <div>Usage content</div>
+        </InsightsSection>
+      </>,
+    );
+
+    const usageButton = screen.getByRole("button", { name: /Usage/i });
+    expect(usageButton.getAttribute("aria-controls")).toBe("insights-usage");
+    expect(screen.getByRole("heading", { name: "How your agents work" })).toBeDefined();
+    expect(document.getElementById("insights-usage")).toBeDefined();
+
+    fireEvent.click(usageButton);
+    expect(onSelect).toHaveBeenCalledWith("usage");
+  });
+
+  it("communicates incomplete invocation-index coverage", () => {
+    const { container } = render(
+      <UsageCoverage
+        payload={{
+          sessions: [],
+          indexedSessions: 2,
+          totalSessions: 4,
+        }}
+      />,
+    );
+
+    expect(container.textContent).toContain("2 / 4 sessions");
+    expect(container.textContent).toContain("50% covered");
+    expect(container.textContent).toContain("Counts will grow");
   });
 });
 

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -110,7 +110,7 @@ describe("Insights sections", () => {
     const usageButton = screen.getByRole("button", { name: /Usage/i });
     expect(usageButton.getAttribute("aria-controls")).toBe("insights-usage");
     expect(screen.getByRole("heading", { name: "How your agents work" })).toBeDefined();
-    expect(document.getElementById("insights-usage")).toBeDefined();
+    expect(document.getElementById("insights-usage")).not.toBeNull();
 
     fireEvent.click(usageButton);
     expect(onSelect).toHaveBeenCalledWith("usage");


### PR DESCRIPTION
## Summary
- Split Insights into Overview, Activity, Usage, and Workspace sections with responsive sidebar/mobile navigation and wide-layout cards.
- Make tool, MCP, and skill facets derive from concrete provider events, including streamed-skill deduplication, MCP normalization, result-presence tracking, orphan completions, and OpenCode/Hermes/Pi indexing.
- Add regression coverage for provider accounting, empty versus missing results, and retained usage summaries.

## Validation
- `VIBE_REPLAY_CONFIG=/tmp/vibe-replay-test-no-remote-config.json pnpm verify`
- Full local dashboard smoke test at `/?view=dashboard&tab=insights`; section navigation and `aria-current` verified.
- Final local scan reached `2,666 / 2,670` sessions indexed during the smoke test.

## Test plan
- [x] Run formatting, lint, typecheck, all package tests, Cloudflare tests, and production build.
- [x] Verify Insights renders with wide layout and section navigation.
- [ ] Review CI and CodeRabbit feedback.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Insights dashboard with section navigation for Overview, Activity, Usage, and Workspace.
  - Added usage coverage indicators and clearer indexing status information.
  - Improved skill activation and MCP server/tool attribution across supported session providers.

- **Bug Fixes**
  - Prevented streamed skill and tool calls from being counted more than once.
  - Preserved orphaned tool results and accurately distinguished completed, empty, and pending results.
  - Improved recovery of tool activity when session completion records are available without matching start events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->