### PR TITLE
feat: add cross-provider session observability coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,17 @@ Pick a session and step through every prompt, thinking block, tool call, and cod
 
 ### Deep insights for every session
 
-Auto-generated analytics: token burn & cost over time, context window usage, cache hit rates, tool call distribution, model breakdown, and per-turn breakdowns.
+Auto-generated analytics: token burn & cost over time, context window usage, cache read share, tool call distribution, model breakdown, and per-turn breakdowns.
 
 <p align="center">
   <img src="docs/screenshots/insights.png" alt="Session insights — token usage, cost tracking, tool distribution, and context window charts" width="800" />
 </p>
+
+The Insights **Coverage** section separates scan completion from metric availability and shows
+provider-level precision for invocations, MCP calls, tokens, cache reads/writes, and compactions.
+“Uncached / miss” is a derived prompt metric (`uncached input + cache writes`); providers do not
+share one universal cache-miss counter. Cursor snapshot totals are marked estimated, and Cursor
+compactions are lower bounds because its local store can retain only the latest summary.
 
 ### Your AI coding wrapped
 

--- a/docs/session-observability-audit.md
+++ b/docs/session-observability-audit.md
@@ -1,0 +1,80 @@
+# Session observability audit
+
+vibe-replay has two different responsibilities:
+
+1. Preserve enough of a session to replay what happened.
+2. Produce a privacy-bounded index that an agent can query without loading the
+   full transcript.
+
+These are related, but they are not the same coverage claim. The dashboard
+therefore reports scan completion, metric availability, and metric quality
+separately in the **Insights → Coverage** section.
+
+## Canonical metric definitions
+
+- `inputTokens` is uncached input after provider-specific normalization.
+- `promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens`.
+- `cacheMissTokens = inputTokens + cacheCreationTokens`.
+- `cacheReadShare = cacheReadTokens / promptTokens`.
+- “Uncached / miss” is derived. There is no provider-independent cache-miss
+  counter, so it must not be presented as an exact billing field.
+- Invocation counts are one event per concrete tool call. MCP calls are removed
+  from the ordinary-tool facet and counted under their server; named MCP tools
+  are measured separately from server-only calls.
+- A completed index with zero invocations is valid evidence of zero calls. It is
+  different from a deferred or failed index.
+- Cursor compaction counts are lower bounds: Cursor persists the latest
+  conversation summary rather than an append-only compaction event log.
+
+## Provider matrix
+
+| Provider | Source | Tools / MCP | Tokens / cache | Compaction |
+| --- | --- | --- | --- | --- |
+| Claude Code / Desktop | JSONL, grouped by assistant message ID | Exact pairing; MCP attribution is propagated across streamed fragments | Provider-reported; cache read/write fields preserved | `compact_boundary` and summary records |
+| Claude Cowork | `audit.jsonl` plus run-level result records | Exact where tool attribution is present; UUID server names are resolved from sibling metadata | Run-level billing is preferred over streaming snapshots | Claude-compatible boundary records |
+| Codex | Rollout JSONL plus state metadata | Includes orphan and serverless MCP completions; server/tool naming is explicit when available | `input_tokens - cached_input_tokens`, cached portion preserved as read-only | `context_compacted`, `compacted`, and response-item variants |
+| Cursor | JSONL, `store.db`, global state, SDK index | Structured calls are deduplicated; unknown MCP server/tool calls remain visible | Snapshot-derived and therefore estimated; missing snapshots remain visible as missing | Latest persisted summary; lower bound |
+| OpenCode | SQLite `session`, `message`, and `part` rows | Completed/error tool parts are retained and repeated call parts are deduplicated | Provider message usage, including cache read/write | User compaction parts, deduplicated by message |
+| Hermes | SQLite session/model/message rows | Native tool calls paired by call ID; skill activation separated from skill management | Provider session/model usage | Compacted run boundaries and summary markers |
+| Pi | Active JSONL branch | Tool results paired by call ID; branch history excludes abandoned entries | Provider message and summary usage | Active-branch compaction entries |
+
+“Exact” means exact for the provider field or event that was persisted; it
+does not mean that a provider necessarily persisted every event that occurred.
+“Partial” means some sessions, calls, names, or source fields are unavailable.
+
+## Query and UI surfaces
+
+- **Sessions**: provider, repository, project, tool, MCP server, MCP tool,
+  skill, and compacted facets. Search also recognizes sessions with token/cache
+  or compaction data.
+- **Insights → Usage**: ranked ordinary tools, MCP servers, named MCP tools,
+  and skills; each entry opens the matching Sessions filter.
+- **Insights → Coverage**: provider-by-provider index, invocation, MCP-name,
+  token, cache, and compaction coverage.
+- **Session details / replay Stats**: source provenance, token components,
+  derived uncached/miss tokens, cache-read share, compaction count, and quality
+  notes.
+- **CLI**: `vibe-replay sessions --compacted` and query output include recorded
+  compaction evidence. Use `--scan` or `--brief` for scan-backed efficiency
+  details.
+
+The usage rollup intentionally contains only counters and timestamps. Full
+inputs, results, prompts, and retained event details remain behind the
+session-specific source/replay endpoints.
+
+## Regression requirements
+
+Provider changes should add fixtures for:
+
+- duplicate streamed tool updates;
+- empty success results versus unresolved calls;
+- error-only and orphan tool completions;
+- MCP calls with server-only or tool-only attribution;
+- repeated skill activation versus skill metadata;
+- compaction records and summary-only sessions;
+- token snapshots with cache reads, writes, resets, and missing model
+  attribution.
+
+Any new deferred path must set `usageIndexed: false`, retain discovery counts,
+and appear in the Coverage report rather than silently being counted as
+complete.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -144,7 +144,8 @@ function getDevViewerOpts(): { externalViewerUrl: string } | undefined {
 // v3 → v4: Cursor project paths decode differently, so cached entries would
 // keep showing the old exploded paths in the picker.
 // v4 → v5: Codex explicit session_index names supersede generated titles.
-const SESSION_DISCOVERY_CACHE_KEY = "session-discovery-v5";
+// v5 → v6: provider compaction counts and Cursor storage fingerprints.
+const SESSION_DISCOVERY_CACHE_KEY = "session-discovery-v6";
 
 function normalizePromptTitle(value?: string): string {
   return normalizeTitle(cleanPromptText(value || "")) || "";
@@ -816,6 +817,7 @@ interface SessionsCommandOptions {
   any?: boolean;
   brief?: boolean;
   dedupe?: boolean;
+  compacted?: boolean;
   json?: boolean;
 }
 
@@ -833,6 +835,7 @@ program
   .option("--any", "Match any query term instead of requiring all terms")
   .option("--brief", "Include scan-backed session briefs and match evidence")
   .option("--dedupe", "Collapse near-duplicate sessions with the same long prompt/title")
+  .option("--compacted", "Only return sessions with recorded context compaction")
   .option("--json", "Print machine-readable JSON")
   .action(async (opts: SessionsCommandOptions, command: Command) => {
     const discoverSpinner = opts.json ? undefined : ora("Discovering sessions...").start();

--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -166,6 +166,16 @@ export function mergeInsights(
   }
 
   for (const scan of scanResults) {
+    // A failed/deferred rich scan is a coverage signal, not fresh session
+    // truth. Do not replace a previously complete durable record with its
+    // discovery-only placeholder.
+    if (
+      scan.dataQualityNotes?.some((note) =>
+        /^Partial [a-z0-9_-]+(?: [a-z0-9_-]+)* scan:/i.test(note),
+      )
+    ) {
+      continue;
+    }
     const targetId = scan.location?.kind === "ssh" ? scan.location.id : undefined;
     const key = insightKey(scan.provider, scan.sessionId, targetId);
     const existing = byId.get(key);

--- a/packages/cli/src/providers/cursor/sqlite-reader.ts
+++ b/packages/cli/src/providers/cursor/sqlite-reader.ts
@@ -1,7 +1,10 @@
 export {
   __testables,
   countComposerConversationHeaders,
+  cursorCompactionCount,
+  cursorCompactions,
   discoverGlobalStateOnlySessions,
+  getCursorSessionFingerprints,
   storeDbPath,
   discoverSqliteOnlySessions,
   isSystemContextText,

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -25,6 +25,7 @@ import { estimateCostIfKnown, estimateCostSimpleIfKnown } from "@vibe-replay/rep
 import { classifyProject, mergeProjectIdentities, projectIdentityKey } from "@vibe-replay/types";
 import { parseCodexSession } from "./providers/codex/parser.js";
 import { parseClaudeCoworkSession } from "@vibe-replay/provider-claude-code/claude-cowork/parser";
+import { parseClaudeCodeSession } from "./providers/claude-code/parser.js";
 import { parseCursorSession } from "./providers/cursor/parser.js";
 import { parseHermesSession } from "@vibe-replay/provider-hermes/parser";
 import { parseOpencodeSession } from "@vibe-replay/provider-opencode/parser";
@@ -33,6 +34,7 @@ import type { ContentBlock } from "@vibe-replay/provider-contract";
 import type { ProviderParseResult } from "./providers/types.js";
 import type {
   DataSource,
+  ParseWarning,
   ProjectIdentity,
   PrLink,
   SessionInfo,
@@ -62,7 +64,9 @@ import { localDayKey, shortenPath } from "./utils.js";
 // MCP entrypoint name.
 // v30: preserve repeated rich-provider skill activations and MCP attribution.
 // v31: deduplicate streamed skill attribution and index OpenCode/Hermes usage.
-export const SCANNER_VERSION = 31;
+// v32: add provider coverage reporting, rich Claude scans, and Cursor compaction
+// summary detection.
+export const SCANNER_VERSION = 32;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -133,6 +137,7 @@ export interface SessionScanResult {
 interface ScanCacheEntry {
   mtimeMs: number;
   fileSize: number;
+  sourceFingerprint?: string;
   scannedAt: string;
   result: SessionScanResult;
 }
@@ -608,6 +613,8 @@ export interface ScanInput {
   workspacePath?: string;
   hasSqlite?: boolean;
   hasSdk?: boolean;
+  /** Provider-side storage fingerprint for cache freshness. */
+  sourceFingerprint?: string;
   deferRichCursorParse?: boolean;
   timestamp?: string;
   title?: string;
@@ -735,6 +742,15 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
       richFallbackProvider = "Claude Cowork";
     }
   }
+  if (input.provider === "claude-code" || input.provider === "claude-desktop") {
+    try {
+      return await scanClaudeCodeSession(input);
+    } catch {
+      // Fall through to the generic JSONL scanner so a partially written
+      // transcript remains visible while the rich parser is unavailable.
+      richFallbackProvider = input.provider === "claude-desktop" ? "Claude Desktop" : "Claude Code";
+    }
+  }
   if (input.provider === "cursor") {
     try {
       return await scanCursorSession(input);
@@ -797,6 +813,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
   const mcpServersUsed = new Set<string>();
   const usageEvents: UsageEvent[] = [];
   const eventByToolUseId = new Map<string, UsageEvent>();
+  const seenToolUseIds = new Set<string>();
   let readAnySourceFile = false;
 
   let promptCount = 0;
@@ -1022,6 +1039,8 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
       if (role === "assistant" && Array.isArray(msgContent)) {
         for (const block of msgContent) {
           if (block.type === "tool_use") {
+            if (typeof block.id === "string" && seenToolUseIds.has(block.id)) continue;
+            if (typeof block.id === "string") seenToolUseIds.add(block.id);
             toolCallCount++;
             const skillName = skillNameFromTool({
               type: "tool_use",
@@ -1238,6 +1257,35 @@ function scanFallbackPrompt(input: ScanInput, placeholder = ""): string {
   return input.firstPrompt || input.title || placeholder;
 }
 
+function buildFailedScanResult(input: ScanInput): SessionScanResult {
+  return {
+    sessionId: input.sessionId,
+    provider: input.provider,
+    location: input.location,
+    transcriptStatus: input.transcriptStatus,
+    project: input.project,
+    projectIdentity: input.projectIdentity,
+    slug: input.slug,
+    title: input.title,
+    firstPrompt: scanFallbackPrompt(input),
+    startTime: input.timestamp,
+    model: input.discoveryModel,
+    promptCount: input.transcriptStatus ? 0 : (input.discoveryPromptCount ?? 0),
+    toolCallCount: input.discoveryToolCallCount ?? 0,
+    editCount: input.discoveryEditCount ?? 0,
+    filesModified: [],
+    tokenUsage: input.discoveryTokenUsage,
+    costEstimate: input.discoveryCostEstimate,
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: input.discoveryCompactionCount ?? 0,
+    usageIndexed: false,
+    dataQualityNotes: [
+      `Partial ${input.provider} scan: the source could not be read, so discovery metadata was retained.`,
+    ],
+  };
+}
+
 /** Keep persisted timing internally consistent without discarding active-time evidence. */
 function ensureEndCoversDuration(
   startTime: string | undefined,
@@ -1274,6 +1322,18 @@ async function scanClaudeCoworkSession(input: ScanInput): Promise<SessionScanRes
     model: input.discoveryModel,
   };
   const parsed = await parseClaudeCoworkSession(input.filePaths, sessionInfo);
+  return buildScanResultFromParsed(input, parsed);
+}
+
+async function scanClaudeCodeSession(input: ScanInput): Promise<SessionScanResult> {
+  const parsed = await parseClaudeCodeSession(input.filePaths);
+  const hasAssistantTurn = parsed.turns.some((turn) => turn.role === "assistant");
+  if (
+    !hasAssistantTurn &&
+    (input.discoveryPromptCount === undefined || input.discoveryPromptCount > 0)
+  ) {
+    throw new Error("Claude transcript did not contain parseable turns");
+  }
   return buildScanResultFromParsed(input, parsed);
 }
 
@@ -1484,6 +1544,7 @@ function buildLightweightOpencodeScanResult(input: ScanInput): SessionScanResult
     compactionCount: input.discoveryCompactionCount ?? 0,
     dataSource: "sqlite",
     dataQualityNotes: [
+      "Partial opencode scan: rich SQLite usage details were not available during this pass.",
       "OpenCode details are read from its SQLite database; rich per-file edit counts are resolved when a replay is generated.",
       "Tool, MCP, and skill usage is not indexed for OpenCode sessions during background scans.",
     ],
@@ -1517,6 +1578,7 @@ function buildLightweightHermesScanResult(input: ScanInput): SessionScanResult {
     compactionCount: input.discoveryCompactionCount ?? 0,
     dataSource: "sqlite",
     dataQualityNotes: [
+      "Partial hermes scan: rich SQLite usage details were not available during this pass.",
       "Hermes details are read from its SQLite database (~/.hermes/state.db); rich per-file edit counts are resolved when a replay is generated.",
       "Tool, MCP, and skill usage is not indexed for Hermes sessions during background scans.",
     ],
@@ -1615,41 +1677,73 @@ function buildScanResultFromParsed(
 
       // Count file modifications from sub-agent scenes
       if (block.name === "Agent" && block._subAgent?.scenes) {
+        const nestedUsageEvents = block._subAgent.usageEvents;
+        if (nestedUsageEvents && nestedUsageEvents.length > 0) {
+          // The replay trace is intentionally capped, but the provider parser
+          // keeps a complete metadata-only invocation index for aggregation.
+          toolCallCount += nestedUsageEvents.length;
+          for (const event of nestedUsageEvents) {
+            if (event.kind === "skill") {
+              usageEvents.push({
+                ...event,
+                parentAgentId: event.parentAgentId || block._subAgent.agentId,
+              });
+              if (event.skillName) skillsUsed.add(event.skillName);
+              continue;
+            }
+            usageEvents.push(
+              toolUsageEvent(event.name, {
+                timestamp: event.timestamp,
+                durationMs: event.durationMs,
+                isError: event.status === "error",
+                hasResult: event.status === "success",
+                parentAgentId: event.parentAgentId || block._subAgent.agentId,
+                mcpServer: event.mcpServer,
+                mcpTool: event.mcpTool,
+                mcpServerNames: parsed.mcpServerNames,
+              }),
+            );
+          }
+        }
         for (const saScene of block._subAgent.scenes) {
           if (saScene.type !== "tool-call") continue;
-          toolCallCount++;
-          const saToolBlock = {
-            name: saScene.toolName || "Unknown",
-            input: saScene.input,
-            _skillName: undefined,
-          } as Extract<ContentBlock, { type: "tool_use" }>;
-          const saSkillName = skillNameFromTool(saToolBlock);
-          if (saSkillName) {
-            usageEvents.push({
-              kind: "skill",
-              name: saSkillName,
-              skillName: saSkillName,
-              timestamp: saScene.timestamp,
-              status: "unknown",
-              attribution: "explicit",
-            });
-            skillsUsed.add(saSkillName);
-            continue;
-          }
-          usageEvents.push(
-            toolUsageEvent(saScene.toolName, {
+          // When a complete provider-side index exists, it has already
+          // contributed the nested call count and usage events above.
+          if (!nestedUsageEvents?.length) {
+            toolCallCount++;
+            const saToolBlock = {
+              name: saScene.toolName || "Unknown",
               input: saScene.input,
-              timestamp: saScene.timestamp,
-              durationMs: saScene.durationMs,
-              isError: saScene.isError,
-              hasResult:
-                (saScene as typeof saScene & { hasResult?: boolean }).hasResult ??
-                (saScene.result !== undefined && saScene.result !== ""),
-              parentAgentId: block._subAgent.agentId,
-              mcpServerNames: parsed.mcpServerNames,
-            }),
-          );
-          const saTool = saScene.toolName;
+              _skillName: undefined,
+            } as Extract<ContentBlock, { type: "tool_use" }>;
+            const saSkillName = skillNameFromTool(saToolBlock);
+            if (saSkillName) {
+              usageEvents.push({
+                kind: "skill",
+                name: saSkillName,
+                skillName: saSkillName,
+                timestamp: saScene.timestamp,
+                status: "unknown",
+                attribution: "explicit",
+              });
+              skillsUsed.add(saSkillName);
+            } else {
+              usageEvents.push(
+                toolUsageEvent(saScene.toolName, {
+                  input: saScene.input,
+                  timestamp: saScene.timestamp,
+                  durationMs: saScene.durationMs,
+                  isError: saScene.isError,
+                  hasResult:
+                    (saScene as typeof saScene & { hasResult?: boolean }).hasResult ??
+                    (saScene.result !== undefined && saScene.result !== ""),
+                  parentAgentId: block._subAgent.agentId,
+                  mcpServerNames: parsed.mcpServerNames,
+                }),
+              );
+            }
+          }
+          const saTool = saScene.toolName || "Unknown";
           if (!FILE_EDIT_TOOLS.has(saTool)) continue;
           const saPath = extractToolFilePath(saScene.input);
           if (!saPath) continue;
@@ -1689,6 +1783,11 @@ function buildScanResultFromParsed(
       attribution: "session-metadata",
     });
   }
+  // Keep the headline tool count aligned with the complete invocation index.
+  // Nested provider traces may contain more calls than the bounded replay scene
+  // list, while skill activations remain a separate usage facet.
+  const indexedToolCallCount = usageEvents.filter((event) => event.kind === "tool").length;
+  toolCallCount = Math.max(toolCallCount, indexedToolCallCount);
   const derivedMcpServers = new Set(
     (parsed.mcpServersUsed || []).map((server) =>
       normalizeMcpServerName(stripCursorServerScope(parsed.mcpServerNames?.[server] || server)),
@@ -1736,7 +1835,7 @@ function buildScanResultFromParsed(
     usageIndexed: true,
     dataSource: parsed.dataSource,
     dataQualityNotes: costDataQualityNotes(
-      parsed.dataSourceInfo?.notes,
+      [...(parsed.dataSourceInfo?.notes || []), ...parseWarningQualityNotes(parsed.parseWarnings)],
       parsed.tokenUsage,
       costEstimate,
     ),
@@ -1745,6 +1844,15 @@ function buildScanResultFromParsed(
       ?.map((t) => t.durationMs)
       .filter((d): d is number => d != null && d > 0),
   };
+}
+
+function parseWarningQualityNotes(warnings: ParseWarning[] | undefined): string[] {
+  if (!warnings || warnings.length === 0) return [];
+  return warnings.map((warning) => {
+    const source = warning.source ? ` in ${warning.source}` : "";
+    const firstLine = warning.firstLine ? ` (first at line ${warning.firstLine})` : "";
+    return `${warning.count} ${warning.kind} record${warning.count === 1 ? "" : "s"} skipped${source}${firstLine}.`;
+  });
 }
 
 function firstUserPrompt(turns: ProviderParseResult["turns"]): string | undefined {
@@ -1826,6 +1934,7 @@ async function getFileMeta(filePaths: string[]): Promise<{ mtimeMs: number; file
 async function getScanCacheMeta(session: ScanInput): Promise<{
   mtimeMs: number;
   fileSize: number;
+  sourceFingerprint?: string;
 }> {
   const paths = [...session.filePaths, ...(session.toolPaths || [])];
   const sourceFilePath = session.sourceFilePath || "";
@@ -1836,16 +1945,19 @@ async function getScanCacheMeta(session: ScanInput): Promise<{
   const meta = await getFileMeta([...new Set(paths)]);
   if (session.hasSqlite) {
     // Marker paths (`db#session:id`) cannot be stat'ed directly. Use the
-    // discovery timestamp as per-session freshness so new SQLite activity
-    // invalidates only the affected cached scan instead of reopening every
-    // session whenever the shared database changes.
+    // discovery timestamp as a fallback for marker paths that cannot be
+    // stat'ed. The provider fingerprint below also catches late SQLite/WAL
+    // updates that do not touch the transcript.
     const sessionTimestampMs = session.timestamp ? Date.parse(session.timestamp) : NaN;
     if (Number.isFinite(sessionTimestampMs) && sessionTimestampMs > meta.mtimeMs) {
       meta.mtimeMs = sessionTimestampMs;
     }
     meta.fileSize += session.sourceFileSize || 0;
   }
-  return meta;
+  return {
+    ...meta,
+    ...(session.sourceFingerprint ? { sourceFingerprint: session.sourceFingerprint } : {}),
+  };
 }
 
 /**
@@ -1855,9 +1967,16 @@ async function getScanCacheMeta(session: ScanInput): Promise<{
 async function checkCache(
   entry: ScanCacheEntry | undefined,
   session: ScanInput,
-): Promise<{ valid: boolean; meta: { mtimeMs: number; fileSize: number } }> {
+): Promise<{
+  valid: boolean;
+  meta: { mtimeMs: number; fileSize: number; sourceFingerprint?: string };
+}> {
   const meta = await getScanCacheMeta(session);
-  const valid = !!entry && entry.mtimeMs === meta.mtimeMs && entry.fileSize === meta.fileSize;
+  const valid =
+    !!entry &&
+    entry.mtimeMs === meta.mtimeMs &&
+    entry.fileSize === meta.fileSize &&
+    entry.sourceFingerprint === meta.sourceFingerprint;
   return { valid, meta };
 }
 
@@ -1933,12 +2052,17 @@ export async function runBackgroundScan(
           cache.entries[cacheKey] = {
             mtimeMs: cacheCheck.meta.mtimeMs,
             fileSize: cacheCheck.meta.fileSize,
+            ...(cacheCheck.meta.sourceFingerprint
+              ? { sourceFingerprint: cacheCheck.meta.sourceFingerprint }
+              : {}),
             scannedAt: new Date().toISOString(),
             result,
           };
         }
       } catch {
-        // Skip failed sessions silently
+        // Keep failed sessions in the snapshot so coverage never turns a
+        // per-session read failure into a false 100% result.
+        results[index] = buildFailedScanResult(session);
       }
     }
 

--- a/packages/cli/src/server-types.ts
+++ b/packages/cli/src/server-types.ts
@@ -25,6 +25,7 @@ export interface SourceSummaryRecord {
   toolPaths?: string[];
   hasSqlite?: boolean;
   hasSdk?: boolean;
+  sourceFingerprint?: string;
   isStarred?: boolean;
   spaceId?: string;
   spaceIdSetBy?: string;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -37,6 +37,7 @@ import { generateOutput, injectDataScript, loadViewerHtml } from "./generator.js
 import { buildInsightsRollup } from "./insights-rollup.js";
 import { mergeInsights, readInsightsStore, writeInsightsStore } from "./insights.js";
 import { loadOverlays, sessionForExternalOutput, sessionWithEffectiveContent } from "./overlays.js";
+import { buildUsageCoverageReport } from "./usage-coverage.js";
 import { parseClaudeCodeLines } from "./providers/claude-code/parser.js";
 import { parseCodexLines } from "./providers/codex/parser.js";
 import { parsePiLines } from "./providers/pi/parser.js";
@@ -105,6 +106,7 @@ import {
   aggregateProjectInsights,
   aggregateUserInsights,
   countPendingCursorUsageIndexes,
+  isPartialScanResult,
   type BackgroundScanState,
   type ProjectInsights,
   projectInsightKey,
@@ -527,6 +529,7 @@ async function buildSourcesResult(
       toolPaths: s.toolPaths,
       hasSqlite: s.hasSqlite,
       hasSdk: s.hasSdk,
+      sourceFingerprint: s.sourceFingerprint,
       gitBranch: s.gitBranch,
       gitRepo,
       model: s.model,
@@ -683,7 +686,8 @@ export async function startServer(
   // v6 → v7: refine Cursor SDK context-worktree identity grouping.
   // v7 → v8: disambiguate Cursor SDK workflow display labels.
   // v8 → v9: Codex source titles now follow explicit session_index names.
-  const sourcesCacheKey = `dashboard-sources-v9-${cacheKeySuffix}`;
+  // v9 → v10: carry provider compaction counts and storage fingerprints.
+  const sourcesCacheKey = `dashboard-sources-v10-${cacheKeySuffix}`;
   const replaysCacheKey = `dashboard-replays-v1-${cacheKeySuffix}`;
   // Keyed by scanner version too: a bump changes the shape of what a scan
   // extracts, so serving the previous run's results would show stale facets
@@ -1033,9 +1037,11 @@ export async function startServer(
     // The fast Cursor pass and its usage backfill complete close together. Keep
     // their read/merge/write cycles ordered or the older, usage-less snapshot
     // can finish last and erase the enriched fields from the durable store.
+    const persistableResults = results.filter((result) => !isPartialScanResult(result));
     const job = insightsPersistChain.then(async () => {
+      if (persistableResults.length === 0) return;
       const store = await readInsightsStore();
-      const updated = mergeInsights(store, results);
+      const updated = mergeInsights(store, persistableResults);
       await writeInsightsStore(updated);
     });
     insightsPersistChain = job.catch(() => {});
@@ -1390,6 +1396,7 @@ export async function startServer(
             workspacePath: s.workspacePath,
             hasSqlite: s.hasSqlite,
             hasSdk: s.hasSdk,
+            sourceFingerprint: s.sourceFingerprint,
             deferRichCursorParse: s.provider === "cursor" && !!(s.hasSqlite || s.hasSdk),
             timestamp: s.timestamp,
             title: s.title,
@@ -1426,7 +1433,7 @@ export async function startServer(
         scanState = {
           running: false,
           scanned: results.length,
-          total: results.length,
+          total: scanInputs.length,
           results,
           revision: scanState.revision + 1,
           hasSnapshot: true,
@@ -2474,6 +2481,7 @@ export async function startServer(
       indexedSessions: scanState.results.filter((scan) => scan.usageIndexed === true).length,
       totalSessions: scanState.results.length,
       scannedAt: scanState.finishedAt,
+      coverage: buildUsageCoverageReport(scanState.results),
     });
   });
 

--- a/packages/cli/src/session-merge.ts
+++ b/packages/cli/src/session-merge.ts
@@ -41,6 +41,9 @@ export function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
     const toolCallCount = group.some((session) => session.toolCallCount != null)
       ? group.reduce((sum, session) => sum + (session.toolCallCount || 0), 0)
       : undefined;
+    const compactionCount = group.some((session) => session.compactionCount != null)
+      ? group.reduce((sum, session) => sum + (session.compactionCount || 0), 0)
+      : undefined;
     const transcriptStatus = group.some((session) => !session.transcriptStatus)
       ? undefined
       : group.some((session) => session.transcriptStatus === "no-prompts")
@@ -55,6 +58,7 @@ export function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
       toolPaths: [...new Set(group.flatMap((session) => session.toolPaths || []))],
       promptCount,
       toolCallCount,
+      compactionCount,
       transcriptStatus,
     });
   }

--- a/packages/cli/src/session-query.ts
+++ b/packages/cli/src/session-query.ts
@@ -3,6 +3,7 @@ import { scanSession, type ScanInput, type SessionScanResult } from "./scanner.j
 import { getRemoteHome } from "./remote.js";
 import type { SessionInfo } from "./types.js";
 import { shortenPath } from "./utils.js";
+import { deriveTokenUsageMetrics } from "@vibe-replay/types";
 
 export interface SessionQueryOptions {
   query?: string;
@@ -13,6 +14,7 @@ export interface SessionQueryOptions {
   any?: boolean;
   brief?: boolean;
   dedupe?: boolean;
+  compacted?: boolean;
 }
 
 export interface SessionQueryMatch {
@@ -37,6 +39,7 @@ export interface SessionQueryMatch {
   toolCallCount?: number;
   editCount?: number;
   durationMs?: number;
+  compactionCount?: number;
   hasPR?: boolean;
   score?: number;
   matchedTerms?: string[];
@@ -60,6 +63,7 @@ export interface SessionQueryScanSummary {
   toolCallsPerPrompt?: number;
   editsPerPrompt?: number;
   medianTurnDurationMs?: number;
+  tokenUsage?: SessionScanResult["tokenUsage"];
   dataQualityNotes?: string[];
 }
 
@@ -111,14 +115,20 @@ export async function queryLocalSessions(
 
 export function filterSessionInfos(
   sessions: SessionInfo[],
-  options: Pick<SessionQueryOptions, "query" | "project" | "provider" | "any" | "dedupe"> = {},
+  options: Pick<
+    SessionQueryOptions,
+    "query" | "project" | "provider" | "any" | "dedupe" | "compacted"
+  > = {},
 ): SessionInfo[] {
   return filterScoredSessionInfos(sessions, options).map(({ session }) => session);
 }
 
 function filterScoredSessionInfos(
   sessions: SessionInfo[],
-  options: Pick<SessionQueryOptions, "query" | "project" | "provider" | "any" | "dedupe"> = {},
+  options: Pick<
+    SessionQueryOptions,
+    "query" | "project" | "provider" | "any" | "dedupe" | "compacted"
+  > = {},
 ): ScoredSessionInfo[] {
   const terms = splitTerms(options.query);
   const projectTerm = normalizeSearch(options.project);
@@ -133,6 +143,7 @@ function filterScoredSessionInfos(
     .filter(({ session, query }) => {
       if (provider && normalizeSearch(session.provider) !== provider) return false;
       if (projectTerm && !sessionProjectHaystack(session).includes(projectTerm)) return false;
+      if (options.compacted && (session.compactionCount || 0) <= 0) return false;
       if (terms.length > 0) {
         if (wideMatch) return query.matchedTerms.length > 0;
         if (query.matchedTerms.length !== terms.length) return false;
@@ -165,6 +176,8 @@ export function scanInputFromSession(session: SessionInfo): ScanInput {
     sourceLineCount: session.lineCount,
     workspacePath: session.workspacePath,
     hasSqlite: session.hasSqlite,
+    hasSdk: session.hasSdk,
+    sourceFingerprint: session.sourceFingerprint,
     timestamp: session.timestamp,
     title: session.title,
     firstPrompt: session.firstPrompt,
@@ -203,6 +216,9 @@ export function formatSessionQueryText(matches: SessionQueryMatch[]): string {
       }
       if (match.whyMatched?.length) lines.push(`   why: ${match.whyMatched.join("; ")}`);
       if (match.firstPrompt) lines.push(`   first prompt: ${previewPrompt(match.firstPrompt)}`);
+      if ((match.compactionCount || 0) > 0) {
+        lines.push(`   compactions: ${match.compactionCount}`);
+      }
       if (match.scan) lines.push(`   efficiency: ${formatScanSummary(match.scan)}`);
       if (match.brief) {
         lines.push(`   brief: ${match.brief.summary}`);
@@ -244,6 +260,7 @@ function sessionInfoToMatch(
     toolCallCount: session.toolCallCount,
     editCount: session.editCountEst,
     durationMs: session.durationMsEst,
+    compactionCount: session.compactionCount,
     hasPR: session.hasPR,
     score: query.score,
     matchedTerms: query.matchedTerms,
@@ -268,6 +285,7 @@ function scanSummary(scan: SessionScanResult): SessionQueryScanSummary {
     toolCallsPerPrompt: ratio(scan.toolCallCount, promptCount),
     editsPerPrompt: ratio(scan.editCount, promptCount),
     medianTurnDurationMs: median(scan.turnDurations),
+    tokenUsage: scan.tokenUsage,
     dataQualityNotes: scan.dataQualityNotes,
   };
 }
@@ -285,6 +303,14 @@ function formatScanSummary(scan: SessionQueryScanSummary): string {
   }
   if (scan.apiErrorCount > 0) parts.push(`${scan.apiErrorCount} API errors`);
   if (scan.compactionCount > 0) parts.push(`${scan.compactionCount} compactions`);
+  if (scan.tokenUsage) {
+    const tokenMetrics = deriveTokenUsageMetrics(scan.tokenUsage);
+    parts.push(`${formatTokenCount(tokenMetrics.promptTokens)} prompt tokens`);
+    parts.push(`${formatTokenCount(tokenMetrics.cacheMissTokens)} uncached/miss`);
+    if (tokenMetrics.cacheReadShare !== undefined) {
+      parts.push(`${Math.round(tokenMetrics.cacheReadShare * 1000) / 10}% cache read`);
+    }
+  }
   return parts.join(", ");
 }
 
@@ -311,6 +337,11 @@ function scoreSession(session: SessionInfo, terms: string[]): SessionQueryScore 
     { name: "provider", value: session.provider, weight: 2 },
     { name: "slug", value: session.slug, weight: 2 },
     { name: "files", value: (session.fsDetectedFiles || []).join(" "), weight: 3 },
+    {
+      name: "signals",
+      value: session.compactionCount ? "compaction compacted" : undefined,
+      weight: 3,
+    },
   ].map((field) => ({ ...field, normalized: normalizeSearch(field.value) }));
 
   const matchedTerms: string[] = [];
@@ -525,4 +556,10 @@ function formatDuration(ms: number): string {
   const hours = Math.floor(minutes / 60);
   const remainder = minutes % 60;
   return remainder ? `${hours}h ${remainder}m` : `${hours}h`;
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return String(tokens);
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -4,6 +4,8 @@ export type {
   DataSource,
   DataSourceInfo,
   InsightsStore,
+  MetricCoverage,
+  MetricQuality,
   OverlaySource,
   ProjectIdentity,
   ParseWarning,
@@ -17,8 +19,11 @@ export type {
   SessionUsageSummary,
   SessionOverlays,
   SubAgent,
+  ProviderCoverage,
   TokenUsage,
+  TokenUsageMetrics,
   TurnStat,
+  UsageCoverageReport,
   UsageEvent,
 } from "@vibe-replay/types";
 

--- a/packages/cli/src/usage-coverage.ts
+++ b/packages/cli/src/usage-coverage.ts
@@ -1,0 +1,271 @@
+import {
+  deriveTokenUsageMetrics,
+  type MetricCoverage,
+  type MetricQuality,
+  type ProviderCoverage,
+  type UsageCoverageReport,
+} from "@vibe-replay/types";
+import type { SessionScanResult } from "./scanner.js";
+
+function sum(values: Record<string, number> | undefined): number {
+  return Object.values(values || {}).reduce((total, value) => total + Math.max(0, value), 0);
+}
+
+function invocationCount(scan: SessionScanResult): number {
+  if (!scan.usageSummary) return 0;
+  return (
+    sum(scan.usageSummary.tools) + sum(scan.usageSummary.mcpServers) + sum(scan.usageSummary.skills)
+  );
+}
+
+function mcpCount(scan: SessionScanResult): number {
+  return sum(scan.usageSummary?.mcpServers);
+}
+
+function mcpToolCount(scan: SessionScanResult): number {
+  return sum(scan.usageSummary?.mcpTools);
+}
+
+function hasExpectedInvocationEvidence(scan: SessionScanResult): boolean {
+  return (
+    scan.toolCallCount > 0 ||
+    (scan.mcpServersUsed?.length ?? 0) > 0 ||
+    (scan.skillsUsed?.length ?? 0) > 0
+  );
+}
+
+function qualityForIndexedMetric(
+  provider: string,
+  metric: "tokens" | "cache",
+  totalSessions: number,
+  availableSessions: number,
+  hasDataLoss: boolean,
+): MetricQuality {
+  if (availableSessions === 0) return "unavailable";
+  if (availableSessions < totalSessions || hasDataLoss) return "partial";
+  // Cursor's tokenCount values are cumulative snapshots which can reset across
+  // branches/resumes; its totals are useful but not billing-grade exact.
+  if (provider === "cursor") return "estimated";
+  return metric === "cache" ? "exact" : "exact";
+}
+
+function compactionQuality(
+  provider: string,
+  totalSessions: number,
+  indexedSessions: number,
+  compactionSessions: number,
+  hasDataLoss: boolean,
+): MetricQuality {
+  if (totalSessions === 0) return "unavailable";
+  // Cursor persists the latest conversation summary, not a durable event log.
+  // A positive count is therefore a lower bound; zero is not proof of absence.
+  if (provider === "cursor") return compactionSessions > 0 ? "partial" : "unavailable";
+  if (indexedSessions < totalSessions || hasDataLoss) return "partial";
+  return "exact";
+}
+
+function providerNotes(provider: string): string[] | undefined {
+  if (provider === "cursor") {
+    return [
+      "Token/cache totals come from Cursor snapshots and are approximate.",
+      "Compactions are lower bounds because Cursor persists the latest summary.",
+    ];
+  }
+  if (provider === "codex") {
+    return [
+      "Input tokens are normalized to exclude cached_input_tokens.",
+      "Codex currently reports cache reads but not cache writes.",
+    ];
+  }
+  if (provider === "claude-cowork") {
+    return ["Run-level result records are preferred over streaming usage snapshots."];
+  }
+  if (provider === "opencode") {
+    return [
+      "Usage is read from the provider SQLite message records; zero cache values mean none were recorded.",
+    ];
+  }
+  if (provider === "hermes") {
+    return [
+      "Usage is read from the provider SQLite session/model records; zero cache values mean none were recorded.",
+    ];
+  }
+  if (provider === "pi") {
+    return [
+      "Usage is read from the active JSONL branch; zero cache values mean none were recorded.",
+    ];
+  }
+  if (provider === "claude-code" || provider === "claude-desktop") {
+    return [
+      "Usage is deduplicated by provider message ID; cache read/write fields are provider-reported.",
+    ];
+  }
+  return undefined;
+}
+
+function coverage(
+  availableSessions: number,
+  totalSessions: number,
+  quality: MetricQuality,
+): MetricCoverage {
+  return { availableSessions, totalSessions, quality };
+}
+
+function buildProviderCoverage(provider: string, scans: SessionScanResult[]): ProviderCoverage {
+  const totalSessions = scans.length;
+  const indexedSessions = scans.filter((scan) => scan.usageIndexed === true).length;
+  const invocationSessions = scans.filter((scan) => invocationCount(scan) > 0).length;
+  const invocationCalls = scans.reduce((total, scan) => total + invocationCount(scan), 0);
+  const missingInvocationSessions = scans.filter(
+    (scan) => scan.usageIndexed !== true && hasExpectedInvocationEvidence(scan),
+  ).length;
+  const mcpSessions = scans.filter(
+    (scan) => mcpCount(scan) > 0 || (scan.mcpServersUsed?.length ?? 0) > 0,
+  ).length;
+  const mcpCalls = scans.reduce((total, scan) => total + mcpCount(scan), 0);
+  const mcpToolSessions = scans.filter((scan) => mcpToolCount(scan) > 0).length;
+  const mcpToolCalls = scans.reduce((total, scan) => total + mcpToolCount(scan), 0);
+  const tokenSessions = scans.filter((scan) => scan.tokenUsage !== undefined).length;
+  const inputTokens = scans.reduce((total, scan) => total + (scan.tokenUsage?.inputTokens || 0), 0);
+  const outputTokens = scans.reduce(
+    (total, scan) => total + (scan.tokenUsage?.outputTokens || 0),
+    0,
+  );
+  const cacheReadTokens = scans.reduce(
+    (total, scan) => total + (scan.tokenUsage?.cacheReadTokens || 0),
+    0,
+  );
+  const cacheCreationTokens = scans.reduce(
+    (total, scan) => total + (scan.tokenUsage?.cacheCreationTokens || 0),
+    0,
+  );
+  const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+  const cacheMissTokens = inputTokens + cacheCreationTokens;
+  const compactionSessions = scans.filter((scan) => scan.compactionCount > 0).length;
+  const compactionCount = scans.reduce((total, scan) => total + scan.compactionCount, 0);
+  const hasDataLoss = scans.some((scan) =>
+    scan.dataQualityNotes?.some((note) =>
+      /skipped|unparseable|malformed|partial .* scan/i.test(note),
+    ),
+  );
+  const invocationQuality: MetricQuality =
+    indexedSessions < totalSessions || missingInvocationSessions > 0 || hasDataLoss
+      ? "partial"
+      : "exact";
+
+  return {
+    provider,
+    totalSessions,
+    indexedSessions,
+    invocationSessions,
+    invocationCalls,
+    missingInvocationSessions,
+    mcpSessions,
+    mcpCalls,
+    mcpToolSessions,
+    mcpToolCalls,
+    tokenSessions,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    promptTokens,
+    cacheMissTokens,
+    compactionSessions,
+    compactionCount,
+    notes: providerNotes(provider),
+    metrics: {
+      invocations: coverage(indexedSessions, totalSessions, invocationQuality),
+      mcpTools: coverage(
+        mcpToolSessions,
+        mcpSessions,
+        mcpCalls === 0
+          ? "unavailable"
+          : mcpToolCalls < mcpCalls || hasDataLoss
+            ? "partial"
+            : "exact",
+      ),
+      tokens: coverage(
+        tokenSessions,
+        totalSessions,
+        qualityForIndexedMetric(provider, "tokens", totalSessions, tokenSessions, hasDataLoss),
+      ),
+      cache: coverage(
+        tokenSessions,
+        totalSessions,
+        qualityForIndexedMetric(provider, "cache", totalSessions, tokenSessions, hasDataLoss),
+      ),
+      compactions: coverage(
+        provider === "cursor" ? compactionSessions : indexedSessions,
+        totalSessions,
+        compactionQuality(
+          provider,
+          totalSessions,
+          indexedSessions,
+          compactionSessions,
+          hasDataLoss,
+        ),
+      ),
+    },
+  };
+}
+
+export function buildUsageCoverageReport(scans: readonly SessionScanResult[]): UsageCoverageReport {
+  const grouped = new Map<string, SessionScanResult[]>();
+  for (const scan of scans) {
+    const group = grouped.get(scan.provider) || [];
+    group.push(scan);
+    grouped.set(scan.provider, group);
+  }
+
+  const providers = [...grouped.entries()]
+    .map(([provider, providerScans]) => buildProviderCoverage(provider, providerScans))
+    .sort((a, b) => b.totalSessions - a.totalSessions || a.provider.localeCompare(b.provider));
+
+  const inputTokens = providers.reduce((total, provider) => total + provider.inputTokens, 0);
+  const outputTokens = providers.reduce((total, provider) => total + provider.outputTokens, 0);
+  const cacheReadTokens = providers.reduce(
+    (total, provider) => total + provider.cacheReadTokens,
+    0,
+  );
+  const cacheCreationTokens = providers.reduce(
+    (total, provider) => total + provider.cacheCreationTokens,
+    0,
+  );
+  const tokenMetrics = deriveTokenUsageMetrics({
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+  });
+
+  return {
+    totalSessions: scans.length,
+    indexedSessions: scans.filter((scan) => scan.usageIndexed === true).length,
+    invocationSessions: providers.reduce(
+      (total, provider) => total + provider.invocationSessions,
+      0,
+    ),
+    invocationCalls: providers.reduce((total, provider) => total + provider.invocationCalls, 0),
+    missingInvocationSessions: providers.reduce(
+      (total, provider) => total + provider.missingInvocationSessions,
+      0,
+    ),
+    mcpCalls: providers.reduce((total, provider) => total + provider.mcpCalls, 0),
+    mcpToolSessions: providers.reduce((total, provider) => total + provider.mcpToolSessions, 0),
+    mcpToolCalls: providers.reduce((total, provider) => total + provider.mcpToolCalls, 0),
+    tokenSessions: scans.filter((scan) => scan.tokenUsage !== undefined).length,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    promptTokens: tokenMetrics.promptTokens,
+    cacheMissTokens: tokenMetrics.cacheMissTokens,
+    compactionSessions: providers.reduce(
+      (total, provider) => total + provider.compactionSessions,
+      0,
+    ),
+    compactionCount: providers.reduce((total, provider) => total + provider.compactionCount, 0),
+    providers,
+  };
+}

--- a/packages/cli/test/insights.test.ts
+++ b/packages/cli/test/insights.test.ts
@@ -177,6 +177,32 @@ describe("mergeInsights", () => {
       ["pi", "shared", 3],
     ]);
   });
+
+  it("does not overwrite a durable record with a partial scan placeholder", () => {
+    const existing = makeInsight({
+      tokenUsage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 30,
+        cacheCreationTokens: 10,
+      },
+      toolCallCount: 12,
+    });
+    const merged = mergeInsights(makeStore([existing]), [
+      makeScan({
+        dataQualityNotes: [
+          "Partial cursor scan: the source could not be read, so discovery metadata was retained.",
+        ],
+        tokenUsage: undefined,
+        toolCallCount: 0,
+      }),
+    ]);
+
+    expect(merged.sessions[0]).toMatchObject({
+      toolCallCount: 12,
+      tokenUsage: existing.tokenUsage,
+    });
+  });
 });
 
 describe("aggregateDailyInsights", () => {

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -246,6 +246,80 @@ describe("scanSession", () => {
     expect(result.usageIndexed).toBe(true);
   });
 
+  it("uses the rich Claude parser so compactions and tool outcomes are indexed", async () => {
+    const path = join(tmpDir, "claude-rich-scan.jsonl");
+    await writeFile(
+      path,
+      [
+        makeLine({
+          type: "user",
+          sessionId: "claude-rich-scan",
+          timestamp: "2025-03-20T10:00:00Z",
+          message: { role: "user", content: "Inspect the auth flow" },
+        }),
+        makeLine({
+          type: "assistant",
+          sessionId: "claude-rich-scan",
+          timestamp: "2025-03-20T10:00:01Z",
+          message: {
+            id: "assistant-1",
+            role: "assistant",
+            model: "claude-sonnet-4-20250514",
+            usage: {
+              input_tokens: 100,
+              output_tokens: 20,
+              cache_creation_input_tokens: 5,
+              cache_read_input_tokens: 30,
+            },
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-1",
+                name: "Read",
+                input: { file_path: "src/auth.ts" },
+              },
+            ],
+          },
+        }),
+        makeLine({
+          type: "user",
+          sessionId: "claude-rich-scan",
+          timestamp: "2025-03-20T10:00:02Z",
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "tool-1", content: "auth source" }],
+          },
+        }),
+        makeLine({
+          type: "system",
+          sessionId: "claude-rich-scan",
+          timestamp: "2025-03-20T10:00:03Z",
+          subtype: "compact_boundary",
+          compactMetadata: { trigger: "context_limit", preTokens: 50_000 },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "claude-rich-scan",
+      provider: "claude-code",
+      project: "~/test/project",
+      slug: "claude-rich-scan",
+      filePaths: [path],
+    });
+
+    expect(result.toolCallCount).toBe(1);
+    expect(result.usageSummary?.tools).toEqual({ Read: 1 });
+    expect(result.compactionCount).toBe(1);
+    expect(result.tokenUsage).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheCreationTokens: 5,
+      cacheReadTokens: 30,
+    });
+  });
+
   it("keeps malformed tool blocks from aborting the usage scan", async () => {
     const path = join(tmpDir, "usage-malformed-tool.jsonl");
     await writeFile(

--- a/packages/cli/test/session-query.test.ts
+++ b/packages/cli/test/session-query.test.ts
@@ -105,6 +105,18 @@ describe("session query", () => {
     expect(result.map((s) => s.sessionId)).toEqual(["older"]);
   });
 
+  it("can query sessions with recorded compactions", () => {
+    const result = filterSessionInfos(
+      [
+        session({ sessionId: "compacted", compactionCount: 2 }),
+        session({ sessionId: "plain", compactionCount: undefined }),
+      ],
+      { compacted: true },
+    );
+
+    expect(result.map((s) => s.sessionId)).toEqual(["compacted"]);
+  });
+
   it("limits query results and formats text output", async () => {
     const result = await queryLocalSessions(sessions, { query: "login", limit: 1 });
     const text = formatSessionQueryText(result);
@@ -217,6 +229,7 @@ describe("session query", () => {
     const input = scanInputFromSession(
       session({
         hasSqlite: true,
+        sourceFingerprint: "cursor-fingerprint",
         workspacePath: "/Users/test/Code/app",
         toolPaths: ["/tmp/tool.txt"],
       }),
@@ -230,6 +243,7 @@ describe("session query", () => {
       toolPaths: ["/tmp/tool.txt"],
       sourceFilePath: "/tmp/session.jsonl",
       hasSqlite: true,
+      sourceFingerprint: "cursor-fingerprint",
       workspacePath: "/Users/test/Code/app",
     });
   });

--- a/packages/cli/test/usage-coverage.test.ts
+++ b/packages/cli/test/usage-coverage.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { buildUsageCoverageReport } from "../src/usage-coverage.js";
+import type { SessionScanResult } from "../src/scanner.js";
+
+function scan(overrides: Partial<SessionScanResult> = {}): SessionScanResult {
+  return {
+    sessionId: "session",
+    provider: "claude-code",
+    project: "~/project",
+    slug: "session",
+    promptCount: 1,
+    toolCallCount: 0,
+    editCount: 0,
+    filesModified: [],
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
+    usageIndexed: true,
+    ...overrides,
+  };
+}
+
+const usage = {
+  tools: { Bash: 2 },
+  mcpServers: { slack: 1 },
+  mcpTools: { "slack/search": 1 },
+  skills: {},
+  successCount: 3,
+  errorCount: 0,
+  totalDurationMs: 0,
+  durationCount: 0,
+};
+
+describe("buildUsageCoverageReport", () => {
+  it("separates index completion from metric availability and derives cache misses", () => {
+    const report = buildUsageCoverageReport([
+      scan({
+        sessionId: "cursor-rich",
+        provider: "cursor",
+        toolCallCount: 3,
+        usageSummary: usage,
+        tokenUsage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 300,
+          cacheCreationTokens: 10,
+        },
+        compactionCount: 1,
+      }),
+      scan({
+        sessionId: "cursor-pending",
+        provider: "cursor",
+        toolCallCount: 2,
+        usageIndexed: false,
+      }),
+      scan({
+        sessionId: "claude-empty",
+        provider: "claude-code",
+      }),
+    ]);
+
+    expect(report.totalSessions).toBe(3);
+    expect(report.indexedSessions).toBe(2);
+    expect(report.missingInvocationSessions).toBe(1);
+    expect(report.promptTokens).toBe(410);
+    expect(report.cacheMissTokens).toBe(110);
+
+    const cursor = report.providers.find((provider) => provider.provider === "cursor");
+    expect(cursor).toMatchObject({
+      totalSessions: 2,
+      indexedSessions: 1,
+      invocationSessions: 1,
+      invocationCalls: 3,
+      mcpCalls: 1,
+      mcpToolCalls: 1,
+      tokenSessions: 1,
+      compactionSessions: 1,
+      compactionCount: 1,
+      metrics: {
+        invocations: { quality: "partial" },
+        mcpTools: { quality: "exact" },
+        tokens: { quality: "partial" },
+        cache: { quality: "partial" },
+        compactions: { quality: "partial" },
+      },
+    });
+  });
+
+  it("treats an indexed zero-invocation session as complete rather than missing", () => {
+    const report = buildUsageCoverageReport([
+      scan({ provider: "opencode", sessionId: "empty", usageIndexed: true }),
+    ]);
+
+    expect(report.missingInvocationSessions).toBe(0);
+    expect(report.providers[0]?.metrics.invocations).toEqual({
+      availableSessions: 1,
+      totalSessions: 1,
+      quality: "exact",
+    });
+    expect(report.providers[0]?.metrics.compactions.quality).toBe("exact");
+  });
+});

--- a/packages/provider-claude-code/src/claude-code/discover.ts
+++ b/packages/provider-claude-code/src/claude-code/discover.ts
@@ -114,6 +114,9 @@ export async function extractSessionInfo(
   let durationMsEst = 0;
   let hasPR = false;
   let model: string | undefined;
+  let compactionBoundaryCount = 0;
+  let compactionSummaryCount = 0;
+  const seenCompactionSummaries = new Set<string>();
   let sawParseableRecord = false;
   let readFailed = false;
 
@@ -152,6 +155,16 @@ export async function extractSessionInfo(
       if (toolMatches) {
         toolCallCount += toolMatches.length;
         if (editToolRe.test(line)) editCountEst++;
+      }
+      if (/(?:^|[{,])\s*"subtype"\s*:\s*"compact_boundary"/.test(line)) {
+        compactionBoundaryCount++;
+      }
+      if (/(?:^|[{,])\s*"isCompactSummary"\s*:\s*true/.test(line)) {
+        const uuid = line.match(/"uuid"\s*:\s*"([^"]+)"/)?.[1];
+        if (!uuid || !seenCompactionSummaries.has(uuid)) {
+          if (uuid) seenCompactionSummaries.add(uuid);
+          compactionSummaryCount++;
+        }
       }
       if (!model && line.includes('"assistant"') && line.includes('"model"')) {
         const m = line.match(modelRe);
@@ -285,6 +298,7 @@ export async function extractSessionInfo(
     model,
     durationMsEst: durationMsEst || undefined,
     editCountEst: editCountEst || undefined,
+    compactionCount: Math.max(compactionBoundaryCount, compactionSummaryCount) || undefined,
     hasPR: hasPR || undefined,
     ...(unreadable || prompts.length === 0
       ? { transcriptStatus: unreadable ? ("unreadable" as const) : ("no-prompts" as const) }

--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -1,6 +1,6 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { PrLink, SubAgent, TurnStat } from "@vibe-replay/types";
+import type { PrLink, SubAgent, TurnStat, UsageEvent } from "@vibe-replay/types";
 import { isSystemGeneratedMessage } from "@vibe-replay/provider-core/clean-prompt";
 import { estimateActiveDuration, getTimestampBounds } from "@vibe-replay/provider-core/duration";
 import type { ContentBlock, ParsedTurn, RawMessage } from "@vibe-replay/provider-contract";
@@ -122,6 +122,7 @@ export async function parseClaudeCodeLines(
   const assistantBlocks = new Map<string, ContentBlock[]>();
   const assistantTimestamps = new Map<string, string>();
   const assistantModels = new Map<string, string>();
+  const assistantAttributions = new Map<string, { mcpServer?: string; mcpTool?: string }>();
   const assistantOrder: string[] = [];
 
   // Collect tool results by tool_use_id
@@ -366,7 +367,11 @@ export async function parseClaudeCodeLines(
       // or newer sourceToolUseID/origin fields on the raw object. Process
       // tool_result blocks for result matching, but skip emitting a user turn.
       const isToolSearchResponse =
-        !!obj.sourceToolAssistantUUID || !!obj.sourceToolUseID || obj.origin === "tool_result";
+        !!obj.sourceToolAssistantUUID ||
+        !!obj.sourceToolUseID ||
+        !!obj.parentToolUseID ||
+        !!obj.parent_tool_use_id ||
+        obj.origin === "tool_result";
 
       const textParts: string[] = [];
       const userImages: string[] = [];
@@ -425,6 +430,14 @@ export async function parseClaudeCodeLines(
         // assistant messages, so it is vocabulary evidence, not an activation.
         if (skillName) skillsUsed.add(skillName);
       }
+      if (obj.attributionMcpServer || obj.attributionMcpTool) {
+        const previous = assistantAttributions.get(msgId) || {};
+        assistantAttributions.set(msgId, {
+          ...previous,
+          ...(obj.attributionMcpServer ? { mcpServer: obj.attributionMcpServer } : {}),
+          ...(obj.attributionMcpTool ? { mcpTool: obj.attributionMcpTool } : {}),
+        });
+      }
       // attributionMcpTool is tool-level detail; the replay metadata currently
       // summarizes MCP usage by server only, so keep the typed field for
       // forward compatibility without surfacing another aggregate today.
@@ -457,6 +470,7 @@ export async function parseClaudeCodeLines(
       }
 
       const blocks = assistantBlocks.get(msgId)!;
+      const attribution = assistantAttributions.get(msgId);
       const seenToolIds = new Set(
         blocks
           .filter(
@@ -483,8 +497,12 @@ export async function parseClaudeCodeLines(
               : undefined;
           blocks.push({
             ...block,
-            ...(obj.attributionMcpServer ? { _mcpServer: obj.attributionMcpServer } : {}),
-            ...(obj.attributionMcpTool ? { _mcpTool: obj.attributionMcpTool } : {}),
+            ...(obj.attributionMcpServer || attribution?.mcpServer
+              ? { _mcpServer: obj.attributionMcpServer || attribution?.mcpServer }
+              : {}),
+            ...(obj.attributionMcpTool || attribution?.mcpTool
+              ? { _mcpTool: obj.attributionMcpTool || attribution?.mcpTool }
+              : {}),
             ...(skillName ? { _skillName: skillName } : {}),
           });
           if (skillName) recordSkillActivation(skillName);
@@ -495,6 +513,17 @@ export async function parseClaudeCodeLines(
           }
         }
       }
+    }
+  }
+
+  for (const [msgId, attribution] of assistantAttributions) {
+    if (attribution.mcpServer) mcpServersUsed.add(attribution.mcpServer);
+    const blocks = assistantBlocks.get(msgId);
+    if (!blocks) continue;
+    for (const block of blocks) {
+      if (block.type !== "tool_use") continue;
+      if (attribution.mcpServer && !block._mcpServer) block._mcpServer = attribution.mcpServer;
+      if (attribution.mcpTool && !block._mcpTool) block._mcpTool = attribution.mcpTool;
     }
   }
 
@@ -773,6 +802,25 @@ function extractToolResultText(block: ContentBlock): string {
   return JSON.stringify(content);
 }
 
+function claudeSkillNameFromTool(
+  block: Extract<ContentBlock, { type: "tool_use" }>,
+): string | undefined {
+  if (block.name.trim().toLowerCase() !== "skill") return undefined;
+  for (const key of ["name", "skill", "skillName", "skill_name"]) {
+    const value = block.input?.[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function durationBetweenTimestamps(start?: string, end?: string): number | undefined {
+  if (!start || !end) return undefined;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
+  return endMs - startMs;
+}
+
 /**
  * Claude Code wraps oversized tool results as:
  *   <persisted-output>
@@ -914,6 +962,7 @@ interface SubAgentParsed {
   toolCalls: number;
   thinkingBlocks: number;
   textResponses: number;
+  usageEvents: UsageEvent[];
   tokenUsage?: {
     inputTokens: number;
     outputTokens: number;
@@ -993,6 +1042,7 @@ async function readSubagents(
     let toolCalls = 0;
     let thinkingBlocks = 0;
     let textResponses = 0;
+    const usageEvents: UsageEvent[] = [];
     const scenes: SubAgentParsed["scenes"] = [];
     const saUsageByMessageId = new Map<string, TokenUsage>();
 
@@ -1000,6 +1050,7 @@ async function readSubagents(
     const saToolResults = new Map<string, string>();
     const saToolResultIds = new Set<string>();
     const saToolErrors = new Map<string, boolean>();
+    const saToolResultTimestamps = new Map<string, string>();
 
     // Collect assistant blocks by message ID (same dedup as main parser)
     const saAssistantBlocks = new Map<string, ContentBlock[]>();
@@ -1049,6 +1100,7 @@ async function readSubagents(
             const resultText = extractToolResultText(block as ContentBlock);
             saToolResults.set(block.tool_use_id, resultText.slice(0, 1000));
             saToolResultIds.add(block.tool_use_id);
+            if (obj.timestamp) saToolResultTimestamps.set(block.tool_use_id, obj.timestamp);
             if (block.is_error) saToolErrors.set(block.tool_use_id, true);
           }
         }
@@ -1119,6 +1171,27 @@ async function readSubagents(
           const toolResult = saToolResults.get(block.id) || "";
           const hasResult = saToolResultIds.has(block.id);
           const isError = saToolErrors.get(block.id);
+          const skillName = claudeSkillNameFromTool(block);
+          usageEvents.push({
+            kind: skillName ? "skill" : "tool",
+            name: skillName || block.name,
+            ...(skillName ? { skillName } : {}),
+            timestamp: ts,
+            ...(durationBetweenTimestamps(ts, saToolResultTimestamps.get(block.id)) !== undefined
+              ? {
+                  durationMs: durationBetweenTimestamps(ts, saToolResultTimestamps.get(block.id)),
+                }
+              : {}),
+            status: isError ? "error" : hasResult ? "success" : "unknown",
+            ...(block.name.startsWith("mcp__")
+              ? {
+                  mcpServer: block.name.split("__")[1],
+                  mcpTool: block.name.split("__").slice(2).join("__"),
+                }
+              : {}),
+            attribution: "explicit",
+            parentAgentId: agentId,
+          });
           scenes.push({
             type: "tool-call",
             toolName: block.name,
@@ -1157,6 +1230,7 @@ async function readSubagents(
       toolCalls,
       thinkingBlocks,
       textResponses,
+      usageEvents,
       tokenUsage: saUsage,
       model,
       scenes: cappedScenes,

--- a/packages/provider-claude-code/src/claude-cowork/discover.ts
+++ b/packages/provider-claude-code/src/claude-cowork/discover.ts
@@ -141,6 +141,9 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
   let lineCount = 0;
   let toolCallCount = 0;
   let promptCount = 0;
+  let compactionBoundaryCount = 0;
+  let compactionSummaryCount = 0;
+  const seenCompactionSummaries = new Set<string>();
   const earlyLines: string[] = [];
   const originalUserKeys = new Set<string>();
   const countedReplayKeys = new Set<string>();
@@ -156,6 +159,16 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
       if (earlyLines.length < PROMPT_SCAN_LINES) earlyLines.push(line);
       const m = line.match(TOOL_USE_RE);
       if (m) toolCallCount += m.length;
+      if (/(?:^|[{,])\s*"subtype"\s*:\s*"compact_boundary"/.test(line)) {
+        compactionBoundaryCount++;
+      }
+      if (/(?:^|[{,])\s*"isCompactSummary"\s*:\s*true/.test(line)) {
+        const uuid = line.match(/"uuid"\s*:\s*"([^"]+)"/)?.[1];
+        if (!uuid || !seenCompactionSummaries.has(uuid)) {
+          if (uuid) seenCompactionSummaries.add(uuid);
+          compactionSummaryCount++;
+        }
+      }
       if (line.includes('"type":"user"') || line.includes('"type": "user"')) {
         try {
           const obj = JSON.parse(line) as Record<string, any>;
@@ -233,6 +246,7 @@ export async function extractCoworkSessionInfo(jsonPath: string): Promise<Sessio
     prompts,
     promptCount,
     toolCallCount,
+    compactionCount: Math.max(compactionBoundaryCount, compactionSummaryCount) || undefined,
     model,
     isStarred: meta.isStarred,
     spaceId: meta.spaceId,

--- a/packages/provider-codex/src/codex/discover.ts
+++ b/packages/provider-codex/src/codex/discover.ts
@@ -199,6 +199,8 @@ export async function extractCodexSessionInfo(
   let toolCallCount = 0;
   let editCountEst = 0;
   let durationMsEst = 0;
+  let compactionCount = 0;
+  const compactionTimestamps: string[] = [];
   const prompts: string[] = [];
   const promptSeen = new Map<string, number[]>();
   let sawKnownRecord = false;
@@ -232,6 +234,21 @@ export async function extractCodexSessionInfo(
 
       if (obj.timestamp) timestamp = obj.timestamp;
 
+      const recordCompaction = (kind: string) => {
+        const current = obj.timestamp ? Date.parse(obj.timestamp) : Number.NaN;
+        const duplicate = compactionTimestamps.some((previous) => {
+          const prior = Date.parse(previous);
+          return Number.isFinite(current) && Number.isFinite(prior)
+            ? Math.abs(current - prior) <= 2_000
+            : previous === `${kind}:${obj.timestamp || lineCount}`;
+        });
+        if (duplicate) return;
+        compactionTimestamps.push(
+          Number.isFinite(current) ? obj.timestamp : `${kind}:${obj.timestamp || lineCount}`,
+        );
+        compactionCount++;
+      };
+
       if (obj.type === "session_meta") {
         const p = obj.payload || {};
         sessionId = sessionId || p.id || "";
@@ -262,11 +279,13 @@ export async function extractCodexSessionInfo(
         if (p.type === "exec_command_end" && typeof p.duration?.secs === "number") {
           durationMsEst += p.duration.secs * 1000 + Math.round((p.duration.nanos || 0) / 1_000_000);
         }
+        if (p.type === "context_compacted") recordCompaction("codex-context");
         continue;
       }
 
       if (obj.type === "response_item") {
         const p = obj.payload || {};
+        if (p.type === "compaction") recordCompaction("codex");
         if (p.type === "message" && p.role === "user") {
           const rawText = contentText(p.content);
           const cleaned = normalizeDiscoveredUserMessage(rawText);
@@ -280,6 +299,7 @@ export async function extractCodexSessionInfo(
           if (isEditTool(p.name)) editCountEst++;
         }
       }
+      if (obj.type === "compacted") recordCompaction("codex");
     }
   } catch {
     readFailed = true;
@@ -326,6 +346,7 @@ export async function extractCodexSessionInfo(
     model,
     durationMsEst: durationMsEst || undefined,
     editCountEst: editCountEst || undefined,
+    compactionCount: compactionCount || undefined,
   };
 }
 

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -12,6 +12,8 @@ interface PendingTool {
   name: string;
   input: Record<string, any>;
   timestamp?: string;
+  mcpServer?: string;
+  mcpTool?: string;
 }
 
 interface ToolResult {
@@ -253,8 +255,18 @@ export function parseCodexLines(
       }
       if (p.type === "mcp_tool_call_end" && p.call_id) {
         const invocation = p.invocation || {};
-        const server = typeof invocation.server === "string" ? invocation.server : "";
-        const toolName = typeof invocation.tool === "string" ? invocation.tool : "";
+        const server =
+          typeof invocation.server === "string"
+            ? invocation.server
+            : typeof invocation.server_name === "string"
+              ? invocation.server_name
+              : "";
+        const toolName =
+          typeof invocation.tool === "string"
+            ? invocation.tool
+            : typeof invocation.tool_name === "string"
+              ? invocation.tool_name
+              : "";
         let tool = tools.get(p.call_id);
         if (server) {
           mcpServersUsed.add(server);
@@ -268,10 +280,16 @@ export function parseCodexLines(
                     server,
                   },
               timestamp: obj.timestamp,
+              mcpServer: server,
+              ...(toolName ? { mcpTool: toolName } : {}),
             };
             tools.set(p.call_id, tool);
-          } else if (toolName) {
-            tool.name = `mcp__${server}__${toolName}`;
+          } else {
+            tool.mcpServer = server;
+            if (toolName) {
+              tool.mcpTool = toolName;
+              tool.name = `mcp__${server}__${toolName}`;
+            }
           }
         } else if (!tool) {
           // The completion event itself proves that Codex attempted an MCP
@@ -281,7 +299,10 @@ export function parseCodexLines(
             name: "mcp",
             input: {},
             timestamp: obj.timestamp,
+            mcpServer: "Unknown",
           });
+        } else {
+          tool.mcpServer ||= "Unknown";
         }
         mergeToolResult(toolResults, p.call_id, {
           result: formatMcpToolResult(p),
@@ -427,9 +448,11 @@ export function parseCodexLines(
           name: normalizeToolName(tool.name),
           input: normalizeToolInput(tool.name, tool.input),
           _hasResult: toolResults.has(tool.id),
-          _result: tr?.result || "",
+          ...(tr ? { _result: tr.result } : {}),
           ...(tr?.isError ? { _isError: true } : {}),
           ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
+          ...(tool.mcpServer ? { _mcpServer: tool.mcpServer } : {}),
+          ...(tool.mcpTool ? { _mcpTool: tool.mcpTool } : {}),
         },
       ],
     });

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -1254,6 +1254,39 @@ describe("Codex parser", () => {
     });
   });
 
+  it("keeps a serverless MCP completion in the MCP facet", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-05-03T06:55:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-session-mcp-unknown", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-05-03T06:55:01.000Z",
+          type: "event_msg",
+          payload: {
+            type: "mcp_tool_call_end",
+            call_id: "mcp_unknown",
+            invocation: {},
+            result: { Err: "server unavailable" },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      name: "mcp",
+      _mcpServer: "Unknown",
+      _hasResult: true,
+      _isError: true,
+    });
+  });
+
   it("marks Codex MCP result.isError payloads as errors", () => {
     const result = parseCodexLines(
       [

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -2,18 +2,30 @@ import type {
   CursorSidecars,
   DataSource,
   DataSourceInfo,
+  MetricCoverage,
+  MetricQuality,
   ParseWarning,
   ProjectIdentity,
   PrLink,
+  ProviderCoverage,
   SessionLocation,
   SessionTranscriptStatus,
   SubAgent,
   TokenUsage,
+  TokenUsageMetrics,
   TurnStat,
+  UsageCoverageReport,
 } from "@vibe-replay/types";
 
 export type { DataSource, DataSourceInfo, SessionLocation, TokenUsage };
 export type { SessionTranscriptStatus };
+export type {
+  MetricCoverage,
+  MetricQuality,
+  ProviderCoverage,
+  TokenUsageMetrics,
+  UsageCoverageReport,
+};
 
 /** Stable provider API version for the current in-repo provider contract. */
 export const PROVIDER_API_VERSION = 1;
@@ -55,6 +67,8 @@ export interface SessionInfo {
   filePath: string; // primary file (most recent)
   filePaths: string[]; // all JSONL files for this session (sorted by timestamp asc)
   toolPaths?: string[]; // cursor tool outputs associated with this session
+  /** Provider-side storage fingerprint used to invalidate rich scan caches. */
+  sourceFingerprint?: string;
   workspacePath?: string; // absolute workspace path for Cursor lookup
   hasSqlite?: boolean; // true if any Cursor SQLite source exists (store.db or global state DB)
   hasSdk?: boolean; // true if a Cursor SDK agent record exists in sdk-agent-store/index.db
@@ -106,6 +120,8 @@ export interface RawMessage {
   sourceToolAssistantUUID?: string;
   /** Newer Claude Code field for tool-originated user messages. */
   sourceToolUseID?: string;
+  /** Legacy snake_case spelling of the parent tool for tool-originated messages. */
+  parent_tool_use_id?: string;
   /** Source classification for user messages (for example, tool-originated messages). */
   origin?: string;
   /**
@@ -265,6 +281,7 @@ export interface Compaction {
   timestamp: string;
   trigger: string;
   preTokens?: number;
+  accuracy?: "exact" | "estimated" | "lower-bound";
 }
 
 export interface ProviderParseResult {

--- a/packages/provider-cursor/src/cursor/discover.ts
+++ b/packages/provider-cursor/src/cursor/discover.ts
@@ -7,6 +7,7 @@ import { classifyProject, isCursorSdkAutomationPath } from "@vibe-replay/types";
 import {
   discoverGlobalStateOnlySessions,
   discoverSqliteOnlySessions,
+  getCursorSessionFingerprints,
   listStoreDbSessionIds,
 } from "./sqlite-reader.js";
 import { discoverSdkAgents, type SdkAgent } from "./sdk-reader.js";
@@ -41,7 +42,7 @@ async function discoverCursorSessionsOnce(): Promise<SessionInfo[]> {
   try {
     projectDirs = await readdir(CURSOR_DIR);
   } catch {
-    return sessions;
+    projectDirs = [];
   }
 
   const projectSessions = await mapLimit(projectDirs, PROJECT_DISCOVERY_CONCURRENCY, (projDir) =>
@@ -65,18 +66,35 @@ async function discoverCursorSessionsOnce(): Promise<SessionInfo[]> {
   // Discover sessions kept in Cursor global state DB (composerData/bubbleId).
   const globalState = await discoverGlobalStateOnlySessions(knownIds, decodedPaths);
   sessions.push(...globalState.sessions);
+  const globalStateById = new Map(
+    globalState.allSessions.map((session) => [session.sessionId, session]),
+  );
 
   // Mark transcript-discovered sessions that have any SQLite-backed rich data.
   const storeDbSessionIds = await listStoreDbSessionIds();
   for (const session of transcriptSessions) {
     const hasStoreDb = storeDbSessionIds.has(session.sessionId);
     session.hasSqlite = hasStoreDb || globalState.sessionIds.has(session.sessionId);
+    const globalStateSession = globalStateById.get(session.sessionId);
+    if (globalStateSession?.compactionCount) {
+      session.compactionCount = Math.max(
+        session.compactionCount || 0,
+        globalStateSession.compactionCount,
+      );
+    }
   }
 
   // Cursor SDK sessions live alongside Cursor IDE chats but in their own SQLite
   // store. Mark transcripts that also have an SDK record so the parser can enrich
   // them with structured tool results, run timing, and per-turn model.
   await enrichWithSdkAgents(sessions, await sdkAgentsPromise);
+  const fingerprints = await getCursorSessionFingerprints(
+    sessions.map((session) => session.sessionId),
+  );
+  for (const session of sessions) {
+    const fingerprint = fingerprints.get(session.sessionId);
+    if (fingerprint) session.sourceFingerprint = fingerprint;
+  }
 
   sessions.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return sessions;

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -12,7 +12,12 @@ import {
   buildTurnDurationIntervals,
   sumDurationIntervals,
 } from "@vibe-replay/provider-core/duration";
-import type { ContentBlock, ParsedTurn, SessionInfo } from "@vibe-replay/provider-contract";
+import type {
+  Compaction,
+  ContentBlock,
+  ParsedTurn,
+  SessionInfo,
+} from "@vibe-replay/provider-contract";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import type { ProviderParseResult } from "@vibe-replay/provider-contract";
 import {
@@ -127,7 +132,7 @@ function closeCachedSqlJsDb(): void {
 
 let cachedStoreDbIndex: Map<string, StoreDbIndexEntry> | null = null;
 const resolvedProjectRootCache = new Map<string, Promise<string | null>>();
-const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v5";
+const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v7";
 
 interface CursorComposerHeader {
   composerId: string;
@@ -606,6 +611,44 @@ async function findStoreDb(sessionId: string): Promise<string | null> {
   if (cached.has(sessionId)) return cached.get(sessionId)?.dbPath || null;
   const refreshed = await getStoreDbIndex(true);
   return refreshed.get(sessionId)?.dbPath || null;
+}
+
+/**
+ * Build a cheap freshness token for Cursor's split storage. A shared global
+ * state component deliberately invalidates all Cursor sessions when the global
+ * database changes: it is the only reliable signal for late tool results and
+ * conversation summaries that may not touch the transcript or store.db.
+ */
+export async function getCursorSessionFingerprints(
+  sessionIds: readonly string[],
+): Promise<Map<string, string>> {
+  const storeIndex = await getStoreDbIndex();
+  const globalStateDb = await openGlobalStateDb();
+  const globalPart = globalStateDb
+    ? [
+        globalStateDb.dbPath,
+        globalStateDb.size,
+        globalStateDb.mtimeMs,
+        globalStateDb.walSize,
+        globalStateDb.walMtimeMs,
+      ].join(":")
+    : "no-global-state";
+
+  const entries = await Promise.all(
+    sessionIds.map(async (sessionId) => {
+      const store = storeIndex.get(sessionId);
+      const wal = store ? await stat(`${store.dbPath}-wal`).catch(() => null) : null;
+      const storePart = store
+        ? [store.dbPath, store.size, store.mtimeMs, wal?.size || 0, wal?.mtimeMs || 0].join(":")
+        : "no-store-db";
+      const fingerprint = createHash("sha1")
+        .update(`${sessionId}|${globalPart}|${storePart}`)
+        .digest("hex")
+        .slice(0, 20);
+      return [sessionId, fingerprint] as const;
+    }),
+  );
+  return new Map(entries);
 }
 
 async function existingPath(path: string): Promise<string | null> {
@@ -1360,6 +1403,8 @@ export async function discoverSqliteOnlySessions(
 export interface GlobalStateDiscoveryResult {
   sessions: SessionInfo[];
   sessionIds: Set<string>;
+  /** All replayable global-state sessions, including IDs already found in transcripts. */
+  allSessions: SessionInfo[];
 }
 
 export function countComposerConversationHeaders(composer: Record<string, any>): number {
@@ -1370,6 +1415,60 @@ export function countComposerConversationHeaders(composer: Record<string, any>):
     ? composer.conversation.length
     : 0;
   return Math.max(fullHeaders, legacyConversation);
+}
+
+function cursorLatestSummaryText(composer: Record<string, any>): string | undefined {
+  const latest = composer.latestConversationSummary;
+  if (!latest || typeof latest !== "object") return undefined;
+  const summary = (latest as Record<string, any>).summary;
+  if (typeof summary === "string" && summary.trim()) return summary;
+  if (summary && typeof summary === "object") {
+    const text = (summary as Record<string, any>).summary;
+    if (typeof text === "string" && text.trim()) return text;
+  }
+  return undefined;
+}
+
+/**
+ * Cursor keeps the latest compaction summary on composerData rather than a
+ * durable event list. Treat its presence as one known compaction and expose
+ * the result as a lower bound; older summaries may have been overwritten.
+ */
+export function cursorCompactionCount(composer: Record<string, any>): number {
+  return cursorLatestSummaryText(composer) ? 1 : 0;
+}
+
+export function cursorCompactions(
+  composer: Record<string, any>,
+  fallbackTimestamp?: string,
+): Compaction[] | undefined {
+  if (!cursorLatestSummaryText(composer)) return undefined;
+  const latest = composer.latestConversationSummary as Record<string, any>;
+  const summary =
+    latest.summary && typeof latest.summary === "object"
+      ? (latest.summary as Record<string, any>)
+      : latest;
+  const timestamp =
+    maxIsoTimestamp([
+      latest.createdAt,
+      latest.created_at,
+      latest.timestamp,
+      latest.lastUpdatedAt,
+      summary.createdAt,
+      summary.created_at,
+      summary.timestamp,
+      composer.lastUpdatedAt,
+      composer.createdAt,
+    ]) ||
+    fallbackTimestamp ||
+    new Date().toISOString();
+  return [
+    {
+      timestamp,
+      trigger: "cursor-context",
+      accuracy: "lower-bound",
+    },
+  ];
 }
 
 function composerHeaderBubbleIds(composer: Record<string, any>): string[] {
@@ -1451,7 +1550,7 @@ export async function discoverGlobalStateOnlySessions(
 ): Promise<GlobalStateDiscoveryResult> {
   const sessionIds = new Set<string>();
   const globalStateDb = await openGlobalStateDb();
-  if (!globalStateDb) return { sessions: [], sessionIds };
+  if (!globalStateDb) return { sessions: [], sessionIds, allSessions: [] };
   const { dbPath } = globalStateDb;
   const decodedPathsHash = hashWorkspacePaths(decodedWorkspacePaths);
   const cacheKey = `${GLOBAL_STATE_DISCOVERY_CACHE_PREFIX}-${decodedPathsHash}`;
@@ -1469,6 +1568,7 @@ export async function discoverGlobalStateOnlySessions(
     return {
       sessions: finalizeGlobalStateDiscovery(cached.data.sessions, knownSessionIds),
       sessionIds: cachedIds,
+      allSessions: cached.data.sessions,
     };
   }
 
@@ -1485,6 +1585,9 @@ export async function discoverGlobalStateOnlySessions(
             "json_extract(kv.value,'$.lastUpdatedAt') AS lastUpdatedAt,",
             "json_extract(kv.value,'$.createdAt') AS createdAt,",
             "json_extract(kv.value,'$.name') AS title,",
+            "CASE WHEN json_type(kv.value,'$.latestConversationSummary.summary.summary') = 'text'",
+            "AND length(trim(json_extract(kv.value,'$.latestConversationSummary.summary.summary'))) > 0",
+            "THEN 1 ELSE 0 END AS hasLatestConversationSummary,",
             "length(kv.value) AS fileSize,",
             `${replayableGlobalStateBubbleCountSql("kv.value", "kv.key")} AS replayableBubbleCount`,
             `FROM cursorDiskKV AS kv WHERE ${sqlKeyPrefixRange(
@@ -1494,7 +1597,7 @@ export async function discoverGlobalStateOnlySessions(
           ].join(" ")
         : `SELECT key, value FROM cursorDiskKV WHERE ${sqlKeyPrefixRange("composerData:")}`;
     const rows = await queryGlobalStateRows(globalStateDb, composerDiscoverySql);
-    if (rows.length === 0) return { sessions: [], sessionIds };
+    if (rows.length === 0) return { sessions: [], sessionIds, allSessions: [] };
 
     for (const row of rows) {
       const key = valueToString(row.key);
@@ -1551,6 +1654,9 @@ export async function discoverGlobalStateOnlySessions(
         workspacePath: projectPath,
         hasSqlite: true,
         firstPrompt,
+        compactionCount: composer
+          ? cursorCompactionCount(composer)
+          : toNonNegativeInt(row.hasLatestConversationSummary),
       };
       discoveredSessions.push(sessionInfo);
     }
@@ -1572,6 +1678,7 @@ export async function discoverGlobalStateOnlySessions(
   return {
     sessions: finalizeGlobalStateDiscovery(discoveredSessions, knownSessionIds),
     sessionIds,
+    allSessions: discoveredSessions,
   };
 }
 
@@ -2664,6 +2771,7 @@ function mergeCursorParseResults(
   const mergedTurnStats = mergeTurnStats(primary.turnStats, enrichment.turnStats, {
     preferEnrichmentDuration,
   });
+  const mergedCompactions = mergeCursorCompactions(primary.compactions, enrichment.compactions);
   const mergedTokenUsage = primary.tokenUsage || enrichment.tokenUsage;
   const mergedTokenUsageByModel = primary.tokenUsageByModel || enrichment.tokenUsageByModel;
   const mergedTotalDurationMs =
@@ -2692,6 +2800,8 @@ function mergeCursorParseResults(
     (!!enrichment.contextFiles?.length && !primary.contextFiles?.length) ||
     (!!enrichment.cursorSidecars && !primary.cursorSidecars) ||
     mergedSubagents ||
+    JSON.stringify(mergedCompactions || undefined) !==
+      JSON.stringify(primary.compactions || undefined) ||
     (!!mergedTurnStats &&
       JSON.stringify(mergedTurnStats) !== JSON.stringify(primary.turnStats || undefined));
   const primaryNotes = (primary.dataSourceInfo?.notes || []).filter(
@@ -2722,6 +2832,7 @@ function mergeCursorParseResults(
     ...(mergedTokenUsage ? { tokenUsage: mergedTokenUsage } : {}),
     ...(mergedTokenUsageByModel ? { tokenUsageByModel: mergedTokenUsageByModel } : {}),
     ...(mergedTurnStats ? { turnStats: mergedTurnStats } : {}),
+    ...(mergedCompactions ? { compactions: mergedCompactions } : {}),
     ...(primary.gitBranch ? {} : enrichment.gitBranch ? { gitBranch: enrichment.gitBranch } : {}),
     ...(primary.gitBranches
       ? {}
@@ -2746,6 +2857,37 @@ function mergeCursorParseResults(
         }
       : enrichment.dataSourceInfo,
   };
+}
+
+function mergeCursorCompactions(
+  primary: Compaction[] | undefined,
+  enrichment: Compaction[] | undefined,
+): Compaction[] | undefined {
+  const merged: Compaction[] = [];
+  for (const compaction of [...(primary || []), ...(enrichment || [])]) {
+    const timestampMs = Date.parse(compaction.timestamp);
+    const existing = merged.find((candidate) => {
+      const candidateMs = Date.parse(candidate.timestamp);
+      return Number.isFinite(timestampMs) && Number.isFinite(candidateMs)
+        ? Math.abs(timestampMs - candidateMs) <= 2_000
+        : candidate.timestamp === compaction.timestamp;
+    });
+    if (!existing) {
+      merged.push(compaction);
+      continue;
+    }
+    if (compactionAccuracy(compaction) > compactionAccuracy(existing)) {
+      Object.assign(existing, compaction);
+    }
+  }
+  return merged.length > 0 ? merged : undefined;
+}
+
+function compactionAccuracy(compaction: Compaction): number {
+  if (compaction.accuracy === "exact") return 3;
+  if (compaction.accuracy === "estimated") return 2;
+  if (compaction.accuracy === "lower-bound") return 1;
+  return 0;
 }
 
 function mergeCursorSidecars(
@@ -3186,6 +3328,7 @@ async function parseCursorGlobalStateDb(
 
     const turns = entries.map((entry) => entry.turn);
     if (turns.length === 0) return null;
+    const summaryText = cursorLatestSummaryText(composer);
     const structuredSubagentCount = attachStructuredCursorSubagents(
       turns,
       sessionId,
@@ -3214,6 +3357,18 @@ async function parseCursorGlobalStateDb(
       composer.conversationCheckpointLastUpdatedAt,
       ...turnTimestamps,
     ]);
+    const compactions = cursorCompactions(composer, endTime);
+    const replayTurns = summaryText
+      ? [
+          {
+            role: "user" as const,
+            subtype: "compaction-summary" as const,
+            timestamp: compactions?.[0]?.timestamp,
+            blocks: [{ type: "text" as const, text: summaryText }],
+          },
+          ...turns,
+        ]
+      : turns;
     const sessionTokenUsage = tokenUsageFromCursorTokenCount(composer.tokenCount);
     const metrics = buildGlobalStateMetrics(entries, modelName, sessionTokenUsage);
     const branchMeta = extractCursorBranchMetadata(composer);
@@ -3235,6 +3390,11 @@ async function parseCursorGlobalStateDb(
       notes.push("Token usage is estimated from Cursor token snapshots and may be approximate.");
     } else {
       notes.push("Token usage is estimated from Cursor token snapshots.");
+    }
+    if (compactions) {
+      notes.push(
+        "Cursor persisted a conversation summary; compaction count is a lower bound because older summaries may be overwritten.",
+      );
     }
     if (metrics.totalDurationMs !== undefined) {
       notes.push(
@@ -3301,13 +3461,14 @@ async function parseCursorGlobalStateDb(
       ...(metrics.tokenUsage ? { tokenUsage: metrics.tokenUsage } : {}),
       ...(metrics.tokenUsageByModel ? { tokenUsageByModel: metrics.tokenUsageByModel } : {}),
       ...(metrics.turnStats ? { turnStats: metrics.turnStats } : {}),
+      ...(compactions ? { compactions } : {}),
       ...(branchMeta.gitBranch ? { gitBranch: branchMeta.gitBranch } : {}),
       ...(branchMeta.gitBranches ? { gitBranches: branchMeta.gitBranches } : {}),
       ...(prLinks.length > 0 ? { prLinks } : {}),
       ...(apiErrors ? { apiErrors } : {}),
       ...(contextSummary.contextFiles ? { contextFiles: contextSummary.contextFiles } : {}),
       ...(cursorSidecars ? { cursorSidecars } : {}),
-      turns,
+      turns: replayTurns,
       dataSource: "global-state",
       dataSourceInfo: {
         primary: "global-state",
@@ -3502,6 +3663,8 @@ export const __testables = {
   loadAgentKvBlobMessages,
   cursorComposerSidecarMetadata,
   composerHeaderBubbleIds,
+  cursorCompactionCount,
+  cursorCompactions,
   extractCursorBranchMetadata,
   extractCursorContextSummary,
   extractCursorPrLinks,

--- a/packages/provider-cursor/test/sqlite-reader.test.ts
+++ b/packages/provider-cursor/test/sqlite-reader.test.ts
@@ -61,6 +61,42 @@ describe("structured Cursor subagents", () => {
   });
 });
 
+describe("Cursor compaction metadata", () => {
+  it("detects the persisted latest conversation summary as a lower bound", () => {
+    const composer = {
+      lastUpdatedAt: 1_800_000_000_000,
+      latestConversationSummary: {
+        summary: {
+          summary: "Earlier context was condensed.",
+          includesToolResults: false,
+        },
+      },
+    };
+
+    expect(__testables.cursorCompactionCount(composer)).toBe(1);
+    expect(__testables.cursorCompactions(composer)).toEqual([
+      {
+        timestamp: "2027-01-15T08:00:00.000Z",
+        trigger: "cursor-context",
+        accuracy: "lower-bound",
+      },
+    ]);
+  });
+
+  it("does not treat an empty summary container as a compaction", () => {
+    expect(
+      __testables.cursorCompactionCount({
+        latestConversationSummary: { summary: { summary: "" } },
+      }),
+    ).toBe(0);
+    expect(
+      __testables.cursorCompactions({
+        latestConversationSummary: { summary: { summary: "" } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
 describe("countComposerConversationHeaders", () => {
   it("returns zero when headers are missing", () => {
     expect(countComposerConversationHeaders({})).toBe(0);

--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -279,6 +279,7 @@ export function parseSessionFromDb(
           id: call.call_id || call.id || `hermes-${rawName}-${message.id}`,
           name,
           input: mappedInput,
+          _hasResult: false,
           ...(rawName === "skill_view" &&
           typeof mappedInput.name === "string" &&
           mappedInput.name.trim()

--- a/packages/provider-opencode/src/opencode/discover.ts
+++ b/packages/provider-opencode/src/opencode/discover.ts
@@ -159,10 +159,12 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
   const compactionCounts = countBySession(
     db,
     `
-      SELECT session_id, count(*) AS c
-      FROM part
-      WHERE json_extract(data, '$.type') = 'compaction'
-      GROUP BY session_id
+      SELECT m.session_id, count(DISTINCT m.id) AS c
+      FROM part p
+      JOIN message m ON m.id = p.message_id
+      WHERE json_extract(m.data, '$.role') = 'user'
+        AND json_extract(p.data, '$.type') = 'compaction'
+      GROUP BY m.session_id
     `,
   );
   const firstPrompts = firstUserPrompts(db);
@@ -247,9 +249,9 @@ function firstUserPrompts(db: Database): Map<string, string> {
       const parsed = JSON.parse(row.data as string) as { text?: string };
       text = typeof parsed.text === "string" ? parsed.text : "";
     } catch {
-      // skip malformed part; fall through to keep map entry reserved
+      // Skip malformed parts and keep looking for the next valid user text.
     }
-    map.set(sessionId, text);
+    if (text.trim()) map.set(sessionId, text);
   }
   return map;
 }

--- a/packages/provider-opencode/src/opencode/parser.ts
+++ b/packages/provider-opencode/src/opencode/parser.ts
@@ -184,6 +184,9 @@ export function parseSessionFromDb(
     `,
     { sid: sessionId },
   ) as OpencodeMessageRow[];
+  if (!session) {
+    throw new Error(`opencode session '${sessionId}' not found`);
+  }
 
   const turns: ParsedTurn[] = [];
   const allTimestamps: string[] = [];
@@ -255,26 +258,17 @@ export function parseSessionFromDb(
     }
 
     if (meta.role === "assistant") {
-      if (meta.finish === "error" || meta.finish === "unknown") {
-        // opencode writes `finish: "error"` on failed steps; surface the last
-        // text part (if any) so the failure is visible rather than dropped.
-        const parts = partsForMessage(db, message.id, parseWarnings);
-        const text = parts
-          .filter((p) => p.type === "text" && p.text)
-          .map((p) => p.text)
-          .join("\n");
-        if (text.trim()) {
-          turns.push({
-            role: "assistant",
-            timestamp,
-            blocks: [{ type: "text", text }],
-            model: meta.modelID,
-          });
-        }
-        continue;
-      }
-
       const blocks = assistantBlocksFromParts(db, message.id, parseWarnings);
+      if (meta.finish === "error" || meta.finish === "unknown") {
+        // Keep concrete tool parts even when the assistant message failed.
+        // Previously this branch rendered text only and silently erased failed
+        // tool invocations from both the replay and usage index.
+        for (const block of blocks) {
+          if (block.type === "tool_use" && block._hasResult !== true) {
+            block._isError = true;
+          }
+        }
+      }
       if (blocks.length === 0) continue;
       for (const block of blocks) {
         if (block.type !== "tool_use" || !block._skillName) continue;
@@ -359,6 +353,7 @@ function assistantBlocksFromParts(
   // same callID arrives, remove only that callID's marker so interleaved
   // concurrent tool calls each resolve to their real call with a result.
   const pendingByCallId = new Map<string, Extract<ContentBlock, { type: "tool_use" }>>();
+  const blockByCallId = new Map<string, Extract<ContentBlock, { type: "tool_use" }>>();
 
   for (const part of parts) {
     switch (part.type) {
@@ -386,6 +381,21 @@ function assistantBlocksFromParts(
           (state.status !== "running" && state.status !== "pending" && result.length > 0);
         const durationMs = durationFromState(state.time);
 
+        const existingBlock = blockByCallId.get(callID);
+        if (existingBlock && isPending) {
+          // Streaming can emit several running snapshots for one call. Keep
+          // one logical invocation and wait for its terminal state.
+          continue;
+        }
+        if (existingBlock && !isPending) {
+          // A terminal update supersedes either a pending marker or an older
+          // terminal snapshot for the same call ID.
+          const existingIndex = blocks.indexOf(existingBlock);
+          if (existingIndex >= 0) blocks.splice(existingIndex, 1);
+          blockByCallId.delete(callID);
+          pendingByCallId.delete(callID);
+        }
+
         // A completed tool part supersedes its earlier pending marker: drop the
         // placeholder (by callID) and emit the real call with its result.
         const pendingBlock = pendingByCallId.get(callID);
@@ -411,6 +421,7 @@ function assistantBlocksFromParts(
             : {}),
         };
         blocks.push(block);
+        blockByCallId.set(callID, block);
         if (isPending) {
           pendingByCallId.set(callID, block);
         }

--- a/packages/provider-opencode/test/parser.test.ts
+++ b/packages/provider-opencode/test/parser.test.ts
@@ -187,6 +187,46 @@ describe("opencode parser", () => {
     }
   });
 
+  it("retains concrete failed tool parts on an error finish", async () => {
+    const db = await buildOpencodeDb({
+      session: [baseSession],
+      messages: [
+        {
+          id: "msg_tool_error",
+          sessionId: "ses_111",
+          role: "assistant",
+          modelID: "deepseek-v4-flash-free",
+          timeCreated: 1_800_000_003_500,
+          finish: "error",
+          parts: [
+            {
+              type: "tool",
+              tool: "bash",
+              callID: "call_error",
+              state: { status: "error", input: { command: "false" }, output: "permission denied" },
+            },
+          ],
+        },
+      ],
+    });
+
+    try {
+      const result = parseSessionFromDb(db, "ses_111");
+      const tool = result.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use");
+      expect(tool).toMatchObject({
+        type: "tool_use",
+        name: "Bash",
+        _hasResult: true,
+        _isError: true,
+        _result: "permission denied",
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("marks running tool parts without dropping their call", async () => {
     const db = await buildOpencodeDb({
       session: [baseSession],

--- a/packages/provider-pi/src/pi/discover.ts
+++ b/packages/provider-pi/src/pi/discover.ts
@@ -78,6 +78,10 @@ async function extractPiSessionInfo(
   let promptCount = 0;
   let toolCallCount = 0;
   let editCountEst = 0;
+  let compactionCount = 0;
+  const entryParents = new Map<string, string | null | undefined>();
+  const compactionEntryIds = new Set<string>();
+  let lastEntryId: string | undefined;
   let model: string | undefined;
   let title: string | undefined;
   const prompts: string[] = [];
@@ -101,6 +105,10 @@ async function extractPiSessionInfo(
       }
       if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
       sawParseableRecord = true;
+      if (entry.id) {
+        entryParents.set(entry.id, entry.parentId);
+        lastEntryId = entry.id;
+      }
 
       if (typeof entry.timestamp === "string" && entry.timestamp) {
         timestamp = entry.timestamp;
@@ -119,6 +127,12 @@ async function extractPiSessionInfo(
       if (entry.type === "session_info") {
         const name = typeof entry.name === "string" ? entry.name.trim() : "";
         title = name || undefined;
+        continue;
+      }
+
+      if (entry.type === "compaction") {
+        if (entry.id) compactionEntryIds.add(entry.id);
+        else compactionCount++;
         continue;
       }
 
@@ -159,6 +173,17 @@ async function extractPiSessionInfo(
     rl.close();
   }
 
+  if (compactionEntryIds.size > 0) {
+    const activeIds = new Set<string>();
+    let current = lastEntryId;
+    while (current && !activeIds.has(current)) {
+      activeIds.add(current);
+      const parent = entryParents.get(current);
+      current = typeof parent === "string" ? parent : undefined;
+    }
+    compactionCount += [...compactionEntryIds].filter((id) => activeIds.has(id)).length;
+  }
+
   const sessionId = header?.id || basename(filePath, ".jsonl");
   if (!sessionId) return null;
 
@@ -190,6 +215,7 @@ async function extractPiSessionInfo(
     toolCallCount,
     model,
     editCountEst,
+    compactionCount: compactionCount || undefined,
     ...(unreadable || prompts.length === 0
       ? { transcriptStatus: unreadable ? ("unreadable" as const) : ("no-prompts" as const) }
       : {}),

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -13,7 +13,7 @@ import type {
   SessionTranscriptStatus,
   SubAgent,
 } from "@vibe-replay/types";
-import { REPLAY_SCHEMA_VERSION } from "@vibe-replay/types";
+import { deriveTokenUsageMetrics, REPLAY_SCHEMA_VERSION } from "@vibe-replay/types";
 import { estimateTokens } from "./utils/tokenEstimate.js";
 
 type ToolCallScene = Extract<Scene, { type: "tool-call" }>;
@@ -253,6 +253,7 @@ export function transformToReplay(
         );
         scene.timestamp = turn.timestamp;
         scene.isError = !!block._isError;
+        scene.hasResult = block._hasResult ?? block._result !== undefined;
         if (block._durationMs) scene.durationMs = block._durationMs;
         // Attach subagent data for Agent tool calls
         if (block.name === "Agent" && block._subAgent) {
@@ -338,6 +339,7 @@ export function transformToReplay(
         thinkingBlocks,
         durationMs,
         tokenUsage: parsed.tokenUsage,
+        ...(parsed.tokenUsage ? { tokenMetrics: deriveTokenUsageMetrics(parsed.tokenUsage) } : {}),
         costEstimate,
         ...(parsed.turnStats ? { turnStats: parsed.turnStats } : {}),
       },
@@ -709,6 +711,11 @@ function redactSubAgentScene(s: Scene): Scene {
       toolName,
       input: s.input ? sanitizeInput(s.input) : {},
       result: truncate(redactPath(resultRaw), 1000),
+      ...(s.hasResult !== undefined
+        ? { hasResult: s.hasResult }
+        : resultRaw.length > 0
+          ? { hasResult: true }
+          : {}),
       timestamp: s.timestamp,
       isError: s.isError || false,
       ...(s.durationMs ? { durationMs: s.durationMs } : {}),

--- a/packages/replay-core/test/transform-comprehensive.test.ts
+++ b/packages/replay-core/test/transform-comprehensive.test.ts
@@ -75,6 +75,42 @@ describe("transform — scene generation", () => {
     expect(replay.scenes[0].content).toBe("Hello world");
   });
 
+  it("preserves empty and missing tool results as distinct states", () => {
+    const replay = transformToReplay(
+      buildParsed({
+        turns: [
+          {
+            role: "assistant",
+            blocks: [
+              {
+                type: "tool_use",
+                id: "empty-result",
+                name: "Read",
+                input: { file_path: "/tmp/empty" },
+                _hasResult: true,
+                _result: "",
+              },
+              {
+                type: "tool_use",
+                id: "missing-result",
+                name: "Read",
+                input: { file_path: "/tmp/missing" },
+                _hasResult: false,
+              },
+            ],
+          },
+        ],
+      }),
+      "claude-code",
+      "~/test",
+    );
+
+    const tools = replay.scenes.filter((scene) => scene.type === "tool-call");
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toMatchObject({ toolName: "Read", result: "", hasResult: true });
+    expect(tools[1]).toMatchObject({ toolName: "Read", result: "", hasResult: false });
+  });
+
   it("propagates parse warnings into replay metadata", () => {
     const replay = transformToReplay(
       buildParsed({

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,10 +3,35 @@ import type { ProjectIdentity } from "./project-identity.js";
 export type DataSource = "jsonl" | "sqlite" | "jsonl+tools" | "global-state";
 
 export interface TokenUsage {
+  /**
+   * Uncached input tokens after provider-specific normalization.
+   * The full prompt footprint is input + cacheRead + cacheCreation.
+   */
   inputTokens: number;
   outputTokens: number;
   cacheCreationTokens: number;
   cacheReadTokens: number;
+}
+
+export interface TokenUsageMetrics {
+  /** Full prompt footprint sent to the model. */
+  promptTokens: number;
+  /**
+   * Prompt tokens not served by a cache read. This is derived as uncached input
+   * plus cache writes; providers do not expose a universal "miss" counter.
+   */
+  cacheMissTokens: number;
+  /** Fraction of prompt tokens served by a cache read, when promptTokens > 0. */
+  cacheReadShare?: number;
+}
+
+export function deriveTokenUsageMetrics(usage: TokenUsage): TokenUsageMetrics {
+  const promptTokens = usage.inputTokens + usage.cacheReadTokens + usage.cacheCreationTokens;
+  return {
+    promptTokens,
+    cacheMissTokens: usage.inputTokens + usage.cacheCreationTokens,
+    ...(promptTokens > 0 ? { cacheReadShare: usage.cacheReadTokens / promptTokens } : {}),
+  };
 }
 
 export interface TurnStat {
@@ -85,6 +110,11 @@ export interface SubAgent {
   tokenUsage?: TokenUsage;
   model?: string;
   scenes: Scene[];
+  /**
+   * Complete invocation index for scanner aggregation. This is intentionally
+   * omitted by replay transformation so large child traces can stay bounded.
+   */
+  usageEvents?: UsageEvent[];
 }
 
 export interface FileDiff {
@@ -116,6 +146,11 @@ export type Scene =
       toolName: string;
       input: Record<string, any>;
       result: string;
+      /**
+       * Whether the provider recorded a result for this call. This is separate
+       * from `result` because an empty string can be a valid completed result.
+       */
+      hasResult?: boolean;
       timestamp?: string;
       isError?: boolean;
       /** Primary/first diff, retained for backward compatibility. */
@@ -253,6 +288,67 @@ export interface SessionUsageSummary {
   durationCount: number;
 }
 
+export type MetricQuality = "exact" | "estimated" | "partial" | "unavailable";
+
+export interface MetricCoverage {
+  /** Sessions for which this metric was observed or conclusively indexed. */
+  availableSessions: number;
+  totalSessions: number;
+  quality: MetricQuality;
+}
+
+/** Provider-level observability audit data; contains no prompt or tool payloads. */
+export interface ProviderCoverage {
+  provider: string;
+  totalSessions: number;
+  indexedSessions: number;
+  invocationSessions: number;
+  invocationCalls: number;
+  missingInvocationSessions: number;
+  mcpSessions: number;
+  mcpCalls: number;
+  mcpToolSessions: number;
+  mcpToolCalls: number;
+  tokenSessions: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  promptTokens: number;
+  cacheMissTokens: number;
+  compactionSessions: number;
+  compactionCount: number;
+  notes?: string[];
+  metrics: {
+    invocations: MetricCoverage;
+    mcpTools: MetricCoverage;
+    tokens: MetricCoverage;
+    cache: MetricCoverage;
+    compactions: MetricCoverage;
+  };
+}
+
+export interface UsageCoverageReport {
+  totalSessions: number;
+  indexedSessions: number;
+  invocationSessions: number;
+  invocationCalls: number;
+  missingInvocationSessions: number;
+  mcpCalls: number;
+  mcpToolSessions: number;
+  mcpToolCalls: number;
+  tokenSessions: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  promptTokens: number;
+  cacheMissTokens: number;
+  compactionSessions: number;
+  compactionCount: number;
+  providers: ProviderCoverage[];
+}
+
 /**
  * A single session's insights — lightweight metadata persisted locally so it
  * survives after source JSONL files are deleted (e.g. Claude Code 30-day cleanup).
@@ -345,20 +441,28 @@ export interface SessionScanWireData {
   endTime?: string;
   durationMs?: number;
   gitBranch?: string;
+  gitBranches?: string[];
   model?: string;
   promptCount: number;
   toolCallCount: number;
   editCount: number;
   filesModified: Array<{ file: string; count: number }>;
+  tokenUsage?: TokenUsage;
   costEstimate?: number;
   subAgentCount: number;
+  apiErrorCount: number;
   entrypoint?: string;
+  permissionMode?: string;
   prLinks?: PrLink[];
   skillsUsed?: string[];
   mcpServersUsed?: string[];
   usageSummary?: SessionUsageSummary;
+  usageIndexed?: boolean;
+  compactionCount: number;
   dataSource?: DataSource;
   dataQualityNotes?: string[];
+  turnStatCount?: number;
+  turnDurations?: number[];
 }
 
 export interface ReplaySession {
@@ -390,6 +494,7 @@ export interface ReplaySession {
       thinkingBlocks?: number;
       durationMs?: number;
       tokenUsage?: TokenUsage;
+      tokenMetrics?: TokenUsageMetrics;
       costEstimate?: number;
       turnStats?: TurnStat[];
     };
@@ -401,6 +506,8 @@ export interface ReplaySession {
       timestamp: string;
       trigger: string;
       preTokens?: number;
+      /** Cursor only exposes the latest persisted summary, so this can be a lower bound. */
+      accuracy?: "exact" | "estimated" | "lower-bound";
     }>;
     subAgentSummary?: Array<{
       agentId: string;

--- a/packages/viewer/src/components/BashBlock.tsx
+++ b/packages/viewer/src/components/BashBlock.tsx
@@ -9,6 +9,7 @@ interface Props {
   durationMs?: number;
   resultTokens?: number;
   isError?: boolean;
+  hasResult?: boolean;
 }
 
 export default memo(function BashBlock({
@@ -18,9 +19,11 @@ export default memo(function BashBlock({
   durationMs,
   resultTokens,
   isError,
+  hasResult,
 }: Props) {
   const [expanded, setExpanded] = useState(true);
   const hasOutput = stdout.trim().length > 0;
+  const resultRecorded = hasResult !== false && (hasResult === true || hasOutput);
   const tokenLabel = formatTokens(resultTokens);
   const durationLabel = formatToolDuration(durationMs);
 
@@ -29,7 +32,7 @@ export default memo(function BashBlock({
       className={`bg-terminal-surface rounded-xl overflow-hidden shadow-layer-sm ${isError ? "ring-1 ring-red-500/40" : ""}`}
     >
       <button
-        onClick={() => hasOutput && setExpanded(!expanded)}
+        onClick={() => resultRecorded && setExpanded(!expanded)}
         className={`w-full flex items-center gap-2 px-3 py-2 hover:bg-terminal-surface-hover transition-colors duration-200 ease-material text-left ${isError ? "bg-red-500/5" : ""}`}
       >
         <span
@@ -39,6 +42,26 @@ export default memo(function BashBlock({
         </span>
         <span className="text-xs font-mono text-terminal-text truncate flex-1">{command}</span>
         {isError && <ErrorBadge />}
+        {hasResult === false && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title={
+              isError
+                ? "The command failed before a result was recorded."
+                : "No command result was recorded."
+            }
+          >
+            {isError ? "no result" : "pending"}
+          </span>
+        )}
+        {hasResult === true && !hasOutput && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title="The provider recorded a successful empty result."
+          >
+            empty result
+          </span>
+        )}
         {tokenLabel && (
           <span
             className="text-[10px] text-terminal-dimmer font-mono shrink-0"
@@ -55,7 +78,7 @@ export default memo(function BashBlock({
             {durationLabel}
           </span>
         )}
-        {hasOutput && (
+        {resultRecorded && (
           <span
             className={`text-xs text-terminal-dim transition-transform ${expanded ? "rotate-90" : ""}`}
           >
@@ -63,12 +86,22 @@ export default memo(function BashBlock({
           </span>
         )}
       </button>
-      {expanded && hasOutput && (
-        <div className="px-3 py-2 max-h-[300px] overflow-y-auto">
-          <pre className="text-xs font-mono text-terminal-dim whitespace-pre-wrap break-words">
-            {stdout}
-          </pre>
-        </div>
+      {expanded && (
+        <>
+          {hasResult === false ? (
+            <div className="px-3 py-2 text-xs font-mono text-terminal-dimmer">
+              Result not recorded.
+            </div>
+          ) : (
+            resultRecorded && (
+              <div className="px-3 py-2 max-h-[300px] overflow-y-auto">
+                <pre className="text-xs font-mono text-terminal-dim whitespace-pre-wrap break-words">
+                  {stdout || "(empty result)"}
+                </pre>
+              </div>
+            )
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -20,6 +20,7 @@ interface Props {
   isError?: boolean;
   durationMs?: number;
   resultTokens?: number;
+  hasResult?: boolean;
 }
 
 interface DiffLine {
@@ -81,6 +82,7 @@ export default memo(function CodeDiffBlock({
   isError,
   durationMs,
   resultTokens,
+  hasResult,
 }: Props) {
   const diffLines = useMemo(() => computeDiff(oldContent, newContent), [oldContent, newContent]);
   const language = guessLanguage(filePath);
@@ -102,6 +104,26 @@ export default memo(function CodeDiffBlock({
         </span>
         <span className="text-xs font-mono text-terminal-blue truncate flex-1">{filePath}</span>
         {isError && <ErrorBadge />}
+        {hasResult === false && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title={
+              isError
+                ? "The edit failed before a result was recorded."
+                : "No edit result was recorded."
+            }
+          >
+            {isError ? "no result" : "pending"}
+          </span>
+        )}
+        {hasResult === true && (
+          <span
+            className="text-[10px] text-terminal-dimmer font-mono shrink-0"
+            title="The provider recorded a result for this edit."
+          >
+            result recorded
+          </span>
+        )}
         <ToolTokens tokens={resultTokens} />
         <ToolDuration ms={durationMs} />
         {isNewFile && (

--- a/packages/viewer/src/components/CodeDiffBlock.tsx
+++ b/packages/viewer/src/components/CodeDiffBlock.tsx
@@ -21,6 +21,7 @@ interface Props {
   durationMs?: number;
   resultTokens?: number;
   hasResult?: boolean;
+  resultEmpty?: boolean;
 }
 
 interface DiffLine {
@@ -83,6 +84,7 @@ export default memo(function CodeDiffBlock({
   durationMs,
   resultTokens,
   hasResult,
+  resultEmpty,
 }: Props) {
   const diffLines = useMemo(() => computeDiff(oldContent, newContent), [oldContent, newContent]);
   const language = guessLanguage(filePath);
@@ -121,7 +123,7 @@ export default memo(function CodeDiffBlock({
             className="text-[10px] text-terminal-dimmer font-mono shrink-0"
             title="The provider recorded a result for this edit."
           >
-            result recorded
+            {resultEmpty ? "empty result" : "result recorded"}
           </span>
         )}
         <ToolTokens tokens={resultTokens} />

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import type {
   SessionUsageSummary,
   SourceSession,
 } from "../types";
+import { deriveTokenUsageMetrics } from "@vibe-replay/types";
 import DashboardHome from "./DashboardHome";
 import { isInInsightsRange, rangeSince as insightsRangeSince } from "../engine/insights-rollup";
 import {
@@ -168,6 +169,7 @@ export interface SessionScanData {
   skillsUsed?: string[];
   mcpServersUsed?: string[];
   usageSummary?: SessionUsageSummary;
+  usageIndexed?: boolean;
   model?: string;
   gitBranch?: string;
   startTime?: string;
@@ -667,6 +669,7 @@ export function SessionDetailPopup({
   const transcriptStatus = s.transcriptStatus || scanData?.transcriptStatus;
   const transcriptStatusText = transcriptStatusLabel(transcriptStatus);
   const transcriptStatusHelp = transcriptStatusDescription(transcriptStatus);
+  const compactionCount = Math.max(scanData?.compactionCount ?? 0, s.compactionCount ?? 0);
 
   // Use scan data when available, fall back to discovery estimates
   const promptCount = scanData?.promptCount ?? s.promptCount;
@@ -674,9 +677,13 @@ export function SessionDetailPopup({
   const editCount = scanData?.editCount ?? s.editCountEst;
   const durationMs = scanData?.durationMs ?? s.durationMsEst;
   const cost = scanData?.costEstimate ?? s.replay?.stats?.costEstimate;
-  const totalTokens = scanData?.tokenUsage
-    ? scanData.tokenUsage.inputTokens + scanData.tokenUsage.outputTokens
+  const tokenMetrics = scanData?.tokenUsage
+    ? deriveTokenUsageMetrics(scanData.tokenUsage)
     : undefined;
+  const totalTokens =
+    tokenMetrics && scanData?.tokenUsage
+      ? tokenMetrics.promptTokens + scanData.tokenUsage.outputTokens
+      : undefined;
   const startedAt = scanData?.startTime || s.timestamp;
 
   const handleSaveTitle = async () => {
@@ -901,7 +908,7 @@ export function SessionDetailPopup({
                   value={totalTokens.toLocaleString()}
                   title={
                     scanData?.tokenUsage
-                      ? `In: ${scanData.tokenUsage.inputTokens.toLocaleString()} / Out: ${scanData.tokenUsage.outputTokens.toLocaleString()} / Cache write: ${scanData.tokenUsage.cacheCreationTokens.toLocaleString()} / Cache read: ${scanData.tokenUsage.cacheReadTokens.toLocaleString()}`
+                      ? `Prompt: ${tokenMetrics?.promptTokens.toLocaleString()} / Input (uncached): ${scanData.tokenUsage.inputTokens.toLocaleString()} / Out: ${scanData.tokenUsage.outputTokens.toLocaleString()} / Cache write: ${scanData.tokenUsage.cacheCreationTokens.toLocaleString()} / Cache read: ${scanData.tokenUsage.cacheReadTokens.toLocaleString()} / Uncached or miss: ${tokenMetrics?.cacheMissTokens.toLocaleString()}`
                       : undefined
                   }
                 />
@@ -909,9 +916,7 @@ export function SessionDetailPopup({
               {scanData != null && scanData.subAgentCount > 0 && (
                 <InfoRow label="Agents" value={`${scanData.subAgentCount} sub-agents`} />
               )}
-              {scanData != null && scanData.compactionCount > 0 && (
-                <InfoRow label="Compacts" value={String(scanData.compactionCount)} />
-              )}
+              {compactionCount > 0 && <InfoRow label="Compacts" value={String(compactionCount)} />}
               {scanData != null && scanData.apiErrorCount > 0 && (
                 <InfoRow label="Errors" value={`${scanData.apiErrorCount} API errors`} />
               )}
@@ -1284,11 +1289,16 @@ function ReplayCard({
   const tooBig = s.replaySize != null && s.replaySize > 10 * 1024 * 1024;
   const compactionCount = s.compactionCount ?? 0;
   const costTitle = s.stats.tokenUsage
-    ? `${formatTokens(s.stats.tokenUsage.cacheReadTokens)} cache read · ${formatTokens(
-        s.stats.tokenUsage.cacheCreationTokens,
-      )} cache write · ${formatTokens(s.stats.tokenUsage.inputTokens)} in · ${formatTokens(
-        s.stats.tokenUsage.outputTokens,
-      )} out`
+    ? (() => {
+        const tokenMetrics = deriveTokenUsageMetrics(s.stats.tokenUsage);
+        return `${formatTokens(tokenMetrics.promptTokens)} prompt · ${formatTokens(
+          tokenMetrics.cacheMissTokens,
+        )} uncached/miss · ${formatTokens(s.stats.tokenUsage.cacheReadTokens)} cache read · ${formatTokens(
+          s.stats.tokenUsage.cacheCreationTokens,
+        )} cache write · ${formatTokens(s.stats.tokenUsage.inputTokens)} in · ${formatTokens(
+          s.stats.tokenUsage.outputTokens,
+        )} out`;
+      })()
     : "Estimated cost";
 
   return (
@@ -1979,6 +1989,8 @@ function UsageChip({
  */
 function SessionUsageDetails({
   summary,
+  usageIndexed,
+  expectedCalls,
   selectedTools,
   selectedMcpTools,
   selectedSkills,
@@ -1987,6 +1999,8 @@ function SessionUsageDetails({
   onSkillToggle,
 }: {
   summary?: SessionUsageSummary;
+  usageIndexed?: boolean;
+  expectedCalls?: number;
   selectedTools: readonly string[];
   selectedMcpTools: readonly string[];
   selectedSkills: readonly string[];
@@ -1996,7 +2010,19 @@ function SessionUsageDetails({
 }) {
   const [expanded, setExpanded] = useState(false);
   const breakdown = useMemo(() => summarizeSessionUsage(summary), [summary]);
-  if (!breakdown) return null;
+  if (!breakdown) {
+    if (usageIndexed === false && (expectedCalls ?? 0) > 0) {
+      return (
+        <div
+          className="text-[10px] font-mono text-terminal-orange"
+          title="Rich usage indexing is still pending for this session"
+        >
+          usage indexing pending
+        </div>
+      );
+    }
+    return null;
+  }
 
   const headline = [
     breakdown.totalCalls > 0 ? `${breakdown.totalCalls} calls` : null,
@@ -2563,6 +2589,10 @@ function SessionsPanel() {
           ...usage.mcpServers,
           ...usage.mcpTools,
           ...usage.skills,
+          ...((scanData?.compactionCount ?? s.compactionCount ?? 0) > 0
+            ? ["compaction", "compacted"]
+            : []),
+          ...(scanData?.tokenUsage ? ["token", "tokens", "cache", "input", "output"] : []),
         ]
           .filter(Boolean)
           .some((value) => String(value).toLowerCase().includes(query));
@@ -3571,11 +3601,16 @@ function SessionsPanel() {
                   .filter(Boolean)
                   .join(" · ");
                 const costTitle = scanData?.tokenUsage
-                  ? `${formatTokens(scanData.tokenUsage.cacheReadTokens)} cache read · ${formatTokens(
-                      scanData.tokenUsage.cacheCreationTokens,
-                    )} cache write · ${formatTokens(scanData.tokenUsage.inputTokens)} in · ${formatTokens(
-                      scanData.tokenUsage.outputTokens,
-                    )} out`
+                  ? (() => {
+                      const tokenMetrics = deriveTokenUsageMetrics(scanData.tokenUsage);
+                      return `${formatTokens(tokenMetrics.promptTokens)} prompt · ${formatTokens(
+                        tokenMetrics.cacheMissTokens,
+                      )} uncached/miss · ${formatTokens(scanData.tokenUsage.cacheReadTokens)} cache read · ${formatTokens(
+                        scanData.tokenUsage.cacheCreationTokens,
+                      )} cache write · ${formatTokens(scanData.tokenUsage.inputTokens)} in · ${formatTokens(
+                        scanData.tokenUsage.outputTokens,
+                      )} out`;
+                    })()
                   : "Estimated cost";
                 return (
                   <div
@@ -3846,6 +3881,8 @@ function SessionsPanel() {
 
                     <SessionUsageDetails
                       summary={scanData?.usageSummary}
+                      usageIndexed={scanData?.usageIndexed}
+                      expectedCalls={displayToolCount}
                       selectedTools={selectedTools}
                       selectedMcpTools={selectedMcpTools}
                       selectedSkills={selectedSkills}

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -1,3 +1,5 @@
+import { deriveTokenUsageMetrics } from "@vibe-replay/types";
+
 export interface TurnDurationHistogramData {
   buckets: Array<{ label: string; count: number; pct: number }>;
   percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
@@ -106,7 +108,7 @@ const TOKEN_COLORS = [
   { key: "cacheRead", label: "Cache Read", color: "bg-terminal-purple" },
   { key: "cacheCreation", label: "Cache Write", color: "bg-terminal-orange" },
   { key: "output", label: "Output", color: "bg-terminal-green" },
-  { key: "input", label: "Input", color: "bg-terminal-blue" },
+  { key: "input", label: "Input (uncached)", color: "bg-terminal-blue" },
 ] as const;
 
 function formatTokenCount(value: number): string {
@@ -118,6 +120,12 @@ function formatTokenCount(value: number): string {
 export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownData }) {
   const total = breakdown.input + breakdown.output + breakdown.cacheRead + breakdown.cacheCreation;
   if (total === 0) return null;
+  const tokenMetrics = deriveTokenUsageMetrics({
+    inputTokens: breakdown.input,
+    outputTokens: breakdown.output,
+    cacheReadTokens: breakdown.cacheRead,
+    cacheCreationTokens: breakdown.cacheCreation,
+  });
 
   const items = TOKEN_COLORS.map((token) => ({
     ...token,
@@ -136,6 +144,34 @@ export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownDa
             style={{ width: `${item.pct}%`, opacity: 0.7 }}
           />
         ))}
+      </div>
+      <div className="grid grid-cols-2 gap-2 border-y border-terminal-border/20 py-3 sm:grid-cols-4">
+        <div title="Uncached input + cache writes. Providers do not expose a universal miss counter.">
+          <div className="text-[11px] font-mono font-bold text-terminal-orange">
+            {formatTokenCount(tokenMetrics.cacheMissTokens)}
+          </div>
+          <div className="text-[10px] font-mono text-terminal-dimmer">uncached / miss</div>
+        </div>
+        <div title="Input + cache read + cache write tokens for the prompt context.">
+          <div className="text-[11px] font-mono font-bold text-terminal-blue">
+            {formatTokenCount(tokenMetrics.promptTokens)}
+          </div>
+          <div className="text-[10px] font-mono text-terminal-dimmer">prompt footprint</div>
+        </div>
+        <div title="Tokens served from the provider cache.">
+          <div className="text-[11px] font-mono font-bold text-terminal-purple">
+            {formatTokenCount(breakdown.cacheRead)}
+          </div>
+          <div className="text-[10px] font-mono text-terminal-dimmer">cache read</div>
+        </div>
+        <div title="Cache read divided by the prompt footprint; this is a cache-read share, not a provider billing guarantee.">
+          <div className="text-[11px] font-mono font-bold text-terminal-green">
+            {tokenMetrics.cacheReadShare !== undefined
+              ? `${Math.round(tokenMetrics.cacheReadShare * 1000) / 10}%`
+              : "—"}
+          </div>
+          <div className="text-[10px] font-mono text-terminal-dimmer">read share</div>
+        </div>
       </div>
       <div className="space-y-2">
         {items.map((item) => (

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -25,7 +25,14 @@ import {
 } from "../engine/insights-rollup";
 import { AnimatedValue } from "../hooks/useAnimatedNumber";
 import { getInsightsRangeFromUrl, INSIGHTS_RANGE_PARAM } from "../hooks/usePanelFilters";
-import type { SessionLocation, SessionSummary, SourceSession } from "../types";
+import type {
+  MetricCoverage,
+  ProviderCoverage,
+  SessionLocation,
+  SessionSummary,
+  SourceSession,
+  UsageCoverageReport,
+} from "../types";
 import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
 import { TokenBreakdownChart, TurnDurationChart } from "./InsightCharts";
@@ -53,6 +60,7 @@ interface UsageRollupPayload {
   sessions: UsageRollupSession[];
   indexedSessions: number;
   totalSessions: number;
+  coverage?: UsageCoverageReport;
 }
 
 type ComputedStats = InsightsRangeStats;
@@ -308,7 +316,7 @@ function rangeLabel(range: TimeRange): string {
   return "All Time";
 }
 
-type InsightsSectionId = "overview" | "activity" | "usage" | "workspace";
+type InsightsSectionId = "overview" | "activity" | "usage" | "coverage" | "workspace";
 
 const INSIGHTS_SECTIONS: Array<{
   id: InsightsSectionId;
@@ -331,6 +339,11 @@ const INSIGHTS_SECTIONS: Array<{
     description: "Tools, MCP, and tokens",
   },
   {
+    id: "coverage",
+    label: "Coverage",
+    description: "What was captured",
+  },
+  {
     id: "workspace",
     label: "Workspace",
     description: "Projects and models",
@@ -345,6 +358,7 @@ function InsightsSectionIcon({ section }: { section: InsightsSectionId }) {
     overview: "M3 3h6v6H3zM15 3h6v6h-6zM3 15h6v6H3zM15 15h6v6h-6z",
     activity: "M3 12h4l2-7 4 14 2-7h6",
     usage: "M4 5h16M4 12h16M4 19h16",
+    coverage: "M12 3v18M3 12h18M5 5l14 14M19 5 5 19",
     workspace: "M4 5h6v6H4zM14 5h6v6h-6zM4 15h6v6H4zM14 15h6v6h-6z",
   };
 
@@ -1519,17 +1533,243 @@ export function UsageCoverage({ payload }: { payload: UsageRollupPayload | null 
   if (!payload || payload.totalSessions <= 0) return null;
   const indexed = Math.min(payload.indexedSessions, payload.totalSessions);
   const coverage = Math.round((indexed / payload.totalSessions) * 100);
+  const report = payload.coverage;
+  const invocationSessions = report?.invocationSessions ?? payload.sessions.length;
+  const missingInvocationSessions = report?.missingInvocationSessions ?? 0;
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-terminal-border-subtle pt-3 text-[10px] font-mono text-terminal-dimmer">
-      <span className="uppercase tracking-widest">Invocation index</span>
+      <span className="uppercase tracking-widest">Index status</span>
       <span className="text-terminal-dim">
         {indexed.toLocaleString()} / {payload.totalSessions.toLocaleString()} sessions
       </span>
       <span className={coverage === 100 ? "text-terminal-green" : "text-terminal-orange"}>
-        {coverage}% covered
+        {coverage}% indexed
       </span>
+      <span className="text-terminal-dim">
+        {invocationSessions.toLocaleString()} with invocation records
+      </span>
+      {missingInvocationSessions > 0 && (
+        <span className="text-terminal-orange">
+          {missingInvocationSessions.toLocaleString()} expected records missing
+        </span>
+      )}
       {coverage < 100 && <span>Counts will grow as provider details finish indexing.</span>}
+    </div>
+  );
+}
+
+function qualityLabel(quality: MetricCoverage["quality"]): string {
+  return quality;
+}
+
+function qualityClass(quality: MetricCoverage["quality"]): string {
+  if (quality === "exact") return "text-terminal-green";
+  if (quality === "estimated") return "text-terminal-blue";
+  if (quality === "partial") return "text-terminal-orange";
+  return "text-terminal-dimmer";
+}
+
+function CoverageMetricCell({ metric, detail }: { metric: MetricCoverage; detail: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-xs font-mono text-terminal-text tabular-nums">{detail}</div>
+      <div className={`text-[10px] font-mono ${qualityClass(metric.quality)}`}>
+        {qualityLabel(metric.quality)}
+      </div>
+    </div>
+  );
+}
+
+export function CoverageAudit({ report }: { report?: UsageCoverageReport }) {
+  if (!report || report.totalSessions === 0) {
+    return (
+      <div className={`${INSIGHTS_CARD_CLASS} px-5 py-6 text-center`}>
+        <div className="text-xs font-mono text-terminal-dimmer">
+          Coverage audit will appear after the session scan finishes.
+        </div>
+      </div>
+    );
+  }
+
+  const indexedPct = Math.round((report.indexedSessions / report.totalSessions) * 100);
+  const tokenPct = Math.round((report.tokenSessions / report.totalSessions) * 100);
+  const cacheReadShare =
+    report.promptTokens > 0 ? (report.cacheReadTokens / report.promptTokens) * 100 : undefined;
+  const noInvocationSessions = Math.max(0, report.indexedSessions - report.invocationSessions);
+
+  return (
+    <div className={`${INSIGHTS_CARD_CLASS} space-y-5 p-5 md:p-6`}>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="rounded-lg bg-terminal-bg px-3 py-2">
+          <div className="text-lg font-mono font-bold text-terminal-green tabular-nums">
+            {indexedPct}%
+          </div>
+          <div className="ui-section-title">scan indexed</div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+            {report.indexedSessions.toLocaleString()} / {report.totalSessions.toLocaleString()}
+          </div>
+        </div>
+        <div className="rounded-lg bg-terminal-bg px-3 py-2">
+          <div className="text-lg font-mono font-bold text-terminal-orange tabular-nums">
+            {report.invocationSessions.toLocaleString()}
+          </div>
+          <div className="ui-section-title">sessions with calls</div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+            {report.invocationCalls.toLocaleString()} invocations
+          </div>
+        </div>
+        <div className="rounded-lg bg-terminal-bg px-3 py-2">
+          <div className="text-lg font-mono font-bold text-terminal-blue tabular-nums">
+            {tokenPct}%
+          </div>
+          <div className="ui-section-title">token records</div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+            {report.tokenSessions.toLocaleString()} / {report.totalSessions.toLocaleString()}
+          </div>
+        </div>
+        <div className="rounded-lg bg-terminal-bg px-3 py-2">
+          <div className="text-lg font-mono font-bold text-terminal-purple tabular-nums">
+            {report.compactionCount.toLocaleString()}
+          </div>
+          <div className="ui-section-title">compactions observed</div>
+          <div className="mt-0.5 text-[10px] font-mono text-terminal-dimmer">
+            {report.compactionSessions.toLocaleString()} sessions
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-terminal-blue/20 bg-terminal-blue/5 px-3 py-2.5 text-[11px] font-mono leading-relaxed text-terminal-dim">
+        <div>
+          Prompt footprint:{" "}
+          <span className="text-terminal-text">{formatCompactNum(report.promptTokens)}</span> tokens
+          · uncached / miss:{" "}
+          <span className="text-terminal-orange">{formatCompactNum(report.cacheMissTokens)}</span>
+        </div>
+        <div>
+          Cache read:{" "}
+          <span className="text-terminal-purple">{formatCompactNum(report.cacheReadTokens)}</span>
+          {cacheReadShare !== undefined
+            ? ` (${cacheReadShare.toFixed(1)}% of prompt footprint)`
+            : ""}
+          . “Miss” is derived as uncached input + cache writes; providers do not expose one
+          universal miss counter.
+        </div>
+        <div>
+          No invocation events recorded in{" "}
+          <span className="text-terminal-text">{noInvocationSessions.toLocaleString()}</span>{" "}
+          indexed sessions; this is distinct from sessions whose invocation index is still missing.
+        </div>
+        {report.missingInvocationSessions > 0 && (
+          <div className="mt-1 text-terminal-orange">
+            {report.missingInvocationSessions} sessions advertise calls but have no indexed
+            invocation summary.
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[880px] border-collapse text-left">
+          <caption className="sr-only">Session observability coverage by provider</caption>
+          <thead>
+            <tr className="border-b border-terminal-border-subtle text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+              <th className="px-2 py-2 font-normal">Provider</th>
+              <th className="px-2 py-2 font-normal">Index</th>
+              <th className="px-2 py-2 font-normal">Calls</th>
+              <th className="px-2 py-2 font-normal">MCP</th>
+              <th className="px-2 py-2 font-normal">MCP tools</th>
+              <th className="px-2 py-2 font-normal">Tokens</th>
+              <th className="px-2 py-2 font-normal">Cache</th>
+              <th className="px-2 py-2 font-normal">Compaction</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.providers.map((provider: ProviderCoverage) => {
+              const providerCacheShare =
+                provider.promptTokens > 0
+                  ? `${((provider.cacheReadTokens / provider.promptTokens) * 100).toFixed(1)}% read`
+                  : "no reads";
+              return (
+                <tr
+                  key={provider.provider}
+                  className="border-b border-terminal-border/40 last:border-0"
+                >
+                  <th
+                    className="px-2 py-3 text-xs font-sans font-semibold text-terminal-text"
+                    title={provider.notes?.join("\n")}
+                  >
+                    {providerDisplayName(provider.provider)}
+                    <div className="text-[10px] font-mono font-normal text-terminal-dimmer">
+                      {provider.totalSessions.toLocaleString()} sessions
+                    </div>
+                    {provider.notes?.[0] && (
+                      <div className="mt-1 max-w-52 text-[10px] font-mono font-normal leading-relaxed text-terminal-dimmer">
+                        {provider.notes[0]}
+                      </div>
+                    )}
+                  </th>
+                  <td className="px-2 py-3">
+                    <CoverageMetricCell
+                      metric={provider.metrics.invocations}
+                      detail={`${provider.indexedSessions}/${provider.totalSessions}`}
+                    />
+                  </td>
+                  <td className="px-2 py-3">
+                    <div className="text-xs font-mono text-terminal-text tabular-nums">
+                      {provider.invocationCalls.toLocaleString()}
+                    </div>
+                    <div className="text-[10px] font-mono text-terminal-dimmer">
+                      {provider.invocationSessions} sessions
+                    </div>
+                  </td>
+                  <td className="px-2 py-3">
+                    <div className="text-xs font-mono text-terminal-text tabular-nums">
+                      {provider.mcpCalls.toLocaleString()}
+                    </div>
+                    <div className="text-[10px] font-mono text-terminal-dimmer">
+                      {provider.mcpSessions} sessions
+                    </div>
+                  </td>
+                  <td className="px-2 py-3">
+                    <CoverageMetricCell
+                      metric={provider.metrics.mcpTools}
+                      detail={
+                        provider.mcpCalls > 0
+                          ? `${provider.mcpToolCalls}/${provider.mcpCalls}`
+                          : "—"
+                      }
+                    />
+                  </td>
+                  <td className="px-2 py-3">
+                    <CoverageMetricCell
+                      metric={provider.metrics.tokens}
+                      detail={`${provider.tokenSessions}/${provider.totalSessions}`}
+                    />
+                  </td>
+                  <td className="px-2 py-3">
+                    <CoverageMetricCell
+                      metric={provider.metrics.cache}
+                      detail={providerCacheShare}
+                    />
+                  </td>
+                  <td className="px-2 py-3">
+                    <CoverageMetricCell
+                      metric={provider.metrics.compactions}
+                      detail={`${provider.compactionCount} · ${provider.compactionSessions}/${provider.totalSessions}`}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="text-[10px] font-mono leading-relaxed text-terminal-dimmer">
+        Exact = provider-reported or conclusively indexed. Estimated = provider snapshots or
+        inferred timing. Partial = some sessions or events are missing. Cursor compactions are lower
+        bounds because Cursor keeps the latest summary rather than a durable compaction log.
+      </div>
     </div>
   );
 }
@@ -1715,11 +1955,15 @@ export default function InsightsPage() {
     : 0;
   const currentSourceSessionCount = homePageCounts?.sessions ?? userInsights.totalSessions;
   const pendingSessionDelta = Math.max(0, currentSourceSessionCount - userInsights.totalSessions);
-  const showSnapshotNotice = Boolean(scanStatus?.running && scanStatus?.hasCachedResults);
+  const backgroundRefreshRunning = Boolean(
+    scanStatus?.running || scanStatus?.usageBackfill?.running,
+  );
+  const showSnapshotNotice = Boolean(backgroundRefreshRunning && scanStatus?.hasCachedResults);
   const snapshotAge = scanStatus?.cachedAt ? formatCompactAge(scanStatus.cachedAt) : "";
-  const refreshProgress =
-    scanStatus?.total && scanStatus.total > 0
-      ? `${Math.min(scanStatus.scanned, scanStatus.total)}/${scanStatus.total}`
+  const refreshProgress = scanStatus?.usageBackfill?.running
+    ? `${scanStatus.usageBackfill.scanned}/${scanStatus.usageBackfill.total} usage indexes`
+    : scanStatus?.total && scanStatus.total > 0
+      ? `${Math.min(scanStatus.scanned, scanStatus.total)}/${scanStatus.total} sessions`
       : undefined;
 
   return (
@@ -1767,7 +2011,9 @@ export default function InsightsPage() {
                 <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-terminal-blue" />
                 <div className="space-y-1">
                   <div className="text-xs font-sans font-semibold text-terminal-text">
-                    Showing cached insights snapshot while the background refresh runs
+                    {scanStatus?.usageBackfill?.running
+                      ? "Indexing tool, MCP, and skill usage in the background"
+                      : "Showing cached insights snapshot while the background refresh runs"}
                   </div>
                   <div className="text-xs font-mono text-terminal-dim">
                     {snapshotAge
@@ -2002,8 +2248,24 @@ export default function InsightsPage() {
             </InsightsSection>
 
             <InsightsSection
+              id="coverage"
+              eyebrow="04 / Coverage"
+              title="What was captured"
+              description="All-time audit: separate scan completion from metric availability and provider precision."
+              meta={
+                usagePayload ? (
+                  <span className="text-[10px] font-mono text-terminal-dimmer">
+                    {usagePayload.totalSessions.toLocaleString()} all-time sessions audited
+                  </span>
+                ) : null
+              }
+            >
+              <CoverageAudit report={usagePayload?.coverage} />
+            </InsightsSection>
+
+            <InsightsSection
               id="workspace"
-              eyebrow="04 / Workspace"
+              eyebrow="05 / Workspace"
               title="Your working set"
               description="The projects, models, and providers that shaped your sessions in this range."
             >

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -402,10 +402,14 @@ export function ScanFailureNotice({ failedProviders }: { failedProviders?: strin
 }
 
 export function ScanProgressBar({ status }: { status: ScanStatus }) {
-  if (!status.running) return null;
-  const pct = status.total > 0 ? Math.round((status.scanned / status.total) * 100) : 0;
-  const label =
-    status.phase === "discovering"
+  const backfillRunning = status.usageBackfill?.running === true;
+  if (!status.running && !backfillRunning) return null;
+  const progressTotal = backfillRunning ? status.usageBackfill?.total || 0 : status.total;
+  const progressScanned = backfillRunning ? status.usageBackfill?.scanned || 0 : status.scanned;
+  const pct = progressTotal > 0 ? Math.round((progressScanned / progressTotal) * 100) : 0;
+  const label = backfillRunning
+    ? `Indexing usage... ${progressScanned}/${progressTotal}`
+    : status.phase === "discovering"
       ? "Discovering sessions..."
       : status.total > 0
         ? `Refreshing insights... ${status.scanned}/${status.total}`
@@ -419,7 +423,7 @@ export function ScanProgressBar({ status }: { status: ScanStatus }) {
           showing {status.cachedResultCount || status.resultCount} cached
         </span>
       )}
-      {status.total > 0 && (
+      {progressTotal > 0 && (
         <div className="flex-1 max-w-[120px] h-1 rounded-full bg-terminal-surface-2 overflow-hidden">
           <div
             className="h-full bg-terminal-purple rounded-full transition-all duration-300"

--- a/packages/viewer/src/components/StatsPanel.tsx
+++ b/packages/viewer/src/components/StatsPanel.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { deriveTokenUsageMetrics } from "@vibe-replay/types";
 import type { ReplaySession } from "../types";
 import { getToolDiffs } from "../utils/sceneDiffs";
 import { formatReplaySourceLabel } from "../utils/format";
@@ -76,6 +77,9 @@ export default function StatsPanel({ session }: Props) {
       topTools,
       durationMs: meta.stats.durationMs,
       tokenUsage: meta.stats.tokenUsage,
+      tokenMetrics: meta.stats.tokenUsage
+        ? deriveTokenUsageMetrics(meta.stats.tokenUsage)
+        : undefined,
       costEstimate: meta.stats.costEstimate,
       compactions: meta.compactions,
       peakContextTokens: (() => {
@@ -240,7 +244,8 @@ export default function StatsPanel({ session }: Props) {
           </div>
           <div className="text-terminal-dim leading-relaxed space-y-0.5">
             <div>
-              In: <span className="text-terminal-blue">{fmtNum(stats.tokenUsage.inputTokens)}</span>
+              Input:{" "}
+              <span className="text-terminal-blue">{fmtNum(stats.tokenUsage.inputTokens)}</span>
               {" / "}
               Out:{" "}
               <span className="text-terminal-green">{fmtNum(stats.tokenUsage.outputTokens)}</span>
@@ -255,8 +260,30 @@ export default function StatsPanel({ session }: Props) {
               <span className="text-terminal-orange">
                 {fmtNum(stats.tokenUsage.cacheCreationTokens)}
               </span>{" "}
-              created
+              write
             </div>
+            {stats.tokenMetrics && (
+              <div className="pt-1 text-[10px] text-terminal-dimmer">
+                Prompt{" "}
+                <span className="text-terminal-blue">
+                  {fmtNum(stats.tokenMetrics.promptTokens)}
+                </span>
+                {" · "}
+                uncached/miss{" "}
+                <span className="text-terminal-orange">
+                  {fmtNum(stats.tokenMetrics.cacheMissTokens)}
+                </span>
+                {stats.tokenMetrics.cacheReadShare !== undefined && (
+                  <>
+                    {" · "}
+                    read share{" "}
+                    <span className="text-terminal-green">
+                      {Math.round(stats.tokenMetrics.cacheReadShare * 1000) / 10}%
+                    </span>
+                  </>
+                )}
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -368,7 +395,10 @@ export default function StatsPanel({ session }: Props) {
                 className="text-terminal-dim text-xs flex items-baseline gap-1.5 flex-wrap"
               >
                 <span className="text-terminal-orange">●</span>
-                <span>{c.trigger}</span>
+                <span>
+                  {c.accuracy === "lower-bound" ? "at least " : ""}
+                  {c.trigger}
+                </span>
                 {c.preTokens && (
                   <span className="text-terminal-text">{fmtNum(c.preTokens)} tokens</span>
                 )}

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -298,6 +298,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
         <span className="truncate flex-1">{summarizeInput(scene.toolName, scene.input)}</span>
         {scene.subAgent && <AgentTypeBadge type={scene.subAgent.agentType} />}
         {scene.isError && <ErrorBadge />}
+        <ToolResultBadge scene={scene} />
         <ToolTokens tokens={scene.resultTokens} />
         <ToolDuration ms={scene.durationMs} />
       </div>
@@ -333,6 +334,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
         durationMs={scene.durationMs}
         resultTokens={scene.resultTokens}
         hasResult={scene.hasResult}
+        resultEmpty={(scene.result || "").length === 0}
       />
     );
   }
@@ -351,6 +353,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
             durationMs={index === 0 ? scene.durationMs : undefined}
             resultTokens={index === 0 ? scene.resultTokens : undefined}
             hasResult={index === 0 ? scene.hasResult : undefined}
+            resultEmpty={index === 0 ? (scene.result || "").length === 0 : undefined}
           />
         ))}
       </div>

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -41,6 +41,35 @@ interface Props {
   forceCollapse?: boolean;
 }
 
+function ToolResultBadge({ scene }: { scene: ToolScene }) {
+  if (scene.hasResult === false) {
+    const label = scene.isError ? "no result" : "pending";
+    return (
+      <span
+        className="text-[10px] font-mono text-terminal-dimmer shrink-0"
+        title={
+          scene.isError
+            ? "The tool failed before a result was recorded."
+            : "No tool result was recorded."
+        }
+      >
+        {label}
+      </span>
+    );
+  }
+  if (scene.hasResult === true && scene.result.length === 0) {
+    return (
+      <span
+        className="text-[10px] font-mono text-terminal-dimmer shrink-0"
+        title="The provider recorded a successful empty result."
+      >
+        empty result
+      </span>
+    );
+  }
+  return null;
+}
+
 function toolIcon(name: string): string {
   if (name.startsWith("mcp__")) return "🔌"; // 🔌
   switch (name) {
@@ -227,13 +256,24 @@ function SubAgentSceneItem({ scene }: { scene: Scene }) {
             {summarizeInput(toolScene.toolName, toolScene.input)}
           </span>
           {toolScene.isError && <ErrorBadge />}
+          <ToolResultBadge scene={toolScene} />
           <ToolTokens tokens={toolScene.resultTokens} />
           <ToolDuration ms={toolScene.durationMs} />
         </button>
-        {expanded && toolScene.result && (
-          <pre className="text-[9px] text-terminal-dim font-mono whitespace-pre-wrap break-words max-h-[100px] overflow-y-auto mt-0.5 px-1 bg-terminal-bg/50 rounded">
-            {toolScene.result.slice(0, 500)}
-          </pre>
+        {expanded && (
+          <>
+            {toolScene.hasResult === false ? (
+              <div className="text-[9px] text-terminal-dimmer font-mono mt-0.5 px-1">
+                Result not recorded.
+              </div>
+            ) : (
+              (toolScene.result || toolScene.hasResult === true) && (
+                <pre className="text-[9px] text-terminal-dim font-mono whitespace-pre-wrap break-words max-h-[100px] overflow-y-auto mt-0.5 px-1 bg-terminal-bg/50 rounded">
+                  {toolScene.result ? toolScene.result.slice(0, 500) : "(empty result)"}
+                </pre>
+              )
+            )}
+          </>
         )}
       </div>
     );
@@ -274,6 +314,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
         durationMs={scene.durationMs}
         resultTokens={scene.resultTokens}
         isError={scene.isError}
+        hasResult={scene.hasResult}
       />
     );
   }
@@ -291,6 +332,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
         isError={scene.isError}
         durationMs={scene.durationMs}
         resultTokens={scene.resultTokens}
+        hasResult={scene.hasResult}
       />
     );
   }
@@ -308,6 +350,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
             isError={scene.isError}
             durationMs={index === 0 ? scene.durationMs : undefined}
             resultTokens={index === 0 ? scene.resultTokens : undefined}
+            hasResult={index === 0 ? scene.hasResult : undefined}
           />
         ))}
       </div>
@@ -357,6 +400,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
             >
               {CHEVRON}
             </span>
+            <ToolResultBadge scene={scene} />
           </div>
           {/* Description — large, like a section title */}
           {description && (
@@ -392,6 +436,7 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
             {summarizeInput(scene.toolName, scene.input)}
           </span>
           {scene.isError && <ErrorBadge />}
+          <ToolResultBadge scene={scene} />
           <ToolTokens tokens={scene.resultTokens} />
           <ToolDuration ms={scene.durationMs} />
           <span
@@ -408,13 +453,19 @@ export default memo(function ToolCallBlock({ scene, isActive, forceCollapse }: P
                 {JSON.stringify(scene.input, null, 2)}
               </pre>
             </div>
-            {scene.result && (
+            {scene.hasResult === false ? (
               <div className="px-3 py-2 border-t border-terminal-border-subtle">
-                <div className="text-xs text-terminal-dim font-mono mb-1">Result:</div>
-                <pre className="text-xs text-terminal-text font-mono whitespace-pre-wrap break-words max-h-[200px] overflow-y-auto">
-                  {scene.result}
-                </pre>
+                <div className="text-xs text-terminal-dimmer font-mono">Result not recorded.</div>
               </div>
+            ) : (
+              (scene.result || scene.hasResult === true) && (
+                <div className="px-3 py-2 border-t border-terminal-border-subtle">
+                  <div className="text-xs text-terminal-dim font-mono mb-1">Result:</div>
+                  <pre className="text-xs text-terminal-text font-mono whitespace-pre-wrap break-words max-h-[200px] overflow-y-auto">
+                    {scene.result || "(empty result)"}
+                  </pre>
+                </div>
+              )
             )}
             {scene.images && scene.images.length > 0 && (
               <div className="px-3 py-2 border-t border-terminal-border-subtle">

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -57,7 +57,7 @@ function ToolResultBadge({ scene }: { scene: ToolScene }) {
       </span>
     );
   }
-  if (scene.hasResult === true && scene.result.length === 0) {
+  if (scene.hasResult === true && (scene.result || "").length === 0) {
     return (
       <span
         className="text-[10px] font-mono text-terminal-dimmer shrink-0"

--- a/packages/viewer/src/components/__tests__/insights-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-panel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { ScanFailureNotice } from "../InsightsPanel";
+import { ScanFailureNotice, ScanProgressBar } from "../InsightsPanel";
 
 afterEach(() => cleanup());
 
@@ -17,5 +17,23 @@ describe("ScanFailureNotice", () => {
     const { container } = render(<ScanFailureNotice failedProviders={[]} />);
 
     expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("ScanProgressBar", () => {
+  it("surfaces deferred usage indexing even after the fast scan completes", () => {
+    render(
+      <ScanProgressBar
+        status={{
+          running: false,
+          scanned: 10,
+          total: 10,
+          resultCount: 10,
+          usageBackfill: { running: true, scanned: 2, total: 8 },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Indexing usage... 2/8")).toBeDefined();
   });
 });

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -6,6 +6,7 @@ import {
   InsightsSectionNav,
   navigateToUsageSessions,
   TopProjectsList,
+  CoverageAudit,
   UsageBarList,
   UsageCoverage,
 } from "../InsightsPage";
@@ -128,8 +129,69 @@ describe("Insights sections", () => {
     );
 
     expect(container.textContent).toContain("2 / 4 sessions");
-    expect(container.textContent).toContain("50% covered");
+    expect(container.textContent).toContain("50% indexed");
     expect(container.textContent).toContain("Counts will grow");
+  });
+
+  it("shows provider precision and derived cache-miss coverage", () => {
+    render(
+      <CoverageAudit
+        report={{
+          totalSessions: 2,
+          indexedSessions: 2,
+          invocationSessions: 1,
+          invocationCalls: 3,
+          missingInvocationSessions: 0,
+          mcpCalls: 1,
+          mcpToolSessions: 1,
+          mcpToolCalls: 1,
+          tokenSessions: 1,
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 300,
+          cacheCreationTokens: 10,
+          promptTokens: 410,
+          cacheMissTokens: 110,
+          compactionSessions: 1,
+          compactionCount: 1,
+          providers: [
+            {
+              provider: "cursor",
+              totalSessions: 2,
+              indexedSessions: 2,
+              invocationSessions: 1,
+              invocationCalls: 3,
+              missingInvocationSessions: 0,
+              mcpSessions: 1,
+              mcpCalls: 1,
+              mcpToolSessions: 1,
+              mcpToolCalls: 1,
+              tokenSessions: 1,
+              inputTokens: 100,
+              outputTokens: 20,
+              cacheReadTokens: 300,
+              cacheCreationTokens: 10,
+              promptTokens: 410,
+              cacheMissTokens: 110,
+              compactionSessions: 1,
+              compactionCount: 1,
+              metrics: {
+                invocations: { availableSessions: 2, totalSessions: 2, quality: "exact" },
+                mcpTools: { availableSessions: 1, totalSessions: 1, quality: "exact" },
+                tokens: { availableSessions: 1, totalSessions: 2, quality: "partial" },
+                cache: { availableSessions: 1, totalSessions: 2, quality: "partial" },
+                compactions: { availableSessions: 1, totalSessions: 2, quality: "partial" },
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("uncached / miss");
+    expect(screen.getByText("110")).toBeDefined();
+    expect(screen.getAllByText("partial").length).toBeGreaterThan(0);
+    expect(screen.getByText("Cursor")).toBeDefined();
   });
 });
 

--- a/packages/viewer/src/components/__tests__/project-performance.test.tsx
+++ b/packages/viewer/src/components/__tests__/project-performance.test.tsx
@@ -53,7 +53,7 @@ describe("ProjectPerformance", () => {
     expect(screen.getByText("P90")).toBeDefined();
     expect(screen.getByText("8s")).toBeDefined();
     expect(screen.getByText("Cache Read")).toBeDefined();
-    expect(screen.getAllByText("1k")).toHaveLength(2);
+    expect(screen.getAllByText("1k")).toHaveLength(4);
   });
 
   it("keeps zero token categories visible", () => {
@@ -68,7 +68,7 @@ describe("ProjectPerformance", () => {
       />,
     );
 
-    expect(screen.getByText("Input")).toBeDefined();
+    expect(screen.getByText("Input (uncached)")).toBeDefined();
     expect(screen.getByText("Output")).toBeDefined();
     expect(screen.getByText("Cache Read")).toBeDefined();
     expect(screen.getByText("Cache Write")).toBeDefined();

--- a/packages/viewer/src/components/__tests__/tool-call-diffs.test.tsx
+++ b/packages/viewer/src/components/__tests__/tool-call-diffs.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Scene } from "../../types";
 import ToolCallBlock from "../ToolCallBlock";
@@ -25,5 +25,45 @@ describe("ToolCallBlock multi-file diffs", () => {
 
     expect(screen.getByText("src/app.ts")).toBeTruthy();
     expect(screen.getByText("src/auth.ts")).toBeTruthy();
+  });
+});
+
+describe("ToolCallBlock result state", () => {
+  it("shows an empty recorded result instead of treating it as missing", () => {
+    render(
+      <ToolCallBlock
+        scene={{
+          type: "tool-call",
+          toolName: "Custom",
+          input: {},
+          result: "",
+          hasResult: true,
+        }}
+        isActive={false}
+      />,
+    );
+
+    expect(screen.getByText("empty result")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("(empty result)")).toBeTruthy();
+  });
+
+  it("shows when a tool result was not recorded", () => {
+    render(
+      <ToolCallBlock
+        scene={{
+          type: "tool-call",
+          toolName: "Custom",
+          input: {},
+          result: "",
+          hasResult: false,
+        }}
+        isActive={false}
+      />,
+    );
+
+    expect(screen.getByText("pending")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Result not recorded.")).toBeTruthy();
   });
 });

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -5,6 +5,9 @@ export type {
   DataSource,
   DataSourceInfo,
   FileDiff,
+  MetricCoverage,
+  MetricQuality,
+  ProviderCoverage,
   OverlaySource,
   ProjectIdentity,
   PrLink,
@@ -17,7 +20,9 @@ export type {
   SessionTranscriptStatus,
   SubAgent,
   TokenUsage,
+  TokenUsageMetrics,
   TurnStat,
+  UsageCoverageReport,
 } from "@vibe-replay/types";
 
 // Re-import for local use in this file
@@ -91,6 +96,7 @@ export interface SourceSession {
   toolPaths?: string[];
   hasSqlite?: boolean;
   hasSdk?: boolean;
+  sourceFingerprint?: string;
   gitBranch?: string;
   gitRepo?: string;
   existingReplay: string | null;

--- a/skills/replay/SKILL.md
+++ b/skills/replay/SKILL.md
@@ -67,6 +67,7 @@ npx vibe-replay sessions --project "vibe-replay" --json
 npx vibe-replay sessions --provider cursor --query "auth bug" --json
 npx vibe-replay sessions --query "codex parser" --scan --json
 npx vibe-replay sessions --query "PR review CI" --any --brief --dedupe --json
+npx vibe-replay sessions --compacted --limit 10 --json
 ```
 
 Search workflow:
@@ -215,6 +216,9 @@ For efficiency analysis, look at:
 - Prompt count and whether the user had to repeat intent.
 - Tool calls per prompt and edit count per prompt.
 - Long duration, API errors, compactions, and subagent count.
+- Token input/output, cache read/write, and the derived uncached/miss prompt
+  footprint. Treat Cursor token snapshots and compaction counts as estimated or
+  lower-bound evidence, respectively.
 - First prompt clarity: goal, constraints, files, expected verification, and merge/review instructions.
 
 Prefer actionable advice such as "the first prompt had a clear goal but missed verification criteria" or "the session became expensive because it searched broadly before narrowing to one file."


### PR DESCRIPTION
## Summary
- Separate scan completion from invocation, MCP, token/cache, and compaction coverage across all providers.
- Add provider precision notes, derived prompt-footprint/uncached metrics, Cursor storage freshness, and compaction discovery.
- Preserve tool-result states through replay and surface Coverage, usage facets, query filters, and data-quality context in the UI/CLI.
- Document the audit model and add parser, scanner, replay, API, and viewer regression coverage.

## Test plan
- [x] `pnpm build`
- [x] `VIBE_REPLAY_CONFIG=/dev/null pnpm test`
- [x] `pnpm --filter @vibe-replay/cloudflare test`
- [x] `pnpm typecheck`
- [x] `pnpm lint:check`
- [x] Local dashboard verification against 2,673 discovered sessions

## Local audit evidence
- 2,673/2,673 sessions indexed
- 2,292 sessions with invocation records
- 904 sessions with token records
- 431 sessions with observed compactions; Cursor observations are explicitly lower bounds

Made with [Cursor](https://cursor.com)