### PR TITLE
fix: keep dashboard insights fresh and readable

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -66,7 +66,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v31: deduplicate streamed skill attribution and index OpenCode/Hermes usage.
 // v32: add provider coverage reporting, rich Claude scans, and Cursor compaction
 // summary detection.
-export const SCANNER_VERSION = 32;
+// v33: reject Cursor request-relative timing values as session timestamps.
+export const SCANNER_VERSION = 33;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1477,6 +1477,14 @@ export async function startServer(
 
   const app = new Hono();
 
+  // Dashboard APIs are mutable scan snapshots. Prevent browser/proxy caching
+  // from serving an earlier aggregate after a background scan completes.
+  app.use("/api/*", async (c, next) => {
+    await next();
+    c.header("Cache-Control", "no-store, max-age=0");
+    c.header("Pragma", "no-cache");
+  });
+
   // Serve viewer HTML with editor flag (prod) or redirect to Vite dev server (dev)
   app.get("/", (c) => {
     if (isDevMode) {

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -932,6 +932,16 @@ function toIsoTimestamp(value: unknown): string | undefined {
   return undefined;
 }
 
+function toPlausibleCursorTimestamp(value: unknown): string | undefined {
+  const iso = toIsoTimestamp(value);
+  if (!iso) return undefined;
+  const timestampMs = Date.parse(iso);
+  // Cursor's timingInfo.clientStartTime is sometimes elapsed milliseconds
+  // since the request began, not an epoch timestamp. Do not turn that value
+  // into a fake 1970 session start.
+  return timestampMs >= Date.UTC(2000, 0, 1) ? iso : undefined;
+}
+
 function cursorComposerSidecarMetadata(composer: Record<string, any>): CursorSidecars | undefined {
   const conversationCheckpointLastUpdatedAt = toIsoTimestamp(
     composer.conversationCheckpointLastUpdatedAt,
@@ -983,11 +993,11 @@ function bubbleTimestamp(bubble: Record<string, any>): string | undefined {
       ? (bubble.timingInfo as Record<string, any>)
       : undefined;
   return (
-    toIsoTimestamp(bubble.createdAt) ||
-    toIsoTimestamp(bubble.lastUpdatedAt) ||
-    toIsoTimestamp(timingInfo?.clientStartTime) ||
-    toIsoTimestamp(timingInfo?.clientEndTime) ||
-    toIsoTimestamp(timingInfo?.clientSettleTime)
+    toPlausibleCursorTimestamp(bubble.createdAt) ||
+    toPlausibleCursorTimestamp(bubble.lastUpdatedAt) ||
+    toPlausibleCursorTimestamp(timingInfo?.clientStartTime) ||
+    toPlausibleCursorTimestamp(timingInfo?.clientEndTime) ||
+    toPlausibleCursorTimestamp(timingInfo?.clientSettleTime)
   );
 }
 
@@ -1373,9 +1383,7 @@ export async function discoverSqliteOnlySessions(
 
       const project = hashToProject.get(entry.workspaceHash) || "";
       const firstPrompt = meta.name || "(sqlite-only session)";
-      const timestamp = meta.createdAt
-        ? new Date(meta.createdAt).toISOString()
-        : new Date(entry.mtimeMs).toISOString();
+      const timestamp = toIsoTimestamp(meta.createdAt) || new Date(entry.mtimeMs).toISOString();
 
       sessions.push({
         provider: "cursor",
@@ -2077,7 +2085,7 @@ function buildCursorStoreResult(
     model:
       normalizeCursorModelName(metaJson.lastUsedModel) ||
       turnStats.find((stat) => typeof stat.model === "string" && stat.model)?.model,
-    startTime: metaJson.createdAt ? new Date(metaJson.createdAt).toISOString() : undefined,
+    startTime: toIsoTimestamp(metaJson.createdAt),
     ...(totalDurationMs !== undefined ? { totalDurationMs } : {}),
     ...(turnStats.length > 0 ? { turnStats } : {}),
     turns,

--- a/packages/provider-cursor/test/sqlite-reader.test.ts
+++ b/packages/provider-cursor/test/sqlite-reader.test.ts
@@ -97,6 +97,21 @@ describe("Cursor compaction metadata", () => {
   });
 });
 
+describe("Cursor timestamp normalization", () => {
+  it("does not treat request-relative timing as a 1970 session timestamp", () => {
+    expect(
+      __testables.bubbleTimestamp({
+        timingInfo: { clientStartTime: 3568.9 },
+      }),
+    ).toBeUndefined();
+    expect(
+      __testables.bubbleTimestamp({
+        timingInfo: { clientStartTime: 3568.9, clientEndTime: 1_754_501_490_954 },
+      }),
+    ).toBe("2025-08-06T17:31:30.954Z");
+  });
+});
+
 describe("countComposerConversationHeaders", () => {
   it("returns zero when headers are missing", () => {
     expect(countComposerConversationHeaders({})).toBe(0);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -99,6 +99,8 @@ interface ScanResultsPayload {
   results: SessionScanData[] | null;
   /** When the last full background scan finished (global, not per-session). */
   finishedAt?: string;
+  /** Result generation used to reject responses from an older scan. */
+  revision?: number;
 }
 let scanResultsCache: ScanResultsPayload | null = null;
 let scanResultsFetchPromise: Promise<ScanResultsPayload | null> | null = null;
@@ -123,6 +125,7 @@ function fetchScanResults(forceRefresh = false): Promise<ScanResultsPayload | nu
       const payload: ScanResultsPayload = {
         results: data?.results ?? null,
         finishedAt: data?.finishedAt,
+        revision: data?.revision,
       };
       scanResultsCache = payload;
       // Invalidate after 30s so fresh data can come in
@@ -2377,6 +2380,15 @@ function SessionsPanel() {
       // facets do not stay blind to newly indexed usage for 30 seconds.
       const payload = await fetchScanResults(refresh);
       if (cancelled || !payload?.results) return;
+      // A scan can finish between the status poll and this response. Never
+      // let an older generation replace facets for the newer revision.
+      if (
+        payload.revision !== undefined &&
+        scanStatus?.revision !== undefined &&
+        payload.revision !== scanStatus.revision
+      ) {
+        return;
+      }
       setScanFinishedAt(payload.finishedAt ?? null);
       setScanResultsIndex(buildSessionScanIndex(payload.results));
     };
@@ -4302,6 +4314,13 @@ function ReplaysPanel() {
     const loadScanResults = async (refresh = false) => {
       const payload = await fetchScanResults(refresh);
       if (cancelled || !payload?.results) return;
+      if (
+        payload.revision !== undefined &&
+        scanStatus?.revision !== undefined &&
+        payload.revision !== scanStatus.revision
+      ) {
+        return;
+      }
       setScanResultsIndex(buildSessionScanIndex(payload.results));
     };
     void loadScanResults(forceRefresh);

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -113,7 +113,7 @@ function fetchScanResults(forceRefresh = false): Promise<ScanResultsPayload | nu
   if (scanResultsCache) return Promise.resolve(scanResultsCache);
   if (scanResultsFetchPromise) return scanResultsFetchPromise;
   const requestVersion = ++scanResultsRequestVersion;
-  const request = fetch("/api/scan/results")
+  const request = fetch("/api/scan/results", { cache: "no-store" })
     .then((r) => (r.ok ? r.json() : null))
     .then((data) => {
       // A usage-backfill refresh may have superseded this request while it was
@@ -397,7 +397,9 @@ function RawJsonModal({
     setLoadingId(itemId);
     setRemoteErrors((prev) => ({ ...prev, [itemId]: "" }));
     const targetQuery = targetId ? `&targetId=${encodeURIComponent(targetId)}` : "";
-    fetch(`/api/session?slug=${encodeURIComponent(fetchReplaySlug)}${targetQuery}`)
+    fetch(`/api/session?slug=${encodeURIComponent(fetchReplaySlug)}${targetQuery}`, {
+      cache: "no-store",
+    })
       .then(async (resp) => {
         const data = await resp.json().catch(() => null);
         if (!resp.ok) throw new Error(data?.error || "Failed to load replay JSON");
@@ -2189,7 +2191,11 @@ function SessionsPanel() {
     source: SourceSession;
     scanData: SessionScanData | null;
   } | null>(null);
-  const scanResultsRefreshRef = useRef({ running: false, usageBackfillKey: "none" });
+  const scanResultsRefreshRef = useRef({
+    running: false,
+    usageBackfillKey: "none",
+    revision: undefined as number | undefined,
+  });
   // When another panel (Projects → Timeline / Hot Files) opens a session via
   // the `vibe-open-session` event, route the slug into the popup. Two paths:
   //   1. If SessionsPanel just mounted (e.g. tab switched from Projects),
@@ -2286,13 +2292,13 @@ function SessionsPanel() {
     setRefreshing(false);
     setStaleCachedAt(null);
 
-    const archive = await fetch("/api/archived")
+    const archive = await fetch("/api/archived", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : { slugs: [] }))
       .catch(() => ({ slugs: [] as string[] }));
     setArchivedSlugs(new Set(archive.slugs));
 
     let servedFromCache = false;
-    const cached = await fetch("/api/sources/cached")
+    const cached = await fetch("/api/sources/cached", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .catch(() => null);
     setFailedRemoteSources(remoteSourceFailureIds(cached));
@@ -2358,8 +2364,13 @@ function SessionsPanel() {
     const scanRunning = scanStatus?.running === true;
     const forceRefresh =
       scanResultsRefreshRef.current.running !== scanRunning ||
-      scanResultsRefreshRef.current.usageBackfillKey !== usageBackfillKey;
-    scanResultsRefreshRef.current = { running: scanRunning, usageBackfillKey };
+      scanResultsRefreshRef.current.usageBackfillKey !== usageBackfillKey ||
+      scanResultsRefreshRef.current.revision !== scanStatus?.revision;
+    scanResultsRefreshRef.current = {
+      running: scanRunning,
+      usageBackfillKey,
+      revision: scanStatus?.revision,
+    };
     const loadScanResults = async (refresh = false) => {
       // The fast pass and usage backfill both update the same result endpoint;
       // invalidate the short-lived module cache when that phase changes so
@@ -2380,7 +2391,7 @@ function SessionsPanel() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [scanStatus?.running, usageBackfillKey, sources.length]);
+  }, [scanStatus?.running, scanStatus?.revision, usageBackfillKey, sources.length]);
 
   useEffect(() => {
     if (!loading && !hasCursorSources && !wasEnrichingRef.current) return;
@@ -2388,7 +2399,7 @@ function SessionsPanel() {
     let cancelled = false;
     let timer: number | undefined;
     const refreshSourcesFromCache = async () => {
-      const payload = await fetch("/api/sources/cached")
+      const payload = await fetch("/api/sources/cached", { cache: "no-store" })
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
       const cached = parseCachedList<SourceSession>(payload);
@@ -2397,7 +2408,7 @@ function SessionsPanel() {
       }
     };
     const poll = async () => {
-      const status = await fetch("/api/sources/enrichment-status")
+      const status = await fetch("/api/sources/enrichment-status", { cache: "no-store" })
         .then((r) => (r.ok ? (r.json() as Promise<SourcesEnrichmentStatus>) : null))
         .catch(() => null);
       if (!status || cancelled) return;
@@ -4185,7 +4196,11 @@ function ReplaysPanel() {
       ? "running"
       : "done"
     : "none";
-  const scanResultsRefreshRef = useRef({ running: false, usageBackfillKey: "none" });
+  const scanResultsRefreshRef = useRef({
+    running: false,
+    usageBackfillKey: "none",
+    revision: undefined as number | undefined,
+  });
 
   // Roll worktree paths up to the parent project so URL navigation to a
   // (possibly cleaned-up) worktree path still hits the parent's data.
@@ -4209,7 +4224,7 @@ function ReplaysPanel() {
       setRefreshing(false);
       setStaleCachedAt(null);
 
-      const archive = await fetch("/api/archived")
+      const archive = await fetch("/api/archived", { cache: "no-store" })
         .then((r) => (r.ok ? r.json() : { slugs: [] }))
         .catch(() => ({ slugs: [] as string[] }));
       if (mounted) {
@@ -4217,7 +4232,7 @@ function ReplaysPanel() {
       }
 
       let servedFromCache = false;
-      const cached = await fetch("/api/sessions/cached")
+      const cached = await fetch("/api/sessions/cached", { cache: "no-store" })
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
       const cachedData = parseCachedList<SessionSummary>(cached);
@@ -4277,8 +4292,13 @@ function ReplaysPanel() {
     const scanRunning = scanStatus?.running === true;
     const forceRefresh =
       scanResultsRefreshRef.current.running !== scanRunning ||
-      scanResultsRefreshRef.current.usageBackfillKey !== usageBackfillKey;
-    scanResultsRefreshRef.current = { running: scanRunning, usageBackfillKey };
+      scanResultsRefreshRef.current.usageBackfillKey !== usageBackfillKey ||
+      scanResultsRefreshRef.current.revision !== scanStatus?.revision;
+    scanResultsRefreshRef.current = {
+      running: scanRunning,
+      usageBackfillKey,
+      revision: scanStatus?.revision,
+    };
     const loadScanResults = async (refresh = false) => {
       const payload = await fetchScanResults(refresh);
       if (cancelled || !payload?.results) return;
@@ -4295,7 +4315,7 @@ function ReplaysPanel() {
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [scanStatus?.running, usageBackfillKey, sessions.length]);
+  }, [scanStatus?.running, scanStatus?.revision, usageBackfillKey, sessions.length]);
 
   useEffect(() => {
     const timer = window.setInterval(() => setRefreshClockMs(Date.now()), 30_000);

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -265,9 +265,10 @@ function formatCost(cost: number): string {
   return `$${Math.round(cost)}`;
 }
 
-function formatCompactNum(n: number): string {
-  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`;
-  return n.toLocaleString();
+export function formatCompactNum(n: number): string {
+  const rounded = Math.round(n);
+  if (rounded >= 10000) return `${(rounded / 1000).toFixed(1)}k`;
+  return rounded.toLocaleString();
 }
 
 function buildAggregateMetricQuality(notes: string[] | undefined): {
@@ -1385,7 +1386,7 @@ function useInsightsRollup(scanFinishedAt?: string, scanRevision?: number) {
     let stopped = false;
     setLoading(true);
     setError(false);
-    fetch("/api/insights/rollup")
+    fetch("/api/insights/rollup", { cache: "no-store" })
       .then(async (r) => {
         if (!r.ok) throw new Error(`Insights rollup request failed: ${r.status}`);
         return (await r.json()) as InsightsRollupPayload;
@@ -1427,7 +1428,7 @@ function useUsageRollupSessions(
 
   useEffect(() => {
     let stopped = false;
-    fetch("/api/usage/rollup")
+    fetch("/api/usage/rollup", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: UsageRollupPayload | null) => {
         if (!stopped && data?.sessions) setPayload(data);

--- a/packages/viewer/src/components/InsightsPanel.tsx
+++ b/packages/viewer/src/components/InsightsPanel.tsx
@@ -233,7 +233,7 @@ export function ScanInsightsProvider({ children }: { children: ReactNode }) {
 
     const scheduleRefresh = async () => {
       try {
-        const resp = await fetch("/api/scan/status");
+        const resp = await fetch("/api/scan/status", { cache: "no-store" });
         if (!resp.ok || stopped) return;
         const status = (await resp.json()) as ScanStatus;
         setScanStatus(status);
@@ -270,7 +270,7 @@ export function ScanInsightsProvider({ children }: { children: ReactNode }) {
 
     const poll = async () => {
       try {
-        const resp = await fetch("/api/scan/status");
+        const resp = await fetch("/api/scan/status", { cache: "no-store" });
         if (!resp.ok || stopped) return null;
         const status = (await resp.json()) as ScanStatus;
         setScanStatus(status);
@@ -283,7 +283,7 @@ export function ScanInsightsProvider({ children }: { children: ReactNode }) {
     const fetchUserInsights = async () => {
       setLoading(true);
       try {
-        const resp = await fetch("/api/insights");
+        const resp = await fetch("/api/insights", { cache: "no-store" });
         if (resp.ok) {
           const data = await resp.json();
           if (data.type === "user" && !stopped) {
@@ -349,7 +349,9 @@ export function ScanInsightsProvider({ children }: { children: ReactNode }) {
       if (projectInsightsCache.has(cacheKey) && !staleCacheRef.current) return;
       setLoading(true);
       const targetQuery = targetId ? `&targetId=${encodeURIComponent(targetId)}` : "";
-      fetch(`/api/insights?project=${encodeURIComponent(project)}${targetQuery}`)
+      fetch(`/api/insights?project=${encodeURIComponent(project)}${targetQuery}`, {
+        cache: "no-store",
+      })
         .then((resp) => (resp.ok ? resp.json() : null))
         .then((data) => {
           if (data?.type === "project") {

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -7,6 +7,7 @@ import {
   navigateToUsageSessions,
   TopProjectsList,
   CoverageAudit,
+  formatCompactNum,
   UsageBarList,
   UsageCoverage,
 } from "../InsightsPage";
@@ -88,6 +89,13 @@ describe("UsageBarList", () => {
     const params = new URLSearchParams(window.location.search);
     expect(params.get("mcpTool")).toBe(value);
     expect(getMultiFromUrl("mcpTool")).toEqual([value]);
+  });
+});
+
+describe("insight metric formatting", () => {
+  it("rounds animated intermediate values so metric cards cannot overflow", () => {
+    expect(formatCompactNum(555.225)).toBe("555");
+    expect(formatCompactNum(158_900.4)).toBe("158.9k");
   });
 });
 


### PR DESCRIPTION
## Summary
- Prevent browser/proxy caching from leaving Insights, scan facets, and replay/source data stale after background scans.
- Refresh Dashboard scan results when the scan revision changes so token/cache/MCP facets match Coverage.
- Normalize Cursor request-relative timing fields and invalidate scanner caches to prevent fake 1970 dates and incorrect coding-age metrics.
- Round animated metric values so 30d/90d Insights cards remain readable while numbers transition.

## Validation
- [x] Screenshot QA: Home, Sessions, Replays, Replay Insights, Share & Export, Projects Overview/Timeline/Hot Files
- [x] Screenshot QA: Insights 7d/30d/90d/All and tool/MCP/cache/compaction drilldowns
- [x] `VIBE_REPLAY_CONFIG=/dev/null pnpm verify`
- [x] `pnpm test:e2e`
- [x] Cursor timestamp regression test
- [x] No browser console errors or page errors in manual QA

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session timestamps that could incorrectly appear as dates in 1970.
  * Improved scan result and insights freshness by preventing stale cached responses.
  * Ensured dashboard panels refresh when scan results change.
  * Fixed metric formatting so rounded values display correctly without overflow.
* **Improvements**
  * Existing cached sessions are rescanned to apply updated timestamp handling.
* **Tests**
  * Added coverage for timestamp validation and rounded insight metric formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->