### PR TITLE
fix(pi): filesystem-aware decode for hyphenated project dirs

### DIFF
--- a/packages/provider-pi/src/pi/discover.ts
+++ b/packages/provider-pi/src/pi/discover.ts
@@ -8,6 +8,8 @@ import { readGitRepo } from "@vibe-replay/provider-core/utils";
 import { getPiSessionsDir } from "./config.js";
 const PROMPT_SCAN_LIMIT = 2;
 
+const decodedProjectDirCache = new Map<string, string | Promise<string>>();
+
 interface PiSessionHeader {
   type: "session";
   version?: number;
@@ -187,7 +189,7 @@ async function extractPiSessionInfo(
   const sessionId = header?.id || basename(filePath, ".jsonl");
   if (!sessionId) return null;
 
-  const cwd = header?.cwd || decodeProjectDir(encodedProjectDir);
+  const cwd = header?.cwd || (await decodeProjectDir(encodedProjectDir));
   const gitRepo = resolveGitRepo ? await readGitRepo(cwd) : undefined;
   const slug = basename(filePath, ".jsonl").replace(/^\d{4}-\d{2}-\d{2}T[^_]+_/, "");
   const fallbackTimestamp =
@@ -222,11 +224,93 @@ async function extractPiSessionInfo(
   };
 }
 
-function decodeProjectDir(encoded: string): string {
+export async function decodeProjectDir(encoded: string): Promise<string> {
+  const cached = decodedProjectDirCache.get(encoded);
+  if (cached !== undefined) return cached;
+  const promise = decodeProjectDirUncached(encoded)
+    .catch((error) => {
+      decodedProjectDirCache.delete(encoded);
+      throw error;
+    })
+    .then((value) => {
+      decodedProjectDirCache.set(encoded, value);
+      return value;
+    });
+  decodedProjectDirCache.set(encoded, promise);
+  return promise;
+}
+
+async function decodeProjectDirUncached(encoded: string): Promise<string> {
   if (encoded.startsWith("--") && encoded.endsWith("--")) {
-    return `/${encoded.slice(2, -2).replace(/-/g, "/")}`;
+    const inner = encoded.slice(2, -2);
+    const parts = inner.split("-");
+    const resolved = await resolveEncodedProjectParts(parts, 0, "");
+    if (resolved) return joinUnresolvedRemainder(resolved, parts, "/");
+    return `/${inner.replace(/-/g, "/")}`;
   }
   return encoded;
+}
+
+export function clearDecodedProjectDirCache(): void {
+  decodedProjectDirCache.clear();
+}
+
+interface PartialResolution {
+  path: string;
+  nextIdx: number;
+}
+
+function joinUnresolvedRemainder(
+  resolved: PartialResolution,
+  parts: string[],
+  separator: string,
+): string {
+  if (resolved.nextIdx >= parts.length) return resolved.path;
+  const remainder = parts.slice(resolved.nextIdx).join("-");
+  return resolved.path.endsWith(separator)
+    ? `${resolved.path}${remainder}`
+    : `${resolved.path}${separator}${remainder}`;
+}
+
+async function resolveEncodedProjectParts(
+  parts: string[],
+  idx: number,
+  current: string,
+): Promise<PartialResolution | null> {
+  if (idx >= parts.length) {
+    const candidate = current || "/";
+    const currentStat = await stat(candidate).catch(() => null);
+    return currentStat?.isDirectory() ? { path: candidate, nextIdx: idx } : null;
+  }
+
+  const probePath = current || "/";
+  const entries = await readdir(probePath, { withFileTypes: true }).catch(() => []);
+  if (entries.length === 0) return null;
+
+  const dirNames = new Set(
+    entries
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .map((entry) => entry.name),
+  );
+
+  let deepest: PartialResolution | null = null;
+
+  for (let end = idx + 1; end <= parts.length; end++) {
+    const candidate = parts.slice(idx, end).join("-");
+    const actual = dirNames.has(candidate)
+      ? candidate
+      : dirNames.has(`.${candidate}`)
+        ? `.${candidate}`
+        : null;
+    const candidatePath = join(probePath, actual ?? candidate);
+    if (!actual) continue;
+    const resolved = await resolveEncodedProjectParts(parts, end, candidatePath);
+    if (resolved?.nextIdx === parts.length) return resolved;
+    const best = resolved ?? { path: candidatePath, nextIdx: end };
+    if (!deepest || best.nextIdx > deepest.nextIdx) deepest = best;
+  }
+
+  return deepest;
 }
 
 function extractText(content: unknown): string {

--- a/packages/provider-pi/test/discover.test.ts
+++ b/packages/provider-pi/test/discover.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { discoverPiSessions } from "../src/pi/discover.js";
+import {
+  clearDecodedProjectDirCache,
+  decodeProjectDir,
+  discoverPiSessions,
+} from "../src/pi/discover.js";
 
 const originalSessionDir = process.env.PI_CODING_AGENT_SESSION_DIR;
 const tempDirs: string[] = [];
@@ -10,6 +14,7 @@ const tempDirs: string[] = [];
 afterEach(async () => {
   if (originalSessionDir === undefined) delete process.env.PI_CODING_AGENT_SESSION_DIR;
   else process.env.PI_CODING_AGENT_SESSION_DIR = originalSessionDir;
+  clearDecodedProjectDirCache();
   for (const dir of tempDirs.splice(0)) {
     await rm(dir, { recursive: true, force: true });
   }
@@ -120,5 +125,55 @@ describe("discoverPiSessions", () => {
       timestamp: mtime.toISOString(),
       transcriptStatus: "unreadable",
     });
+  });
+
+  it("decodes hyphenated project dirs without splitting segment names", async () => {
+    // vibe-replay and tuo-lei-com contain hyphens that naive split would break
+    const tmpRoot = await mkdtemp(join(tmpdir(), "vibe-pi-decode-"));
+    tempDirs.push(tmpRoot);
+    // Create real directories so filesystem-aware decode can resolve them
+    const realProject = join(tmpRoot, "real-fs");
+    await mkdir(join(realProject, "Code", "vibe-replay"), { recursive: true });
+    await mkdir(join(realProject, "Code", "tuo-lei-com"), { recursive: true });
+
+    // Simulate Pi encoding: the directory name is the encoded path
+    // For /tmp/.../real-fs/Code/vibe-replay -> encode as --tmp-...-real-fs-Code-vibe-replay--
+    // But decodeProjectDir walks from / so we test the inner split logic directly
+    // by using a real path that exists under /
+    const decoded1 = await decodeProjectDir("--Users-tuo-Code-vibe-replay--");
+    // On this machine /Users/tuo/Code/vibe-replay exists, so it should resolve correctly
+    // If the filesystem walk fails (e.g. in CI without that path), fallback is naive
+    // At minimum it should not crash and should return a string starting with /
+    expect(typeof decoded1).toBe("string");
+    expect(decoded1.startsWith("/")).toBe(true);
+
+    // Direct hyphen preservation: create a temp structure to test deterministically
+    const encoded = `--${realProject.replace(/^\//, "").replace(/\//g, "-")}--`;
+    // Create the session dir structure Pi uses
+    const sessionsRoot = await mkdtemp(join(tmpdir(), "vibe-pi-sessions-"));
+    tempDirs.push(sessionsRoot);
+    const vibeProjectDir = join(
+      sessionsRoot,
+      `--${join(realProject, "Code", "vibe-replay").replace(/^\//, "").replace(/\//g, "-")}--`,
+    );
+    await mkdir(vibeProjectDir, { recursive: true });
+    await writeFile(
+      join(vibeProjectDir, "2026-01-01T00-00-00-000Z_test.jsonl"),
+      `${JSON.stringify({ type: "session", version: 3, id: "hyphen-test", timestamp: "2026-01-01T00:00:00.000Z" })}\n${JSON.stringify({ type: "message", timestamp: "2026-01-01T00:00:01.000Z", message: { role: "user", content: [{ type: "text", text: "hello" }] } })}\n`,
+      "utf-8",
+    );
+    clearDecodedProjectDirCache();
+    const sessions = await discoverPiSessions(sessionsRoot, false, false);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].project).toBe(join(realProject, "Code", "vibe-replay"));
+    expect(sessions[0].cwd).toBe(join(realProject, "Code", "vibe-replay"));
+
+    void encoded;
+  });
+
+  it("falls back to naive decode when filesystem walk finds no match", async () => {
+    clearDecodedProjectDirCache();
+    const decoded = await decodeProjectDir("--nonexistent-path-with-dashes--");
+    expect(decoded).toBe("/nonexistent/path/with/dashes");
   });
 });


### PR DESCRIPTION
## Summary

Local data audit on 179 opencode + 115 hermes + 12 pi sessions (306 total) found one concrete indexing bug and verified the rest of the recent feature surface is healthy.

**Bug fixed:** Pi `decodeProjectDir` used a naive `replace(/-/g, "/")` which splits hyphenated directory names. `--Users-tuo-Code-vibe-replay--` decoded to `/Users/tuo/Code/vibe/replay` and `--Users-tuo-Code-tuo-lei-com--` to `/Users/tuo/Code/tuo/lei/com`. Currently masked because every local Pi session carries `header.cwd`, so the fallback is unused — but any session without a header (corrupt/truncated JSONL, future Pi versions, manual session dirs) would show a wrong project and break dashboard grouping + replay `project`/`cwd`.

**Fix:** Walk the real filesystem like `provider-cursor` does: try slash boundaries that match actual directory entries (including `.<name>` for dotfiles), keep the deepest valid prefix, and join any unresolved remainder as one segment so deleted workspaces and UUID-tailed dirs aren't shredded. Added in-memory caching (`clearDecodedProjectDirCache` exported for tests) and fallback to the naive replace when the walk finds no match.

## Audit findings (healthy)

- **Discovery:** opencode 179, hermes 115, pi 12 — all discovered via their providers.
- **Scanner:** `scanSession` succeeds for all sampled sessions (opencode/hermes SQLite-backed + pi JSONL), including `buildLightweight*` fallbacks, compaction counts, `usageIndexed`, and `dataQualityNotes`.
- **Replay generation:** `parse*Session` + `transformToReplay` produces valid scenes for sampled sessions of each provider.
- **Recent features:** scanner v33, insights rollups, custom provider endpoint hardening, AI Studio embedding, and SSH settings show no breakage against local data. `pnpm test` (461 cli + 332 viewer + provider suites), `pnpm lint:check`, `pnpm typecheck`, and `pnpm build` all pass.

## Tests

- Added `provider-pi` discover tests: hyphenated dirs via real temp filesystem dirs, plus fallback path.
- Verified locally with `decodeProjectDir("--Users-tuo-Code-vibe-replay--") === "/Users/tuo/Code/vibe-replay"`.

## Checklist

- [x] `pnpm lint:check` — pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm test` — pass
- [x] `pnpm build` — pass
- [x] Manual local-data verification (see above)