### PR TITLE
docs: refresh CLI help and website Features for recent changes

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,14 +80,23 @@ https://your-host/viewer.html?url=https://example.com/replay.json
 ## Options
 
 ```
-Usage: vibe-replay [options]
+Usage: vibe-replay [options] [command]
 
 Options:
-  -s, --session <path>    Path to a specific JSONL session file
-  -p, --provider <name>   Provider name (default: claude-code; supports pi)
-  --dev                   Write demo.json for HMR development
   -V, --version           Output the version number
-  -h, --help              Display help
+  -s, --session <path>    Path to a specific JSONL session file
+  -p, --provider <name>   Provider name (default: claude-code)
+  -t, --title <name>      Custom title for the replay
+  -d, --dashboard         Open dashboard directly (skip picker)
+  --open                  After generation, open in browser and exit
+  --github                Generate GitHub export and exit
+  -h, --help              Display help for command
+
+Commands:
+  sessions [options]      Search local sessions (agent-friendly)
+  auth                    Manage authentication
+  share [options] [path]  Share a replay via cloud
+  live [options]          Watch a running session live
 ```
 
 ## Search Local Sessions

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -2,7 +2,7 @@
 const features = [
   {
     title: "Zero config, one command",
-    desc: "No setup, no account, no config files. Just run npx vibe-replay and pick a session. Works instantly with your existing Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions.",
+    desc: "No setup, no account, no config files. Just run npx vibe-replay and pick a session. Works instantly with local Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions — plus remote Codex/Claude Code/Pi hosts over SSH and the embedded AI Studio (no external CLI required).",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" /></svg>`,
   },
   {
@@ -17,7 +17,7 @@ const features = [
   },
   {
     title: "Personal insights dashboard",
-    desc: "Your AI coding wrapped: GitHub-style activity heatmap, streaks, weekly trends, top projects, model usage, and cost tracking. Browse all sessions across projects with the local dashboard.",
+    desc: "Your AI coding wrapped: GitHub-style heatmap, streaks, weekly trends, top projects, model usage, and cost tracking — with drilldowns by provider, tool, MCP server, and time range. Works for local sessions and remote SSH sources alike.",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" /></svg>`,
   },
   {


### PR DESCRIPTION
## Summary

Small doc/website sync for changes since the last `chore(website): refresh` (#450).

- **`packages/cli/README.md` `Options`** now matches `vibe-replay --help`: `-t`/`-d`/`--open`/`--github` and commands `sessions`/`auth`/`share`/`live`. The old `--dev`-only block was stale.
- **`website/src/components/Features.astro`** — `Zero config` now mentions local + remote (SSH) sources and the embedded AI Studio; `Personal insights dashboard` now mentions drilldowns by provider/tool/MCP server/time range and that it covers both local and remote sessions. Keeps the marketing copy aligned with the SSH/AI Studio/insights work.

No functional code changes. `pnpm lint` / `oxfmt` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CLI usage guide to reflect the command-based interface and current options.
  - Added documentation for the `sessions`, `auth`, `share`, and `live` commands.
  - Clarified provider defaults and removed outdated option references.

- **Website**
  - Expanded feature descriptions to highlight remote SSH support for Codex, Claude Code, and Pi.
  - Documented AI Studio availability and dashboard drilldowns by provider, tool, MCP server, and time range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->