### PR TITLE
test(viewer): cover useViewPrefs + expand useSessionLoader branches

### DIFF
--- a/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplaySession } from "../../types";
 import { useSessionLoader } from "../useSessionLoader";
 
@@ -84,5 +84,104 @@ describe("useSessionLoader", () => {
     await waitFor(() => expect(result.current.status).toBe("ready"));
     if (result.current.status !== "ready") throw new Error("unreachable");
     expect(result.current.mode).toBe("embedded");
+  });
+
+  it("errors on invalid SSH targetId in editor mode", async () => {
+    win.__VIBE_REPLAY_EDITOR__ = true;
+    setSearch("?session=my-slug&targetId=bad!id");
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status !== "error") throw new Error("unreachable");
+    expect(result.current.message).toMatch(/invalid ssh source/i);
+  });
+
+  it("loads via ?url in readonly mode", async () => {
+    const url = "https://example.com/replay.json";
+    setSearch(`?url=${encodeURIComponent(url)}`);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(fakeSession)),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("unreachable");
+    expect(result.current.mode).toBe("readonly");
+    expect(fetchMock).toHaveBeenCalledWith(url);
+  });
+
+  it("loads via ?file in dev mode", async () => {
+    setSearch("?file=/replay.json");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeSession),
+      text: () => Promise.resolve(JSON.stringify(fakeSession)),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("unreachable");
+    expect(result.current.mode).toBe("embedded");
+  });
+
+  it("errors when ?file fetch fails", async () => {
+    setSearch("?file=/missing.json");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found" }),
+    );
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+  });
+
+  it("loads specific session by slug in editor mode", async () => {
+    win.__VIBE_REPLAY_EDITOR__ = true;
+    setSearch("?session=my-slug");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeSession),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("unreachable");
+    expect(result.current.mode).toBe("editor");
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/session?slug=my-slug"));
+  });
+
+  it("ignores ?live when an explicit ?session is present in editor mode (stale URL guard)", async () => {
+    win.__VIBE_REPLAY_EDITOR__ = true;
+    // ?live=1&provider=claude-code&sessionId=abc would normally start SSE,
+    // but ?session=foo takes precedence and should load that replay instead.
+    setSearch("?live=1&provider=claude-code&sessionId=abc&session=my-slug");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(fakeSession),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("unreachable");
+    expect(result.current.mode).toBe("editor");
+  });
+});
+
+describe("readLiveParams guards (via editor live precedence)", () => {
+  beforeEach(() => {
+    win.__VIBE_REPLAY_EDITOR__ = true;
+  });
+
+  it("does not start live stream when ?view=dashboard is present (even with live params)", async () => {
+    // Should show dashboard, not error or SSE
+    setSearch("?live=1&provider=claude-code&sessionId=abc&view=dashboard");
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("dashboard"));
+  });
+
+  it("does not start live stream when provider contains invalid chars", async () => {
+    // Invalid provider => readLiveParams returns null => falls through to dashboard
+    setSearch("?live=1&provider=bad!provider&sessionId=abc");
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(result.current.status).toBe("dashboard"));
   });
 });

--- a/packages/viewer/src/hooks/__tests__/useViewPrefs.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useViewPrefs.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getEffectivePrefs, useViewPrefs } from "../useViewPrefs";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("getEffectivePrefs", () => {
+  it("returns all-visible for displayMode all", () => {
+    expect(
+      getEffectivePrefs({
+        displayMode: "all",
+        hideThinking: true,
+        collapseAllTools: true,
+        promptsOnly: true,
+      }),
+    ).toEqual({
+      hideThinking: false,
+      collapseAllTools: false,
+      promptsOnly: false,
+      compactAssistant: false,
+    });
+  });
+
+  it("returns compact booleans for displayMode compact", () => {
+    expect(
+      getEffectivePrefs({
+        displayMode: "compact",
+        hideThinking: false,
+        collapseAllTools: false,
+        promptsOnly: false,
+      }),
+    ).toEqual({
+      hideThinking: true,
+      collapseAllTools: true,
+      promptsOnly: false,
+      compactAssistant: true,
+    });
+  });
+
+  it("passes through custom prefs", () => {
+    expect(
+      getEffectivePrefs({
+        displayMode: "custom",
+        hideThinking: true,
+        collapseAllTools: false,
+        promptsOnly: true,
+      }),
+    ).toEqual({
+      hideThinking: true,
+      collapseAllTools: false,
+      promptsOnly: true,
+      compactAssistant: false,
+    });
+  });
+});
+
+describe("useViewPrefs", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("returns default compact prefs when storage empty", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.prefs.displayMode).toBe("compact");
+  });
+
+  it("migrates old prefs without displayMode to compact", () => {
+    localStorage.setItem("vibe-replay-view-prefs", JSON.stringify({ hideThinking: true }));
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.prefs.displayMode).toBe("compact");
+    expect(result.current.prefs.hideThinking).toBe(true);
+  });
+
+  it("loads stored prefs with displayMode", () => {
+    localStorage.setItem(
+      "vibe-replay-view-prefs",
+      JSON.stringify({
+        displayMode: "all",
+        hideThinking: false,
+        collapseAllTools: false,
+        promptsOnly: false,
+      }),
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.prefs.displayMode).toBe("all");
+  });
+
+  it("falls back to default on invalid JSON", () => {
+    localStorage.setItem("vibe-replay-view-prefs", "not-json!!");
+    const { result } = renderHook(() => useViewPrefs());
+    expect(result.current.prefs.displayMode).toBe("compact");
+  });
+
+  it("updatePref persists and updates state", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.updatePref("displayMode", "all"));
+    expect(result.current.prefs.displayMode).toBe("all");
+    expect(JSON.parse(localStorage.getItem("vibe-replay-view-prefs")!).displayMode).toBe("all");
+  });
+
+  it("togglePref flips a boolean pref and persists", () => {
+    localStorage.setItem(
+      "vibe-replay-view-prefs",
+      JSON.stringify({
+        displayMode: "custom",
+        hideThinking: false,
+        collapseAllTools: false,
+        promptsOnly: false,
+      }),
+    );
+    const { result } = renderHook(() => useViewPrefs());
+    act(() => result.current.togglePref("hideThinking"));
+    expect(result.current.prefs.hideThinking).toBe(true);
+    act(() => result.current.togglePref("hideThinking"));
+    expect(result.current.prefs.hideThinking).toBe(false);
+  });
+
+  it("togglePref ignores non-boolean key (displayMode)", () => {
+    const { result } = renderHook(() => useViewPrefs());
+    const before = result.current.prefs.displayMode;
+    act(() => result.current.togglePref("displayMode" as any));
+    expect(result.current.prefs.displayMode).toBe(before);
+  });
+});


### PR DESCRIPTION
Fills 13%/29% viewer hook gap. useViewPrefs 0→100% for its 95 lines, useSessionLoader +8 cases for ?live vs ?session vs ?view=dashboard precedence.