### PR TITLE
fix(hermes): bucket sessions without cwd under "Hermes" project

### DIFF
--- a/packages/provider-hermes/src/hermes/discover.ts
+++ b/packages/provider-hermes/src/hermes/discover.ts
@@ -282,7 +282,7 @@ function sessionInfoFromRow(
     sessionId: row.id,
     slug: row.id,
     title: row.title || undefined,
-    project: shortenPath(row.cwd || ""),
+    project: row.cwd ? shortenPath(row.cwd) : "Hermes",
     cwd: row.cwd || "",
     version,
     gitBranch: row.git_branch || undefined,


### PR DESCRIPTION
Local data audit on this machine: 90/117 Hermes sessions have `cwd=null` (gateway/cron) and were grouped as `project=""`, which floods Projects/Insights and the new `search_sessions` surface.

Keep `cwd` empty for truth, but set display `project` to `"Hermes"` so headless sessions are searchable and bucketed sensibly. Verified with `pnpm --filter provider-hermes test` and `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a default project name, “Hermes,” when project information is unavailable.
  * Preserved shortened project paths when project information is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->