### PR TITLE
fix(viewer): nudge Ask FAB and clarify Custom OpenAI gateway copy

### DIFF
--- a/packages/viewer/src/components/AiProviderSettings.tsx
+++ b/packages/viewer/src/components/AiProviderSettings.tsx
@@ -264,7 +264,7 @@ export function AiProviderSettings({
     type: "success" | "error";
     text: string;
   } | null>(null);
-  const [customName, setCustomName] = useState("Local LiteLLM");
+  const [customName, setCustomName] = useState("Custom gateway");
   const [customBaseUrl, setCustomBaseUrl] = useState("http://127.0.0.1:58788/v1");
   const [customApiKey, setCustomApiKey] = useState("");
   const [customRunning, setCustomRunning] = useState(false);
@@ -619,7 +619,9 @@ export function AiProviderSettings({
         </div>
         <p className="text-[10px] font-mono leading-relaxed text-terminal-dimmer">
           Discover models from <code>/models</code> (or <code>/model</code>) and use Chat
-          Completions. LiteLLM and local OpenAI-compatible gateways work here.
+          Completions. Any OpenAI-compatible gateway works — local LiteLLM / Ollama / vLLM or remote{" "}
+          <code>https://</code> endpoint. Plain <code>http://</code> is only allowed for loopback (
+          <code>127.0.0.1</code> / <code>localhost</code>).
         </p>
         <input
           aria-label="Custom AI provider name"

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -267,6 +267,7 @@ export default function LocalChatAssistant({ context }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [panelSize, setPanelSize] = useState<PanelSize>(DEFAULT_PANEL_SIZE);
   const [resizing, setResizing] = useState(false);
+  const [nudge, setNudge] = useState(false);
   const controllerRef = useRef<AbortController | null>(null);
   const resizeStartRef = useRef<
     { x: number; y: number; width: number; height: number; edges: ResizeEdges } | undefined
@@ -299,6 +300,18 @@ export default function LocalChatAssistant({ context }: Props) {
   useEffect(() => {
     setPanelSize(readPanelSize());
   }, []);
+
+  // Subtle periodic nudge so first-time users notice the FAB is tappable.
+  // Respects prefers-reduced-motion and pauses while open/hovered.
+  useEffect(() => {
+    if (open) return;
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
+    const id = window.setInterval(() => {
+      setNudge(true);
+      window.setTimeout(() => setNudge(false), 650);
+    }, 5200);
+    return () => window.clearInterval(id);
+  }, [open]);
 
   useEffect(() => {
     try {
@@ -904,14 +917,19 @@ export default function LocalChatAssistant({ context }: Props) {
         <button
           type="button"
           onClick={() => setOpen(true)}
+          onMouseEnter={() => setNudge(false)}
           aria-label="Ask Replay"
           title="Ask Replay — local assistant"
-          className="flex items-center gap-1 rounded-full border border-terminal-green/30 bg-terminal-surface/85 px-2.5 py-1.5 text-[11px] font-semibold tracking-tight text-terminal-text shadow-layer-md backdrop-blur-md transition-all hover:border-terminal-green/60 hover:bg-terminal-surface hover:text-terminal-green"
+          className={`flex items-center gap-1 rounded-full border bg-terminal-surface/85 px-2.5 py-1.5 text-[11px] font-semibold tracking-tight shadow-layer-md backdrop-blur-md transition-all duration-300 hover:border-terminal-green/60 hover:bg-terminal-surface hover:text-terminal-green ${nudge ? "scale-[1.04] border-terminal-green/55 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]" : "scale-100 border-terminal-green/30 text-terminal-text"}`}
         >
-          <span className="text-terminal-green leading-none">✦</span>
+          <span
+            className={`leading-none transition-transform ${nudge ? "scale-110" : ""} text-terminal-green`}
+          >
+            ✦
+          </span>
           <span className="leading-none">Ask</span>
           <span
-            className="ml-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-terminal-green/80"
+            className={`ml-0.5 h-1.5 w-1.5 shrink-0 rounded-full ${nudge ? "animate-ping bg-terminal-green" : "bg-terminal-green/80"}`}
             aria-hidden="true"
           />
         </button>


### PR DESCRIPTION
- **Ask FAB**: adds a subtle periodic nudge (scale + shadow + dot ping every ~5.2s for 650ms, pauses while panel open, on hover, or when `prefers-reduced-motion`). Keeps the FAB concise (`Ask` + dot) but makes affordance discoverable.

- **Custom OpenAI-compatible** (`AiProviderSettings.tsx:267`): default name `Local LiteLLM` → `Custom gateway` (not LiteLLM-specific) and help text now says *Any OpenAI-compatible gateway — local LiteLLM/Ollama/vLLM **or** remote `https://`*; `http://` only for loopback. This matches `ai-runtime.ts:583` validation (`http` requires loopback, otherwise `https`) and answers the remote-gateway question.