### PR TITLE
feat(viewer): split AI auth settings and add section navigation

### DIFF
--- a/packages/viewer/src/components/AiProviderSettings.tsx
+++ b/packages/viewer/src/components/AiProviderSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import type {
+  AiAuthMethodInfo,
   AiModelInfo,
   AiProviderInfo,
   AiProviderSettingsActions,
@@ -30,14 +31,66 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-function providerStatus(provider: AiProviderInfo): string {
-  if (!provider.configured) return "not configured";
+function providerStatus(provider: AiProviderInfo, method?: AiAuthMethodInfo["type"]): string {
+  if (!provider.configured || (method && provider.authType !== method)) return "not configured";
   if (provider.authType === "oauth") {
-    return provider.authMethods.find((method) => method.type === "oauth")?.subscription
+    return provider.authMethods.find((candidate) => candidate.type === "oauth")?.subscription
       ? "subscription / OAuth"
       : "OAuth";
   }
   return provider.authSource || "API key";
+}
+
+function authMethodKind(method: AiAuthMethodInfo): string {
+  return method.type === "oauth" ? "Account login" : "API key";
+}
+
+function ProviderAuthCard({
+  provider,
+  method,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  provider: AiProviderInfo;
+  method: AiAuthMethodInfo;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const configured = provider.configured && provider.authType === method.type;
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
+        selected
+          ? "border-terminal-purple/50 bg-terminal-purple-subtle"
+          : "border-terminal-border-subtle bg-terminal-bg hover:border-terminal-purple/30"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="min-w-0 truncate text-xs font-mono font-semibold text-terminal-text">
+          {provider.name}
+        </span>
+        <span
+          className={`shrink-0 text-[9px] font-mono ${
+            configured ? "text-terminal-green" : "text-terminal-orange"
+          }`}
+        >
+          {configured ? "ready" : "setup"}
+        </span>
+      </div>
+      <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+        {provider.models.length} model{provider.models.length === 1 ? "" : "s"}
+      </div>
+      <div className="mt-2 text-[10px] font-mono text-terminal-purple">
+        {authMethodKind(method)}
+        {method.subscription ? " · subscription" : ""}
+      </div>
+    </button>
+  );
 }
 
 function ModelPicker({
@@ -258,6 +311,10 @@ export function AiProviderSettings({
     saveAiSelectionAsDefault,
   } = actions;
   const [authMethod, setAuthMethod] = useState<"api_key" | "oauth">("api_key");
+  const authMethodOverrideRef = useRef<{
+    providerId: string;
+    method: AiAuthMethodInfo["type"];
+  } | null>(null);
   const [apiKey, setApiKey] = useState("");
   const [authRunning, setAuthRunning] = useState(false);
   const [authStatus, setAuthStatus] = useState<{
@@ -274,15 +331,33 @@ export function AiProviderSettings({
   } | null>(null);
 
   const selectedProvider = providers.find((provider) => provider.id === providerId) || null;
+  const selectedAuthMethod = selectedProvider?.authMethods.find(
+    (method) => method.type === authMethod,
+  );
+  const selectedProviderAuthStatus = selectedProvider
+    ? providerStatus(selectedProvider, authMethod)
+    : "not configured";
+  const apiKeyProviders = providers.filter((provider) =>
+    provider.authMethods.some((method) => method.type === "api_key"),
+  );
+  const accountProviders = providers.filter((provider) =>
+    provider.authMethods.some((method) => method.type === "oauth"),
+  );
   const customProvider = providers.find((provider) => provider.id === "custom-openai") || null;
   const selectionLocked = busy || authRunning || customRunning;
 
   useEffect(() => {
-    const preferred =
-      selectedProvider?.authType ||
-      selectedProvider?.authMethods.find((method) => method.subscription)?.type ||
-      selectedProvider?.authMethods[0]?.type;
-    if (preferred) setAuthMethod(preferred);
+    const override = authMethodOverrideRef.current;
+    const hasOverride = override?.providerId === selectedProvider?.id;
+    if (override && !hasOverride) authMethodOverrideRef.current = null;
+    setAuthMethod(
+      hasOverride && override
+        ? override.method
+        : selectedProvider?.authType ||
+            selectedProvider?.authMethods.find((method) => method.subscription)?.type ||
+            selectedProvider?.authMethods[0]?.type ||
+            "api_key",
+    );
     setAuthStatus(null);
   }, [selectedProvider]);
 
@@ -306,6 +381,15 @@ export function AiProviderSettings({
       onModelChange?.(nextModelId);
     },
     [onModelChange, setAiModelId],
+  );
+
+  const handleAuthMethodChange = useCallback(
+    (nextProviderId: string, method: AiAuthMethodInfo["type"]) => {
+      authMethodOverrideRef.current = { providerId: nextProviderId, method };
+      setAuthMethod(method);
+      handleProviderChange(nextProviderId);
+    },
+    [handleProviderChange],
   );
 
   const handleAuthenticate = useCallback(async () => {
@@ -412,8 +496,9 @@ export function AiProviderSettings({
         <div>
           <h2 className="text-lg font-sans font-semibold text-terminal-text">AI providers</h2>
           <p className="mt-1 max-w-2xl text-[10px] font-sans leading-relaxed text-terminal-dim">
-            Configure built-in providers or connect an OpenAI-compatible gateway. Keys stay in the
-            local credential store and are never included in provider metadata.
+            Configure built-in providers or connect an OpenAI-compatible gateway. API keys and
+            account sign-ins are shown separately; credentials stay in the local store and are never
+            included in provider metadata.
           </p>
         </div>
         {refreshAiProviders && (
@@ -447,36 +532,64 @@ export function AiProviderSettings({
         </div>
       ) : (
         <>
-          <div className="grid gap-2 sm:grid-cols-2">
-            {providers.map((provider) => (
-              <button
-                key={provider.id}
-                type="button"
-                onClick={() => handleProviderChange(provider.id)}
-                disabled={selectionLocked}
-                className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
-                  provider.id === providerId
-                    ? "border-terminal-purple/50 bg-terminal-purple-subtle"
-                    : "border-terminal-border-subtle bg-terminal-bg hover:border-terminal-purple/30"
-                }`}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="min-w-0 truncate text-xs font-mono font-semibold text-terminal-text">
-                    {provider.name}
-                  </span>
-                  <span
-                    className={`shrink-0 text-[9px] font-mono ${
-                      provider.configured ? "text-terminal-green" : "text-terminal-orange"
-                    }`}
-                  >
-                    {provider.configured ? "ready" : "setup"}
+          <div className="space-y-4">
+            {accountProviders.length > 0 && (
+              <div>
+                <div className="mb-2 flex items-baseline justify-between gap-3">
+                  <h3 className="text-xs font-sans font-semibold text-terminal-text">Accounts</h3>
+                  <span className="text-[10px] font-mono text-terminal-dimmer">
+                    Sign in through the provider
                   </span>
                 </div>
-                <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-                  {provider.models.length} model{provider.models.length === 1 ? "" : "s"}
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {accountProviders.map((provider) => {
+                    const method = provider.authMethods.find(
+                      (candidate) => candidate.type === "oauth",
+                    );
+                    if (!method) return null;
+                    return (
+                      <ProviderAuthCard
+                        key={`${provider.id}:oauth`}
+                        provider={provider}
+                        method={method}
+                        selected={provider.id === providerId && authMethod === "oauth"}
+                        disabled={selectionLocked}
+                        onSelect={() => handleAuthMethodChange(provider.id, "oauth")}
+                      />
+                    );
+                  })}
                 </div>
-              </button>
-            ))}
+              </div>
+            )}
+
+            {apiKeyProviders.length > 0 && (
+              <div>
+                <div className="mb-2 flex items-baseline justify-between gap-3">
+                  <h3 className="text-xs font-sans font-semibold text-terminal-text">API keys</h3>
+                  <span className="text-[10px] font-mono text-terminal-dimmer">
+                    Use a provider-issued key
+                  </span>
+                </div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {apiKeyProviders.map((provider) => {
+                    const method = provider.authMethods.find(
+                      (candidate) => candidate.type === "api_key",
+                    );
+                    if (!method) return null;
+                    return (
+                      <ProviderAuthCard
+                        key={`${provider.id}:api_key`}
+                        provider={provider}
+                        method={method}
+                        selected={provider.id === providerId && authMethod === "api_key"}
+                        disabled={selectionLocked}
+                        onSelect={() => handleAuthMethodChange(provider.id, "api_key")}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
           </div>
 
           {selectedProvider && selectedProvider.models.length > 0 && (
@@ -513,28 +626,22 @@ export function AiProviderSettings({
                 <span className="text-xs font-mono text-terminal-dim">Authentication</span>
                 <span
                   className={`text-[10px] font-mono ${
-                    selectedProvider.configured ? "text-terminal-green" : "text-terminal-orange"
+                    selectedProviderAuthStatus === "not configured"
+                      ? "text-terminal-orange"
+                      : "text-terminal-green"
                   }`}
                 >
-                  {providerStatus(selectedProvider)}
+                  {selectedProviderAuthStatus}
                 </span>
               </div>
 
-              {selectedProvider.authMethods.length > 1 && (
-                <select
-                  aria-label="AI authentication method"
-                  value={authMethod}
-                  onChange={(event) => setAuthMethod(event.target.value as "api_key" | "oauth")}
-                  disabled={selectionLocked}
-                  className={INPUT_CLASS}
-                >
-                  {selectedProvider.authMethods.map((method) => (
-                    <option key={method.type} value={method.type}>
-                      {method.label}
-                      {method.subscription ? " (subscription)" : ""}
-                    </option>
-                  ))}
-                </select>
+              {selectedAuthMethod && (
+                <div className="flex flex-wrap items-center gap-2 text-[10px] font-mono">
+                  <span className="rounded-md bg-terminal-purple-subtle px-2 py-1 text-terminal-purple">
+                    {authMethodKind(selectedAuthMethod)}
+                  </span>
+                  <span className="text-terminal-dimmer">{selectedAuthMethod.label}</span>
+                </div>
               )}
 
               {authMethod === "api_key" &&
@@ -584,7 +691,8 @@ export function AiProviderSettings({
               {selectedProvider.configured &&
                 logoutAiProvider &&
                 (selectedProvider.authType === "oauth" ||
-                  selectedProvider.authSource === "stored credential") && (
+                  selectedProvider.authSource === "stored credential") &&
+                (!selectedAuthMethod || selectedProvider.authType === selectedAuthMethod.type) && (
                   <button
                     type="button"
                     onClick={() => void handleLogout()}

--- a/packages/viewer/src/components/AiProviderSettings.tsx
+++ b/packages/viewer/src/components/AiProviderSettings.tsx
@@ -337,6 +337,8 @@ export function AiProviderSettings({
   const selectedProviderAuthStatus = selectedProvider
     ? providerStatus(selectedProvider, authMethod)
     : "not configured";
+  const selectedAuthConfigured =
+    selectedProvider?.id === "custom-openai" || selectedProviderAuthStatus !== "not configured";
   const apiKeyProviders = providers.filter((provider) =>
     provider.authMethods.some((method) => method.type === "api_key"),
   );
@@ -592,34 +594,6 @@ export function AiProviderSettings({
             )}
           </div>
 
-          {selectedProvider && selectedProvider.models.length > 0 && (
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-mono text-terminal-dim">Model</span>
-              <ModelPicker
-                models={selectedProvider.models}
-                value={modelId || ""}
-                onChange={handleModelChange}
-                disabled={selectionLocked}
-              />
-              {saveAiSelectionAsDefault && (
-                <button
-                  type="button"
-                  onClick={saveAiSelectionAsDefault}
-                  disabled={selectionLocked || !modelId}
-                  className={`shrink-0 rounded-lg px-2 py-1.5 text-[10px] font-mono transition-colors disabled:opacity-40 ${
-                    providerId === defaultAiProviderId && modelId === defaultAiModelId
-                      ? "bg-terminal-green-subtle text-terminal-green"
-                      : "bg-terminal-surface-2 text-terminal-dim hover:text-terminal-text"
-                  }`}
-                >
-                  {providerId === defaultAiProviderId && modelId === defaultAiModelId
-                    ? "Default"
-                    : "Set default"}
-                </button>
-              )}
-            </div>
-          )}
-
           {selectedProvider && selectedProvider.id !== "custom-openai" && (
             <div className="rounded-lg border border-terminal-border-subtle bg-terminal-bg p-3 space-y-2">
               <div className="flex items-center justify-between gap-2">
@@ -715,6 +689,45 @@ export function AiProviderSettings({
               )}
             </div>
           )}
+
+          {selectedProvider &&
+            selectedProvider.models.length > 0 &&
+            (selectedAuthConfigured ? (
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-mono text-terminal-dim">Model</span>
+                <ModelPicker
+                  models={selectedProvider.models}
+                  value={modelId || ""}
+                  onChange={handleModelChange}
+                  disabled={selectionLocked}
+                />
+                {saveAiSelectionAsDefault && (
+                  <button
+                    type="button"
+                    onClick={saveAiSelectionAsDefault}
+                    disabled={selectionLocked || !modelId}
+                    className={`shrink-0 rounded-lg px-2 py-1.5 text-[10px] font-mono transition-colors disabled:opacity-40 ${
+                      providerId === defaultAiProviderId && modelId === defaultAiModelId
+                        ? "bg-terminal-green-subtle text-terminal-green"
+                        : "bg-terminal-surface-2 text-terminal-dim hover:text-terminal-text"
+                    }`}
+                  >
+                    {providerId === defaultAiProviderId && modelId === defaultAiModelId
+                      ? "Default"
+                      : "Set default"}
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-terminal-border-subtle bg-terminal-bg px-3 py-2.5 text-[10px] font-mono">
+                <div className="text-terminal-dim">Connect first to choose a model.</div>
+                <div className="mt-1 text-terminal-dimmer">
+                  Complete{" "}
+                  {selectedAuthMethod ? authMethodKind(selectedAuthMethod) : "authentication"} for{" "}
+                  {selectedProvider.name} above.
+                </div>
+              </div>
+            ))}
         </>
       )}
 

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -5445,6 +5445,7 @@ export default function Dashboard({
     // Reset cross-tab list state to avoid landing on empty views due to stale project/filter params.
     navigateTo({
       tab: id,
+      settingsSection: null,
       project: null,
       q: null,
       archived: null,

--- a/packages/viewer/src/components/SettingsPanel.tsx
+++ b/packages/viewer/src/components/SettingsPanel.tsx
@@ -249,6 +249,7 @@ export default function SettingsPanel() {
   const contentRef = useRef<HTMLElement>(null);
   const initialSectionRef = useRef<SettingsSectionId>(getSettingsSectionFromUrl());
   const initialScrollDoneRef = useRef(false);
+  const programmaticSectionRef = useRef<{ section: SettingsSectionId; until: number } | null>(null);
   const [activeSection, setActiveSection] = useState<SettingsSectionId>(initialSectionRef.current);
 
   const updateSectionUrl = useCallback((section: SettingsSectionId, replace: boolean) => {
@@ -267,6 +268,7 @@ export default function SettingsPanel() {
   const handleSectionSelect = useCallback(
     (section: SettingsSectionId) => {
       initialScrollDoneRef.current = true;
+      programmaticSectionRef.current = { section, until: Date.now() + 1_000 };
       setActiveSection(section);
       updateSectionUrl(section, false);
       scrollToSection(section, "smooth");
@@ -309,6 +311,10 @@ export default function SettingsPanel() {
     const timer = window.setTimeout(() => {
       if (initialScrollDoneRef.current) return;
       initialScrollDoneRef.current = true;
+      programmaticSectionRef.current = {
+        section: initialSectionRef.current,
+        until: Date.now() + 1_000,
+      };
       setActiveSection(initialSectionRef.current);
       scrollToSection(initialSectionRef.current, "auto");
     }, 0);
@@ -318,6 +324,7 @@ export default function SettingsPanel() {
   useEffect(() => {
     const handlePopState = () => {
       const section = getSettingsSectionFromUrl();
+      programmaticSectionRef.current = { section, until: Date.now() + 1_000 };
       initialScrollDoneRef.current = true;
       setActiveSection(section);
       window.setTimeout(() => scrollToSection(section, "auto"), 0);
@@ -334,21 +341,47 @@ export default function SettingsPanel() {
 
     const updateActiveSection = () => {
       if (!initialScrollDoneRef.current) return;
-      const rootTop = root.getBoundingClientRect().top;
+      const programmatic = programmaticSectionRef.current;
+      if (programmatic) {
+        if (Date.now() < programmatic.until) {
+          setActiveSection((current) =>
+            current === programmatic.section ? current : programmatic.section,
+          );
+          updateSectionUrl(programmatic.section, true);
+          return;
+        }
+        programmaticSectionRef.current = null;
+      }
+
+      const rootRect = root.getBoundingClientRect();
       let next: SettingsSectionId = "ai";
+      let lastVisible: SettingsSectionId | undefined;
       for (const section of SETTINGS_SECTIONS) {
         const element = document.getElementById(settingsSectionElementId(section.id));
-        if (element && element.getBoundingClientRect().top - rootTop <= 144) {
-          next = section.id;
-        }
+        if (!element) continue;
+        const rect = element.getBoundingClientRect();
+        const top = rect.top - rootRect.top;
+        if (top <= 144) next = section.id;
+        if (top < root.clientHeight && rect.bottom > rootRect.top) lastVisible = section.id;
       }
+      if (next === "ai" && lastVisible) next = lastVisible;
       setActiveSection((current) => (current === next ? current : next));
       updateSectionUrl(next, true);
     };
 
+    const cancelProgrammaticScroll = () => {
+      programmaticSectionRef.current = null;
+    };
+
     updateActiveSection();
     root.addEventListener("scroll", updateActiveSection, { passive: true });
-    return () => root.removeEventListener("scroll", updateActiveSection);
+    root.addEventListener("wheel", cancelProgrammaticScroll, { passive: true });
+    root.addEventListener("touchstart", cancelProgrammaticScroll, { passive: true });
+    return () => {
+      root.removeEventListener("scroll", updateActiveSection);
+      root.removeEventListener("wheel", cancelProgrammaticScroll);
+      root.removeEventListener("touchstart", cancelProgrammaticScroll);
+    };
   }, [
     aiProviderSettings.aiProviders.length,
     aiProviderSettings.aiProvidersLoading,

--- a/packages/viewer/src/components/SettingsPanel.tsx
+++ b/packages/viewer/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
-import { providerDisplayName } from "./dashboard-utils";
+import { navigateTo, providerDisplayName } from "./dashboard-utils";
 import { AiProviderSettings } from "./AiProviderSettings";
 import { useAiProviderSettings } from "../hooks/useAiProviderSettings";
 
@@ -34,6 +34,123 @@ const REMOTE_PROVIDERS: Array<{ value: RemoteProvider; label: string }> = [
 
 const INPUT_CLASS =
   "w-full rounded-lg border border-terminal-border-subtle bg-terminal-bg px-3 py-2 text-xs font-mono text-terminal-text outline-none transition-colors placeholder:text-terminal-dimmer focus:border-terminal-green/60 focus:ring-1 focus:ring-terminal-green/30";
+
+export type SettingsSectionId = "ai" | "remote" | "more";
+
+const SETTINGS_SECTION_PARAM = "settingsSection";
+const SETTINGS_SECTIONS: Array<{
+  id: SettingsSectionId;
+  label: string;
+  description: string;
+}> = [
+  { id: "ai", label: "AI", description: "Providers & authentication" },
+  { id: "remote", label: "Remote SSH", description: "Hosts & source discovery" },
+  { id: "more", label: "More", description: "Additional options" },
+];
+
+function settingsSectionElementId(section: SettingsSectionId): string {
+  return `settings-${section}`;
+}
+
+export function getSettingsSectionFromUrl(): SettingsSectionId {
+  if (typeof window === "undefined") return "ai";
+  const value = new URLSearchParams(window.location.search).get(SETTINGS_SECTION_PARAM);
+  return value === "remote" || value === "more" ? value : "ai";
+}
+
+function SettingsSectionIcon({ section }: { section: SettingsSectionId }) {
+  const paths: Record<SettingsSectionId, string> = {
+    ai: "M12 3v18M3 12h18M5 5l14 14M19 5 5 19",
+    remote: "M4 6h16v12H4zM8 10h.01M11 10h.01M14 10h.01M7 15h10",
+    more: "M5 7h14M5 12h14M5 17h14",
+  };
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={paths[section]} />
+    </svg>
+  );
+}
+
+export function SettingsSectionNav({
+  activeSection,
+  onSelect,
+}: {
+  activeSection: SettingsSectionId;
+  onSelect: (section: SettingsSectionId) => void;
+}) {
+  return (
+    <aside className="shrink-0 border-b border-terminal-border-subtle bg-terminal-bg/70 md:w-56 md:border-b-0 md:border-r">
+      <div className="flex gap-3 overflow-x-auto p-3 md:sticky md:top-0 md:flex-col md:gap-6 md:p-5">
+        <div className="hidden md:block">
+          <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-dimmer">
+            Settings
+          </div>
+          <p className="mt-2 text-xs font-sans leading-relaxed text-terminal-dim">
+            Configure local providers and session sources.
+          </p>
+        </div>
+
+        <nav aria-label="Settings sections" className="flex min-w-max gap-1 md:min-w-0 md:flex-col">
+          {SETTINGS_SECTIONS.map((section, index) => {
+            const selected = activeSection === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                aria-current={selected ? "location" : undefined}
+                aria-controls={settingsSectionElementId(section.id)}
+                onClick={() => onSelect(section.id)}
+                className={`group flex min-w-[118px] items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition-colors md:min-w-0 ${
+                  selected
+                    ? "bg-terminal-green-subtle text-terminal-green"
+                    : "text-terminal-dim hover:bg-terminal-surface hover:text-terminal-text"
+                }`}
+              >
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-md ${
+                    selected
+                      ? "bg-terminal-green/15"
+                      : "bg-terminal-surface-2 text-terminal-dimmer group-hover:text-terminal-dim"
+                  }`}
+                >
+                  <SettingsSectionIcon section={section.id} />
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-xs font-sans font-semibold">{section.label}</span>
+                  <span className="hidden truncate text-[10px] font-mono text-terminal-dimmer md:block">
+                    {section.description}
+                  </span>
+                </span>
+                <span className="ml-auto hidden text-[10px] font-mono tabular-nums text-terminal-dimmer md:block">
+                  0{index + 1}
+                </span>
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="hidden border-t border-terminal-border-subtle pt-4 md:block">
+          <div className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+            Tip
+          </div>
+          <p className="mt-2 text-[11px] font-sans leading-relaxed text-terminal-dimmer">
+            Use the menu or a settingsSection URL to jump between sections.
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}
 
 function emptyDraft(): RemoteSourceDraft {
   return {
@@ -129,6 +246,33 @@ export default function SettingsPanel() {
   const [message, setMessage] = useState<string | null>(null);
   const sourceRequestVersion = useRef(0);
   const sourceActionsLocked = loading || saving || refreshing;
+  const contentRef = useRef<HTMLElement>(null);
+  const initialSectionRef = useRef<SettingsSectionId>(getSettingsSectionFromUrl());
+  const initialScrollDoneRef = useRef(false);
+  const [activeSection, setActiveSection] = useState<SettingsSectionId>(initialSectionRef.current);
+
+  const updateSectionUrl = useCallback((section: SettingsSectionId, replace: boolean) => {
+    const current = new URLSearchParams(window.location.search).get(SETTINGS_SECTION_PARAM);
+    if (current === section) return;
+    navigateTo({ [SETTINGS_SECTION_PARAM]: section }, { replace, notify: false });
+  }, []);
+
+  const scrollToSection = useCallback((section: SettingsSectionId, behavior: ScrollBehavior) => {
+    const target = document.getElementById(settingsSectionElementId(section));
+    if (target && typeof target.scrollIntoView === "function") {
+      target.scrollIntoView({ behavior, block: "start" });
+    }
+  }, []);
+
+  const handleSectionSelect = useCallback(
+    (section: SettingsSectionId) => {
+      initialScrollDoneRef.current = true;
+      setActiveSection(section);
+      updateSectionUrl(section, false);
+      scrollToSection(section, "smooth");
+    },
+    [scrollToSection, updateSectionUrl],
+  );
 
   const loadSettings = useCallback(async () => {
     const requestVersion = ++sourceRequestVersion.current;
@@ -156,6 +300,62 @@ export default function SettingsPanel() {
   useEffect(() => {
     void loadSettings();
   }, [loadSettings]);
+
+  // Apply a deep link after both sections have had a chance to render. The
+  // remote section moves when its settings load, so scrolling only on mount
+  // would land at the wrong place for ?settingsSection=remote.
+  useEffect(() => {
+    if (initialScrollDoneRef.current || loading || aiProviderSettings.aiProvidersLoading) return;
+    const timer = window.setTimeout(() => {
+      if (initialScrollDoneRef.current) return;
+      initialScrollDoneRef.current = true;
+      setActiveSection(initialSectionRef.current);
+      scrollToSection(initialSectionRef.current, "auto");
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [aiProviderSettings.aiProvidersLoading, loading, scrollToSection]);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      const section = getSettingsSectionFromUrl();
+      initialScrollDoneRef.current = true;
+      setActiveSection(section);
+      window.setTimeout(() => scrollToSection(section, "auto"), 0);
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [scrollToSection]);
+
+  // Keep the left navigation and the deep-link query parameter in sync while
+  // the user scrolls, without adding a browser-history entry for every tick.
+  useEffect(() => {
+    const root = contentRef.current;
+    if (!root) return;
+
+    const updateActiveSection = () => {
+      if (!initialScrollDoneRef.current) return;
+      const rootTop = root.getBoundingClientRect().top;
+      let next: SettingsSectionId = "ai";
+      for (const section of SETTINGS_SECTIONS) {
+        const element = document.getElementById(settingsSectionElementId(section.id));
+        if (element && element.getBoundingClientRect().top - rootTop <= 144) {
+          next = section.id;
+        }
+      }
+      setActiveSection((current) => (current === next ? current : next));
+      updateSectionUrl(next, true);
+    };
+
+    updateActiveSection();
+    root.addEventListener("scroll", updateActiveSection, { passive: true });
+    return () => root.removeEventListener("scroll", updateActiveSection);
+  }, [
+    aiProviderSettings.aiProviders.length,
+    aiProviderSettings.aiProvidersLoading,
+    loading,
+    sources.length,
+    updateSectionUrl,
+  ]);
 
   const saveSources = async (nextSources: RemoteSource[], successMessage: string) => {
     const requestVersion = ++sourceRequestVersion.current;
@@ -276,320 +476,329 @@ export default function SettingsPanel() {
   const editingLabel = editingId === null ? "Add SSH source" : "Edit SSH source";
 
   return (
-    <main className="min-h-0 flex-1 overflow-y-auto bg-terminal-bg">
-      <div className="mx-auto w-full max-w-5xl space-y-5 p-5 md:p-8">
-        <header>
-          <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-green">
-            Settings
-          </div>
-          <h1 className="mt-2 text-2xl font-sans font-bold text-terminal-text">
-            Local workspace settings
-          </h1>
-          <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
-            Configure the sources and defaults used by this dashboard. Settings stay on this machine
-            and are stored outside the repository.
-          </p>
-        </header>
-
-        {(error || message) && (
-          <div
-            className={`rounded-xl border px-4 py-3 text-xs font-mono ${
-              error
-                ? "border-terminal-red/30 bg-terminal-red-subtle text-terminal-red"
-                : "border-terminal-green/30 bg-terminal-green-subtle text-terminal-green"
-            }`}
-            role={error ? "alert" : "status"}
-          >
-            {error || message}
-          </div>
-        )}
-
-        <section className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm md:p-6">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <h2 className="text-lg font-sans font-semibold text-terminal-text">
-                Remote SSH sources
-              </h2>
-              <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
-                Add a host alias or address from your normal OpenSSH configuration. vibe-replay
-                never stores passwords, private keys, or SSH commands here.
-              </p>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row">
+      <SettingsSectionNav activeSection={activeSection} onSelect={handleSectionSelect} />
+      <main ref={contentRef} className="min-w-0 flex-1 overflow-y-auto bg-terminal-bg">
+        <div className="mx-auto w-full max-w-5xl space-y-5 p-5 md:p-8">
+          <header>
+            <div className="text-[10px] font-mono font-semibold uppercase tracking-[0.18em] text-terminal-green">
+              Settings
             </div>
-            <button
-              type="button"
-              disabled={sourceActionsLocked}
-              onClick={() => {
-                setDraft(emptyDraft());
-                setEditingId(null);
-                setError(null);
-                setMessage(null);
-              }}
-              className="rounded-lg bg-terminal-blue-subtle px-3 py-2 text-xs font-mono font-semibold text-terminal-blue transition-colors hover:bg-terminal-blue/20"
+            <h1 className="mt-2 text-2xl font-sans font-bold text-terminal-text">
+              Local workspace settings
+            </h1>
+            <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
+              Configure the sources and defaults used by this dashboard. Settings stay on this
+              machine and are stored outside the repository.
+            </p>
+          </header>
+
+          {(error || message) && (
+            <div
+              className={`rounded-xl border px-4 py-3 text-xs font-mono ${
+                error
+                  ? "border-terminal-red/30 bg-terminal-red-subtle text-terminal-red"
+                  : "border-terminal-green/30 bg-terminal-green-subtle text-terminal-green"
+              }`}
+              role={error ? "alert" : "status"}
             >
-              + Add SSH source
-            </button>
+              {error || message}
+            </div>
+          )}
+
+          <div id={settingsSectionElementId("ai")} className="scroll-mt-5">
+            <AiProviderSettings actions={aiProviderSettings} variant="inline" />
           </div>
 
-          {loading ? (
-            <div className="mt-5 rounded-lg bg-terminal-bg px-4 py-5 text-xs font-mono text-terminal-dimmer">
-              Loading SSH settings…
+          <section
+            id={settingsSectionElementId("remote")}
+            className="rounded-xl bg-terminal-surface p-5 shadow-layer-sm md:p-6 scroll-mt-5"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-sans font-semibold text-terminal-text">
+                  Remote SSH sources
+                </h2>
+                <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
+                  Add a host alias or address from your normal OpenSSH configuration. vibe-replay
+                  never stores passwords, private keys, or SSH commands here.
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={sourceActionsLocked}
+                onClick={() => {
+                  setDraft(emptyDraft());
+                  setEditingId(null);
+                  setError(null);
+                  setMessage(null);
+                }}
+                className="rounded-lg bg-terminal-blue-subtle px-3 py-2 text-xs font-mono font-semibold text-terminal-blue transition-colors hover:bg-terminal-blue/20"
+              >
+                + Add SSH source
+              </button>
             </div>
-          ) : sources.length === 0 ? (
-            <div className="mt-5 rounded-lg border border-dashed border-terminal-border-subtle bg-terminal-bg px-4 py-6 text-center text-xs font-mono text-terminal-dimmer">
-              No remote SSH sources configured.
-            </div>
-          ) : (
-            <div className="mt-5 space-y-3">
-              {sources.map((source) => {
-                const result = testResults[source.id];
-                return (
-                  <div
-                    key={source.id}
-                    className="rounded-lg border border-terminal-border-subtle bg-terminal-bg p-4"
-                  >
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-sm font-sans font-semibold text-terminal-text">
-                            {source.label}
-                          </h3>
-                          <span className="rounded bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] font-mono text-terminal-dimmer">
-                            {source.id}
-                          </span>
-                        </div>
-                        <div className="mt-1 break-all text-xs font-mono text-terminal-blue">
-                          {source.sshHost}
-                        </div>
-                        <div className="mt-2 flex flex-wrap gap-1.5">
-                          {source.providers.map((provider) => (
-                            <span
-                              key={provider}
-                              className="rounded-full bg-terminal-purple-subtle px-2 py-0.5 text-[10px] font-mono text-terminal-purple"
-                            >
-                              {providerDisplayName(provider)}
+
+            {loading ? (
+              <div className="mt-5 rounded-lg bg-terminal-bg px-4 py-5 text-xs font-mono text-terminal-dimmer">
+                Loading SSH settings…
+              </div>
+            ) : sources.length === 0 ? (
+              <div className="mt-5 rounded-lg border border-dashed border-terminal-border-subtle bg-terminal-bg px-4 py-6 text-center text-xs font-mono text-terminal-dimmer">
+                No remote SSH sources configured.
+              </div>
+            ) : (
+              <div className="mt-5 space-y-3">
+                {sources.map((source) => {
+                  const result = testResults[source.id];
+                  return (
+                    <div
+                      key={source.id}
+                      className="rounded-lg border border-terminal-border-subtle bg-terminal-bg p-4"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-sm font-sans font-semibold text-terminal-text">
+                              {source.label}
+                            </h3>
+                            <span className="rounded bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] font-mono text-terminal-dimmer">
+                              {source.id}
                             </span>
-                          ))}
-                          <span className="rounded-full bg-terminal-surface-2 px-2 py-0.5 text-[10px] font-mono text-terminal-dimmer">
-                            {Math.round(source.connectTimeoutMs / 1_000)}s timeout
-                          </span>
+                          </div>
+                          <div className="mt-1 break-all text-xs font-mono text-terminal-blue">
+                            {source.sshHost}
+                          </div>
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {source.providers.map((provider) => (
+                              <span
+                                key={provider}
+                                className="rounded-full bg-terminal-purple-subtle px-2 py-0.5 text-[10px] font-mono text-terminal-purple"
+                              >
+                                {providerDisplayName(provider)}
+                              </span>
+                            ))}
+                            <span className="rounded-full bg-terminal-surface-2 px-2 py-0.5 text-[10px] font-mono text-terminal-dimmer">
+                              {Math.round(source.connectTimeoutMs / 1_000)}s timeout
+                            </span>
+                          </div>
+                          {result && (
+                            <output
+                              className={`mt-2 text-[10px] font-mono ${
+                                result.ok ? "text-terminal-green" : "text-terminal-red"
+                              }`}
+                            >
+                              {result.ok ? "✓ " : "✕ "}
+                              {result.message}
+                            </output>
+                          )}
                         </div>
-                        {result && (
-                          <output
-                            className={`mt-2 text-[10px] font-mono ${
-                              result.ok ? "text-terminal-green" : "text-terminal-red"
-                            }`}
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <button
+                            type="button"
+                            onClick={() => void testSource(source)}
+                            disabled={sourceActionsLocked || testingId === source.id}
+                            className="rounded-md bg-terminal-green-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-green transition-colors hover:bg-terminal-green/20 disabled:cursor-wait disabled:opacity-50"
                           >
-                            {result.ok ? "✓ " : "✕ "}
-                            {result.message}
-                          </output>
-                        )}
-                      </div>
-                      <div className="flex shrink-0 items-center gap-1.5">
-                        <button
-                          type="button"
-                          onClick={() => void testSource(source)}
-                          disabled={sourceActionsLocked || testingId === source.id}
-                          className="rounded-md bg-terminal-green-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-green transition-colors hover:bg-terminal-green/20 disabled:cursor-wait disabled:opacity-50"
-                        >
-                          {testingId === source.id ? "Testing…" : "Test"}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDraft(sourceToDraft(source));
-                            setEditingId(source.id);
-                            setError(null);
-                            setMessage(null);
-                          }}
-                          disabled={sourceActionsLocked}
-                          className="rounded-md bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => void removeSource(source)}
-                          disabled={sourceActionsLocked}
-                          className="rounded-md bg-terminal-red-subtle px-2.5 py-1.5 text-[10px] font-mono text-terminal-red transition-colors hover:bg-terminal-red/20"
-                        >
-                          Remove
-                        </button>
+                            {testingId === source.id ? "Testing…" : "Test"}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDraft(sourceToDraft(source));
+                              setEditingId(source.id);
+                              setError(null);
+                              setMessage(null);
+                            }}
+                            disabled={sourceActionsLocked}
+                            className="rounded-md bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void removeSource(source)}
+                            disabled={sourceActionsLocked}
+                            className="rounded-md bg-terminal-red-subtle px-2.5 py-1.5 text-[10px] font-mono text-terminal-red transition-colors hover:bg-terminal-red/20"
+                          >
+                            Remove
+                          </button>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {draft && (
-            <form
-              onSubmit={(event) => void submitDraft(event)}
-              className="mt-5 space-y-4 rounded-lg border border-terminal-blue/30 bg-terminal-blue/5 p-4"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <h3 className="text-sm font-sans font-semibold text-terminal-text">
-                  {editingLabel}
-                </h3>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setDraft(null);
-                    setEditingId(null);
-                  }}
-                  className="text-xs font-mono text-terminal-dimmer hover:text-terminal-text"
-                >
-                  Cancel
-                </button>
+                  );
+                })}
               </div>
-              <div className="grid gap-4 md:grid-cols-2">
-                <label htmlFor="remote-source-id" className="space-y-1.5">
-                  <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
-                    Stable id
-                  </span>
-                  <input
-                    id="remote-source-id"
-                    aria-label="Stable id"
-                    className={INPUT_CLASS}
-                    value={draft.id}
-                    disabled={editingId !== null}
-                    onChange={(event) => setDraft({ ...draft, id: event.target.value })}
-                    placeholder="remote-devspace"
-                    autoComplete="off"
-                  />
-                  <span className="block text-[10px] font-sans text-terminal-dimmer">
-                    Used to keep this source’s cached sessions separate.
-                  </span>
-                </label>
-                <label htmlFor="remote-source-label" className="space-y-1.5">
-                  <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
-                    Display label
-                  </span>
-                  <input
-                    id="remote-source-label"
-                    aria-label="Display label"
-                    className={INPUT_CLASS}
-                    value={draft.label}
-                    onChange={(event) => setDraft({ ...draft, label: event.target.value })}
-                    placeholder="ROS devspace"
-                    autoComplete="off"
-                  />
-                </label>
-                <label htmlFor="remote-source-host" className="space-y-1.5 md:col-span-2">
-                  <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
-                    SSH host
-                  </span>
-                  <input
-                    id="remote-source-host"
-                    aria-label="SSH host"
-                    className={INPUT_CLASS}
-                    value={draft.sshHost}
-                    onChange={(event) => setDraft({ ...draft, sshHost: event.target.value })}
-                    placeholder="dev.example.internal"
-                    autoComplete="off"
-                    spellCheck={false}
-                  />
-                  <span className="block text-[10px] font-sans text-terminal-dimmer">
-                    This is passed as the OpenSSH host argument. Configure aliases, keys, and
-                    ProxyJump in your normal SSH config.
-                  </span>
-                </label>
-              </div>
+            )}
 
-              <fieldset>
-                <legend className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
-                  Providers to scan
-                </legend>
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {REMOTE_PROVIDERS.map((provider) => {
-                    const checked = draft.providers.includes(provider.value);
-                    return (
-                      <label
-                        key={provider.value}
-                        className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-xs font-mono transition-colors ${
-                          checked
-                            ? "border-terminal-green/40 bg-terminal-green-subtle text-terminal-green"
-                            : "border-terminal-border-subtle bg-terminal-bg text-terminal-dim"
-                        }`}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={() =>
-                            setDraft({
-                              ...draft,
-                              providers: checked
-                                ? draft.providers.filter((value) => value !== provider.value)
-                                : [...draft.providers, provider.value],
-                            })
-                          }
-                          className="accent-terminal-green"
-                        />
-                        {provider.label}
-                      </label>
-                    );
-                  })}
+            {draft && (
+              <form
+                onSubmit={(event) => void submitDraft(event)}
+                className="mt-5 space-y-4 rounded-lg border border-terminal-blue/30 bg-terminal-blue/5 p-4"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-sm font-sans font-semibold text-terminal-text">
+                    {editingLabel}
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDraft(null);
+                      setEditingId(null);
+                    }}
+                    className="text-xs font-mono text-terminal-dimmer hover:text-terminal-text"
+                  >
+                    Cancel
+                  </button>
                 </div>
-              </fieldset>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label htmlFor="remote-source-id" className="space-y-1.5">
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                      Stable id
+                    </span>
+                    <input
+                      id="remote-source-id"
+                      aria-label="Stable id"
+                      className={INPUT_CLASS}
+                      value={draft.id}
+                      disabled={editingId !== null}
+                      onChange={(event) => setDraft({ ...draft, id: event.target.value })}
+                      placeholder="remote-devspace"
+                      autoComplete="off"
+                    />
+                    <span className="block text-[10px] font-sans text-terminal-dimmer">
+                      Used to keep this source’s cached sessions separate.
+                    </span>
+                  </label>
+                  <label htmlFor="remote-source-label" className="space-y-1.5">
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                      Display label
+                    </span>
+                    <input
+                      id="remote-source-label"
+                      aria-label="Display label"
+                      className={INPUT_CLASS}
+                      value={draft.label}
+                      onChange={(event) => setDraft({ ...draft, label: event.target.value })}
+                      placeholder="ROS devspace"
+                      autoComplete="off"
+                    />
+                  </label>
+                  <label htmlFor="remote-source-host" className="space-y-1.5 md:col-span-2">
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                      SSH host
+                    </span>
+                    <input
+                      id="remote-source-host"
+                      aria-label="SSH host"
+                      className={INPUT_CLASS}
+                      value={draft.sshHost}
+                      onChange={(event) => setDraft({ ...draft, sshHost: event.target.value })}
+                      placeholder="dev.example.internal"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <span className="block text-[10px] font-sans text-terminal-dimmer">
+                      This is passed as the OpenSSH host argument. Configure aliases, keys, and
+                      ProxyJump in your normal SSH config.
+                    </span>
+                  </label>
+                </div>
 
-              <div className="flex flex-wrap items-end justify-between gap-4">
-                <label htmlFor="remote-source-timeout" className="w-40 space-y-1.5">
-                  <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
-                    Connect timeout (seconds)
-                  </span>
-                  <input
-                    id="remote-source-timeout"
-                    aria-label="Connect timeout (seconds)"
-                    type="number"
-                    min={1}
-                    max={60}
-                    step={1}
-                    className={INPUT_CLASS}
-                    value={draft.connectTimeoutSeconds}
-                    onChange={(event) =>
-                      setDraft({ ...draft, connectTimeoutSeconds: event.target.value })
-                    }
-                  />
-                </label>
-                <button
-                  type="submit"
-                  disabled={saving}
-                  className="rounded-lg bg-terminal-blue px-4 py-2 text-xs font-mono font-semibold text-terminal-bg transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-50"
-                >
-                  {saving ? "Saving…" : "Save SSH source"}
-                </button>
-              </div>
-            </form>
-          )}
+                <fieldset>
+                  <legend className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                    Providers to scan
+                  </legend>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {REMOTE_PROVIDERS.map((provider) => {
+                      const checked = draft.providers.includes(provider.value);
+                      return (
+                        <label
+                          key={provider.value}
+                          className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-xs font-mono transition-colors ${
+                            checked
+                              ? "border-terminal-green/40 bg-terminal-green-subtle text-terminal-green"
+                              : "border-terminal-border-subtle bg-terminal-bg text-terminal-dim"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() =>
+                              setDraft({
+                                ...draft,
+                                providers: checked
+                                  ? draft.providers.filter((value) => value !== provider.value)
+                                  : [...draft.providers, provider.value],
+                              })
+                            }
+                            className="accent-terminal-green"
+                          />
+                          {provider.label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </fieldset>
 
-          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-terminal-border-subtle pt-4">
-            <p className="max-w-2xl text-[10px] font-sans leading-relaxed text-terminal-dimmer">
-              Saving starts a background scan. Use this button when you want to refresh the source
-              catalog immediately.
+                <div className="flex flex-wrap items-end justify-between gap-4">
+                  <label htmlFor="remote-source-timeout" className="w-40 space-y-1.5">
+                    <span className="text-[10px] font-mono uppercase tracking-widest text-terminal-dimmer">
+                      Connect timeout (seconds)
+                    </span>
+                    <input
+                      id="remote-source-timeout"
+                      aria-label="Connect timeout (seconds)"
+                      type="number"
+                      min={1}
+                      max={60}
+                      step={1}
+                      className={INPUT_CLASS}
+                      value={draft.connectTimeoutSeconds}
+                      onChange={(event) =>
+                        setDraft({ ...draft, connectTimeoutSeconds: event.target.value })
+                      }
+                    />
+                  </label>
+                  <button
+                    type="submit"
+                    disabled={saving}
+                    className="rounded-lg bg-terminal-blue px-4 py-2 text-xs font-mono font-semibold text-terminal-bg transition-opacity hover:opacity-90 disabled:cursor-wait disabled:opacity-50"
+                  >
+                    {saving ? "Saving…" : "Save SSH source"}
+                  </button>
+                </div>
+              </form>
+            )}
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-terminal-border-subtle pt-4">
+              <p className="max-w-2xl text-[10px] font-sans leading-relaxed text-terminal-dimmer">
+                Saving starts a background scan. Use this button when you want to refresh the source
+                catalog immediately.
+              </p>
+              <button
+                type="button"
+                onClick={() => void refreshSources()}
+                disabled={sourceActionsLocked}
+                className="rounded-lg bg-terminal-surface-2 px-3 py-2 text-xs font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:cursor-wait disabled:opacity-50"
+              >
+                {refreshing ? "Refreshing…" : "Refresh sources now"}
+              </button>
+            </div>
+          </section>
+
+          <section
+            id={settingsSectionElementId("more")}
+            className="rounded-xl border border-dashed border-terminal-border-subtle bg-terminal-surface/50 p-5 md:p-6 scroll-mt-5"
+          >
+            <h2 className="text-sm font-sans font-semibold text-terminal-text">More settings</h2>
+            <p className="mt-1 text-xs font-sans leading-relaxed text-terminal-dim">
+              Additional common options can be added here without changing provider session data or
+              replay files.
             </p>
-            <button
-              type="button"
-              onClick={() => void refreshSources()}
-              disabled={sourceActionsLocked}
-              className="rounded-lg bg-terminal-surface-2 px-3 py-2 text-xs font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:cursor-wait disabled:opacity-50"
-            >
-              {refreshing ? "Refreshing…" : "Refresh sources now"}
-            </button>
-          </div>
-        </section>
-
-        <section>
-          <AiProviderSettings actions={aiProviderSettings} variant="inline" />
-        </section>
-
-        <section className="rounded-xl border border-dashed border-terminal-border-subtle bg-terminal-surface/50 p-5 md:p-6">
-          <h2 className="text-sm font-sans font-semibold text-terminal-text">More settings</h2>
-          <p className="mt-1 text-xs font-sans leading-relaxed text-terminal-dim">
-            Additional common options can be added here without changing provider session data or
-            replay files.
-          </p>
-        </section>
-      </div>
-    </main>
+          </section>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
@@ -129,6 +129,33 @@ describe("AiStudioPanel", () => {
     expect(screen.queryByText("opencode run")).toBeNull();
   });
 
+  it("keeps API-key and account authentication choices in separate groups", () => {
+    const actions = makeActions([
+      provider({
+        id: "openrouter",
+        name: "OpenRouter",
+        configured: false,
+        authType: undefined,
+        authSource: undefined,
+        authMethods: [
+          { type: "api_key", label: "OpenRouter API key", subscription: false },
+          { type: "oauth", label: "Sign in with OpenRouter", subscription: false },
+        ],
+      }),
+    ]);
+
+    render(<AiStudioPanel {...actions} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    const authHeadings = screen
+      .getAllByRole("heading")
+      .map((heading) => heading.textContent)
+      .filter((text): text is string => text === "Accounts" || text === "API keys");
+    expect(authHeadings).toEqual(["Accounts", "API keys"]);
+    fireEvent.click(screen.getByRole("button", { name: /OpenRouter.*Account login/ }));
+    expect(screen.getByRole("button", { name: "Sign in with provider" })).toBeDefined();
+  });
+
   it("saves an API key through the provider auth action", async () => {
     const authenticate = vi.fn(async () => {});
     const actions = makeActions([provider()], {

--- a/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
@@ -129,6 +129,23 @@ describe("AiStudioPanel", () => {
     expect(screen.queryByText("opencode run")).toBeNull();
   });
 
+  it("requires authentication before model selection", () => {
+    const actions = makeActions([
+      provider({
+        configured: false,
+        authType: undefined,
+        authSource: undefined,
+      }),
+    ]);
+
+    render(<AiStudioPanel {...actions} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    expect(screen.getByText("Connect first to choose a model.")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "AI model" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Set default" })).toBeNull();
+  });
+
   it("keeps API-key and account authentication choices in separate groups", () => {
     const actions = makeActions([
       provider({

--- a/packages/viewer/src/components/__tests__/settings-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/settings-panel.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import SettingsPanel from "../SettingsPanel";
+import SettingsPanel, { getSettingsSectionFromUrl } from "../SettingsPanel";
 
 const source = {
   id: "remote-devspace",
@@ -70,6 +70,64 @@ describe("SettingsPanel", () => {
     expect(screen.getByText("Codex")).toBeDefined();
     expect(screen.getByText("AI providers")).toBeDefined();
     expect(screen.getByLabelText("Custom AI endpoint")).toBeDefined();
+  });
+
+  it("follows the settings section URL and updates it from the left menu", async () => {
+    window.history.replaceState({}, "", "/?view=dashboard&tab=settings&settingsSection=remote");
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: function (this: HTMLElement) {
+        const topById: Record<string, number> = {
+          "settings-ai": 200,
+          "settings-remote": 0,
+          "settings-more": 200,
+        };
+        const top = topById[this.id];
+        if (top === undefined) return originalGetBoundingClientRect.call(this);
+        return {
+          bottom: top + 100,
+          height: 100,
+          left: 0,
+          right: 100,
+          top,
+          width: 100,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        } as DOMRect;
+      },
+    });
+
+    try {
+      expect(getSettingsSectionFromUrl()).toBe("remote");
+      render(<SettingsPanel />);
+
+      await waitFor(() => expect(screen.getByText("ROS devspace")).toBeDefined());
+      expect(screen.getByRole("button", { name: /^Remote SSH/ }).getAttribute("aria-current")).toBe(
+        "location",
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /^AI/ }));
+      expect(new URLSearchParams(window.location.search).get("settingsSection")).toBe("ai");
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      });
+      Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+        configurable: true,
+        value: originalGetBoundingClientRect,
+      });
+      window.history.replaceState({}, "", "/");
+    }
   });
 
   it("tests an SSH source without exposing credentials", async () => {

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -531,6 +531,7 @@ export function navigateTo(
 
 export const DASHBOARD_PARAMS = [
   "tab",
+  "settingsSection",
   "project",
   "targetId",
   "q",


### PR DESCRIPTION
## Summary
- show provider account sign-ins before API-key authentication in AI settings
- require the selected authentication method to connect before model selection or setting a default
- add responsive settings section navigation with URL-synced deep links
- keep AI providers above Remote SSH sources and add regression coverage

## Security note
API keys are submitted only to the same-origin local CLI API and persisted by the CLI in `~/.vibe-replay/ai-auth.json` (or `VIBE_REPLAY_AI_AUTH`), with atomic `0600` file writes. Browser `localStorage` contains only the non-secret provider/model selection preference; the API-key form itself is held in React memory and sent to the local API only on submit.

## Validation
- `pnpm verify`
- `pnpm test:e2e`
- manual Playwright smoke test: settings deep link, Accounts-before-API-keys order, unauthenticated model gating, and Remote SSH URL navigation
- CI required checks: lint, test, build, audit, e2e, and windows-smoke
