### PR TITLE
fix(viewer): make AI default selection explicit

### DIFF
--- a/packages/viewer/src/components/AiProviderSettings.tsx
+++ b/packages/viewer/src/components/AiProviderSettings.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
 import type {
   AiAuthMethodInfo,
@@ -51,45 +58,61 @@ function ProviderAuthCard({
   selected,
   disabled,
   onSelect,
+  children,
 }: {
   provider: AiProviderInfo;
   method: AiAuthMethodInfo;
   selected: boolean;
   disabled: boolean;
   onSelect: () => void;
+  children?: ReactNode;
 }) {
   const configured = provider.configured && provider.authType === method.type;
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      disabled={disabled}
-      className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
+    <div
+      className={`overflow-hidden rounded-lg border transition-colors ${
         selected
           ? "border-terminal-purple/50 bg-terminal-purple-subtle"
-          : "border-terminal-border-subtle bg-terminal-bg hover:border-terminal-purple/30"
+          : "border-terminal-border-subtle bg-terminal-bg"
       }`}
     >
-      <div className="flex items-start justify-between gap-2">
-        <span className="min-w-0 truncate text-xs font-mono font-semibold text-terminal-text">
-          {provider.name}
-        </span>
-        <span
-          className={`shrink-0 text-[9px] font-mono ${
-            configured ? "text-terminal-green" : "text-terminal-orange"
-          }`}
-        >
-          {configured ? "ready" : "setup"}
-        </span>
-      </div>
-      <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-        {provider.models.length} model{provider.models.length === 1 ? "" : "s"}
-      </div>
-      <div className="mt-2 text-[10px] font-mono text-terminal-purple">
-        {authMethodKind(method)}
-        {method.subscription ? " · subscription" : ""}
-      </div>
-    </button>
+      <button
+        type="button"
+        onClick={onSelect}
+        disabled={disabled}
+        aria-pressed={selected}
+        className={`w-full cursor-pointer p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-terminal-purple/60 disabled:cursor-not-allowed disabled:opacity-50 ${
+          selected
+            ? "hover:bg-terminal-purple/10"
+            : "hover:bg-terminal-surface-hover hover:border-terminal-purple/30"
+        }`}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="min-w-0 truncate text-xs font-mono font-semibold text-terminal-text">
+            {provider.name}
+          </span>
+          <span
+            className={`shrink-0 text-[9px] font-mono ${
+              configured ? "text-terminal-green" : "text-terminal-orange"
+            }`}
+          >
+            {configured ? "ready" : "setup"}
+          </span>
+        </div>
+        <div className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+          {provider.models.length} model{provider.models.length === 1 ? "" : "s"}
+        </div>
+        <div className="mt-2 text-[10px] font-mono text-terminal-purple">
+          {authMethodKind(method)}
+          {method.subscription ? " · subscription" : ""}
+        </div>
+      </button>
+      {selected && children && (
+        <div className="border-t border-terminal-purple/20 bg-terminal-surface/30 px-3 pb-3 pt-3">
+          {children}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -233,7 +256,7 @@ function ModelPicker({
                       setOpen(false);
                       setQuery("");
                     }}
-                    className={`flex w-full items-start justify-between gap-3 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-terminal-purple-subtle ${
+                    className={`flex w-full cursor-pointer items-start justify-between gap-3 rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-terminal-purple-subtle ${
                       model.id === value
                         ? "bg-terminal-purple-subtle text-terminal-text"
                         : "text-terminal-dim"
@@ -275,12 +298,69 @@ function ModelPicker({
           setOpen((current) => !current);
           setQuery("");
         }}
-        className="flex w-full items-center justify-between gap-2 rounded-lg border border-terminal-border bg-terminal-surface px-2.5 py-2 text-left text-xs font-mono text-terminal-text outline-none transition-colors hover:border-terminal-purple/40 disabled:opacity-50"
+        className="flex w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-terminal-border bg-terminal-surface px-2.5 py-2 text-left text-xs font-mono text-terminal-text outline-none transition-colors hover:border-terminal-purple/40 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-terminal-purple/60"
       >
         <span className="min-w-0 truncate">{selected?.name || value || "Select a model"}</span>
         <span className="shrink-0 text-terminal-dimmer">⌄</span>
       </button>
       {menu}
+    </div>
+  );
+}
+
+function ProviderModelSelection({
+  provider,
+  authConfigured,
+  authMethod,
+  modelId,
+  onModelChange,
+  disabled,
+  saveAiSelectionAsDefault,
+  isDefault,
+}: {
+  provider: AiProviderInfo;
+  authConfigured: boolean;
+  authMethod: AiAuthMethodInfo;
+  modelId: string | null;
+  onModelChange: (modelId: string) => void;
+  disabled: boolean;
+  saveAiSelectionAsDefault: (() => void) | null;
+  isDefault: boolean;
+}) {
+  if (provider.models.length === 0) return null;
+
+  return authConfigured ? (
+    <div className="border-t border-terminal-border-subtle pt-3">
+      <div className="flex items-center gap-2">
+        <span className="shrink-0 text-[10px] font-mono text-terminal-dim">Model</span>
+        <ModelPicker
+          models={provider.models}
+          value={modelId || ""}
+          onChange={onModelChange}
+          disabled={disabled}
+        />
+        {saveAiSelectionAsDefault && (
+          <button
+            type="button"
+            onClick={() => saveAiSelectionAsDefault()}
+            disabled={disabled || !modelId || isDefault}
+            className={`shrink-0 cursor-pointer rounded-lg px-2 py-1.5 text-[10px] font-mono transition-colors disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-purple/60 ${
+              isDefault
+                ? "bg-terminal-green-subtle text-terminal-green"
+                : "bg-terminal-surface-2 text-terminal-dim hover:bg-terminal-purple-subtle hover:text-terminal-purple"
+            }`}
+          >
+            {isDefault ? "Default" : "Set default"}
+          </button>
+        )}
+      </div>
+    </div>
+  ) : (
+    <div className="border-t border-terminal-border-subtle pt-3 text-[10px] font-mono">
+      <div className="text-terminal-dim">Connect first to choose a model.</div>
+      <div className="mt-1 text-terminal-dimmer">
+        Complete {authMethodKind(authMethod)} for {provider.name} above.
+      </div>
     </div>
   );
 }
@@ -331,14 +411,6 @@ export function AiProviderSettings({
   } | null>(null);
 
   const selectedProvider = providers.find((provider) => provider.id === providerId) || null;
-  const selectedAuthMethod = selectedProvider?.authMethods.find(
-    (method) => method.type === authMethod,
-  );
-  const selectedProviderAuthStatus = selectedProvider
-    ? providerStatus(selectedProvider, authMethod)
-    : "not configured";
-  const selectedAuthConfigured =
-    selectedProvider?.id === "custom-openai" || selectedProviderAuthStatus !== "not configured";
   const apiKeyProviders = providers.filter((provider) =>
     provider.authMethods.some((method) => method.type === "api_key"),
   );
@@ -346,6 +418,9 @@ export function AiProviderSettings({
     provider.authMethods.some((method) => method.type === "oauth"),
   );
   const customProvider = providers.find((provider) => provider.id === "custom-openai") || null;
+  const defaultProvider = providers.find((provider) => provider.id === defaultAiProviderId) || null;
+  const defaultModel =
+    defaultProvider?.models.find((model) => model.id === defaultAiModelId) || null;
   const selectionLocked = busy || authRunning || customRunning;
 
   useEffect(() => {
@@ -492,6 +567,107 @@ export function AiProviderSettings({
     }
   }, [removeAiCustomProvider]);
 
+  const renderInlineProviderSetup = (provider: AiProviderInfo, method: AiAuthMethodInfo) => {
+    if (provider.id === "custom-openai") return null;
+    const authConfigured = provider.configured && provider.authType === method.type;
+    const status = providerStatus(provider, method.type);
+
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[10px] font-mono text-terminal-dim">
+            {method.type === "api_key" ? "API key" : "Account access"}
+          </span>
+          <span
+            className={`text-[10px] font-mono ${
+              authConfigured ? "text-terminal-green" : "text-terminal-orange"
+            }`}
+          >
+            {status}
+          </span>
+        </div>
+
+        {method.type === "api_key" && (
+          <div className="flex gap-2">
+            <input
+              aria-label="AI API key"
+              name={`ai-api-key-${provider.id}`}
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              placeholder={authConfigured ? "Enter a new API key…" : "Paste API key…"}
+              autoComplete="off"
+              disabled={selectionLocked}
+              className={`min-w-0 flex-1 ${INPUT_CLASS}`}
+            />
+            <button
+              type="button"
+              onClick={() => (authRunning ? cancelAiAuthentication?.() : void handleAuthenticate())}
+              disabled={busy || (authRunning ? !cancelAiAuthentication : !apiKey.trim())}
+              className="shrink-0 cursor-pointer rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-purple/60"
+            >
+              {authRunning ? "Cancel" : "Save key"}
+            </button>
+          </div>
+        )}
+
+        {method.type === "oauth" && (
+          <div className="space-y-2">
+            <div className="text-[10px] font-mono text-terminal-dimmer">{method.label}</div>
+            <button
+              type="button"
+              onClick={() => (authRunning ? cancelAiAuthentication?.() : void handleAuthenticate())}
+              disabled={busy || (authRunning ? !cancelAiAuthentication : false)}
+              className="w-full cursor-pointer rounded-lg bg-terminal-blue-subtle px-3 py-2 text-xs font-mono font-semibold text-terminal-blue transition-colors hover:bg-terminal-blue/20 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-blue/60"
+            >
+              {authRunning
+                ? "Cancel browser sign-in"
+                : authConfigured
+                  ? "Sign in again"
+                  : "Sign in with provider"}
+            </button>
+          </div>
+        )}
+
+        {provider.configured &&
+          logoutAiProvider &&
+          (provider.authType === "oauth" || provider.authSource === "stored credential") &&
+          provider.authType === method.type && (
+            <button
+              type="button"
+              onClick={() => void handleLogout()}
+              disabled={selectionLocked}
+              className="cursor-pointer text-[10px] font-mono text-terminal-dimmer transition-colors hover:text-terminal-red disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-red/50"
+            >
+              Sign out this provider
+            </button>
+          )}
+
+        {authStatus && (
+          <div
+            role={authStatus.type === "error" ? "alert" : "status"}
+            className={`text-[10px] font-mono leading-relaxed ${
+              authStatus.type === "error" ? "text-terminal-red" : "text-terminal-green"
+            }`}
+          >
+            {authStatus.text}
+          </div>
+        )}
+
+        <ProviderModelSelection
+          provider={provider}
+          authConfigured={authConfigured}
+          authMethod={method}
+          modelId={modelId}
+          onModelChange={handleModelChange}
+          disabled={selectionLocked}
+          saveAiSelectionAsDefault={saveAiSelectionAsDefault}
+          isDefault={providerId === defaultAiProviderId && modelId === defaultAiModelId}
+        />
+      </div>
+    );
+  };
+
   const settingsBody = (
     <div className="space-y-5">
       <div className="flex items-start justify-between gap-3">
@@ -500,7 +676,8 @@ export function AiProviderSettings({
           <p className="mt-1 max-w-2xl text-[10px] font-sans leading-relaxed text-terminal-dim">
             Configure built-in providers or connect an OpenAI-compatible gateway. API keys and
             account sign-ins are shown separately; credentials stay in the local store and are never
-            included in provider metadata.
+            included in provider metadata. The default model is shown below and is shared by Ask
+            Replay and AI Studio.
           </p>
         </div>
         {refreshAiProviders && (
@@ -508,7 +685,7 @@ export function AiProviderSettings({
             type="button"
             onClick={() => void handleRefresh()}
             disabled={selectionLocked || aiProvidersLoading}
-            className="shrink-0 rounded-lg bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:opacity-40"
+            className="shrink-0 cursor-pointer rounded-lg bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40"
           >
             {aiProvidersLoading ? "Refreshing…" : "Refresh"}
           </button>
@@ -523,6 +700,39 @@ export function AiProviderSettings({
           {aiProvidersError}
         </div>
       )}
+
+      <div className="rounded-xl border border-terminal-green/25 bg-terminal-green-subtle/20 px-3 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[10px] font-mono uppercase tracking-[0.14em] text-terminal-green">
+              Default for Ask Replay & AI Studio
+            </div>
+            <div className="mt-1 truncate text-sm font-mono font-semibold text-terminal-text">
+              {defaultProvider && defaultModel
+                ? `${defaultProvider.name} · ${defaultModel.name || defaultModel.id}`
+                : "No default model selected"}
+            </div>
+          </div>
+          <span
+            className={`shrink-0 text-[9px] font-mono ${
+              defaultProvider?.configured && defaultModel
+                ? "text-terminal-green"
+                : "text-terminal-orange"
+            }`}
+          >
+            {defaultProvider && defaultModel
+              ? defaultProvider.configured
+                ? "active"
+                : "needs setup"
+              : "select below"}
+          </span>
+        </div>
+        <p className="mt-2 text-[10px] font-mono leading-relaxed text-terminal-dim">
+          {defaultProvider && defaultModel
+            ? "This is the provider and model used by default. Selecting another card below does not change it."
+            : "Select a provider and model below, then choose Set default to use it across AI features."}
+        </p>
+      </div>
 
       {providers.length === 0 && aiProvidersLoading ? (
         <div className="rounded-lg bg-terminal-bg px-3 py-4 text-center text-[10px] font-mono text-terminal-dimmer">
@@ -549,15 +759,19 @@ export function AiProviderSettings({
                       (candidate) => candidate.type === "oauth",
                     );
                     if (!method) return null;
+                    const selected = provider.id === providerId && authMethod === "oauth";
                     return (
-                      <ProviderAuthCard
-                        key={`${provider.id}:oauth`}
-                        provider={provider}
-                        method={method}
-                        selected={provider.id === providerId && authMethod === "oauth"}
-                        disabled={selectionLocked}
-                        onSelect={() => handleAuthMethodChange(provider.id, "oauth")}
-                      />
+                      <div key={`${provider.id}:oauth`} className={selected ? "sm:col-span-2" : ""}>
+                        <ProviderAuthCard
+                          provider={provider}
+                          method={method}
+                          selected={selected}
+                          disabled={selectionLocked}
+                          onSelect={() => handleAuthMethodChange(provider.id, "oauth")}
+                        >
+                          {renderInlineProviderSetup(provider, method)}
+                        </ProviderAuthCard>
+                      </div>
                     );
                   })}
                 </div>
@@ -578,156 +792,28 @@ export function AiProviderSettings({
                       (candidate) => candidate.type === "api_key",
                     );
                     if (!method) return null;
+                    const selected = provider.id === providerId && authMethod === "api_key";
                     return (
-                      <ProviderAuthCard
+                      <div
                         key={`${provider.id}:api_key`}
-                        provider={provider}
-                        method={method}
-                        selected={provider.id === providerId && authMethod === "api_key"}
-                        disabled={selectionLocked}
-                        onSelect={() => handleAuthMethodChange(provider.id, "api_key")}
-                      />
+                        className={selected ? "sm:col-span-2" : ""}
+                      >
+                        <ProviderAuthCard
+                          provider={provider}
+                          method={method}
+                          selected={selected}
+                          disabled={selectionLocked}
+                          onSelect={() => handleAuthMethodChange(provider.id, "api_key")}
+                        >
+                          {renderInlineProviderSetup(provider, method)}
+                        </ProviderAuthCard>
+                      </div>
                     );
                   })}
                 </div>
               </div>
             )}
           </div>
-
-          {selectedProvider && selectedProvider.id !== "custom-openai" && (
-            <div className="rounded-lg border border-terminal-border-subtle bg-terminal-bg p-3 space-y-2">
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-xs font-mono text-terminal-dim">Authentication</span>
-                <span
-                  className={`text-[10px] font-mono ${
-                    selectedProviderAuthStatus === "not configured"
-                      ? "text-terminal-orange"
-                      : "text-terminal-green"
-                  }`}
-                >
-                  {selectedProviderAuthStatus}
-                </span>
-              </div>
-
-              {selectedAuthMethod && (
-                <div className="flex flex-wrap items-center gap-2 text-[10px] font-mono">
-                  <span className="rounded-md bg-terminal-purple-subtle px-2 py-1 text-terminal-purple">
-                    {authMethodKind(selectedAuthMethod)}
-                  </span>
-                  <span className="text-terminal-dimmer">{selectedAuthMethod.label}</span>
-                </div>
-              )}
-
-              {authMethod === "api_key" &&
-                selectedProvider.authMethods.some((method) => method.type === "api_key") && (
-                  <div className="flex gap-2">
-                    <input
-                      aria-label="AI API key"
-                      type="password"
-                      value={apiKey}
-                      onChange={(event) => setApiKey(event.target.value)}
-                      placeholder="Paste API key"
-                      autoComplete="off"
-                      disabled={selectionLocked}
-                      className={`min-w-0 flex-1 ${INPUT_CLASS}`}
-                    />
-                    <button
-                      type="button"
-                      onClick={() =>
-                        authRunning ? cancelAiAuthentication?.() : void handleAuthenticate()
-                      }
-                      disabled={busy || (authRunning ? !cancelAiAuthentication : !apiKey.trim())}
-                      className="shrink-0 rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:opacity-40"
-                    >
-                      {authRunning ? "Cancel" : "Save key"}
-                    </button>
-                  </div>
-                )}
-
-              {authMethod === "oauth" &&
-                selectedProvider.authMethods.some((method) => method.type === "oauth") && (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      authRunning ? cancelAiAuthentication?.() : void handleAuthenticate()
-                    }
-                    disabled={busy || (authRunning ? !cancelAiAuthentication : false)}
-                    className="w-full rounded-lg bg-terminal-blue-subtle px-3 py-2 text-xs font-mono font-semibold text-terminal-blue transition-colors hover:bg-terminal-blue/20 disabled:opacity-40"
-                  >
-                    {authRunning
-                      ? "Cancel browser sign-in"
-                      : selectedProvider.configured && selectedProvider.authType === "oauth"
-                        ? "Sign in again"
-                        : "Sign in with provider"}
-                  </button>
-                )}
-
-              {selectedProvider.configured &&
-                logoutAiProvider &&
-                (selectedProvider.authType === "oauth" ||
-                  selectedProvider.authSource === "stored credential") &&
-                (!selectedAuthMethod || selectedProvider.authType === selectedAuthMethod.type) && (
-                  <button
-                    type="button"
-                    onClick={() => void handleLogout()}
-                    disabled={selectionLocked}
-                    className="text-[10px] font-mono text-terminal-dimmer transition-colors hover:text-terminal-red disabled:opacity-40"
-                  >
-                    Sign out this provider
-                  </button>
-                )}
-
-              {authStatus && (
-                <div
-                  role={authStatus.type === "error" ? "alert" : "status"}
-                  className={`text-[10px] font-mono leading-relaxed ${
-                    authStatus.type === "error" ? "text-terminal-red" : "text-terminal-green"
-                  }`}
-                >
-                  {authStatus.text}
-                </div>
-              )}
-            </div>
-          )}
-
-          {selectedProvider &&
-            selectedProvider.models.length > 0 &&
-            (selectedAuthConfigured ? (
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-mono text-terminal-dim">Model</span>
-                <ModelPicker
-                  models={selectedProvider.models}
-                  value={modelId || ""}
-                  onChange={handleModelChange}
-                  disabled={selectionLocked}
-                />
-                {saveAiSelectionAsDefault && (
-                  <button
-                    type="button"
-                    onClick={saveAiSelectionAsDefault}
-                    disabled={selectionLocked || !modelId}
-                    className={`shrink-0 rounded-lg px-2 py-1.5 text-[10px] font-mono transition-colors disabled:opacity-40 ${
-                      providerId === defaultAiProviderId && modelId === defaultAiModelId
-                        ? "bg-terminal-green-subtle text-terminal-green"
-                        : "bg-terminal-surface-2 text-terminal-dim hover:text-terminal-text"
-                    }`}
-                  >
-                    {providerId === defaultAiProviderId && modelId === defaultAiModelId
-                      ? "Default"
-                      : "Set default"}
-                  </button>
-                )}
-              </div>
-            ) : (
-              <div className="rounded-lg border border-dashed border-terminal-border-subtle bg-terminal-bg px-3 py-2.5 text-[10px] font-mono">
-                <div className="text-terminal-dim">Connect first to choose a model.</div>
-                <div className="mt-1 text-terminal-dimmer">
-                  Complete{" "}
-                  {selectedAuthMethod ? authMethodKind(selectedAuthMethod) : "authentication"} for{" "}
-                  {selectedProvider.name} above.
-                </div>
-              </div>
-            ))}
         </>
       )}
 
@@ -780,7 +866,7 @@ export function AiProviderSettings({
               customRunning ? cancelAiAuthentication?.() : void handleConfigureCustomProvider()
             }
             disabled={busy || (customRunning ? !cancelAiAuthentication : !customBaseUrl.trim())}
-            className="shrink-0 rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:opacity-40"
+            className="shrink-0 cursor-pointer rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:cursor-not-allowed disabled:opacity-40"
           >
             {customRunning ? "Cancel" : customProvider ? "Update" : "Discover"}
           </button>
@@ -795,7 +881,7 @@ export function AiProviderSettings({
             type="button"
             onClick={() => void handleRemoveCustomProvider()}
             disabled={selectionLocked}
-            className="text-[10px] font-mono text-terminal-dimmer transition-colors hover:text-terminal-red disabled:opacity-40"
+            className="cursor-pointer text-[10px] font-mono text-terminal-dimmer transition-colors hover:text-terminal-red disabled:cursor-not-allowed disabled:opacity-40"
           >
             Remove custom endpoint and key
           </button>
@@ -809,6 +895,24 @@ export function AiProviderSettings({
           >
             {customStatus.text}
           </div>
+        )}
+        {selectedProvider?.id === "custom-openai" && (
+          <ProviderModelSelection
+            provider={selectedProvider}
+            authConfigured
+            authMethod={
+              selectedProvider.authMethods[0] || {
+                type: "api_key",
+                label: "Custom endpoint",
+                subscription: false,
+              }
+            }
+            modelId={modelId}
+            onModelChange={handleModelChange}
+            disabled={selectionLocked}
+            saveAiSelectionAsDefault={saveAiSelectionAsDefault}
+            isDefault={providerId === defaultAiProviderId && modelId === defaultAiModelId}
+          />
         )}
       </div>
     </div>
@@ -850,7 +954,7 @@ export function AiProviderSettingsModal({
       <button
         type="button"
         aria-label="Close AI provider settings"
-        className="absolute inset-0 bg-black/50"
+        className="absolute inset-0 cursor-pointer bg-black/50 transition-colors hover:bg-black/60"
         onClick={onClose}
       />
       <dialog
@@ -871,7 +975,7 @@ export function AiProviderSettingsModal({
               <button
                 type="button"
                 onClick={onOpenSettings}
-                className="rounded-lg px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text"
+                className="cursor-pointer rounded-lg px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text"
               >
                 Open full Settings
               </button>
@@ -879,7 +983,7 @@ export function AiProviderSettingsModal({
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg px-2 py-1 text-sm text-terminal-dim transition-colors hover:text-terminal-text"
+              className="cursor-pointer rounded-lg px-2 py-1 text-sm text-terminal-dim transition-colors hover:text-terminal-text"
             >
               ×
             </button>

--- a/packages/viewer/src/components/AiStudioPanel.tsx
+++ b/packages/viewer/src/components/AiStudioPanel.tsx
@@ -106,6 +106,8 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
     aiProvidersLoading,
     setAiProviderId,
     setAiModelId,
+    defaultAiProviderId,
+    defaultAiModelId,
   } = annotationActions;
 
   const hasAiFeedback = annotationActions.annotations.some((a) => a.author === "vibe-feedback");
@@ -136,8 +138,11 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
   // Both hooks discover the same provider registry. Keep the annotation hook as
   // the source for setup/status and synchronize the selection into overlays.
   const providers = aiProviders.length > 0 ? aiProviders : studioProviders;
-  const providerId = aiProviderId || studioProviderId;
-  const modelId = aiModelId || studioModelId;
+  const defaultProvider = providers.find((provider) => provider.id === defaultAiProviderId);
+  const defaultModel = defaultProvider?.models.find((model) => model.id === defaultAiModelId);
+  const defaultSelectionReady = Boolean(defaultProvider?.configured && defaultModel);
+  const providerId = defaultSelectionReady ? defaultAiProviderId : aiProviderId || studioProviderId;
+  const modelId = defaultSelectionReady ? defaultAiModelId : aiModelId || studioModelId;
   const selectedProvider = providers.find((provider) => provider.id === providerId) || null;
   const selectedModel = selectedProvider?.models.find((model) => model.id === modelId) || null;
   const providerConfigured = selectedProvider?.configured === true;
@@ -306,7 +311,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
         {overlayCount > 0 && (
           <button
             onClick={revertAll}
-            className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple hover:bg-terminal-red-subtle hover:text-terminal-red transition-colors"
+            className="cursor-pointer text-[10px] font-mono px-1.5 py-0.5 rounded bg-terminal-purple-subtle text-terminal-purple hover:bg-terminal-red-subtle hover:text-terminal-red transition-colors"
           >
             Revert All ({overlayCount})
           </button>
@@ -317,10 +322,12 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
         <div className="border-b border-terminal-border-subtle bg-terminal-surface/30 px-4 py-3 space-y-3">
           <div className="flex items-center justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-xs font-mono text-terminal-dim">Provider</div>
+              <div className="text-xs font-mono text-terminal-dim">
+                {defaultSelectionReady ? "Default model" : "Provider"}
+              </div>
               <div className="mt-1 truncate text-xs font-mono font-semibold text-terminal-text">
                 {selectedProvider?.name || "Select a provider"}
-                {modelId ? ` · ${modelId}` : ""}
+                {selectedModel ? ` · ${selectedModel.name || selectedModel.id}` : ""}
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-1.5">
@@ -328,7 +335,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
                 type="button"
                 onClick={() => setProviderSettingsOpen(true)}
                 disabled={isAnyRunning}
-                className="rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:opacity-40"
+                className="cursor-pointer rounded-lg bg-terminal-purple-subtle px-2.5 py-1.5 text-[10px] font-mono font-semibold text-terminal-purple transition-colors hover:bg-terminal-purple/20 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Manage
               </button>
@@ -336,7 +343,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
                 type="button"
                 onClick={openFullSettings}
                 disabled={isAnyRunning}
-                className="rounded-lg bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:opacity-40"
+                className="cursor-pointer rounded-lg bg-terminal-surface-2 px-2.5 py-1.5 text-[10px] font-mono text-terminal-dim transition-colors hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Settings
               </button>
@@ -463,7 +470,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
                     value={targetLang}
                     onChange={(e) => setTargetLang(e.target.value)}
                     disabled={isAnyRunning}
-                    className="flex-1 bg-terminal-surface border border-terminal-border rounded px-2 py-1 text-xs font-mono text-terminal-text outline-none disabled:opacity-50"
+                    className="flex-1 cursor-pointer bg-terminal-surface border border-terminal-border rounded px-2 py-1 text-xs font-mono text-terminal-text outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {TARGET_LANGUAGES.map((lang) => (
                       <option key={lang} value={lang}>
@@ -521,7 +528,7 @@ export default function AiStudioPanel({ annotationActions, overlayActions }: Pro
                       setToneStyle(e.target.value as "professional" | "neutral" | "friendly")
                     }
                     disabled={isAnyRunning}
-                    className="flex-1 bg-terminal-surface border border-terminal-border rounded px-2 py-1 text-xs font-mono text-terminal-text outline-none disabled:opacity-50"
+                    className="flex-1 cursor-pointer bg-terminal-surface border border-terminal-border rounded px-2 py-1 text-xs font-mono text-terminal-text outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {TONE_STYLES.map((s) => (
                       <option key={s.value} value={s.value}>
@@ -594,7 +601,7 @@ function FeatureCard({
           <button
             onClick={onRun}
             disabled={disabled}
-            className="px-3.5 py-1.5 text-xs font-mono rounded-lg bg-terminal-purple-subtle text-terminal-purple hover:bg-terminal-purple-emphasis transition-colors disabled:opacity-40 flex items-center gap-1.5"
+            className="cursor-pointer px-3.5 py-1.5 text-xs font-mono rounded-lg bg-terminal-purple-subtle text-terminal-purple hover:bg-terminal-purple-emphasis transition-colors disabled:cursor-not-allowed disabled:opacity-40 flex items-center gap-1.5"
           >
             {running ? (
               <>
@@ -608,7 +615,7 @@ function FeatureCard({
           {running && onCancel && (
             <button
               onClick={onCancel}
-              className="text-xs font-mono text-terminal-dim hover:text-terminal-text transition-colors"
+              className="cursor-pointer text-xs font-mono text-terminal-dim hover:text-terminal-text transition-colors"
             >
               Cancel
             </button>
@@ -621,13 +628,13 @@ function FeatureCard({
             <span className="text-terminal-orange flex-1">{rerunWarning}</span>
             <button
               onClick={onCancelRerun}
-              className="text-terminal-dim hover:text-terminal-text transition-colors"
+              className="cursor-pointer text-terminal-dim hover:text-terminal-text transition-colors"
             >
               Cancel
             </button>
             <button
               onClick={onConfirmRerun}
-              className="text-terminal-purple hover:text-terminal-text transition-colors font-medium"
+              className="cursor-pointer text-terminal-purple hover:text-terminal-text transition-colors font-medium"
             >
               Continue
             </button>

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -427,6 +427,7 @@ export default function LocalChatAssistant({ context }: Props) {
   >(undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
   const providerSettings = useAiProviderSettings(true);
+  const { refreshAiProviders } = providerSettings;
   const availableProviders = providerSettings.aiProviders.filter(
     (provider) => provider.configured && provider.models.length > 0,
   );
@@ -462,6 +463,14 @@ export default function LocalChatAssistant({ context }: Props) {
     ? "Open provider settings"
     : "Set up an AI provider";
   const remoteSession = Boolean(context.currentSession?.targetId);
+  const retryProviderSetup = useCallback(async () => {
+    try {
+      await refreshAiProviders?.();
+    } catch {
+      // The provider hook exposes the error state; retry should not create an
+      // unhandled rejection in the chat surface.
+    }
+  }, [refreshAiProviders]);
 
   useEffect(() => {
     setPanelSize(readPanelSize());
@@ -845,7 +854,7 @@ export default function LocalChatAssistant({ context }: Props) {
                   hasAvailableProvider={availableProviders.length > 0}
                   onOpenSettings={openProviderSettings}
                   onChooseModel={() => setSwitchOpen(true)}
-                  onRetry={() => void providerSettings.refreshAiProviders?.()}
+                  onRetry={retryProviderSetup}
                 />
               ) : (
                 <div className="pt-8 text-center">
@@ -997,7 +1006,7 @@ export default function LocalChatAssistant({ context }: Props) {
                   type="button"
                   onClick={() => {
                     if (providerSettings.aiProvidersError) {
-                      void providerSettings.refreshAiProviders?.();
+                      void retryProviderSetup();
                     } else if (canChooseModel) {
                       setSwitchOpen(true);
                     } else {

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -67,6 +67,158 @@ const DEFAULT_PANEL_SIZE = { width: 520, height: 720 };
 type PanelSize = typeof DEFAULT_PANEL_SIZE;
 type ResizeEdges = { left?: boolean; right?: boolean; top?: boolean; bottom?: boolean };
 
+type ProviderSetupEmptyStateProps = {
+  loading: boolean;
+  error: string | null;
+  hasConfiguredProvider: boolean;
+  hasAvailableProvider: boolean;
+  onOpenSettings: () => void;
+  onChooseModel: () => void;
+  onRetry: () => void;
+};
+
+function ProviderSetupEmptyState({
+  loading,
+  error,
+  hasConfiguredProvider,
+  hasAvailableProvider,
+  onOpenSettings,
+  onChooseModel,
+  onRetry,
+}: ProviderSetupEmptyStateProps) {
+  if (loading) {
+    return (
+      <output
+        className="flex min-h-full items-center justify-center py-10 text-xs font-mono text-terminal-dim"
+        aria-live="polite"
+      >
+        <span
+          className="mr-2 h-2 w-2 animate-pulse rounded-full bg-terminal-green"
+          aria-hidden="true"
+        />
+        Checking provider setup…
+      </output>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-full items-center justify-center py-10">
+        <div className="w-full max-w-[360px] rounded-2xl border border-terminal-red/25 bg-terminal-red-subtle/40 p-5">
+          <div className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-terminal-red/15 text-lg text-terminal-red">
+              <span aria-hidden="true">!</span>
+            </div>
+            <div>
+              <div className="text-[10px] font-mono uppercase tracking-[0.16em] text-terminal-red">
+                Provider setup unavailable
+              </div>
+              <h2 className="mt-1 text-base font-semibold text-terminal-text">
+                We couldn’t check your provider
+              </h2>
+            </div>
+          </div>
+          <p className="mt-3 text-xs leading-relaxed text-terminal-dim">
+            Ask Replay can’t start until your local provider settings are available. Try again or
+            open settings to check the configuration.
+          </p>
+          <div className="mt-5 flex gap-2">
+            <button
+              type="button"
+              onClick={onRetry}
+              className="flex-1 cursor-pointer rounded-lg border border-terminal-border-subtle bg-terminal-surface px-3 py-2 text-xs font-semibold text-terminal-text transition-colors hover:border-terminal-green/50 hover:text-terminal-green focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="flex-1 cursor-pointer rounded-lg bg-terminal-green px-3 py-2 text-xs font-semibold text-terminal-bg transition-colors hover:bg-terminal-green/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
+            >
+              Open Settings
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const needsConnection = !hasConfiguredProvider;
+  const needsModel = hasConfiguredProvider && !hasAvailableProvider;
+
+  return (
+    <div className="flex min-h-full items-center justify-center py-10">
+      <div className="w-full max-w-[360px]">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-terminal-orange/30 bg-terminal-orange-subtle text-xl text-terminal-orange">
+            <span aria-hidden="true">✦</span>
+          </div>
+          <div className="min-w-0 pt-0.5">
+            <div className="text-[10px] font-mono uppercase tracking-[0.16em] text-terminal-orange">
+              {needsConnection ? "Setup required" : needsModel ? "Almost ready" : "One step left"}
+            </div>
+            <h2 className="mt-1 text-base font-semibold text-terminal-text [text-wrap:balance]">
+              {needsConnection
+                ? "Connect a provider to start"
+                : needsModel
+                  ? "Finish your provider setup"
+                  : "Choose a provider & model"}
+            </h2>
+          </div>
+        </div>
+
+        <p className="mt-4 text-xs leading-relaxed text-terminal-dim">
+          {needsConnection
+            ? "Ask Replay needs an AI provider before it can search your local sessions or explain usage data."
+            : needsModel
+              ? "Your provider is connected, but Ask Replay still needs a usable model before you can ask questions."
+              : "Choose which configured provider and model should power this chat."}
+        </p>
+
+        {needsConnection && (
+          <ol className="mt-5 space-y-2.5">
+            {[
+              ["1", "Connect a provider", "Use an API key, OAuth, or a local runtime."],
+              ["2", "Choose a model", "Pick the model you want to use for this chat."],
+              ["3", "Start asking", "Search sessions, inspect replays, and explain usage."],
+            ].map(([step, title, description]) => (
+              <li key={step} className="flex items-start gap-2.5">
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-terminal-border-subtle bg-terminal-surface text-[10px] font-mono text-terminal-dim">
+                  {step}
+                </span>
+                <div className="min-w-0 text-xs">
+                  <div className="font-medium text-terminal-text">{title}</div>
+                  <div className="mt-0.5 leading-relaxed text-terminal-dim">{description}</div>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <button
+          type="button"
+          onClick={needsConnection || needsModel ? onOpenSettings : onChooseModel}
+          className="mt-6 flex w-full cursor-pointer items-center justify-between rounded-xl bg-terminal-green px-3.5 py-3 text-left text-xs font-semibold text-terminal-bg transition-colors hover:bg-terminal-green/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/60 focus-visible:ring-offset-2 focus-visible:ring-offset-terminal-bg"
+        >
+          <span>
+            {needsConnection
+              ? "Set Up an AI Provider"
+              : needsModel
+                ? "Open Provider Settings"
+                : "Choose Provider & Model"}
+          </span>
+          <span aria-hidden="true" className="text-sm">
+            →
+          </span>
+        </button>
+        <p className="mt-3 text-center text-[10px] leading-relaxed font-mono text-terminal-dimmer">
+          Credentials stay in the local provider store. Ask Replay is read-only.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function readPanelSize(): PanelSize {
   try {
     const raw = localStorage.getItem(CHAT_SIZE_STORAGE_KEY);
@@ -275,27 +427,40 @@ export default function LocalChatAssistant({ context }: Props) {
   >(undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
   const providerSettings = useAiProviderSettings(true);
-  const selectedProvider = providerSettings.aiProviders.find(
-    (provider) => provider.id === providerSettings.aiProviderId,
-  );
   const availableProviders = providerSettings.aiProviders.filter(
     (provider) => provider.configured && provider.models.length > 0,
   );
-  const selectedModel = selectedProvider?.models.find(
-    (model) => model.id === providerSettings.aiModelId,
+  const defaultProvider = providerSettings.aiProviders.find(
+    (provider) => provider.id === providerSettings.defaultAiProviderId,
   );
+  const defaultModel = defaultProvider?.models.find(
+    (model) => model.id === providerSettings.defaultAiModelId,
+  );
+  const defaultSelectionReady = Boolean(defaultProvider?.configured && defaultModel);
+  const chatProviderId = defaultSelectionReady
+    ? providerSettings.defaultAiProviderId
+    : providerSettings.aiProviderId;
+  const chatModelId = defaultSelectionReady
+    ? providerSettings.defaultAiModelId
+    : providerSettings.aiModelId;
+  const selectedProvider = providerSettings.aiProviders.find(
+    (provider) => provider.id === chatProviderId,
+  );
+  const selectedModel = selectedProvider?.models.find((model) => model.id === chatModelId);
   const providerReady = Boolean(selectedProvider?.configured && selectedModel);
   const hasConfiguredProvider = providerSettings.aiProviders.some(
     (provider) => provider.configured,
   );
-  const providerSetupMessage = !hasConfiguredProvider
-    ? "No AI provider is configured yet."
-    : availableProviders.length === 0
-      ? "Your configured provider has no usable model yet."
-      : "Select a provider and model in AI Studio.";
+  const providerSetupMessage = providerSettings.aiProvidersError
+    ? "Provider setup is unavailable."
+    : !hasConfiguredProvider
+      ? "Set up an AI provider to continue."
+      : availableProviders.length === 0
+        ? "Choose a usable model to continue."
+        : "Choose a provider and model to continue.";
   const providerSetupAction = hasConfiguredProvider
-    ? "Open provider settings →"
-    : "Set up an AI provider →";
+    ? "Open provider settings"
+    : "Set up an AI provider";
   const remoteSession = Boolean(context.currentSession?.targetId);
 
   useEffect(() => {
@@ -371,7 +536,7 @@ export default function LocalChatAssistant({ context }: Props) {
     // A selection can change in AI Studio or Settings while Ask Replay stays
     // mounted. Do not keep showing the model used by an older answer.
     setProviderLabel(null);
-  }, [providerSettings.aiModelId, providerSettings.aiProviderId]);
+  }, [chatModelId, chatProviderId]);
 
   useEffect(() => {
     setAllowRemoteData(false);
@@ -431,8 +596,8 @@ export default function LocalChatAssistant({ context }: Props) {
           tab: params.get("tab") || undefined,
           project: params.get("project") || undefined,
         },
-        ...(providerSettings.aiProviderId ? { providerId: providerSettings.aiProviderId } : {}),
-        ...(providerSettings.aiModelId ? { modelId: providerSettings.aiModelId } : {}),
+        ...(chatProviderId ? { providerId: chatProviderId } : {}),
+        ...(chatModelId ? { modelId: chatModelId } : {}),
       };
       const response = await fetch("/api/assistant/chat", {
         method: "POST",
@@ -449,7 +614,7 @@ export default function LocalChatAssistant({ context }: Props) {
         if (payload.type === "start") {
           const name = typeof payload.providerName === "string" ? payload.providerName : null;
           const model = typeof payload.modelId === "string" ? payload.modelId : null;
-          setProviderLabel(name && model ? `${name} · ${model}` : name);
+          setProviderLabel(name && model ? `Default · ${name} · ${model}` : name);
         } else if (payload.type === "tool_start") {
           const name = typeof payload.toolName === "string" ? payload.toolName : "tool";
           setActiveTool(name);
@@ -524,12 +689,39 @@ export default function LocalChatAssistant({ context }: Props) {
     input,
     messages,
     providerReady,
-    providerSettings.aiModelId,
-    providerSettings.aiProviderId,
+    chatModelId,
+    chatProviderId,
     running,
   ]);
 
   const cancel = () => controllerRef.current?.abort();
+  const openProviderSettings = () =>
+    navigateTo({ view: "dashboard", session: null, tab: "settings" });
+  const providerStatus = providerSettings.aiProvidersLoading
+    ? "Checking provider setup…"
+    : providerSettings.aiProvidersError
+      ? "Provider setup unavailable"
+      : providerReady && selectedProvider && selectedModel
+        ? `${defaultSelectionReady ? "Default" : "Selected"} · ${selectedProvider.name} · ${selectedModel.name || selectedModel.id}`
+        : !hasConfiguredProvider
+          ? "Setup required"
+          : availableProviders.length === 0
+            ? "Model setup required"
+            : "Choose provider & model";
+  const canChooseModel = availableProviders.length > 0;
+
+  const chooseDefaultProvider = (providerId: string) => {
+    const provider = availableProviders.find((candidate) => candidate.id === providerId);
+    const modelId = provider?.models[0]?.id;
+    if (!modelId) return;
+    providerSettings.saveAiSelectionAsDefault?.({ providerId, modelId });
+    setProviderLabel(null);
+  };
+  const chooseDefaultModel = (modelId: string) => {
+    if (!chatProviderId) return;
+    providerSettings.saveAiSelectionAsDefault?.({ providerId: chatProviderId, modelId });
+    setProviderLabel(null);
+  };
 
   return (
     <div className={`fixed right-3 bottom-3 z-[60] font-sans ${resizing ? "select-none" : ""}`}>
@@ -552,40 +744,49 @@ export default function LocalChatAssistant({ context }: Props) {
                   Local
                 </span>
               </div>
-              <div className="mt-1 truncate text-[10px] font-mono text-terminal-dim">
-                {providerLabel ||
-                  (providerReady && selectedProvider && selectedModel
-                    ? `${selectedProvider.name} · ${selectedModel.name || selectedModel.id}`
-                    : null) ||
-                  (providerSettings.aiProvidersLoading
-                    ? "Loading provider…"
-                    : providerSettings.aiProvidersError
-                      ? "Provider settings unavailable"
-                      : providerSetupMessage)}
+              <div
+                className={`mt-1 flex items-center gap-1.5 truncate text-[10px] font-mono ${providerReady ? "text-terminal-dim" : "text-terminal-orange"}`}
+                aria-live="polite"
+              >
+                {!providerReady && !providerSettings.aiProvidersLoading && (
+                  <span
+                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-terminal-orange"
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="truncate">
+                  {providerReady && providerLabel ? providerLabel : providerStatus}
+                </span>
               </div>
             </div>
             <div className="flex items-center gap-1">
               <button
                 type="button"
-                onClick={() => setSwitchOpen((current) => !current)}
-                disabled={providerSettings.aiProvidersLoading || availableProviders.length === 0}
-                className="rounded-md px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40"
-                aria-expanded={switchOpen}
+                onClick={() => {
+                  if (canChooseModel) {
+                    setSwitchOpen((current) => !current);
+                  } else {
+                    openProviderSettings();
+                  }
+                }}
+                disabled={providerSettings.aiProvidersLoading}
+                className="cursor-pointer rounded-md px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
+                aria-expanded={canChooseModel ? switchOpen : undefined}
               >
-                Switch model
+                {canChooseModel ? (providerReady ? "Switch model" : "Choose model") : "Set up"}
               </button>
               <button
                 type="button"
                 onClick={clearConversation}
                 disabled={running || messages.length === 0}
-                className="rounded-md px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40"
+                className="cursor-pointer rounded-md px-2 py-1 text-[10px] font-mono text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
               >
                 Clear
               </button>
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="rounded-md px-2 py-1 text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text"
+                className="cursor-pointer rounded-md px-2 py-1 text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
                 aria-label="Close Ask Replay"
               >
                 ×
@@ -598,12 +799,11 @@ export default function LocalChatAssistant({ context }: Props) {
               <div className="flex gap-2">
                 <select
                   aria-label="AI provider"
-                  value={providerSettings.aiProviderId || ""}
+                  value={chatProviderId || ""}
                   onChange={(event) => {
-                    providerSettings.setAiProviderId?.(event.target.value);
-                    setProviderLabel(null);
+                    chooseDefaultProvider(event.target.value);
                   }}
-                  className="min-w-0 flex-1 rounded-lg border border-terminal-border-subtle bg-terminal-bg px-2 py-1.5 text-[10px] font-mono text-terminal-text outline-none focus:border-terminal-green/50"
+                  className="min-w-0 flex-1 cursor-pointer rounded-lg border border-terminal-border-subtle bg-terminal-bg px-2 py-1.5 text-[10px] font-mono text-terminal-text outline-none focus:border-terminal-green/50"
                 >
                   {availableProviders.map((provider) => (
                     <option key={provider.id} value={provider.id}>
@@ -613,12 +813,11 @@ export default function LocalChatAssistant({ context }: Props) {
                 </select>
                 <select
                   aria-label="AI model"
-                  value={providerSettings.aiModelId || ""}
+                  value={chatModelId || ""}
                   onChange={(event) => {
-                    providerSettings.setAiModelId?.(event.target.value);
-                    setProviderLabel(null);
+                    chooseDefaultModel(event.target.value);
                   }}
-                  className="min-w-0 flex-[1.4] rounded-lg border border-terminal-border-subtle bg-terminal-bg px-2 py-1.5 text-[10px] font-mono text-terminal-text outline-none focus:border-terminal-green/50"
+                  className="min-w-0 flex-[1.4] cursor-pointer rounded-lg border border-terminal-border-subtle bg-terminal-bg px-2 py-1.5 text-[10px] font-mono text-terminal-text outline-none focus:border-terminal-green/50"
                 >
                   {(selectedProvider?.models || []).map((model) => (
                     <option key={model.id} value={model.id}>
@@ -628,42 +827,56 @@ export default function LocalChatAssistant({ context }: Props) {
                 </select>
               </div>
               <div className="text-[9px] font-mono text-terminal-dimmer">
-                Selection is remembered locally. Credentials stay in the local provider store.
+                Default model is shared across Ask Replay and AI Studio. Credentials stay in the
+                local provider store.
               </div>
             </div>
           )}
 
           <div ref={scrollRef} className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4">
-            {messages.length === 0 && (
-              <div className="pt-8 text-center">
-                <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-terminal-green-subtle text-xl text-terminal-green">
-                  ✦
+            {messages.length === 0 &&
+              (providerSettings.aiProvidersLoading ||
+              providerSettings.aiProvidersError ||
+              !providerReady ? (
+                <ProviderSetupEmptyState
+                  loading={providerSettings.aiProvidersLoading}
+                  error={providerSettings.aiProvidersError}
+                  hasConfiguredProvider={hasConfiguredProvider}
+                  hasAvailableProvider={availableProviders.length > 0}
+                  onOpenSettings={openProviderSettings}
+                  onChooseModel={() => setSwitchOpen(true)}
+                  onRetry={() => void providerSettings.refreshAiProviders?.()}
+                />
+              ) : (
+                <div className="pt-8 text-center">
+                  <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-terminal-green-subtle text-xl text-terminal-green">
+                    <span aria-hidden="true">✦</span>
+                  </div>
+                  <h2 className="text-sm font-semibold text-terminal-text [text-wrap:balance]">
+                    What would you like to find?
+                  </h2>
+                  <div className="mx-auto mt-2 max-w-[280px] text-xs leading-relaxed text-terminal-dim">
+                    Search local sessions, explain usage data, read replay scenes, and open the
+                    relevant view.
+                  </div>
+                  <div className="mt-5 space-y-2 text-left">
+                    {[
+                      "Find my most recent sessions",
+                      "Why was my last session expensive?",
+                      "Show sessions with compaction",
+                    ].map((suggestion) => (
+                      <button
+                        key={suggestion}
+                        type="button"
+                        onClick={() => setInput(suggestion)}
+                        className="block w-full cursor-pointer rounded-lg border border-terminal-border-subtle bg-terminal-surface/50 px-3 py-2 text-left text-xs text-terminal-dim transition-colors hover:border-terminal-green/40 hover:text-terminal-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
+                      >
+                        {suggestion}
+                      </button>
+                    ))}
+                  </div>
                 </div>
-                <div className="text-sm font-semibold text-terminal-text">
-                  What would you like to find?
-                </div>
-                <div className="mx-auto mt-2 max-w-[280px] text-xs leading-relaxed text-terminal-dim">
-                  I can search local sessions, explain usage data, read replay scenes, and open the
-                  relevant view.
-                </div>
-                <div className="mt-5 space-y-2 text-left">
-                  {[
-                    "Find my most recent sessions",
-                    "Why was my last session expensive?",
-                    "Show sessions with compaction",
-                  ].map((suggestion) => (
-                    <button
-                      key={suggestion}
-                      type="button"
-                      onClick={() => setInput(suggestion)}
-                      className="block w-full rounded-lg border border-terminal-border-subtle bg-terminal-surface/50 px-3 py-2 text-left text-xs text-terminal-dim transition-colors hover:border-terminal-green/40 hover:text-terminal-text"
-                    >
-                      {suggestion}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
+              ))}
 
             {messages.map((message, index) => (
               <div
@@ -726,7 +939,7 @@ export default function LocalChatAssistant({ context }: Props) {
                           key={`${citation.label}-${citationIndex}`}
                           type="button"
                           onClick={() => navigateCitation(citation)}
-                          className="max-w-full truncate rounded-full border border-terminal-blue/25 bg-terminal-blue-subtle px-2 py-1 text-[10px] font-mono text-terminal-blue transition-colors hover:border-terminal-blue/50"
+                          className="max-w-full cursor-pointer truncate rounded-full border border-terminal-blue/25 bg-terminal-blue-subtle px-2 py-1 text-[10px] font-mono text-terminal-blue transition-colors hover:border-terminal-blue/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-blue/50"
                           title={citation.label}
                         >
                           {citation.type === "scene" ? "scene · " : ""}
@@ -743,7 +956,7 @@ export default function LocalChatAssistant({ context }: Props) {
                           key={`${action.type}-${actionIndex}`}
                           type="button"
                           onClick={() => navigateAction(action)}
-                          className="rounded-lg bg-terminal-green px-2.5 py-1.5 text-[10px] font-semibold text-terminal-bg transition-colors hover:bg-terminal-green/80"
+                          className="cursor-pointer rounded-lg bg-terminal-green px-2.5 py-1.5 text-[10px] font-semibold text-terminal-bg transition-colors hover:bg-terminal-green/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
                         >
                           {action.label}
                         </button>
@@ -774,20 +987,38 @@ export default function LocalChatAssistant({ context }: Props) {
               void sendMessage();
             }}
           >
-            {!providerSettings.aiProvidersLoading && !providerReady && (
-              <div className="mb-2 rounded-lg border border-terminal-orange/30 bg-terminal-orange-subtle px-3 py-2.5 text-[10px] font-mono leading-relaxed text-terminal-orange">
-                <div>{providerSetupMessage}</div>
+            {messages.length > 0 && !providerSettings.aiProvidersLoading && !providerReady && (
+              <output
+                className="mb-2 flex items-center justify-between gap-3 rounded-lg border border-terminal-orange/30 bg-terminal-orange-subtle px-3 py-2.5 text-[10px] font-mono leading-relaxed text-terminal-orange"
+                aria-live="polite"
+              >
+                <span className="min-w-0">{providerSetupMessage}</span>
                 <button
                   type="button"
-                  onClick={() => navigateTo({ view: "dashboard", session: null, tab: "settings" })}
-                  className="mt-1 font-semibold underline underline-offset-2 transition-colors hover:text-terminal-text"
+                  onClick={() => {
+                    if (providerSettings.aiProvidersError) {
+                      void providerSettings.refreshAiProviders?.();
+                    } else if (canChooseModel) {
+                      setSwitchOpen(true);
+                    } else {
+                      openProviderSettings();
+                    }
+                  }}
+                  className="shrink-0 cursor-pointer font-semibold underline underline-offset-2 transition-colors hover:text-terminal-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
                 >
-                  {providerSetupAction}
+                  {providerSettings.aiProvidersError
+                    ? "Retry"
+                    : canChooseModel
+                      ? "Choose model"
+                      : providerSetupAction}
                 </button>
-              </div>
+              </output>
             )}
-            <div className="flex items-end gap-2 rounded-xl border border-terminal-border-subtle bg-terminal-bg px-3 py-2 focus-within:border-terminal-green/50">
+            <div className="flex items-end gap-2 rounded-xl border border-terminal-border-subtle bg-terminal-bg px-3 py-2 focus-within:border-terminal-green/50 focus-within:ring-1 focus-within:ring-terminal-green/20">
               <textarea
+                name="assistant-question"
+                autoComplete="off"
+                aria-label="Ask about your sessions"
                 value={input}
                 onChange={(event) => setInput(event.target.value)}
                 onKeyDown={(event) => {
@@ -801,9 +1032,13 @@ export default function LocalChatAssistant({ context }: Props) {
                 placeholder={
                   providerReady
                     ? "Ask about your sessions…"
-                    : hasConfiguredProvider
-                      ? "Choose a provider and model first…"
-                      : "Set up an AI provider first…"
+                    : providerSettings.aiProvidersLoading
+                      ? "Checking provider setup…"
+                      : providerSettings.aiProvidersError
+                        ? "Provider setup unavailable…"
+                        : hasConfiguredProvider
+                          ? "Choose a provider and model to start…"
+                          : "Set up a provider to start…"
                 }
                 className="max-h-28 min-h-10 flex-1 resize-none bg-transparent text-sm text-terminal-text outline-none placeholder:text-terminal-dimmer disabled:opacity-50"
               />
@@ -811,7 +1046,7 @@ export default function LocalChatAssistant({ context }: Props) {
                 <button
                   type="button"
                   onClick={cancel}
-                  className="rounded-lg bg-terminal-red-subtle px-2.5 py-1.5 text-[10px] font-semibold text-terminal-red"
+                  className="cursor-pointer rounded-lg bg-terminal-red-subtle px-2.5 py-1.5 text-[10px] font-semibold text-terminal-red transition-colors hover:bg-terminal-red/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-red/50"
                 >
                   Stop
                 </button>
@@ -819,13 +1054,13 @@ export default function LocalChatAssistant({ context }: Props) {
                 <button
                   type="submit"
                   disabled={!input.trim() || !providerReady}
-                  className="rounded-lg bg-terminal-green px-2.5 py-1.5 text-[10px] font-semibold text-terminal-bg transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+                  className="cursor-pointer rounded-lg bg-terminal-green px-2.5 py-1.5 text-[10px] font-semibold text-terminal-bg transition-colors hover:bg-terminal-green/80 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
                 >
                   Ask
                 </button>
               )}
             </div>
-            {(remoteSession || context.mode === "dashboard") && (
+            {providerReady && (remoteSession || context.mode === "dashboard") && (
               <label className="mt-2 flex items-start gap-2 rounded-lg border border-terminal-yellow/25 bg-terminal-yellow-subtle px-2.5 py-2 text-[9px] leading-relaxed font-mono text-terminal-yellow">
                 <input
                   type="checkbox"
@@ -843,18 +1078,20 @@ export default function LocalChatAssistant({ context }: Props) {
             <div className="mt-2 flex items-center justify-between text-[9px] font-mono text-terminal-dimmer">
               <span>
                 Read-only ·{" "}
-                {allowRemoteData
-                  ? "SSH consent granted"
-                  : remoteSession
-                    ? "SSH consent required"
-                    : "local sessions only"}
+                {!providerReady
+                  ? "provider setup required"
+                  : allowRemoteData
+                    ? "SSH consent granted"
+                    : remoteSession
+                      ? "SSH consent required"
+                      : "local sessions only"}
               </span>
               <button
                 type="button"
-                onClick={() => navigateTo({ view: "dashboard", session: null, tab: "settings" })}
-                className="transition-colors hover:text-terminal-text"
+                onClick={openProviderSettings}
+                className="cursor-pointer transition-colors hover:text-terminal-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
               >
-                Open provider settings
+                Provider settings
               </button>
             </div>
             <button
@@ -921,7 +1158,7 @@ export default function LocalChatAssistant({ context }: Props) {
           onMouseEnter={() => setNudge(false)}
           aria-label="Ask Replay"
           title="Ask Replay — local assistant"
-          className={`flex items-center gap-1 rounded-full border bg-terminal-surface/85 px-2.5 py-1.5 text-[11px] font-semibold tracking-tight shadow-layer-md backdrop-blur-md transition-all duration-300 hover:border-terminal-green/60 hover:bg-terminal-surface hover:text-terminal-green ${nudge ? "scale-[1.04] border-terminal-green/55 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]" : "scale-100 border-terminal-green/30 text-terminal-text"}`}
+          className={`flex cursor-pointer items-center gap-1 rounded-full border bg-terminal-surface/85 px-2.5 py-1.5 text-[11px] font-semibold tracking-tight shadow-layer-md backdrop-blur-md transition-[transform,box-shadow,border-color,background-color,color] duration-300 hover:border-terminal-green/60 hover:bg-terminal-surface hover:text-terminal-green focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50 ${nudge ? "scale-[1.04] border-terminal-green/55 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]" : "scale-100 border-terminal-green/30 text-terminal-text"}`}
         >
           <span
             className={`leading-none transition-transform ${nudge ? "scale-110" : ""} text-terminal-green`}

--- a/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/ai-studio-panel.test.tsx
@@ -267,7 +267,39 @@ describe("AiStudioPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /GPT Test/ }));
     fireEvent.click(screen.getByRole("button", { name: "Set default" }));
 
-    expect(saveDefault).toHaveBeenCalledTimes(1);
+    expect(saveDefault).toHaveBeenCalledWith();
+  });
+
+  it("keeps the shared default visible while another provider is only a draft", () => {
+    const actions = makeActions(
+      [
+        provider(),
+        provider({
+          id: "openrouter",
+          name: "OpenRouter",
+          models: [
+            {
+              id: "router-test",
+              name: "Router Test",
+              api: "openai-completions",
+              reasoning: false,
+              input: ["text"],
+            },
+          ],
+        }),
+      ],
+      {
+        aiProviderId: "openrouter",
+        aiModelId: "router-test",
+        defaultAiProviderId: "openai",
+        defaultAiModelId: "gpt-test",
+      },
+    );
+
+    render(<AiStudioPanel {...actions} />);
+
+    expect(screen.getByText("Default model")).toBeDefined();
+    expect(screen.getByText("OpenAI · GPT Test")).toBeDefined();
   });
 
   it("closes the model picker before the provider modal on Escape", () => {

--- a/packages/viewer/src/hooks/__tests__/useAiProviderSettings.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useAiProviderSettings.test.tsx
@@ -52,11 +52,21 @@ afterEach(() => {
 });
 
 describe("useAiProviderSettings", () => {
-  it("remembers a manually selected model across remounts", async () => {
+  it("keeps a draft model separate until it is made the default", async () => {
     const { result, unmount } = renderHook(() => useAiProviderSettings(true));
 
     await waitFor(() => expect(result.current.aiModelId).toBe("model-a"));
     act(() => result.current.setAiModelId?.("model-b"));
+
+    expect(result.current.aiModelId).toBe("model-b");
+    expect(result.current.defaultAiModelId).toBe("model-a");
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || "null")).toEqual({
+      providerId: "custom-openai",
+      modelId: "model-a",
+      source: "server",
+    });
+
+    act(() => result.current.saveAiSelectionAsDefault?.());
 
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || "null")).toEqual({
       providerId: "custom-openai",
@@ -71,7 +81,7 @@ describe("useAiProviderSettings", () => {
     second.unmount();
   });
 
-  it("synchronizes model changes across mounted AI surfaces", async () => {
+  it("synchronizes explicit default changes across mounted AI surfaces", async () => {
     const first = renderHook(() => useAiProviderSettings(true));
     const second = renderHook(() => useAiProviderSettings(true));
 
@@ -81,6 +91,9 @@ describe("useAiProviderSettings", () => {
     });
 
     act(() => first.result.current.setAiModelId?.("model-b"));
+    expect(second.result.current.aiModelId).toBe("model-a");
+
+    act(() => first.result.current.saveAiSelectionAsDefault?.());
 
     await waitFor(() => expect(second.result.current.aiModelId).toBe("model-b"));
     first.unmount();

--- a/packages/viewer/src/hooks/useAiProviderSettings.ts
+++ b/packages/viewer/src/hooks/useAiProviderSettings.ts
@@ -34,6 +34,11 @@ export interface CustomAiProviderInput {
   apiKey?: string;
 }
 
+export interface AiSelection {
+  providerId: string;
+  modelId: string;
+}
+
 export interface AiProviderSettingsActions {
   aiProviders: AiProviderInfo[];
   aiProviderId: string | null;
@@ -52,7 +57,7 @@ export interface AiProviderSettingsActions {
   aiProvidersError: string | null;
   defaultAiProviderId: string | null;
   defaultAiModelId: string | null;
-  saveAiSelectionAsDefault: (() => void) | null;
+  saveAiSelectionAsDefault: ((selection?: AiSelection) => void) | null;
 }
 
 const AI_SELECTION_STORAGE_KEY = "vibe-replay-ai-selection-v1";
@@ -63,6 +68,8 @@ interface AiSelectionPreference {
   modelId: string;
   source?: "user" | "server";
 }
+
+type AiSelectionSource = AiSelectionPreference["source"] | "draft";
 
 function readAiSelectionPreference(): AiSelectionPreference | null {
   try {
@@ -122,7 +129,7 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
   const [selection, setSelection] = useState<{
     providerId: string | null;
     modelId: string | null;
-    source?: AiSelectionPreference["source"];
+    source?: AiSelectionSource;
   }>(() => {
     const storedPreference = readAiSelectionPreference();
     return {
@@ -143,11 +150,7 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
   const mountedRef = useRef(true);
 
   const updateSelection = useCallback(
-    (next: {
-      providerId: string | null;
-      modelId: string | null;
-      source?: AiSelectionPreference["source"];
-    }) => {
+    (next: { providerId: string | null; modelId: string | null; source?: AiSelectionSource }) => {
       selectionRef.current = next;
       if (mountedRef.current) setSelection(next);
     },
@@ -204,22 +207,11 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
     };
   }, [enabled, updateSelection]);
 
-  // Provider/model selection is a local preference, not replay or credential
-  // data. Remember it as soon as the user changes it so reopening AI Studio
-  // does not silently fall back to the first discovered model. The explicit
-  // "Set default" action remains available as a visible confirmation and for
-  // callers that want to save the current choice deliberately.
-  const rememberSelection = useCallback(
+  // Provider/model changes are drafts. Only the explicit "Set default" action
+  // writes the shared preference used by Ask Replay and the AI tools.
+  const updateDraftSelection = useCallback(
     (next: { providerId: string | null; modelId: string | null }) => {
-      updateSelection({ ...next, source: "user" });
-      if (!next.providerId || !next.modelId) return;
-      const preference = {
-        providerId: next.providerId,
-        modelId: next.modelId,
-        source: "user" as const,
-      };
-      writeAiSelectionPreference(preference);
-      if (mountedRef.current) setDefaultSelection(preference);
+      updateSelection({ ...next, source: "draft" });
     },
     [updateSelection],
   );
@@ -263,7 +255,9 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
         // legacy defaults. Only an explicit user selection is authoritative;
         // this lets a newly discovered server/Pi default replace an old
         // first-catalog-entry fallback without overriding deliberate choices.
-        const useServerDefault = current.source !== "user" || !currentProvider;
+        const preserveCurrentSelection =
+          (current.source === "user" || current.source === "draft") && Boolean(currentProvider);
+        const useServerDefault = !preserveCurrentSelection;
         const nextProviderId = !useServerDefault
           ? (currentProvider?.id ?? null)
           : defaultProviderId &&
@@ -328,7 +322,7 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
   const setAiProviderId = enabled
     ? (providerId: string) => {
         const provider = providersRef.current.find((candidate) => candidate.id === providerId);
-        rememberSelection({
+        updateDraftSelection({
           providerId,
           modelId: provider?.models[0]?.id || null,
         });
@@ -337,13 +331,13 @@ export function useAiProviderSettings(enabled: boolean): AiProviderSettingsActio
 
   const setAiModelId = enabled
     ? (modelId: string) => {
-        rememberSelection({ ...selectionRef.current, modelId });
+        updateDraftSelection({ ...selectionRef.current, modelId });
       }
     : null;
 
   const saveAiSelectionAsDefault = enabled
-    ? () => {
-        const current = selectionRef.current;
+    ? (nextSelection?: AiSelection) => {
+        const current = nextSelection || selectionRef.current;
         if (!current.providerId || !current.modelId) return;
         const next = {
           providerId: current.providerId,

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -383,6 +383,11 @@ export function useAnnotations(
     defaultAiModelId,
     saveAiSelectionAsDefault,
   } = aiProviderSettings;
+  const defaultProvider = aiProviders.find((candidate) => candidate.id === defaultAiProviderId);
+  const defaultModel = defaultProvider?.models.find((model) => model.id === defaultAiModelId);
+  const defaultSelectionReady = Boolean(defaultProvider?.configured && defaultModel);
+  const effectiveAiProviderId = defaultSelectionReady ? defaultAiProviderId : aiProviderId;
+  const effectiveAiModelId = defaultSelectionReady ? defaultAiModelId : aiModelId;
   const [aiCoachRunning, setAiCoachRunning] = useState(false);
   const aiCoachAbortRef = useRef<AbortController | null>(null);
 
@@ -393,7 +398,7 @@ export function useAnnotations(
   }, []);
 
   const runAiCoach =
-    isEditor && aiProviderId && aiModelId
+    isEditor && effectiveAiProviderId && effectiveAiModelId
       ? async () => {
           const controller = new AbortController();
           aiCoachAbortRef.current = controller;
@@ -410,8 +415,8 @@ export function useAnnotations(
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                providerId: aiProviderId,
-                ...(aiModelId ? { modelId: aiModelId } : {}),
+                providerId: effectiveAiProviderId,
+                ...(effectiveAiModelId ? { modelId: effectiveAiModelId } : {}),
               }),
               signal: controller.signal,
             });

--- a/packages/viewer/src/hooks/useOverlays.ts
+++ b/packages/viewer/src/hooks/useOverlays.ts
@@ -89,7 +89,14 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
     setAiProviderId: setStudioProviderId,
     setAiModelId: setStudioModelId,
     refreshAiProviders: refreshStudioProviders,
+    defaultAiProviderId,
+    defaultAiModelId,
   } = aiProviderSettings;
+  const defaultProvider = studioProviders.find((provider) => provider.id === defaultAiProviderId);
+  const defaultModel = defaultProvider?.models.find((model) => model.id === defaultAiModelId);
+  const defaultSelectionReady = Boolean(defaultProvider?.configured && defaultModel);
+  const effectiveStudioProviderId = defaultSelectionReady ? defaultAiProviderId : studioProviderId;
+  const effectiveStudioModelId = defaultSelectionReady ? defaultAiModelId : studioModelId;
 
   // Running states
   const [translating, setTranslating] = useState(false);
@@ -259,7 +266,7 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
 
   const runTranslate = useMemo(
     () =>
-      isEditor && studioProviderId && studioModelId
+      isEditor && effectiveStudioProviderId && effectiveStudioModelId
         ? async (opts: { targetLang: string; sourceLang?: string }) => {
             const controller = new AbortController();
             abortRef.current = controller;
@@ -269,8 +276,8 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                  providerId: studioProviderId,
-                  ...(studioModelId ? { modelId: studioModelId } : {}),
+                  providerId: effectiveStudioProviderId,
+                  ...(effectiveStudioModelId ? { modelId: effectiveStudioModelId } : {}),
                   targetLang: opts.targetLang,
                   sourceLang: opts.sourceLang,
                 }),
@@ -293,12 +300,12 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
             }
           }
         : null,
-    [isEditor, studioModelId, studioProviderId],
+    [effectiveStudioModelId, effectiveStudioProviderId, isEditor],
   );
 
   const runTone = useMemo(
     () =>
-      isEditor && studioProviderId && studioModelId
+      isEditor && effectiveStudioProviderId && effectiveStudioModelId
         ? async (opts: { style: "professional" | "neutral" | "friendly" }) => {
             const controller = new AbortController();
             abortRef.current = controller;
@@ -308,8 +315,8 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                  providerId: studioProviderId,
-                  ...(studioModelId ? { modelId: studioModelId } : {}),
+                  providerId: effectiveStudioProviderId,
+                  ...(effectiveStudioModelId ? { modelId: effectiveStudioModelId } : {}),
                   style: opts.style,
                 }),
                 signal: controller.signal,
@@ -331,7 +338,7 @@ export function useOverlays(session: ReplaySession, mode: ViewerMode = "embedded
             }
           }
         : null,
-    [isEditor, studioModelId, studioProviderId],
+    [effectiveStudioModelId, effectiveStudioProviderId, isEditor],
   );
 
   return {


### PR DESCRIPTION
## Summary
- separate the draft provider/model from the shared default selection
- make Ask Replay and AI Studio consume the explicit default
- surface the default model clearly and add complete hover/cursor feedback

## Verification
- `pnpm --filter @vibe-replay/viewer test`
- `pnpm exec tsc --noEmit -p packages/viewer/tsconfig.json`
- `pnpm exec oxlint ...`
- `pnpm --filter @vibe-replay/viewer build`