### PR TITLE
feat(viewer): show assistant turn metrics

### DIFF
--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -861,15 +861,17 @@ function buildTurnStats(
 ): TurnStat[] {
   if (usageByMsgId.size === 0 && turnDurations.length === 0) return [];
 
-  // Group assistant messageIds by user-turn index (0-based)
-  // A user turn boundary = where role === "user" and subtype is not compaction-summary
+  // Group assistant messageIds by user-turn index (0-based).
+  // Only ordinary user prompts are turn boundaries. Context injections and
+  // compaction summaries are persisted as user-role records, but do not start
+  // a new user turn in the replay UI.
   const turnGroups: Array<{ msgIds: string[]; startTimestamp: string; endTimestamp: string }> = [];
   let currentMsgIds: string[] = [];
   let lastTimestamp = "";
   let turnStartTimestamp = "";
 
   for (const turn of finalTurns) {
-    if (turn.role === "user" && turn.subtype !== "compaction-summary") {
+    if (turn.role === "user" && !turn.subtype) {
       if (turnGroups.length > 0 || currentMsgIds.length > 0) {
         // Close previous turn group
         turnGroups.push({

--- a/packages/provider-claude-code/test/claude-code-source-insights.test.ts
+++ b/packages/provider-claude-code/test/claude-code-source-insights.test.ts
@@ -54,6 +54,12 @@ describe("Claude Code source insights: isMeta as context-injection", () => {
     expect(regularTurns).toHaveLength(2);
   });
 
+  it("does not assign context injections their own turn stats index", async () => {
+    const result = await parseClaudeCodeSession(FIXTURE);
+
+    expect(result.turnStats?.map((stat) => stat.turnIndex)).toEqual([0, 1]);
+  });
+
   it("transforms context-injection to scene with specific injectionType", async () => {
     const parsed = await parseClaudeCodeSession(FIXTURE);
     const replay = transformToReplay(parsed, "claude-code", "~/test");

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -7,7 +7,7 @@ import type { Annotation, Scene, TurnStat } from "../types";
 import { textHighlightsByScene, type TextHighlight } from "../utils/annotation-highlights";
 import { displayToolName } from "../utils/toolName";
 import CompactionSummaryBlock from "./CompactionSummaryBlock";
-import { fmtNum, formatDuration, formatTokens, formatToolDuration } from "./StatsPanel";
+import { fmtNum, formatTokens, formatToolDuration } from "./StatsPanel";
 import TextResponseBlock from "./TextResponseBlock";
 import ThinkingBlock from "./ThinkingBlock";
 import ToolCallBlock from "./ToolCallBlock";
@@ -72,6 +72,87 @@ function formatTime(iso?: string): string {
   } catch {
     return "";
   }
+}
+
+function turnStatForNumber(
+  turnStats: TurnStat[] | undefined,
+  turnNumber?: number,
+): TurnStat | undefined {
+  if (!turnStats || turnNumber === undefined) return undefined;
+  const turnIndex = turnNumber - 1;
+  // Prefer the explicit index because providers may omit stats for a turn
+  // that has no assistant output. Only use the positional fallback for legacy
+  // replays whose stats predate `turnIndex`; otherwise a sparse array could
+  // assign another turn's metrics to this card.
+  const hasExplicitIndexes = turnStats.every((stat) => Number.isInteger(stat.turnIndex));
+  return hasExplicitIndexes ? getTurnStat(turnStats, turnIndex) : turnStats[turnIndex];
+}
+
+function turnDurationFromScenes(scenes: { scene: Scene }[]): number | undefined {
+  const firstTimestamp = scenes[0]?.scene.timestamp;
+  const lastTimestamp = scenes[scenes.length - 1]?.scene.timestamp;
+  if (!firstTimestamp || !lastTimestamp) return undefined;
+  const durationMs = Date.parse(lastTimestamp) - Date.parse(firstTimestamp);
+  return durationMs > 0 ? durationMs : undefined;
+}
+
+function totalTurnTokens(usage: TurnStat["tokenUsage"]): number | undefined {
+  if (!usage) return undefined;
+  const total =
+    usage.inputTokens + usage.outputTokens + usage.cacheCreationTokens + usage.cacheReadTokens;
+  return total > 0 ? total : undefined;
+}
+
+function tokenUsageTitle(usage: NonNullable<TurnStat["tokenUsage"]>): string {
+  const promptTokens = usage.inputTokens + usage.cacheCreationTokens + usage.cacheReadTokens;
+  const totalTokens = promptTokens + usage.outputTokens;
+  const parts = [
+    `${totalTokens.toLocaleString("en-US")} total`,
+    `${promptTokens.toLocaleString("en-US")} prompt`,
+    `${usage.outputTokens.toLocaleString("en-US")} output`,
+  ];
+  if (usage.inputTokens > 0) {
+    parts.push(`${usage.inputTokens.toLocaleString("en-US")} uncached input`);
+  }
+  if (usage.cacheReadTokens > 0) {
+    parts.push(`${usage.cacheReadTokens.toLocaleString("en-US")} cache read`);
+  }
+  if (usage.cacheCreationTokens > 0) {
+    parts.push(`${usage.cacheCreationTokens.toLocaleString("en-US")} cache write`);
+  }
+  return `Recorded token usage for this assistant turn: ${parts.join(" · ")}`;
+}
+
+function AssistantTurnMetrics({
+  turnStat,
+  fallbackDurationMs,
+}: {
+  turnStat?: TurnStat;
+  fallbackDurationMs?: number;
+}) {
+  const durationMs = turnStat?.durationMs ?? fallbackDurationMs;
+  const durationLabel = formatToolDuration(durationMs);
+  const tokenCount = totalTurnTokens(turnStat?.tokenUsage);
+  if (!durationLabel && !tokenCount) return null;
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[10px] font-mono text-terminal-dimmer">
+      {durationLabel && (
+        <span
+          title={
+            turnStat?.durationMs
+              ? "Recorded or timestamp-derived active time for this assistant turn"
+              : "Estimated active time from the assistant scene timestamps"
+          }
+        >
+          · {durationLabel}
+        </span>
+      )}
+      {tokenCount && turnStat?.tokenUsage && (
+        <span title={tokenUsageTitle(turnStat.tokenUsage)}>· {formatTokens(tokenCount)} tok</span>
+      )}
+    </span>
+  );
 }
 
 export default function ConversationView({
@@ -693,6 +774,8 @@ const GroupCard = memo(function GroupCard({
   // Playback advance still updates currentIndex (used for the focus
   // indicator + scroll-follow), but never hides content.
   const groupScenes = group.scenes;
+  const turnStat = turnStatForNumber(turnStats, group.turnNumber);
+  const fallbackTurnDurationMs = useMemo(() => turnDurationFromScenes(groupScenes), [groupScenes]);
 
   const groupHasCurrent = groupScenes.some(({ index }) => index === currentIndex);
   const groupHasFocusedTarget =
@@ -988,9 +1071,7 @@ const GroupCard = memo(function GroupCard({
         onComment={onComment}
         onAnnotationClick={onAnnotationClick}
         overlayActions={overlayActions}
-        turnDurationMs={
-          group.turnNumber ? getTurnStat(turnStats, group.turnNumber - 1)?.durationMs : undefined
-        }
+        turnStat={turnStat}
       />
     );
   }
@@ -1013,6 +1094,9 @@ const GroupCard = memo(function GroupCard({
           <span className="text-[10px] font-mono text-terminal-dimmer">
             {formatTime(group.timestamp)}
           </span>
+        )}
+        {group.type === "assistant" && (
+          <AssistantTurnMetrics turnStat={turnStat} fallbackDurationMs={fallbackTurnDurationMs} />
         )}
         <div className="flex-1" />
         {groupHasFocusedTarget ? (
@@ -1067,7 +1151,7 @@ function CompactAssistantGroup({
   onComment,
   onAnnotationClick,
   overlayActions,
-  turnDurationMs,
+  turnStat,
 }: {
   /** All scenes in the group — used for stable stats (not affected by playback progress) */
   allScenes: { scene: Scene; index: number }[];
@@ -1083,7 +1167,7 @@ function CompactAssistantGroup({
   onComment?: (sceneIndex: number) => void;
   onAnnotationClick?: (annotationId: string) => void;
   overlayActions?: OverlayActions;
-  turnDurationMs?: number;
+  turnStat?: TurnStat;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -1125,14 +1209,7 @@ function CompactAssistantGroup({
       } else if (scene.type === "text-response") responses++;
       else if (scene.type === "thinking") thinking++;
     }
-    // Compute turn duration from scene timestamps
-    let turnDurationMs: number | undefined;
-    const firstTs = allScenes[0]?.scene.timestamp;
-    const lastTs = allScenes[allScenes.length - 1]?.scene.timestamp;
-    if (firstTs && lastTs) {
-      const diff = Date.parse(lastTs) - Date.parse(firstTs);
-      if (diff > 0) turnDurationMs = diff;
-    }
+    const turnDurationMs = turnDurationFromScenes(allScenes);
 
     return {
       totalTools,
@@ -1240,11 +1317,7 @@ function CompactAssistantGroup({
             {formatTime(timestamp)}
           </span>
         )}
-        {(turnDurationMs || stats.turnDurationMs) && (
-          <span className="text-[10px] font-mono text-terminal-dimmer">
-            · {formatDuration(turnDurationMs ?? stats.turnDurationMs)}
-          </span>
-        )}
+        <AssistantTurnMetrics turnStat={turnStat} fallbackDurationMs={stats.turnDurationMs} />
         <div className="flex-1" />
         {groupHasFocusedTarget ? (
           <span className="ui-pill-compact bg-terminal-blue-emphasis text-terminal-blue">

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Scene, TurnStat } from "../../types";
+import { stubBrowserAPIs } from "../../test-utils/jsdom-stubs";
+import type { EffectivePrefs } from "../../hooks/useViewPrefs";
+import ConversationView from "../ConversationView";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(stubBrowserAPIs);
+
+const turnStat: TurnStat = {
+  turnIndex: 0,
+  durationMs: 4_200,
+  tokenUsage: {
+    inputTokens: 900,
+    outputTokens: 800,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 1_500,
+  },
+};
+
+const scenes: Scene[] = [
+  {
+    type: "user-prompt",
+    content: "Explain this change",
+    timestamp: "2026-08-30T10:00:00.000Z",
+  },
+  {
+    type: "text-response",
+    content: "Here is the explanation.",
+    timestamp: "2026-08-30T10:00:04.200Z",
+  },
+];
+
+function prefs(compactAssistant: boolean): EffectivePrefs {
+  return {
+    hideThinking: false,
+    collapseAllTools: false,
+    promptsOnly: false,
+    compactAssistant,
+  };
+}
+
+function renderConversation(compactAssistant: boolean) {
+  return render(
+    <ConversationView
+      scenes={scenes}
+      visibleCount={scenes.length}
+      currentIndex={1}
+      effectivePrefs={prefs(compactAssistant)}
+      turnStats={[turnStat]}
+    />,
+  );
+}
+
+describe("ConversationView assistant metrics", () => {
+  it.each([false, true])("shows duration and recorded token usage in %s mode", (compact) => {
+    renderConversation(compact);
+
+    expect(screen.getByText(/4\.2s/)).toBeTruthy();
+    expect(screen.getByText(/3\.2K tok/)).toBeTruthy();
+    expect(screen.getByTitle(/2,400 prompt.*800 output/)).toBeTruthy();
+  });
+
+  it("uses scene timestamps for duration when per-turn duration is unavailable", () => {
+    const fallbackScenes: Scene[] = [
+      scenes[0],
+      {
+        type: "thinking",
+        content: "Thinking",
+        timestamp: "2026-08-30T10:00:00.000Z",
+      },
+      scenes[1],
+    ];
+    render(
+      <ConversationView
+        scenes={fallbackScenes}
+        visibleCount={fallbackScenes.length}
+        currentIndex={1}
+        effectivePrefs={prefs(false)}
+        turnStats={[{ turnIndex: 0 }]}
+      />,
+    );
+
+    expect(screen.getByText(/4\.2s/)).toBeTruthy();
+    expect(screen.queryByText(/tok/)).toBeNull();
+  });
+});

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -37,6 +37,26 @@ const scenes: Scene[] = [
   },
 ];
 
+const multiTurnScenes: Scene[] = [
+  ...scenes,
+  {
+    type: "context-injection",
+    content: "A skill was loaded",
+    timestamp: "2026-08-30T10:00:05.000Z",
+    injectionType: "skill:demo",
+  },
+  {
+    type: "user-prompt",
+    content: "Now apply it",
+    timestamp: "2026-08-30T10:00:06.000Z",
+  },
+  {
+    type: "text-response",
+    content: "Applied.",
+    timestamp: "2026-08-30T10:00:08.000Z",
+  },
+];
+
 function prefs(compactAssistant: boolean): EffectivePrefs {
   return {
     hideThinking: false,
@@ -88,6 +108,49 @@ describe("ConversationView assistant metrics", () => {
     );
 
     expect(screen.getByText(/4\.2s/)).toBeTruthy();
+    expect(screen.queryByText(/tok/)).toBeNull();
+  });
+
+  it("matches metrics to each real turn across context injections", () => {
+    render(
+      <ConversationView
+        scenes={multiTurnScenes}
+        visibleCount={multiTurnScenes.length}
+        currentIndex={4}
+        effectivePrefs={prefs(false)}
+        turnStats={[
+          turnStat,
+          {
+            turnIndex: 1,
+            durationMs: 8_100,
+            tokenUsage: {
+              inputTokens: 1_000,
+              outputTokens: 1_000,
+              cacheCreationTokens: 0,
+              cacheReadTokens: 0,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/4\.2s/)).toBeTruthy();
+    expect(screen.getByText(/8\.1s/)).toBeTruthy();
+    expect(screen.getByText(/2\.0K tok/)).toBeTruthy();
+  });
+
+  it("does not fall back by position for sparse indexed stats", () => {
+    render(
+      <ConversationView
+        scenes={multiTurnScenes}
+        visibleCount={multiTurnScenes.length}
+        currentIndex={4}
+        effectivePrefs={prefs(false)}
+        turnStats={[{ turnIndex: 1, durationMs: 2_200 }]}
+      />,
+    );
+
+    expect(screen.getByText(/2\.2s/)).toBeTruthy();
     expect(screen.queryByText(/tok/)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- show per-assistant-turn duration and recorded token totals in full and compact replay cards
- expose prompt/output/cache breakdown on token hover
- use explicit turn indexes and timestamp duration fallback without inventing token data

## Verification
- `pnpm verify`
