### PR TITLE
fix: close session parity gaps

### DIFF
--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -2419,7 +2419,10 @@ export function aggregateUserInsights(scans: SessionScanResult[]): UserInsights 
       ps.prUrls.add(`${identity.key}#${identity.prNumber}`);
     }
     const ts = s.startTime || "";
-    if (ts && (!ps.lastActivity || ts > ps.lastActivity)) ps.lastActivity = ts;
+    const activityTs = s.endTime || ts;
+    if (activityTs && (!ps.lastActivity || activityTs > ps.lastActivity)) {
+      ps.lastActivity = activityTs;
+    }
     if (ts && (!first || ts < first)) first = ts;
     if (ts && (!last || ts > last)) last = ts;
 

--- a/packages/cli/src/server-source-catalog.ts
+++ b/packages/cli/src/server-source-catalog.ts
@@ -14,10 +14,50 @@ import type {
   CachedSourceRecord,
   NormalizedSourceSessionCatalogCache,
   ProviderDiscoveryState,
+  ReplaySummary,
   SourceProviderFreshnessProbe,
   SourceSessionCatalogCache,
   SourceSummaryRecord,
 } from "./server-types.js";
+
+/** Strip server-only replay fields before embedding a replay in the sources cache. */
+export function cachedReplaySummary(replay: ReplaySummary): CachedSourceRecord["replay"] {
+  return {
+    slug: replay.slug,
+    sourceSlug: replay.sourceSlug,
+    sessionId: replay.sessionId,
+    title: replay.title,
+    provider: replay.provider,
+    location: replay.location,
+    transcriptStatus: replay.transcriptStatus,
+    model: replay.model,
+    gitRepo: replay.gitRepo,
+    project: replay.project,
+    startTime: replay.startTime,
+    endTime: replay.endTime,
+    stats: replay.stats,
+    compactionCount: replay.compactionCount,
+    compactions: replay.compactions,
+    apiErrors: replay.apiErrors,
+    diagnostics: replay.diagnostics,
+    diagnosticNotes: replay.diagnosticNotes,
+    hasAnnotations: replay.hasAnnotations,
+    annotationCount: replay.annotationCount,
+    firstMessage: replay.firstMessage,
+    messages: replay.messages,
+    replaySize: replay.replaySize,
+    gist: replay.gist,
+    cloud: replay.cloud,
+  };
+}
+
+/** Compare the complete nested replay snapshot, not just its identity fields. */
+export function cachedReplaySummaryChanged(
+  previous: CachedSourceRecord["replay"],
+  next: CachedSourceRecord["replay"],
+): boolean {
+  return JSON.stringify(previous) !== JSON.stringify(next);
+}
 
 export function isSourceSessionCatalogCache(value: unknown): value is SourceSessionCatalogCache {
   return (

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -89,6 +89,8 @@ import {
 } from "./server-enrichment.js";
 import {
   buildSourceSessionCatalogCache,
+  cachedReplaySummary,
+  cachedReplaySummaryChanged,
   getStaleSourceProviders,
   mergeSourceCatalogSessionUpdates,
   normalizeSourceSessionCatalogCache,
@@ -935,35 +937,7 @@ async function buildSourcesResult(
       projectExists:
         s.location?.kind === "ssh" ? undefined : (projectExistsMap.get(s.project) ?? false),
       isGitRepo: s.location?.kind === "ssh" ? undefined : (projectIsGitMap.get(s.project) ?? false),
-      replay: replay
-        ? {
-            slug: replay.slug,
-            sourceSlug: replay.sourceSlug,
-            sessionId: replay.sessionId,
-            title: replay.title,
-            provider: replay.provider,
-            location: replay.location,
-            transcriptStatus: replay.transcriptStatus,
-            model: replay.model,
-            gitRepo: replay.gitRepo,
-            project: replay.project,
-            startTime: replay.startTime,
-            endTime: replay.endTime,
-            stats: replay.stats,
-            compactionCount: replay.compactionCount,
-            compactions: replay.compactions,
-            apiErrors: replay.apiErrors,
-            diagnostics: replay.diagnostics,
-            diagnosticNotes: replay.diagnosticNotes,
-            hasAnnotations: replay.hasAnnotations,
-            annotationCount: replay.annotationCount,
-            firstMessage: replay.firstMessage,
-            messages: replay.messages,
-            replaySize: replay.replaySize,
-            gist: replay.gist,
-            cloud: replay.cloud,
-          }
-        : undefined,
+      replay: replay ? cachedReplaySummary(replay) : undefined,
     };
   });
 }
@@ -1161,52 +1135,20 @@ export async function startServer(
       let changed = false;
       const updated = cached.sessions.map((s) => {
         const replay = findReplayForSource(s, replayMaps, sourceSlugCounts);
+        const nextReplay = replay ? cachedReplaySummary(replay) : undefined;
         const hadReplay = !!s.existingReplay;
         const hasReplay = !!replay;
         if (
           hadReplay !== hasReplay ||
           (hasReplay &&
-            (replay.slug !== s.existingReplay ||
-              replay.title !== s.replay?.title ||
-              replay.sourceSlug !== s.replay?.sourceSlug ||
-              replay.compactionCount !== s.replay?.compactionCount ||
-              JSON.stringify(replay.compactions) !== JSON.stringify(s.replay?.compactions) ||
-              JSON.stringify(replay.apiErrors) !== JSON.stringify(s.replay?.apiErrors) ||
-              JSON.stringify(replay.diagnostics) !== JSON.stringify(s.replay?.diagnostics) ||
-              JSON.stringify(replay.diagnosticNotes) !== JSON.stringify(s.replay?.diagnosticNotes)))
+            (replay.slug !== s.existingReplay || cachedReplaySummaryChanged(s.replay, nextReplay)))
         ) {
           changed = true;
         }
         return {
           ...s,
           existingReplay: replay ? replay.slug : null,
-          replay: replay
-            ? {
-                slug: replay.slug,
-                sourceSlug: replay.sourceSlug,
-                sessionId: replay.sessionId,
-                title: replay.title,
-                provider: replay.provider,
-                location: replay.location,
-                model: replay.model,
-                project: replay.project,
-                startTime: replay.startTime,
-                endTime: replay.endTime,
-                stats: replay.stats,
-                compactionCount: replay.compactionCount,
-                compactions: replay.compactions,
-                apiErrors: replay.apiErrors,
-                diagnostics: replay.diagnostics,
-                diagnosticNotes: replay.diagnosticNotes,
-                hasAnnotations: replay.hasAnnotations,
-                annotationCount: replay.annotationCount,
-                firstMessage: replay.firstMessage,
-                messages: replay.messages,
-                replaySize: replay.replaySize,
-                gist: replay.gist,
-                cloud: replay.cloud,
-              }
-            : undefined,
+          replay: nextReplay,
         };
       });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1055,8 +1055,8 @@ export async function startServer(
   // extracts, so serving the previous run's results would show stale facets
   // until the next scan happened to finish.
   const scanResultsCacheKey = `dashboard-scan-results-v${SCANNER_VERSION}-${cacheKeySuffix}`;
-  // v4 → v5: invalidate persisted project labels after workflow disambiguation.
-  const insightsCacheKey = `dashboard-insights-v5-${cacheKeySuffix}`;
+  // v5 → v6: project lastActivity now uses session end times when available.
+  const insightsCacheKey = `dashboard-insights-v6-${cacheKeySuffix}`;
   const readSourcesCatalogCache = async (): Promise<NormalizedSourceSessionCatalogCache | null> =>
     normalizeSourceSessionCatalogCache(
       await readFileCache<SourceSessionCatalogCache | CachedSourceRecord[]>(sourcesCacheKey),

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -1904,6 +1904,15 @@ describe("aggregateUserInsights", () => {
     expect(insights.topProjects[0].sessions).toBe(1);
   });
 
+  it("uses session end time for project last activity", () => {
+    const endTime = "2025-03-21T15:30:00Z";
+    const insights = aggregateUserInsights([{ ...scans[0], endTime }]);
+
+    expect(insights.topProjects[0].lastActivity).toBe(endTime);
+    expect(insights.timeRange.first).toBe(scans[0].startTime);
+    expect(insights.timeRange.last).toBe(scans[0].startTime);
+  });
+
   it("counts identical project identities separately per location", () => {
     const local = { ...scans[0], sessionId: "local-session" };
     const remoteA = {

--- a/packages/cli/test/server-source-catalog.test.ts
+++ b/packages/cli/test/server-source-catalog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildSourceSessionCatalogCache } from "../src/server-source-catalog.js";
-import type { NormalizedSourceSessionCatalogCache } from "../src/server-types.js";
+import {
+  buildSourceSessionCatalogCache,
+  cachedReplaySummary,
+  cachedReplaySummaryChanged,
+} from "../src/server-source-catalog.js";
+import type { NormalizedSourceSessionCatalogCache, ReplaySummary } from "../src/server-types.js";
 
 const source = (provider: string, sessionId: string) => ({
   provider,
@@ -71,5 +75,43 @@ describe("buildSourceSessionCatalogCache", () => {
     );
 
     expect(catalog.sessions).toEqual([source("cursor", "local-new"), remote]);
+  });
+});
+
+describe("cached replay summaries", () => {
+  it("detects nested replay changes even when identity stays the same", () => {
+    const replay: ReplaySummary = {
+      slug: "session",
+      baseDir: "/tmp/replays",
+      sessionId: "session-id",
+      provider: "opencode",
+      project: "/repo",
+      startTime: "2026-08-20T00:00:00.000Z",
+      stats: {
+        sceneCount: 1,
+        userPrompts: 1,
+        toolCalls: 0,
+        durationMs: 1000,
+        tokenUsage: {
+          inputTokens: 5,
+          outputTokens: 5,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+        costEstimate: 0,
+      },
+      replaySize: 100,
+      replayOutdated: false,
+      hasAnnotations: false,
+      annotationCount: 0,
+    };
+    const previous = cachedReplaySummary(replay);
+    const regenerated = cachedReplaySummary({
+      ...replay,
+      stats: { ...replay.stats, userPrompts: 2 },
+    });
+
+    expect(cachedReplaySummaryChanged(previous, regenerated)).toBe(true);
+    expect(cachedReplaySummaryChanged(previous, previous)).toBe(false);
   });
 });

--- a/packages/provider-cursor/src/cursor/discover.ts
+++ b/packages/provider-cursor/src/cursor/discover.ts
@@ -431,10 +431,7 @@ async function extractSessionInfo(
         } catch {}
       }
 
-      if (
-        (line.includes('"role":"user"') || line.includes('"role": "user"')) &&
-        !line.includes('"tool_result"')
-      ) {
+      if (userRoleRe.test(line) && !line.includes('"tool_result"')) {
         promptCount++;
       }
       const toolMatches = line.match(toolUseRe);

--- a/packages/provider-cursor/src/cursor/discover.ts
+++ b/packages/provider-cursor/src/cursor/discover.ts
@@ -399,17 +399,27 @@ async function extractSessionInfo(
     let editCountEst = 0;
     let model: string | undefined;
     let lineCount = 0;
-    let promptScanCount = 0;
+    let userPromptCandidateCount = 0;
     const toolUseRe = /"type"\s*:\s*"tool_use"/g;
     const editToolRe = /"name"\s*:\s*"(edit_file|file_edit|create_file)"/;
     const modelRe = /"model(?:Id)?"\s*:\s*"([^"]+)"/;
+    const userRoleRe = /"role"\s*:\s*"user"/;
     for (const rawLine of content.split("\n")) {
       const line = rawLine.trim();
       if (!line) continue;
       lineCount++;
 
-      if (!firstPrompt && promptScanCount < 10) {
-        promptScanCount++;
+      // Cursor may prepend many metadata/assistant records before the first
+      // user turn. Bound the expensive JSON parsing by user candidates rather
+      // than raw lines, otherwise eleven harmless records make a valid
+      // session disappear from discovery.
+      if (
+        !firstPrompt &&
+        userPromptCandidateCount < 10 &&
+        userRoleRe.test(line) &&
+        !line.includes('"tool_result"')
+      ) {
+        userPromptCandidateCount++;
         try {
           const obj = JSON.parse(line);
           if (obj.role === "user") {
@@ -565,5 +575,6 @@ async function mapLimit<T, R>(
 
 export const __testables = {
   decodeProjectDir,
+  extractSessionInfo,
   mergeDuplicateTranscriptSessions,
 };

--- a/packages/provider-cursor/test/discover.test.ts
+++ b/packages/provider-cursor/test/discover.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -148,5 +148,35 @@ describe("duplicate Cursor transcript discovery", () => {
       "/cursor/b/same-session.jsonl",
     ]);
     expect(merged[0].toolPaths).toEqual(["/cursor/a/tool-1.txt", "/cursor/b/tool-2.txt"]);
+  });
+});
+
+describe("Cursor transcript metadata discovery", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("finds a prompt after metadata records", async () => {
+    const root = await makeTempRoot();
+    const transcript = join(root, "session.jsonl");
+    const metadata = Array.from({ length: 11 }, (_, index) =>
+      JSON.stringify({ role: "assistant", id: `metadata-${index}` }),
+    );
+    const prompt = JSON.stringify({
+      role: "user",
+      message: { content: [{ type: "text", text: "Inspect the delayed prompt" }] },
+    });
+    await writeFile(transcript, `${metadata.join("\n")}\n${prompt}\n`, "utf8");
+    const fileStat = await stat(transcript);
+
+    const session = await __testables.extractSessionInfo(
+      transcript,
+      fileStat.size,
+      Date.now(),
+      root,
+      [],
+    );
+
+    expect(session?.firstPrompt).toBe("Inspect the delayed prompt");
   });
 });

--- a/packages/provider-cursor/test/discover.test.ts
+++ b/packages/provider-cursor/test/discover.test.ts
@@ -179,4 +179,26 @@ describe("Cursor transcript metadata discovery", () => {
 
     expect(session?.firstPrompt).toBe("Inspect the delayed prompt");
   });
+
+  it("counts user prompts regardless of JSON whitespace", async () => {
+    const root = await makeTempRoot();
+    const transcript = join(root, "session.jsonl");
+    const prompt =
+      '{ "role" : "user", "message": { "content": [{ "type": "text", "text": "Count this prompt" }] } }';
+    await writeFile(transcript, `${JSON.stringify({ role: "assistant" })}\n${prompt}\n`, "utf8");
+    const fileStat = await stat(transcript);
+
+    const session = await __testables.extractSessionInfo(
+      transcript,
+      fileStat.size,
+      Date.now(),
+      root,
+      [],
+    );
+
+    expect(session).toMatchObject({
+      firstPrompt: "Count this prompt",
+      promptCount: 1,
+    });
+  });
 });

--- a/packages/provider-opencode/src/opencode/discover.ts
+++ b/packages/provider-opencode/src/opencode/discover.ts
@@ -126,13 +126,15 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
       SELECT m.session_id, count(DISTINCT m.id) AS c
       FROM part p
       JOIN message m ON m.id = p.message_id
-      WHERE json_extract(m.data, '$.role') = 'user'
-        AND json_extract(p.data, '$.type') = 'text'
+      WHERE CASE WHEN json_valid(m.data) THEN json_extract(m.data, '$.role') END = 'user'
+        AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.type') END = 'text'
         AND NOT EXISTS (
           SELECT 1
           FROM part compact
           WHERE compact.message_id = m.id
-            AND json_extract(compact.data, '$.type') = 'compaction'
+            AND CASE
+              WHEN json_valid(compact.data) THEN json_extract(compact.data, '$.type')
+            END = 'compaction'
         )
       GROUP BY m.session_id
     `,
@@ -142,7 +144,7 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
     `
       SELECT session_id, count(*) AS c
       FROM part
-      WHERE json_extract(data, '$.type') = 'tool'
+      WHERE CASE WHEN json_valid(data) THEN json_extract(data, '$.type') END = 'tool'
       GROUP BY session_id
     `,
   );
@@ -151,8 +153,8 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
     `
       SELECT session_id, count(*) AS c
       FROM part
-      WHERE json_extract(data, '$.type') = 'tool'
-        AND json_extract(data, '$.tool') IN ('edit', 'write', 'patch')
+      WHERE CASE WHEN json_valid(data) THEN json_extract(data, '$.type') END = 'tool'
+        AND CASE WHEN json_valid(data) THEN json_extract(data, '$.tool') END IN ('edit', 'write', 'patch')
       GROUP BY session_id
     `,
   );
@@ -162,8 +164,8 @@ function buildSessionStats(db: Database): Map<string, SessionStats> {
       SELECT m.session_id, count(DISTINCT m.id) AS c
       FROM part p
       JOIN message m ON m.id = p.message_id
-      WHERE json_extract(m.data, '$.role') = 'user'
-        AND json_extract(p.data, '$.type') = 'compaction'
+      WHERE CASE WHEN json_valid(m.data) THEN json_extract(m.data, '$.role') END = 'user'
+        AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.type') END = 'compaction'
       GROUP BY m.session_id
     `,
   );
@@ -221,38 +223,72 @@ function countBySession(db: Database, sql: string): Map<string, number> {
   return map;
 }
 
-/** Map session_id → the first user text prompt (earliest by message time). */
+/**
+ * Map session_id → the first user text prompt (earliest by message time).
+ *
+ * A user message can have several text parts, and individual parts can be
+ * malformed while a later part in the same message remains readable. Keep
+ * the message boundary while walking the ordered rows so one bad part does
+ * not reserve an empty first prompt or discard the rest of the message.
+ */
 function firstUserPrompts(db: Database): Map<string, string> {
   const map = new Map<string, string>();
   const rows = rowValues(
     db,
     `
-      SELECT m.session_id, m.time_created, p.data
+      SELECT m.session_id, m.id AS message_id, m.time_created, p.id AS part_id, p.data
       FROM part p
       JOIN message m ON m.id = p.message_id
-      WHERE json_extract(m.data, '$.role') = 'user'
-        AND json_extract(p.data, '$.type') = 'text'
+      WHERE CASE WHEN json_valid(m.data) THEN json_extract(m.data, '$.role') END = 'user'
+        AND CASE WHEN json_valid(p.data) THEN json_extract(p.data, '$.type') END = 'text'
         AND NOT EXISTS (
           SELECT 1
           FROM part compact
           WHERE compact.message_id = m.id
-            AND json_extract(compact.data, '$.type') = 'compaction'
+            AND CASE
+              WHEN json_valid(compact.data) THEN json_extract(compact.data, '$.type')
+            END = 'compaction'
         )
-      ORDER BY m.session_id ASC, m.time_created ASC
+      ORDER BY m.session_id ASC, m.time_created ASC, m.id ASC, p.id ASC
     `,
   );
+
+  let pendingSessionId = "";
+  let pendingMessageId = "";
+  let pendingTextParts: string[] = [];
+
+  const commitPending = (): void => {
+    if (!pendingSessionId || map.has(pendingSessionId)) return;
+    const text = pendingTextParts.join("\n").trim();
+    if (text) map.set(pendingSessionId, text);
+  };
+
   for (const row of rows) {
     const sessionId = String(row.session_id ?? "");
-    if (!sessionId || map.has(sessionId)) continue;
-    let text = "";
+    const messageId = String(row.message_id ?? "");
+    if (!sessionId || !messageId || map.has(sessionId)) continue;
+
+    if (sessionId !== pendingSessionId || messageId !== pendingMessageId) {
+      commitPending();
+      if (map.has(sessionId)) continue;
+      pendingSessionId = sessionId;
+      pendingMessageId = messageId;
+      pendingTextParts = [];
+    }
+
     try {
       const parsed = JSON.parse(row.data as string) as { text?: string };
-      text = typeof parsed.text === "string" ? parsed.text : "";
+      if (typeof parsed.text === "string" && parsed.text.trim()) {
+        pendingTextParts.push(parsed.text);
+      }
     } catch {
-      // Skip malformed parts and keep looking for the next valid user text.
+      // Keep the message open so a later valid part can still supply its
+      // prompt. If the whole message is malformed, commitPending() leaves it
+      // empty and the next user message gets a chance.
     }
-    if (text.trim()) map.set(sessionId, text);
   }
+
+  commitPending();
   return map;
 }
 

--- a/packages/provider-opencode/test/discover.test.ts
+++ b/packages/provider-opencode/test/discover.test.ts
@@ -112,6 +112,54 @@ describe("opencode discover", () => {
     }
   });
 
+  it("concatenates text parts and skips malformed first parts", async () => {
+    const db = await buildOpencodeDb({
+      session: [{ id: "ses_parts", slug: "parts", directory: "/Users/test/project" }],
+      messages: [
+        {
+          id: "m_parts",
+          sessionId: "ses_parts",
+          role: "user",
+          timeCreated: 1_800_000_010_000,
+          parts: [],
+        },
+      ],
+    });
+
+    // Simulate a malformed JSON part followed by a valid part in the first
+    // user message. The discovery query reads raw SQLite data, so this cannot
+    // be represented by JSON.stringify in the normal seed helper.
+    db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)", [
+      "prt_malformed",
+      "m_parts",
+      "ses_parts",
+      1_800_000_010_000,
+      "{not-json",
+    ]);
+    db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)", [
+      "prt_valid_1",
+      "m_parts",
+      "ses_parts",
+      1_800_000_010_000,
+      JSON.stringify({ type: "text", text: "First part" }),
+    ]);
+    db.run("INSERT INTO part (id, message_id, session_id, time_created, data) VALUES (?,?,?,?,?)", [
+      "prt_valid_2",
+      "m_parts",
+      "ses_parts",
+      1_800_000_010_000,
+      JSON.stringify({ type: "text", text: "second part" }),
+    ]);
+
+    try {
+      const sessions = listSessionsFromDb(db);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].firstPrompt).toBe("First part second part");
+    } finally {
+      db.close();
+    }
+  });
+
   it("indexes context compactions during discovery", async () => {
     const db = await buildOpencodeDb({
       session: [{ id: "ses_compacted", slug: "compacted", directory: "/Users/test/project" }],

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -17,6 +17,7 @@ import {
   matchesProjectFacet,
   matchesProviderFacet,
   matchesRepoFacet,
+  matchesUsageFacetsExcept,
   mergeCompactionCounts,
   NO_REPO_FILTER,
   replayCompactionCount,
@@ -252,6 +253,24 @@ export function shouldIncludeSessionForProject(
   }
   return (
     selectedProjectKey === ALL_PROJECTS ||
+    matchesProjectFacet(session, selectedProjectKey, ALL_PROJECTS, rollupProject, selectedLocation)
+  );
+}
+
+/**
+ * Base visibility for facet derivation. Automated workspaces stay hidden by
+ * default, except that selecting their canonical project must still reveal
+ * them even while the explicit agent-run toggle is off.
+ */
+export function shouldIncludeSessionForFacets(
+  session: Pick<SourceSession, "project" | "projectIdentity" | "location">,
+  selectedProjectKey: string,
+  showAgentRuns: boolean,
+  selectedLocation?: SessionLocation | "local",
+): boolean {
+  if (showAgentRuns || !isAgentRunWorkspace(session.project, session.projectIdentity)) return true;
+  return (
+    selectedProjectKey !== ALL_PROJECTS &&
     matchesProjectFacet(session, selectedProjectKey, ALL_PROJECTS, rollupProject, selectedLocation)
   );
 }
@@ -2563,23 +2582,31 @@ function SessionsPanel() {
       .filter((s) => isAgentRunWorkspace(s.project, s.projectIdentity))
       .map((s) => s.project),
   ).size;
-  const visibleSources = useMemo(
+  // Keep project selection out of the source set used to calculate facet
+  // entries. Otherwise choosing project A removes project B from the sidebar
+  // and forces the user through "All projects" before another project can be
+  // selected.
+  const facetVisibleSources = useMemo(
     () =>
       rangeUnarchivedSources.filter((s) =>
-        shouldIncludeSessionForProject(s, selectedProjectKey, showAgentRuns, selectedLocation),
+        shouldIncludeSessionForFacets(s, selectedProjectKey, showAgentRuns, selectedLocation),
       ),
     [rangeUnarchivedSources, selectedLocation, selectedProjectKey, showAgentRuns],
   );
   const baseSourceCount = useMemo(
     () =>
       unarchivedSources.filter((s) =>
-        shouldIncludeSessionForProject(s, selectedProjectKey, showAgentRuns, selectedLocation),
+        shouldIncludeSessionForFacets(s, selectedProjectKey, showAgentRuns, selectedLocation),
       ).length,
     [selectedLocation, selectedProjectKey, showAgentRuns, unarchivedSources],
   );
 
   const selectedProviderSet = new Set(selectedProviders);
   const selectedRepoSet = new Set(selectedRepos);
+  const selectedToolSet = new Set(selectedTools);
+  const selectedMcpServerSet = new Set(selectedMcpServers);
+  const selectedMcpToolSet = new Set(selectedMcpTools);
+  const selectedSkillSet = new Set(selectedSkills);
   const query = filter.trim().toLowerCase();
 
   const matchesProviderFilter = (s: SourceSession) => matchesProviderFacet(s, selectedProviderSet);
@@ -2588,7 +2615,7 @@ function SessionsPanel() {
     matchesProjectFacet(s, selectedProjectKey, ALL_PROJECTS, rollupProject, selectedLocation);
   const searchMatchedSources = useMemo(
     () =>
-      visibleSources.filter((s) => {
+      facetVisibleSources.filter((s) => {
         if (!query) return true;
         const scanData = findSessionScanData(s, scanResultsIndex);
         const displayTitle = sourceDisplayTitle(s, scanData);
@@ -2620,7 +2647,7 @@ function SessionsPanel() {
           .filter(Boolean)
           .some((value) => String(value).toLowerCase().includes(query));
       }),
-    [query, scanResultsIndex, visibleSources],
+    [facetVisibleSources, query, scanResultsIndex],
   );
   const usageEnrichedSources = useMemo(
     () =>
@@ -2657,13 +2684,24 @@ function SessionsPanel() {
   const projectFacetSources = compactionMatchedSources.filter(
     (s) => matchesProviderFilter(s) && matchesRepoFilter(s),
   );
-  const usageFacetSources = usageEnrichedSources.filter(
+  const usageFacetBaseSources = usageEnrichedSources.filter(
     (s) =>
       matchesProviderFilter(s) &&
       matchesRepoFilter(s) &&
       matchesProjectFilter(s) &&
       matchesCompactionFacet(s, compactionsOnly),
   );
+  const usageFacetSources = (excluded: "tools" | "mcpServers" | "mcpTools" | "skills") =>
+    usageFacetBaseSources.filter((s) =>
+      matchesUsageFacetsExcept(
+        s,
+        excluded,
+        selectedToolSet,
+        selectedMcpServerSet,
+        selectedMcpToolSet,
+        selectedSkillSet,
+      ),
+    );
   const compactionFacetSources = usageMatchedSources.filter(
     (s) => matchesProviderFilter(s) && matchesRepoFilter(s) && matchesProjectFilter(s),
   );
@@ -2673,16 +2711,16 @@ function SessionsPanel() {
   );
   const repoEntries = sortedFacetEntries(facetCountMap(repoFacetSources, repoFilterValue));
   const toolEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSources, (source) => source.tools),
+    multiFacetCountMap(usageFacetSources("tools"), (source) => source.tools),
   );
   const mcpServerEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSources, (source) => source.mcpServers),
+    multiFacetCountMap(usageFacetSources("mcpServers"), (source) => source.mcpServers),
   );
   const mcpToolEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSources, (source) => source.mcpTools),
+    multiFacetCountMap(usageFacetSources("mcpTools"), (source) => source.mcpTools),
   );
   const skillEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSources, (source) => source.skills),
+    multiFacetCountMap(usageFacetSources("skills"), (source) => source.skills),
   );
   const compactedSessionCount = compactionFacetSources.filter(
     (source) => (source.compactionCount ?? 0) > 0,
@@ -4443,12 +4481,20 @@ function ReplaysPanel() {
       .filter((s) => isAgentRunWorkspace(s.project, s.projectIdentity))
       .map((s) => s.project),
   ).size;
-  const visibleSessions = unarchivedSessions.filter((s) =>
-    shouldIncludeSessionForProject(s, selectedProjectKey, showAgentRuns, selectedLocation),
+  // Calculate facet options from all visible projects. Applying the selected
+  // project before this point would make every other project disappear from
+  // the selector until the user clears the current project.
+  const facetVisibleSessions = unarchivedSessions.filter((s) =>
+    shouldIncludeSessionForFacets(s, selectedProjectKey, showAgentRuns, selectedLocation),
   );
+  const visibleSessions = facetVisibleSessions;
 
   const selectedProviderSet = new Set(selectedProviders);
   const selectedRepoSet = new Set(selectedRepos);
+  const selectedToolSet = new Set(selectedTools);
+  const selectedMcpServerSet = new Set(selectedMcpServers);
+  const selectedMcpToolSet = new Set(selectedMcpTools);
+  const selectedSkillSet = new Set(selectedSkills);
   const query = filter.trim().toLowerCase();
 
   const matchesProviderFilter = (s: SessionSummary) => matchesProviderFacet(s, selectedProviderSet);
@@ -4477,7 +4523,7 @@ function ReplaysPanel() {
       .some((value) => String(value).toLowerCase().includes(query));
   };
 
-  const searchMatchedSessions = visibleSessions.filter(matchesSearchFilter);
+  const searchMatchedSessions = facetVisibleSessions.filter(matchesSearchFilter);
   const usageMatchedSessions = applyDashboardFacetFilters(searchMatchedSessions, {
     selectedProviders: [],
     selectedRepos: [],
@@ -4501,13 +4547,24 @@ function ReplaysPanel() {
   const projectFacetSessions = compactionMatchedSessions.filter(
     (s) => matchesProviderFilter(s) && matchesRepoFilter(s),
   );
-  const usageFacetSessions = searchMatchedSessions.filter(
+  const usageFacetBaseSessions = searchMatchedSessions.filter(
     (s) =>
       matchesProviderFilter(s) &&
       matchesRepoFilter(s) &&
       matchesProjectFilter(s) &&
       matchesCompactionFacet(s, compactionsOnly),
   );
+  const usageFacetSessions = (excluded: "tools" | "mcpServers" | "mcpTools" | "skills") =>
+    usageFacetBaseSessions.filter((s) =>
+      matchesUsageFacetsExcept(
+        s,
+        excluded,
+        selectedToolSet,
+        selectedMcpServerSet,
+        selectedMcpToolSet,
+        selectedSkillSet,
+      ),
+    );
   const compactionFacetSessions = usageMatchedSessions.filter(
     (s) => matchesProviderFilter(s) && matchesRepoFilter(s) && matchesProjectFilter(s),
   );
@@ -4517,16 +4574,16 @@ function ReplaysPanel() {
   );
   const repoEntries = sortedFacetEntries(facetCountMap(repoFacetSessions, repoFilterValue));
   const toolEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSessions, (session) => session.tools),
+    multiFacetCountMap(usageFacetSessions("tools"), (session) => session.tools),
   );
   const mcpServerEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSessions, (session) => session.mcpServers),
+    multiFacetCountMap(usageFacetSessions("mcpServers"), (session) => session.mcpServers),
   );
   const mcpToolEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSessions, (session) => session.mcpTools),
+    multiFacetCountMap(usageFacetSessions("mcpTools"), (session) => session.mcpTools),
   );
   const skillEntries = sortedFacetEntries(
-    multiFacetCountMap(usageFacetSessions, (session) => session.skills),
+    multiFacetCountMap(usageFacetSessions("skills"), (session) => session.skills),
   );
   const compactedSessionCount = compactionFacetSessions.filter(
     (session) => (session.compactionCount ?? 0) > 0,

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -9,6 +9,7 @@ import Dashboard, {
   findSessionScanData,
   getSessionRangeTimestamp,
   type SessionScanData,
+  shouldIncludeSessionForFacets,
   shouldIncludeSessionForProject,
   usageFacetValues,
 } from "../Dashboard";
@@ -115,6 +116,13 @@ describe("automated project visibility", () => {
 
   it("shows all automated workspaces when the explicit toggle is enabled", () => {
     expect(shouldIncludeSessionForProject(source, ALL_PROJECTS, true)).toBe(true);
+  });
+
+  it("keeps a selected automated project visible while deriving facets", () => {
+    expect(
+      shouldIncludeSessionForFacets(source, "cursor-sdk:github-pr-review:Roblox/ros", false),
+    ).toBe(true);
+    expect(shouldIncludeSessionForFacets(source, ALL_PROJECTS, false)).toBe(false);
   });
 });
 

--- a/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
+++ b/packages/viewer/src/engine/__tests__/dashboard-filtering.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyDashboardFacetFilters,
   matchesProjectFacet,
+  matchesUsageFacetsExcept,
   mergeCompactionCounts,
   replayCompactionCount,
 } from "../dashboard-filtering";
@@ -83,6 +84,44 @@ describe("dashboard facet filtering", () => {
     });
 
     expect(filtered.map((session) => session.slug)).toEqual(["cursor-1"]);
+  });
+
+  it("keeps other usage selections when calculating a facet", () => {
+    const readAndReview = {
+      tools: ["Read"],
+      mcpServers: [],
+      mcpTools: [],
+      skills: ["review"],
+    };
+    const shellAndReplay = {
+      tools: ["Shell"],
+      mcpServers: [],
+      mcpTools: [],
+      skills: ["replay"],
+    };
+    const selectedTools = new Set(["Read"]);
+    const selectedSkills = new Set(["review"]);
+
+    expect(
+      matchesUsageFacetsExcept(
+        readAndReview,
+        "tools",
+        selectedTools,
+        new Set(),
+        new Set(),
+        selectedSkills,
+      ),
+    ).toBe(true);
+    expect(
+      matchesUsageFacetsExcept(
+        shellAndReplay,
+        "tools",
+        selectedTools,
+        new Set(),
+        new Set(),
+        selectedSkills,
+      ),
+    ).toBe(false);
   });
 
   it("filters to sessions with indexed compactions", () => {

--- a/packages/viewer/src/engine/dashboard-filtering.ts
+++ b/packages/viewer/src/engine/dashboard-filtering.ts
@@ -1,6 +1,7 @@
 import type { ProjectIdentity, SessionLocation } from "@vibe-replay/types";
 
 export const NO_REPO_FILTER = "__no_repo__";
+const EMPTY_FACET_SET: ReadonlySet<string> = new Set();
 
 export interface DashboardFilterItem {
   provider: string;
@@ -69,11 +70,35 @@ export function matchesUsageFacets(
   selectedMcpTools: ReadonlySet<string>,
   selectedSkills: ReadonlySet<string>,
 ): boolean {
+  return matchesUsageFacetsExcept(
+    item,
+    undefined,
+    selectedTools,
+    selectedMcpServers,
+    selectedMcpTools,
+    selectedSkills,
+  );
+}
+
+export function matchesUsageFacetsExcept(
+  item: Pick<DashboardFilterItem, "tools" | "mcpServers" | "mcpTools" | "skills">,
+  excluded: "tools" | "mcpServers" | "mcpTools" | "skills" | undefined,
+  selectedTools: ReadonlySet<string>,
+  selectedMcpServers: ReadonlySet<string>,
+  selectedMcpTools: ReadonlySet<string>,
+  selectedSkills: ReadonlySet<string>,
+): boolean {
   return (
-    matchesMultiValueFacet(item.tools, selectedTools) &&
-    matchesMultiValueFacet(item.mcpServers, selectedMcpServers) &&
-    matchesMultiValueFacet(item.mcpTools, selectedMcpTools) &&
-    matchesMultiValueFacet(item.skills, selectedSkills)
+    matchesMultiValueFacet(item.tools, excluded === "tools" ? EMPTY_FACET_SET : selectedTools) &&
+    matchesMultiValueFacet(
+      item.mcpServers,
+      excluded === "mcpServers" ? EMPTY_FACET_SET : selectedMcpServers,
+    ) &&
+    matchesMultiValueFacet(
+      item.mcpTools,
+      excluded === "mcpTools" ? EMPTY_FACET_SET : selectedMcpTools,
+    ) &&
+    matchesMultiValueFacet(item.skills, excluded === "skills" ? EMPTY_FACET_SET : selectedSkills)
   );
 }
 


### PR DESCRIPTION
## Summary
- Harden OpenCode discovery against malformed JSON parts and concatenate multi-part prompts.
- Find Cursor prompts after leading metadata records.
- Keep project choices available after selection and make usage facet counts respect other selected usage facets.
- Refresh nested replay summaries after regeneration and use session end time for project activity.

## Validation
- `pnpm verify`
- `pnpm exec tsx packages/cli/src/index.ts sessions --query vendor --json --limit 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project activity now reflects when sessions actually ended, improving recency insights.
  * Session discovery is more reliable when transcripts contain malformed data or extensive metadata.
  * First prompts are captured more accurately across multi-part messages.

* **Dashboard Improvements**
  * Automated agent-run workspaces remain hidden by default while staying available when their project is selected.
  * Usage facet counts now remain accurate when multiple filters are applied.
  * Replay details and cache updates now detect nested changes more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->