### PR TITLE
fix: reserve ports across concurrent dev launchers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,15 @@ DOM by adding `// @vitest-environment jsdom` as the first line of the test file,
 and should `afterEach(cleanup)` so window listeners don't leak between tests.
 See `src/hooks/__tests__/usePlayback.test.tsx` for the pattern.
 
-**Daily workflow**: Run `pnpm dev`, open `http://localhost:5173`. Viewer changes hot-reload instantly via Vite HMR. CLI/API changes auto-restart via `tsx watch`. No manual rebuild or restart needed.
+**Daily workflow**: Run `pnpm dev`, then open the viewer URL printed by the
+launcher (usually `http://localhost:5173`). Viewer changes hot-reload instantly
+via Vite HMR. CLI/API changes auto-restart via `tsx watch`. No manual rebuild
+or restart needed.
+
+The dev launchers reserve ports across their entire lifetime, including CLI
+restart windows. This allows multiple worktrees to run concurrently. For fixed
+ports, set `VIBE_API_PORT` and `VIBE_VIEWER_PORT` for `pnpm dev`, or
+`VIBE_VIEWER_PORT` and `VIBE_WEBSITE_PORT` for `pnpm dev:website`.
 
 ## Working with a coding agent
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ pnpm dev              # Viewer (Vite HMR) + CLI (auto-restart) — full HMR
 pnpm dev:website      # Website (Astro HMR) + Viewer (Vite HMR)
 ```
 
+The dev launchers reserve their selected ports for the lifetime of the
+launcher, so multiple worktrees can start at the same time without selecting
+the same port during startup. To choose a fixed pair explicitly, use
+`VIBE_API_PORT` and `VIBE_VIEWER_PORT`:
+
+```bash
+VIBE_API_PORT=13457 VIBE_VIEWER_PORT=5174 pnpm dev
+VIBE_VIEWER_PORT=5175 VIBE_WEBSITE_PORT=4322 pnpm dev:website
+```
+
+The requested ports must be free and different within the same launcher.
+
 CLI usage requires Node.js >= 22.19.0. The `website` package uses Astro 6 and requires Node.js >= 22.12.0. When `nvm` is available, `website` scripts will try `nvm use` from `website/.nvmrc` automatically. If a global package-manager shim selects an older Node for child commands, verify `corepack pnpm exec node -v` and use `corepack pnpm ...` after selecting a compatible Node version; see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for architecture details and development workflow.

--- a/packages/cli/test/dev-utils.test.ts
+++ b/packages/cli/test/dev-utils.test.ts
@@ -1,9 +1,13 @@
+import { spawn } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
+  killProcessTree,
+  isPortFree,
   parsePort,
   readPortOverride,
   reserveFreePort,
   reservePort,
+  waitForProcessTree,
 } from "../../../scripts/dev-utils.mjs";
 
 describe("dev port utilities", () => {
@@ -72,6 +76,65 @@ describe("dev port utilities", () => {
       );
     } finally {
       await first.release();
+    }
+  });
+
+  it("kills a descendant before the port reservation can be reused", async () => {
+    const initial = await reserveFreePort(45_000 + Math.floor(Math.random() * 5_000));
+    const port = initial.port;
+    await initial.release();
+
+    const descendantSource = `
+      import { createServer } from "node:net";
+      const server = createServer();
+      server.listen(${port}, "127.0.0.1", () => process.stdout.write("ready\\n"));
+      setInterval(() => {}, 1000);
+    `;
+    const parentSource = `
+      import { spawn } from "node:child_process";
+      const child = spawn(process.execPath, ["--input-type=module", "-e", ${JSON.stringify(descendantSource)}], {
+        stdio: ["ignore", "pipe", "inherit"],
+      });
+      child.stdout.pipe(process.stdout);
+      setInterval(() => {}, 1000);
+    `;
+    const child = spawn(process.execPath, ["--input-type=module", "-e", parentSource], {
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    try {
+      await new Promise((resolve, reject) => {
+        let output = "";
+        const timer = setTimeout(() => reject(new Error(`child did not bind: ${output}`)), 5_000);
+        child.stdout.on("data", (chunk) => {
+          output += chunk;
+          if (output.includes("ready")) {
+            clearTimeout(timer);
+            resolve();
+          }
+        });
+        child.once("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+      });
+
+      expect(await isPortFree(port)).toBe(false);
+      await killProcessTree(child);
+      await waitForProcessTree(child, 2_000);
+
+      const deadline = Date.now() + 2_000;
+      while (!(await isPortFree(port)) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      const reservation = await reservePort(port, "Test port");
+      await reservation.release();
+      expect(await isPortFree(port)).toBe(true);
+    } finally {
+      await killProcessTree(child);
+      await waitForProcessTree(child, 2_000);
     }
   });
 });

--- a/packages/cli/test/dev-utils.test.ts
+++ b/packages/cli/test/dev-utils.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  parsePort,
+  readPortOverride,
+  reserveFreePort,
+  reservePort,
+} from "../../../scripts/dev-utils.mjs";
+
+describe("dev port utilities", () => {
+  it("validates explicit ports", () => {
+    expect(parsePort("23456")).toBe(23456);
+    expect(parsePort(undefined)).toBeUndefined();
+    expect(() => parsePort("80", "API port")).toThrow(
+      "API port must be an integer between 1024 and 65535",
+    );
+  });
+
+  it("uses the logical port label for override errors", () => {
+    const originalApiPort = process.env.VIBE_API_PORT;
+    process.env.VIBE_API_PORT = "80";
+    try {
+      expect(() => readPortOverride(["VIBE_API_PORT"], "API port")).toThrow(
+        "API port must be an integer between 1024 and 65535",
+      );
+    } finally {
+      if (originalApiPort === undefined) delete process.env.VIBE_API_PORT;
+      else process.env.VIBE_API_PORT = originalApiPort;
+    }
+  });
+
+  it("validates the automatic search range", async () => {
+    await expect(reserveFreePort(65535, 0)).rejects.toThrow(
+      "Port search range must be a positive integer",
+    );
+  });
+
+  it("rejects conflicting port aliases", () => {
+    const originalApiPort = process.env.VIBE_API_PORT;
+    const originalViteApiPort = process.env.VITE_API_PORT;
+    process.env.VIBE_API_PORT = "23456";
+    process.env.VITE_API_PORT = "23457";
+    try {
+      expect(() => readPortOverride(["VIBE_API_PORT", "VITE_API_PORT"], "API port")).toThrow(
+        "API port has conflicting values",
+      );
+    } finally {
+      if (originalApiPort === undefined) delete process.env.VIBE_API_PORT;
+      else process.env.VIBE_API_PORT = originalApiPort;
+      if (originalViteApiPort === undefined) delete process.env.VITE_API_PORT;
+      else process.env.VITE_API_PORT = originalViteApiPort;
+    }
+  });
+
+  it("reserves different ports for concurrent launchers", async () => {
+    const preferred = 40_000 + Math.floor(Math.random() * 10_000);
+    const reservations = await Promise.all([
+      reserveFreePort(preferred),
+      reserveFreePort(preferred),
+    ]);
+    try {
+      expect(reservations[0].port).not.toBe(reservations[1].port);
+    } finally {
+      await Promise.all(reservations.map(({ release }) => release()));
+    }
+  });
+
+  it("does not allow an explicit port to be reserved twice", async () => {
+    const first = await reserveFreePort(50_000 + Math.floor(Math.random() * 10_000));
+    try {
+      await expect(reservePort(first.port, "API port")).rejects.toThrow(
+        `API port ${first.port} is already reserved by another dev process`,
+      );
+    } finally {
+      await first.release();
+    }
+  });
+});

--- a/scripts/dev-utils.mjs
+++ b/scripts/dev-utils.mjs
@@ -2,7 +2,8 @@
  * Shared utilities for dev launcher scripts.
  */
 import { spawn } from "node:child_process";
-import { createServer } from "node:net";
+import { lstat, unlink } from "node:fs/promises";
+import { createConnection, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,7 +16,13 @@ export const IS_WINDOWS = process.platform === "win32";
  * not a concern.
  */
 export function spawnPnpm(args, options = {}) {
-  return spawn("pnpm", args, { ...options, shell: IS_WINDOWS });
+  return spawn("pnpm", args, {
+    ...options,
+    shell: IS_WINDOWS,
+    // Put the child tree in its own group so shutdown can terminate pnpm and
+    // the actual dev server together.
+    detached: !IS_WINDOWS,
+  });
 }
 
 /**
@@ -26,12 +33,91 @@ export function spawnPnpm(args, options = {}) {
  * reliable (no wrapper process).
  */
 export function spawnTsx(scriptArgs, options = {}) {
-  return spawn(process.execPath, ["--import", "tsx", ...scriptArgs], options);
+  return spawn(process.execPath, ["--import", "tsx", ...scriptArgs], {
+    ...options,
+    detached: !IS_WINDOWS,
+  });
+}
+
+/**
+ * Signal a launcher child and all of its descendants. Dev commands often
+ * spawn through pnpm, so killing only the direct child can leave Vite/Astro
+ * listening after the launcher exits.
+ */
+export function killProcessTree(child, signal = "SIGTERM") {
+  if (!child?.pid) return;
+  if (IS_WINDOWS) {
+    try {
+      child.kill(signal);
+    } catch {}
+    spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    }).unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {}
+  }
+}
+
+/** Wait for a detached child process group to exit, then force-kill it. */
+export async function waitForProcessTree(child, timeoutMs = 1_000) {
+  if (!child?.pid || IS_WINDOWS) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(-child.pid, 0);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  killProcessTree(child, "SIGKILL");
 }
 
 /** Cross-platform temp log path for the backgrounded Vite viewer. */
 export function viewerLogPath(port) {
   return join(tmpdir(), `vibe-replay-viewer-${port}.log`);
+}
+
+function portLockPath(port) {
+  return IS_WINDOWS
+    ? `\\\\.\\pipe\\vibe-replay-port-${port}`
+    : join(tmpdir(), `vibe-replay-port-${port}.sock`);
+}
+
+/** Validate a user-supplied TCP port. Port 0 is intentionally not accepted. */
+export function parsePort(value, label = "Port") {
+  if (value === undefined || value === null || value === "") return undefined;
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(`${label} must be an integer between 1024 and 65535`);
+  }
+  return port;
+}
+
+/**
+ * Read one logical port from one or more compatible environment variables.
+ * Supplying aliases with different values is almost certainly a configuration
+ * mistake, so fail before starting either child process.
+ */
+export function readPortOverride(names, label) {
+  const configured = names
+    .map((name) => ({ name, value: process.env[name] }))
+    .filter(({ value }) => value !== undefined && value !== "")
+    .map(({ name, value }) => ({ name, port: parsePort(value, label) }));
+  const ports = new Set(configured.map(({ port }) => port));
+  if (ports.size > 1) {
+    throw new Error(
+      `${label} has conflicting values: ${configured.map(({ name, port }) => `${name}=${port}`).join(", ")}`,
+    );
+  }
+  return configured[0]?.port;
 }
 
 /**
@@ -42,12 +128,12 @@ export function isPortFree(port) {
   return new Promise((resolve) => {
     const s4 = createServer();
     s4.unref();
-    s4.on("error", () => resolve(false));
+    s4.on("error", () => s4.close(() => resolve(false)));
     s4.listen(port, "127.0.0.1", () => {
       s4.close(() => {
         const s6 = createServer();
         s6.unref();
-        s6.on("error", () => resolve(false));
+        s6.on("error", () => s6.close(() => resolve(false)));
         s6.listen(port, "::1", () => {
           s6.close(() => resolve(true));
         });
@@ -56,10 +142,139 @@ export function isPortFree(port) {
   });
 }
 
-/** Find a free port starting from `preferred`, incrementing on conflict. */
-export async function findFreePort(preferred) {
-  for (let port = preferred; port < preferred + 100; port++) {
-    if (await isPortFree(port)) return port;
+function closeLockServer(server) {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+function isLockAlive(lockPath) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const socket = createConnection(lockPath);
+    const finish = (alive) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(alive);
+    };
+    socket.setTimeout(250, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+async function removeStaleLock(lockPath) {
+  if (IS_WINDOWS) {
+    // Named pipes are removed by the OS when their server dies. Retrying is
+    // enough to observe that release; unlink is not reliable for pipe paths.
+    return true;
   }
-  throw new Error(`No free port found in range ${preferred}-${preferred + 99}`);
+  try {
+    if (!(await lstat(lockPath)).isSocket()) return false;
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+  try {
+    await unlink(lockPath);
+    return true;
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+}
+
+/**
+ * Reserve a live IPC endpoint rather than a marker file. A crashed launcher
+ * leaves only a disconnected Unix socket, which the next launcher can safely
+ * reclaim without racing a live owner based on PID checks.
+ */
+async function tryAcquirePortLock(port) {
+  const lockPath = portLockPath(port);
+
+  while (true) {
+    const lockServer = createServer((socket) => socket.end());
+    const acquired = await new Promise((resolve, reject) => {
+      const onError = (error) => {
+        lockServer.removeListener("error", onError);
+        if (error?.code === "EADDRINUSE") resolve(false);
+        else reject(error);
+      };
+      lockServer.once("error", onError);
+      lockServer.listen(lockPath, () => {
+        lockServer.removeListener("error", onError);
+        resolve(true);
+      });
+    });
+
+    if (acquired) {
+      lockServer.unref();
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        await closeLockServer(lockServer);
+      };
+    }
+
+    await closeLockServer(lockServer);
+    if (await isLockAlive(lockPath)) return null;
+    if (!(await removeStaleLock(lockPath))) return null;
+  }
+}
+
+/** Reserve a specific free port until the returned release function is called. */
+export async function reservePort(port, label = "Port") {
+  const parsedPort = parsePort(port, label);
+  const releaseLock = await tryAcquirePortLock(parsedPort);
+  if (!releaseLock) {
+    throw new Error(`${label} ${parsedPort} is already reserved by another dev process`);
+  }
+  if (!(await isPortFree(parsedPort))) {
+    await releaseLock();
+    throw new Error(`${label} ${parsedPort} is already in use`);
+  }
+  return { port: parsedPort, release: releaseLock };
+}
+
+/** Find and reserve a free port starting from `preferred`, incrementing on conflict. */
+export async function reserveFreePort(preferred, range = 100) {
+  const firstPort = parsePort(preferred, "Preferred port");
+  if (!Number.isInteger(range) || range < 1) {
+    throw new Error("Port search range must be a positive integer");
+  }
+  const lastPort = Math.min(65535, firstPort + range - 1);
+  for (let port = firstPort; port <= lastPort; port++) {
+    const releaseLock = await tryAcquirePortLock(port);
+    if (!releaseLock) continue;
+    if (await isPortFree(port)) return { port, release: releaseLock };
+    await releaseLock();
+  }
+  throw new Error(`No free port found in range ${firstPort}-${lastPort}`);
+}
+
+/**
+ * Legacy non-reserving probe. New launchers should use reserveFreePort so a
+ * second launcher cannot select the same port during child startup.
+ */
+export async function findFreePort(preferred) {
+  const reservation = await reserveFreePort(preferred);
+  await reservation.release();
+  return reservation.port;
+}
+
+/** Wait until a child process has actually bound the reserved port. */
+export async function waitForPortBound(port, child, label, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child?.exitCode !== null || child?.signalCode !== null) {
+      throw new Error(`${label} exited before binding port ${port}`);
+    }
+    if (!(await isPortFree(port))) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`${label} did not bind port ${port} within ${timeoutMs}ms`);
 }

--- a/scripts/dev-utils.mjs
+++ b/scripts/dev-utils.mjs
@@ -39,22 +39,61 @@ export function spawnTsx(scriptArgs, options = {}) {
   });
 }
 
+function hasExited(child) {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForChildExit(child, timeoutMs) {
+  if (!child?.pid || hasExited(child)) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let timer;
+    const finish = (exited) => {
+      clearTimeout(timer);
+      child.removeListener("exit", onExit);
+      child.removeListener("error", onError);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    const onError = () => finish(true);
+    child.once("exit", onExit);
+    child.once("error", onError);
+    timer = setTimeout(() => finish(hasExited(child)), timeoutMs);
+  });
+}
+
 /**
  * Signal a launcher child and all of its descendants. Dev commands often
  * spawn through pnpm, so killing only the direct child can leave Vite/Astro
  * listening after the launcher exits.
  */
 export function killProcessTree(child, signal = "SIGTERM") {
-  if (!child?.pid) return;
+  if (!child?.pid) return Promise.resolve();
   if (IS_WINDOWS) {
-    try {
-      child.kill(signal);
-    } catch {}
-    spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
-      stdio: "ignore",
-      windowsHide: true,
-    }).unref();
-    return;
+    return new Promise((resolve) => {
+      let taskkill;
+      const fallback = () => {
+        try {
+          child.kill(signal);
+        } catch {}
+      };
+      try {
+        taskkill = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+        taskkill.once("error", () => {
+          fallback();
+          resolve();
+        });
+        taskkill.once("exit", (code) => {
+          if (code !== 0) fallback();
+          resolve();
+        });
+      } catch {
+        fallback();
+        resolve();
+      }
+    });
   }
   try {
     process.kill(-child.pid, signal);
@@ -63,11 +102,16 @@ export function killProcessTree(child, signal = "SIGTERM") {
       child.kill(signal);
     } catch {}
   }
+  return Promise.resolve();
 }
 
 /** Wait for a detached child process group to exit, then force-kill it. */
 export async function waitForProcessTree(child, timeoutMs = 1_000) {
-  if (!child?.pid || IS_WINDOWS) return;
+  if (!child?.pid) return;
+  if (IS_WINDOWS) {
+    if (!(await waitForChildExit(child, timeoutMs))) await killProcessTree(child, "SIGKILL");
+    return;
+  }
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -85,8 +85,7 @@ async function shutdown(exitCode) {
   if (shuttingDown) return;
   shuttingDown = true;
   try {
-    killProcessTree(astro);
-    killProcessTree(vite);
+    await Promise.all([killProcessTree(astro), killProcessTree(vite)]);
     await Promise.all([waitForProcessTree(astro), waitForProcessTree(vite)]);
     await Promise.all(reservations.map(({ release }) => release()));
   } finally {
@@ -129,7 +128,7 @@ try {
     },
   });
   astro.on("exit", (code) => {
-    if (!shuttingDown) void shutdown(code ?? 0);
+    if (!shuttingDown) void shutdown(code ?? 1);
   });
   await waitForPortBound(astroPort, astro, "Astro");
 } catch (error) {

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -8,13 +8,47 @@
  * Usage:
  *   node scripts/dev-website.mjs
  */
-import { findFreePort, spawnPnpm, viewerLogPath } from "./dev-utils.mjs";
+import {
+  killProcessTree,
+  readPortOverride,
+  reserveFreePort,
+  reservePort,
+  spawnPnpm,
+  waitForProcessTree,
+  waitForPortBound,
+  viewerLogPath,
+} from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const ASTRO_PREFERRED = 4321;
 
-const vitePort = await findFreePort(VITE_PREFERRED);
-const astroPort = await findFreePort(ASTRO_PREFERRED);
+const vitePortOverride = readPortOverride(["VIBE_VIEWER_PORT", "VITE_PORT"], "Viewer port");
+const astroPortOverride = readPortOverride(["VIBE_WEBSITE_PORT", "ASTRO_PORT"], "Website port");
+if (vitePortOverride !== undefined && vitePortOverride === astroPortOverride) {
+  throw new Error(`Viewer port and website port must be different (both are ${vitePortOverride})`);
+}
+
+const reservations = [];
+let viteReservation;
+let astroReservation;
+try {
+  viteReservation =
+    vitePortOverride !== undefined
+      ? await reservePort(vitePortOverride, "Viewer port")
+      : await reserveFreePort(VITE_PREFERRED);
+  reservations.push(viteReservation);
+  astroReservation =
+    astroPortOverride !== undefined
+      ? await reservePort(astroPortOverride, "Website port")
+      : await reserveFreePort(ASTRO_PREFERRED);
+  reservations.push(astroReservation);
+} catch (error) {
+  await Promise.all(reservations.map(({ release }) => release()));
+  throw error;
+}
+
+const vitePort = viteReservation.port;
+const astroPort = astroReservation.port;
 
 console.log();
 console.log(
@@ -29,53 +63,76 @@ console.log(`[vibe-replay] /view/  →     redirects to Vite viewer`);
 console.log();
 
 // Start Vite viewer dev (backgrounded, logs to file)
-const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
+let vite;
+let astro;
+let shuttingDown = false;
+let logStream;
+
+vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
   env: { ...process.env, VITE_PORT: String(vitePort) },
 });
 
 const { createWriteStream } = await import("node:fs");
 const logPath = viewerLogPath(vitePort);
-const logStream = createWriteStream(logPath);
+logStream = createWriteStream(logPath);
 vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
 console.log(`[vibe-replay] Viewer logs:  ${logPath}`);
 
 // If Vite crashes, tear down Astro too
-vite.on("exit", (code) => {
-  if (code !== 0 && code !== null) {
-    console.error(`[vibe-replay] Viewer process exited with code ${code}. Check ${logPath}`);
+async function shutdown(exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    killProcessTree(astro);
+    killProcessTree(vite);
+    await Promise.all([waitForProcessTree(astro), waitForProcessTree(vite)]);
+    await Promise.all(reservations.map(({ release }) => release()));
+  } finally {
+    logStream.end();
+    process.exit(exitCode);
   }
-  astro.kill("SIGTERM");
-  process.exit(code ?? 0);
-});
-
-// Start Astro website dev (foreground, inherits stdio)
-const astro = spawnPnpm(["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
-  stdio: "inherit",
-  env: {
-    ...process.env,
-    DEV_VIEWER_URL: `http://localhost:${vitePort}`,
-  },
-});
-
-function cleanup() {
-  vite.kill("SIGTERM");
 }
 
-astro.on("exit", (code) => {
-  cleanup();
-  process.exit(code ?? 0);
+vite.on("exit", (code) => {
+  if (!shuttingDown) {
+    if (code !== 0 && code !== null) {
+      console.error(`[vibe-replay] Viewer process exited with code ${code}. Check ${logPath}`);
+    }
+    void shutdown(code ?? 1);
+  }
 });
 
 process.on("SIGINT", () => {
-  astro.kill("SIGINT");
-  cleanup();
-  process.exit(130);
+  void shutdown(130);
 });
 
 process.on("SIGTERM", () => {
-  astro.kill("SIGTERM");
-  cleanup();
-  process.exit(143);
+  void shutdown(143);
 });
+
+process.on("SIGHUP", () => {
+  void shutdown(129);
+});
+
+try {
+  await waitForPortBound(vitePort, vite, "Vite");
+
+  // Start Astro after Vite is ready so /view/ never points at an unbound URL.
+  astro = spawnPnpm(["--filter", "@vibe-replay/website", "dev", "--port", String(astroPort)], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      DEV_VIEWER_URL: `http://localhost:${vitePort}`,
+      DEV_STRICT_PORT: "1",
+    },
+  });
+  astro.on("exit", (code) => {
+    if (!shuttingDown) void shutdown(code ?? 0);
+  });
+  await waitForPortBound(astroPort, astro, "Astro");
+} catch (error) {
+  console.error(`[vibe-replay] Website startup failed: ${error.message}`);
+  await shutdown(1);
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -9,7 +9,17 @@
  *   node scripts/dev.mjs --menu     # interactive CLI menu mode
  */
 import { watch } from "node:fs";
-import { findFreePort, spawnPnpm, spawnTsx, viewerLogPath } from "./dev-utils.mjs";
+import {
+  readPortOverride,
+  killProcessTree,
+  reserveFreePort,
+  reservePort,
+  spawnPnpm,
+  spawnTsx,
+  waitForProcessTree,
+  waitForPortBound,
+  viewerLogPath,
+} from "./dev-utils.mjs";
 
 const VITE_PREFERRED = 5173;
 const API_PREFERRED = 13456;
@@ -18,9 +28,41 @@ const forceDashboard = process.argv.includes("-d");
 const menuMode = process.argv.includes("--menu");
 const dashboardMode = forceDashboard || !menuMode;
 
-// Find two non-colliding free ports
-const apiPort = await findFreePort(API_PREFERRED);
-const vitePort = await findFreePort(VITE_PREFERRED);
+const apiPortOverride = readPortOverride(["VIBE_API_PORT", "VITE_API_PORT"], "API port");
+const vitePortOverride = readPortOverride(["VIBE_VIEWER_PORT", "VITE_PORT"], "Viewer port");
+if (apiPortOverride !== undefined && apiPortOverride === vitePortOverride) {
+  throw new Error(`API port and viewer port must be different (both are ${apiPortOverride})`);
+}
+
+// Keep reservations for the entire launcher lifetime. A free-port probe alone
+// has a check-then-bind race when two worktrees start at the same time; the
+// lock prevents another launcher from selecting the same port during startup
+// and during CLI HMR restarts.
+const reservations = [];
+let apiReservation;
+let viteReservation;
+let vite;
+let cli;
+
+try {
+  apiReservation =
+    apiPortOverride !== undefined
+      ? await reservePort(apiPortOverride, "API port")
+      : await reserveFreePort(API_PREFERRED);
+  reservations.push(apiReservation);
+
+  viteReservation =
+    vitePortOverride !== undefined
+      ? await reservePort(vitePortOverride, "Viewer port")
+      : await reserveFreePort(VITE_PREFERRED);
+  reservations.push(viteReservation);
+} catch (error) {
+  await Promise.all(reservations.map(({ release }) => release()));
+  throw error;
+}
+
+const apiPort = apiReservation.port;
+const vitePort = viteReservation.port;
 
 console.log();
 console.log(
@@ -38,9 +80,14 @@ console.log();
 
 // Start Vite dev server (backgrounded) — port + strictPort via env vars in vite.config.ts
 const cloudApiUrl = process.env.VIBE_REPLAY_API_URL || "http://localhost:8787";
-const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
+vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
-  env: { ...process.env, VITE_PORT: String(vitePort), VITE_API_PORT: String(apiPort), VITE_CLOUD_API_URL: cloudApiUrl },
+  env: {
+    ...process.env,
+    VITE_PORT: String(vitePort),
+    VITE_API_PORT: String(apiPort),
+    VITE_CLOUD_API_URL: cloudApiUrl,
+  },
 });
 
 // Pipe Vite output to a log file
@@ -67,10 +114,10 @@ const cliEnv = {
 const cliScript = "packages/cli/src/index.ts";
 const cliExtraArgs = dashboardMode ? ["-d"] : [];
 
-let cli;
 let restarting = false;
 let shuttingDown = false;
 let hasOpenedBrowser = false;
+let startingCli = false;
 
 function startCli() {
   // Run tsx via `node --import tsx` (see spawnTsx) instead of the
@@ -88,14 +135,13 @@ function startCli() {
   hasOpenedBrowser = true;
 
   cli.on("exit", (code, signal) => {
-    if (restarting) return; // will be respawned by the watcher
-    cleanup();
-    process.exit(code ?? (signal === "SIGINT" ? 130 : 0));
+    if (restarting || startingCli || shuttingDown) return; // handled by the caller
+    void shutdown(code ?? (signal === "SIGINT" ? 130 : 1));
   });
 }
 
 function killCli() {
-  try { cli.kill("SIGTERM"); } catch {}
+  killProcessTree(cli);
 }
 
 function restartCli() {
@@ -104,14 +150,61 @@ function restartCli() {
   console.log("\n[dev] change detected — restarting CLI...\n");
   cli.on("exit", () => {
     restarting = false;
+    if (shuttingDown) return;
     startCli();
   });
   killCli();
 }
 
-startCli();
+// Cleanup on exit
+async function shutdown(exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    killProcessTree(cli);
+    killProcessTree(vite);
+    await Promise.all([waitForProcessTree(cli), waitForProcessTree(vite)]);
+    await Promise.all(reservations.map(({ release }) => release()));
+  } finally {
+    logStream.end();
+    process.exit(exitCode);
+  }
+}
 
-// Watch CLI source + shared types for changes
+vite.on("exit", (code) => {
+  if (!shuttingDown) {
+    void shutdown(code ?? 1);
+  }
+});
+
+process.on("SIGINT", () => {
+  void shutdown(130);
+});
+
+process.on("SIGTERM", () => {
+  void shutdown(143);
+});
+
+process.on("SIGHUP", () => {
+  void shutdown(129);
+});
+
+// Start Vite first so the CLI can safely open the viewer when its API binds.
+try {
+  await waitForPortBound(vitePort, vite, "Vite");
+  startingCli = true;
+  startCli();
+  if (dashboardMode) await waitForPortBound(apiPort, cli, "CLI API");
+  startingCli = false;
+} catch (error) {
+  startingCli = false;
+  console.error(`[vibe-replay] Dev server startup failed: ${error.message}`);
+  await shutdown(1);
+}
+
+// Watch CLI source + shared types for changes after the initial child has
+// started. This avoids handling a file event before `cli` exists while Vite
+// or the dashboard API is still becoming ready.
 // Note: fs.watch({ recursive: true }) works on macOS/Windows natively.
 // On Linux it requires Node 22+; older Node only watches the top-level dir.
 let debounce;
@@ -122,22 +215,3 @@ for (const dir of ["packages/cli/src", "packages/types/src"]) {
     debounce = setTimeout(restartCli, 200);
   });
 }
-
-// Cleanup on exit
-function cleanup() {
-  shuttingDown = true;
-  try { vite.kill("SIGTERM"); } catch {}
-}
-
-process.on("SIGINT", () => {
-  cleanup();
-  killCli();
-  // Give children a moment to exit, then force quit
-  setTimeout(() => process.exit(130), 500);
-});
-
-process.on("SIGTERM", () => {
-  cleanup();
-  killCli();
-  setTimeout(() => process.exit(143), 500);
-});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -141,7 +141,7 @@ function startCli() {
 }
 
 function killCli() {
-  killProcessTree(cli);
+  return killProcessTree(cli);
 }
 
 function restartCli() {
@@ -161,8 +161,7 @@ async function shutdown(exitCode) {
   if (shuttingDown) return;
   shuttingDown = true;
   try {
-    killProcessTree(cli);
-    killProcessTree(vite);
+    await Promise.all([killProcessTree(cli), killProcessTree(vite)]);
     await Promise.all([waitForProcessTree(cli), waitForProcessTree(vite)]);
     await Promise.all(reservations.map(({ release }) => release()));
   } finally {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -6,6 +6,7 @@ import { defineConfig } from "astro/config";
 const viewerDevUrl = process.env.DEV_VIEWER_URL;
 // In dev, proxy /api/* to the local Cloudflare Worker so auth + cloud APIs work
 const workerDevUrl = process.env.DEV_WORKER_URL || "http://localhost:8787";
+const strictDevPort = process.env.DEV_STRICT_PORT === "1";
 
 // Pages excluded from sitemap (private / dynamic-only / requires auth).
 // Keep in sync with the noindex meta tags on these routes.
@@ -44,6 +45,7 @@ export default defineConfig({
   ],
   vite: {
     server: {
+      strictPort: strictDevPort,
       proxy: {
         "/api": {
           target: workerDevUrl,


### PR DESCRIPTION
## Summary
- reserve API, viewer, and website ports for the full launcher lifetime
- add cross-platform port validation, live IPC reservations, readiness checks, and process-tree cleanup
- make Astro honor launcher-selected ports and document concurrent worktree usage

## Validation
- `corepack pnpm verify`
- targeted dev utility tests
- dashboard and website smoke tests with explicit ports
- cross-process reservation and stale-lock reclamation checks

## Notes
- E2E fixed worker ports and temporary artifacts remain a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development launchers now reserve ports for their full runtime, enabling multiple worktrees to run concurrently without port collisions.
  * Added optional fixed-port configuration for development and website launchers.
  * Startup now waits for required services to become available before continuing.

* **Bug Fixes**
  * Improved shutdown handling to terminate related processes cleanly and release reserved ports.
  * Configured development servers to fail fast when requested ports are unavailable.

* **Documentation**
  * Updated development workflow guidance with launcher-provided URLs and port configuration instructions.

* **Tests**
  * Added coverage for port validation, reservation, conflicts, and concurrent allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->