### PR TITLE
Fix concurrent dev launcher port handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ or restart needed.
 The dev launchers reserve ports across their entire lifetime, including CLI
 restart windows. This allows multiple worktrees to run concurrently. For fixed
 ports, set `VIBE_API_PORT` and `VIBE_VIEWER_PORT` for `pnpm dev`, or
-`VIBE_VIEWER_PORT` and `VIBE_WEBSITE_PORT` for `pnpm dev:website`.
+`VIBE_VIEWER_PORT` and `VIBE_WEBSITE_PORT` for `pnpm dev:website`. If only one
+port is overridden, automatic selection skips that port as well.
 
 ## Working with a coding agent
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ VIBE_API_PORT=13457 VIBE_VIEWER_PORT=5174 pnpm dev
 VIBE_VIEWER_PORT=5175 VIBE_WEBSITE_PORT=4322 pnpm dev:website
 ```
 
-The requested ports must be free and different within the same launcher.
+The requested ports must be free and different within the same launcher. If
+only one port is overridden, automatic selection skips that port as well.
 
 CLI usage requires Node.js >= 22.19.0. The `website` package uses Astro 6 and requires Node.js >= 22.12.0. When `nvm` is available, `website` scripts will try `nvm use` from `website/.nvmrc` automatically. If a global package-manager shim selects an older Node for child commands, verify `corepack pnpm exec node -v` and use `corepack pnpm ...` after selecting a compatible Node version; see [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,10 +1,10 @@
 pre-commit:
   commands:
     lint:
-      glob: "*.{ts,tsx,js,jsx}"
+      glob: "*.{ts,tsx,js,jsx,mjs}"
       run: pnpm exec oxlint --fix {staged_files}
       stage_fixed: true
     fmt:
-      glob: "*.{ts,tsx,js,jsx,json,jsonc}"
+      glob: "*.{ts,tsx,js,jsx,mjs,json,jsonc}"
       run: pnpm exec oxfmt {staged_files}
       stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "test": "pnpm --filter @vibe-replay/provider-contract test && pnpm --filter @vibe-replay/provider-core test && pnpm --filter @vibe-replay/provider-claude-code test && pnpm --filter @vibe-replay/provider-codex test && pnpm --filter @vibe-replay/provider-cursor test && pnpm --filter @vibe-replay/provider-hermes test && pnpm --filter @vibe-replay/provider-opencode test && pnpm --filter @vibe-replay/provider-pi test && pnpm --filter @vibe-replay/providers-default test && pnpm --filter @vibe-replay/replay-core test && pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test",
     "test:cloudflare": "pnpm --filter @vibe-replay/cloudflare test",
     "test:e2e": "vitest run --config e2e/vitest.config.ts",
-    "lint": "oxlint --fix packages/ website/src cloudflare/src && oxfmt packages/ website/src cloudflare/src",
-    "lint:check": "oxlint packages/ website/src cloudflare/src && oxfmt --check packages/ website/src cloudflare/src",
+    "lint": "oxlint --fix packages/ scripts/ website/astro.config.mjs website/src cloudflare/src && oxfmt packages/ scripts/ website/astro.config.mjs website/src cloudflare/src",
+    "lint:check": "oxlint packages/ scripts/ website/astro.config.mjs website/src cloudflare/src && oxfmt --check packages/ scripts/ website/astro.config.mjs website/src cloudflare/src",
     "typecheck": "tsc --noEmit -p packages/types/tsconfig.json && tsc --noEmit -p packages/provider-contract/tsconfig.json && tsc --noEmit -p packages/provider-core/tsconfig.json && tsc --noEmit -p packages/provider-claude-code/tsconfig.json && tsc --noEmit -p packages/provider-codex/tsconfig.json && tsc --noEmit -p packages/provider-cursor/tsconfig.json && tsc --noEmit -p packages/provider-hermes/tsconfig.json && tsc --noEmit -p packages/provider-opencode/tsconfig.json && tsc --noEmit -p packages/provider-pi/tsconfig.json && tsc --noEmit -p packages/providers-default/tsconfig.json && tsc --noEmit -p packages/replay-core/tsconfig.json && tsc --noEmit -p packages/cli/tsconfig.json && tsc --noEmit -p packages/viewer/tsconfig.json && tsc --noEmit -p cloudflare/tsconfig.json && pnpm --filter @vibe-replay/website check",
     "verify": "pnpm lint:check && pnpm typecheck && pnpm test && pnpm test:cloudflare && pnpm build",
-    "fmt": "oxfmt packages/ website/src cloudflare/src",
+    "fmt": "oxfmt packages/ scripts/ website/astro.config.mjs website/src cloudflare/src",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/packages/cli/test/dev-utils.test.ts
+++ b/packages/cli/test/dev-utils.test.ts
@@ -38,6 +38,16 @@ describe("dev port utilities", () => {
     );
   });
 
+  it("skips ports reserved for another launcher component", async () => {
+    const preferred = 35_000 + Math.floor(Math.random() * 5_000);
+    const reservation = await reserveFreePort(preferred, 5, [preferred]);
+    try {
+      expect(reservation.port).not.toBe(preferred);
+    } finally {
+      await reservation.release();
+    }
+  });
+
   it("rejects conflicting port aliases", () => {
     const originalApiPort = process.env.VIBE_API_PORT;
     const originalViteApiPort = process.env.VITE_API_PORT;
@@ -76,6 +86,53 @@ describe("dev port utilities", () => {
       );
     } finally {
       await first.release();
+    }
+  });
+
+  it("reclaims a reservation after its owner is killed", async () => {
+    const initial = await reserveFreePort(40_000 + Math.floor(Math.random() * 5_000));
+    const port = initial.port;
+    await initial.release();
+
+    const utilityUrl = new URL("../../../scripts/dev-utils.mjs", import.meta.url).href;
+    const holderSource = `
+      import { reservePort } from ${JSON.stringify(utilityUrl)};
+      await reservePort(${port}, "Holder port");
+      process.stdout.write("ready\\n");
+      setInterval(() => {}, 1000);
+    `;
+    const holder = spawn(process.execPath, ["--input-type=module", "-e", holderSource], {
+      detached: process.platform !== "win32",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+
+    try {
+      await new Promise((resolve, reject) => {
+        let output = "";
+        const timer = setTimeout(
+          () => reject(new Error(`holder did not reserve: ${output}`)),
+          5_000,
+        );
+        holder.stdout.on("data", (chunk) => {
+          output += chunk;
+          if (output.includes("ready")) {
+            clearTimeout(timer);
+            resolve();
+          }
+        });
+        holder.once("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+      });
+
+      await killProcessTree(holder, "SIGKILL");
+      await waitForProcessTree(holder, 2_000);
+      const reclaimed = await reservePort(port, "Reclaimed port");
+      await reclaimed.release();
+    } finally {
+      await killProcessTree(holder, "SIGKILL");
+      await waitForProcessTree(holder, 2_000);
     }
   });
 

--- a/scripts/dev-utils.mjs
+++ b/scripts/dev-utils.mjs
@@ -2,7 +2,7 @@
  * Shared utilities for dev launcher scripts.
  */
 import { spawn } from "node:child_process";
-import { lstat, unlink } from "node:fs/promises";
+import { lstat, mkdir, rmdir, unlink } from "node:fs/promises";
 import { createConnection, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -46,7 +46,6 @@ function hasExited(child) {
 function waitForChildExit(child, timeoutMs) {
   if (!child?.pid || hasExited(child)) return Promise.resolve(true);
   return new Promise((resolve) => {
-    let timer;
     const finish = (exited) => {
       clearTimeout(timer);
       child.removeListener("exit", onExit);
@@ -57,7 +56,7 @@ function waitForChildExit(child, timeoutMs) {
     const onError = () => finish(true);
     child.once("exit", onExit);
     child.once("error", onError);
-    timer = setTimeout(() => finish(hasExited(child)), timeoutMs);
+    const timer = setTimeout(() => finish(hasExited(child)), timeoutMs);
   });
 }
 
@@ -109,19 +108,27 @@ export function killProcessTree(child, signal = "SIGTERM") {
 export async function waitForProcessTree(child, timeoutMs = 1_000) {
   if (!child?.pid) return;
   if (IS_WINDOWS) {
-    if (!(await waitForChildExit(child, timeoutMs))) await killProcessTree(child, "SIGKILL");
+    if (await waitForChildExit(child, timeoutMs)) return;
+    await killProcessTree(child, "SIGKILL");
+    await waitForChildExit(child, timeoutMs);
     return;
   }
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      process.kill(-child.pid, 0);
-    } catch {
-      return;
+  const waitForGroupExit = async (waitMs) => {
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+      try {
+        process.kill(-child.pid, 0);
+      } catch (error) {
+        if (error?.code !== "EPERM") return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
     }
-    await new Promise((resolve) => setTimeout(resolve, 25));
-  }
-  killProcessTree(child, "SIGKILL");
+    return false;
+  };
+
+  if (await waitForGroupExit(timeoutMs)) return;
+  await killProcessTree(child, "SIGKILL");
+  await waitForGroupExit(timeoutMs);
 }
 
 /** Cross-platform temp log path for the backgrounded Vite viewer. */
@@ -133,6 +140,10 @@ function portLockPath(port) {
   return IS_WINDOWS
     ? `\\\\.\\pipe\\vibe-replay-port-${port}`
     : join(tmpdir(), `vibe-replay-port-${port}.sock`);
+}
+
+function portClaimPath(port) {
+  return join(tmpdir(), `vibe-replay-port-${port}.claim`);
 }
 
 /** Validate a user-supplied TCP port. Port 0 is intentionally not accepted. */
@@ -196,6 +207,32 @@ function closeLockServer(server) {
   });
 }
 
+/**
+ * Serialize attempts to create or reclaim one port's live socket. The claim
+ * is intentionally not stale-reclaimed: skipping a candidate after a crash
+ * is safer than deleting a claim another process may have just acquired.
+ */
+async function tryAcquirePortClaim(port) {
+  const claimPath = portClaimPath(port);
+  try {
+    await mkdir(claimPath);
+  } catch (error) {
+    if (error?.code === "EEXIST") return null;
+    throw error;
+  }
+
+  let released = false;
+  return async () => {
+    if (released) return;
+    released = true;
+    try {
+      await rmdir(claimPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  };
+}
+
 function isLockAlive(lockPath) {
   return new Promise((resolve) => {
     let settled = false;
@@ -238,35 +275,49 @@ async function removeStaleLock(lockPath) {
  */
 async function tryAcquirePortLock(port) {
   const lockPath = portLockPath(port);
+  const releaseClaim = await tryAcquirePortClaim(port);
+  if (!releaseClaim) return null;
 
-  while (true) {
-    const lockServer = createServer((socket) => socket.end());
-    const acquired = await new Promise((resolve, reject) => {
-      const onError = (error) => {
-        lockServer.removeListener("error", onError);
-        if (error?.code === "EADDRINUSE") resolve(false);
-        else reject(error);
-      };
-      lockServer.once("error", onError);
-      lockServer.listen(lockPath, () => {
-        lockServer.removeListener("error", onError);
-        resolve(true);
+  let claimReleased = false;
+  const releaseClaimOnce = async () => {
+    if (claimReleased) return;
+    claimReleased = true;
+    await releaseClaim();
+  };
+
+  try {
+    while (true) {
+      const lockServer = createServer((socket) => socket.end());
+      const acquired = await new Promise((resolve, reject) => {
+        const onError = (error) => {
+          lockServer.removeListener("error", onError);
+          if (error?.code === "EADDRINUSE") resolve(false);
+          else reject(error);
+        };
+        lockServer.once("error", onError);
+        lockServer.listen(lockPath, () => {
+          lockServer.removeListener("error", onError);
+          resolve(true);
+        });
       });
-    });
 
-    if (acquired) {
-      lockServer.unref();
-      let released = false;
-      return async () => {
-        if (released) return;
-        released = true;
-        await closeLockServer(lockServer);
-      };
+      if (acquired) {
+        lockServer.unref();
+        await releaseClaimOnce();
+        let released = false;
+        return async () => {
+          if (released) return;
+          released = true;
+          await closeLockServer(lockServer);
+        };
+      }
+
+      await closeLockServer(lockServer);
+      if (await isLockAlive(lockPath)) return null;
+      if (!(await removeStaleLock(lockPath))) return null;
     }
-
-    await closeLockServer(lockServer);
-    if (await isLockAlive(lockPath)) return null;
-    if (!(await removeStaleLock(lockPath))) return null;
+  } finally {
+    await releaseClaimOnce();
   }
 }
 
@@ -284,14 +335,19 @@ export async function reservePort(port, label = "Port") {
   return { port: parsedPort, release: releaseLock };
 }
 
-/** Find and reserve a free port starting from `preferred`, incrementing on conflict. */
-export async function reserveFreePort(preferred, range = 100) {
+/**
+ * Find and reserve a free port starting from `preferred`, incrementing on
+ * conflict and skipping ports selected by another launcher component.
+ */
+export async function reserveFreePort(preferred, range = 100, excludedPorts = []) {
   const firstPort = parsePort(preferred, "Preferred port");
   if (!Number.isInteger(range) || range < 1) {
     throw new Error("Port search range must be a positive integer");
   }
+  const excluded = new Set(excludedPorts);
   const lastPort = Math.min(65535, firstPort + range - 1);
   for (let port = firstPort; port <= lastPort; port++) {
+    if (excluded.has(port)) continue;
     const releaseLock = await tryAcquirePortLock(port);
     if (!releaseLock) continue;
     if (await isPortFree(port)) return { port, release: releaseLock };

--- a/scripts/dev-website.mjs
+++ b/scripts/dev-website.mjs
@@ -35,12 +35,16 @@ try {
   viteReservation =
     vitePortOverride !== undefined
       ? await reservePort(vitePortOverride, "Viewer port")
-      : await reserveFreePort(VITE_PREFERRED);
+      : await reserveFreePort(
+          VITE_PREFERRED,
+          100,
+          astroPortOverride !== undefined ? [astroPortOverride] : [],
+        );
   reservations.push(viteReservation);
   astroReservation =
     astroPortOverride !== undefined
       ? await reservePort(astroPortOverride, "Website port")
-      : await reserveFreePort(ASTRO_PREFERRED);
+      : await reserveFreePort(ASTRO_PREFERRED, 100, [viteReservation.port]);
   reservations.push(astroReservation);
 } catch (error) {
   await Promise.all(reservations.map(({ release }) => release()));
@@ -52,10 +56,20 @@ const astroPort = astroReservation.port;
 
 console.log();
 console.log(
-  `[vibe-replay] Viewer port:  ${vitePort}${vitePort !== VITE_PREFERRED ? ` (${VITE_PREFERRED} was busy)` : ""}`,
+  `[vibe-replay] Viewer port:  ${vitePort}${
+    vitePortOverride === undefined &&
+    vitePort !== VITE_PREFERRED &&
+    astroPortOverride !== VITE_PREFERRED
+      ? ` (${VITE_PREFERRED} was busy)`
+      : ""
+  }`,
 );
 console.log(
-  `[vibe-replay] Website port: ${astroPort}${astroPort !== ASTRO_PREFERRED ? ` (${ASTRO_PREFERRED} was busy)` : ""}`,
+  `[vibe-replay] Website port: ${astroPort}${
+    astroPortOverride === undefined && astroPort !== ASTRO_PREFERRED && vitePort !== ASTRO_PREFERRED
+      ? ` (${ASTRO_PREFERRED} was busy)`
+      : ""
+  }`,
 );
 console.log(`[vibe-replay] Website:      http://localhost:${astroPort}  (Astro HMR)`);
 console.log(`[vibe-replay] Viewer:       http://localhost:${vitePort}  (Vite HMR)`);
@@ -63,19 +77,17 @@ console.log(`[vibe-replay] /view/  →     redirects to Vite viewer`);
 console.log();
 
 // Start Vite viewer dev (backgrounded, logs to file)
-let vite;
 let astro;
 let shuttingDown = false;
-let logStream;
 
-vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
+const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
   env: { ...process.env, VITE_PORT: String(vitePort) },
 });
 
 const { createWriteStream } = await import("node:fs");
 const logPath = viewerLogPath(vitePort);
-logStream = createWriteStream(logPath);
+const logStream = createWriteStream(logPath);
 vite.stdout.pipe(logStream);
 vite.stderr.pipe(logStream);
 console.log(`[vibe-replay] Viewer logs:  ${logPath}`);

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -41,20 +41,23 @@ if (apiPortOverride !== undefined && apiPortOverride === vitePortOverride) {
 const reservations = [];
 let apiReservation;
 let viteReservation;
-let vite;
 let cli;
 
 try {
   apiReservation =
     apiPortOverride !== undefined
       ? await reservePort(apiPortOverride, "API port")
-      : await reserveFreePort(API_PREFERRED);
+      : await reserveFreePort(
+          API_PREFERRED,
+          100,
+          vitePortOverride !== undefined ? [vitePortOverride] : [],
+        );
   reservations.push(apiReservation);
 
   viteReservation =
     vitePortOverride !== undefined
       ? await reservePort(vitePortOverride, "Viewer port")
-      : await reserveFreePort(VITE_PREFERRED);
+      : await reserveFreePort(VITE_PREFERRED, 100, [apiReservation.port]);
   reservations.push(viteReservation);
 } catch (error) {
   await Promise.all(reservations.map(({ release }) => release()));
@@ -66,10 +69,18 @@ const vitePort = viteReservation.port;
 
 console.log();
 console.log(
-  `[vibe-replay] API port:    ${apiPort}${apiPort !== API_PREFERRED ? ` (${API_PREFERRED} was busy)` : ""}`,
+  `[vibe-replay] API port:    ${apiPort}${
+    apiPortOverride === undefined && apiPort !== API_PREFERRED && vitePortOverride !== API_PREFERRED
+      ? ` (${API_PREFERRED} was busy)`
+      : ""
+  }`,
 );
 console.log(
-  `[vibe-replay] Viewer port: ${vitePort}${vitePort !== VITE_PREFERRED ? ` (${VITE_PREFERRED} was busy)` : ""}`,
+  `[vibe-replay] Viewer port: ${vitePort}${
+    vitePortOverride === undefined && vitePort !== VITE_PREFERRED && apiPort !== VITE_PREFERRED
+      ? ` (${VITE_PREFERRED} was busy)`
+      : ""
+  }`,
 );
 console.log(`[vibe-replay] Viewer:      http://localhost:${vitePort}  (HMR enabled)`);
 console.log(`[vibe-replay] CLI watch:   auto-restarts on packages/cli/src changes`);
@@ -80,7 +91,7 @@ console.log();
 
 // Start Vite dev server (backgrounded) — port + strictPort via env vars in vite.config.ts
 const cloudApiUrl = process.env.VIBE_REPLAY_API_URL || "http://localhost:8787";
-vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
+const vite = spawnPnpm(["--filter", "@vibe-replay/viewer", "dev"], {
   stdio: ["ignore", "pipe", "pipe"],
   env: {
     ...process.env,


### PR DESCRIPTION
## Summary
- serialize Unix-socket reservation and stale-lock recovery across concurrent launchers
- keep automatically selected ports away from explicit component overrides
- wait for process trees to terminate before releasing reservations
- lint and format `scripts/**/*.mjs` plus the Astro config

## Validation
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm build`
- explicit-port launcher smoke tests for `pnpm dev` and `pnpm dev:website`

Node 20.19.2 emits the repository's existing engine warning; all checks pass in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server port allocation to prevent API, viewer, and website services from selecting the same port.
  * Improved process cleanup and port recovery after development processes are stopped.
  * Startup messages now accurately identify when a preferred port was unavailable.

* **Documentation**
  * Clarified development port override requirements and automatic port selection behavior.

* **Chores**
  * Expanded linting and formatting coverage to include JavaScript modules and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->