### PR TITLE
docs: clarify dev watcher ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ reinstall/re-pin pnpm for that Node) until both checks agree.
 ## Development
 
 ```bash
-pnpm dev              # Viewer (Vite HMR) + CLI (fs.watch + tsx auto-restart)
+pnpm dev              # Viewer (Vite HMR) + CLI (Node fs.watch restarts plain tsx)
 pnpm dev:dashboard    # Same as above, opens dashboard directly
 pnpm dev:website      # Website (Astro HMR) + Viewer (Vite HMR)
 pnpm test             # Run tests


### PR DESCRIPTION
## Summary

- Clarify that the Node `fs.watch` watcher restarts the plain `tsx` process used by `pnpm dev`.
- Follow up on the documentation wording identified during review of #495.

## Validation

- `pnpm lint:check`
- `pnpm --filter vibe-replay exec vitest run test/agent-instructions.test.ts`

The targeted test emits the existing Node engine warning because this local shell uses Node `v20.19.2`; the repository requires Node `>=22.19.0`.
