### PR TITLE
fix(viewer): show cumulative token usage by category

### DIFF
--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -307,7 +307,11 @@ export interface ProviderParseResult {
    */
   reportedCostUsd?: number;
   compactions?: Compaction[];
-  /** Per-turn metrics identified by their 0-based user-prompt turnIndex. */
+  /**
+   * Per-turn metrics identified by their 0-based user-prompt turnIndex.
+   * `segmentIndex` optionally disambiguates assistant continuations within
+   * one prompt when a provider records a compaction or context boundary.
+   */
   turnStats?: TurnStat[];
   /** Provider-reported context window limit for the primary model, if available */
   contextLimit?: number;

--- a/packages/provider-pi/src/pi/parser.ts
+++ b/packages/provider-pi/src/pi/parser.ts
@@ -1013,27 +1013,36 @@ function buildTurnStats(
   usageByMessageId: Map<string, { usage: TokenUsage; model?: string; contextTokens?: number }>,
 ): NonNullable<ProviderParseResult["turnStats"]> {
   const stats: NonNullable<ProviderParseResult["turnStats"]> = [];
-  let current: { turnIndex: number; messageIds: string[] } | undefined;
+  let current: { turnIndex: number; segmentIndex: number; messageIds: string[] } | undefined;
   let turnIndex = -1;
+  let segmentIndex = 0;
+
+  const flushCurrent = () => {
+    if (current && current.messageIds.length > 0) {
+      stats.push(buildTurnStat(current, usageByMessageId));
+    }
+    current = undefined;
+  };
 
   for (const turn of turns) {
-    if (turn.role === "user" && !turn.subtype) {
-      if (current && current.messageIds.length > 0)
-        stats.push(buildTurnStat(current, usageByMessageId));
-      turnIndex++;
-      current = { turnIndex, messageIds: [] };
-    } else if (turn.role === "assistant" && turn.messageId && current) {
+    if (turn.role === "user") {
+      // A compaction/context-injection is not a new user prompt, but it does
+      // start a new assistant metric segment. Otherwise the cards before and
+      // after the boundary receive the same aggregate usage row.
+      flushCurrent();
+      if (!turn.subtype) turnIndex++;
+    } else if (turn.role === "assistant" && turn.messageId && turnIndex >= 0) {
+      current ??= { turnIndex, segmentIndex: segmentIndex++, messageIds: [] };
       current.messageIds.push(turn.messageId);
     }
   }
 
-  if (current && current.messageIds.length > 0)
-    stats.push(buildTurnStat(current, usageByMessageId));
+  flushCurrent();
   return stats;
 }
 
 function buildTurnStat(
-  turn: { turnIndex: number; messageIds: string[] },
+  turn: { turnIndex: number; segmentIndex: number; messageIds: string[] },
   usageByMessageId: Map<string, { usage: TokenUsage; model?: string; contextTokens?: number }>,
 ): NonNullable<ProviderParseResult["turnStats"]>[number] {
   const usages: TokenUsage[] = [];
@@ -1049,6 +1058,7 @@ function buildTurnStat(
   const tokenUsage = aggregateUsage(usages);
   return {
     turnIndex: turn.turnIndex,
+    segmentIndex: turn.segmentIndex,
     ...(model ? { model } : {}),
     ...(tokenUsage ? { tokenUsage } : {}),
     ...(contextTokens ? { contextTokens } : {}),

--- a/packages/provider-pi/test/parser.test.ts
+++ b/packages/provider-pi/test/parser.test.ts
@@ -715,7 +715,7 @@ describe("Pi parser", () => {
     });
   });
 
-  it("counts compaction summary usage and keeps turn stats unchanged", async () => {
+  it("counts compaction summary usage without changing the preceding turn stats", async () => {
     const buildLines = (compaction: Record<string, unknown>) => [
       {
         type: "session",
@@ -771,6 +771,7 @@ describe("Pi parser", () => {
         expect(parsed.turnStats).toEqual([
           {
             turnIndex: 0,
+            segmentIndex: 0,
             model: "gpt-5.5",
             tokenUsage: {
               inputTokens: 100,
@@ -798,6 +799,57 @@ describe("Pi parser", () => {
           cacheCreationTokens: 5,
           cacheReadTokens: 5,
         });
+      },
+    );
+
+    await withPiFixture(
+      [
+        ...buildLines({
+          timestamp: "2026-01-01T00:00:03.000Z",
+          summary: "Earlier work condensed.",
+          tokensBefore: 90_000,
+        }),
+        {
+          type: "message",
+          id: "assistant2",
+          parentId: "compact1",
+          timestamp: "2026-01-01T00:00:04.000Z",
+          message: {
+            role: "assistant",
+            model: "gpt-5.5",
+            content: [{ type: "text", text: "Continuing" }],
+            usage: { input: 200, output: 30, cacheRead: 80, cacheWrite: 10 },
+          },
+        },
+      ],
+      async (path) => {
+        const parsed = await parsePiSession(path);
+        expect(parsed.turnStats).toEqual([
+          {
+            turnIndex: 0,
+            segmentIndex: 0,
+            model: "gpt-5.5",
+            tokenUsage: {
+              inputTokens: 100,
+              outputTokens: 20,
+              cacheCreationTokens: 5,
+              cacheReadTokens: 5,
+            },
+            contextTokens: 110,
+          },
+          {
+            turnIndex: 0,
+            segmentIndex: 1,
+            model: "gpt-5.5",
+            tokenUsage: {
+              inputTokens: 200,
+              outputTokens: 30,
+              cacheCreationTokens: 10,
+              cacheReadTokens: 80,
+            },
+            contextTokens: 290,
+          },
+        ]);
       },
     );
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,12 @@ export function deriveTokenUsageMetrics(usage: TokenUsage): TokenUsageMetrics {
 
 export interface TurnStat {
   turnIndex: number;
+  /**
+   * Optional assistant-segment index within the session. Providers that split
+   * one user prompt at a compaction or context-injection boundary can use this
+   * to keep each rendered assistant card's metrics separate.
+   */
+  segmentIndex?: number;
   model?: string;
   durationMs?: number;
   tokenUsage?: TokenUsage;

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -96,13 +96,6 @@ function turnDurationFromScenes(scenes: { scene: Scene }[]): number | undefined 
   return durationMs > 0 ? durationMs : undefined;
 }
 
-function totalTurnTokens(usage: TurnStat["tokenUsage"]): number | undefined {
-  if (!usage) return undefined;
-  const total =
-    usage.inputTokens + usage.outputTokens + usage.cacheCreationTokens + usage.cacheReadTokens;
-  return total > 0 ? total : undefined;
-}
-
 function tokenUsageTitle(usage: NonNullable<TurnStat["tokenUsage"]>): string {
   const promptTokens = usage.inputTokens + usage.cacheCreationTokens + usage.cacheReadTokens;
   const totalTokens = promptTokens + usage.outputTokens;
@@ -120,7 +113,7 @@ function tokenUsageTitle(usage: NonNullable<TurnStat["tokenUsage"]>): string {
   if (usage.cacheCreationTokens > 0) {
     parts.push(`${usage.cacheCreationTokens.toLocaleString("en-US")} cache write`);
   }
-  return `Recorded token usage for this assistant turn: ${parts.join(" · ")}`;
+  return `Recorded cumulative token usage for this assistant turn: ${parts.join(" · ")}`;
 }
 
 function AssistantTurnMetrics({
@@ -132,8 +125,14 @@ function AssistantTurnMetrics({
 }) {
   const durationMs = turnStat?.durationMs ?? fallbackDurationMs;
   const durationLabel = formatToolDuration(durationMs);
-  const tokenCount = totalTurnTokens(turnStat?.tokenUsage);
-  if (!durationLabel && !tokenCount) return null;
+  const usage = turnStat?.tokenUsage;
+  const hasTokenUsage = usage
+    ? usage.inputTokens > 0 ||
+      usage.outputTokens > 0 ||
+      usage.cacheCreationTokens > 0 ||
+      usage.cacheReadTokens > 0
+    : false;
+  if (!durationLabel && !hasTokenUsage) return null;
 
   return (
     <span className="inline-flex items-center gap-1.5 text-[10px] font-mono text-terminal-dimmer">
@@ -148,8 +147,21 @@ function AssistantTurnMetrics({
           · {durationLabel}
         </span>
       )}
-      {tokenCount && turnStat?.tokenUsage && (
-        <span title={tokenUsageTitle(turnStat.tokenUsage)}>· {formatTokens(tokenCount)} tok</span>
+      {usage && hasTokenUsage && (
+        <span
+          className="inline-flex items-center gap-1.5"
+          title={tokenUsageTitle(usage)}
+          aria-label="Cumulative token usage by category"
+        >
+          {usage.inputTokens > 0 && <span>· {formatTokens(usage.inputTokens)} in</span>}
+          {usage.outputTokens > 0 && <span>· {formatTokens(usage.outputTokens)} out</span>}
+          {usage.cacheReadTokens > 0 && (
+            <span>· {formatTokens(usage.cacheReadTokens)} cache read</span>
+          )}
+          {usage.cacheCreationTokens > 0 && (
+            <span>· {formatTokens(usage.cacheCreationTokens)} cache write</span>
+          )}
+        </span>
       )}
     </span>
   );

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -51,6 +51,7 @@ interface TurnGroup {
   timestamp?: string;
   scenes: { scene: Scene; index: number }[];
   turnNumber?: number;
+  assistantSegmentIndex?: number;
 }
 
 interface StickyPromptSummary {
@@ -86,6 +87,18 @@ function turnStatForNumber(
   // assign another turn's metrics to this card.
   const hasExplicitIndexes = turnStats.every((stat) => Number.isInteger(stat.turnIndex));
   return hasExplicitIndexes ? getTurnStat(turnStats, turnIndex) : turnStats[turnIndex];
+}
+
+function turnStatForGroup(
+  turnStats: TurnStat[] | undefined,
+  turnNumber: number | undefined,
+  assistantSegmentIndex: number | undefined,
+): TurnStat | undefined {
+  if (turnStats?.some((stat) => Number.isInteger(stat.segmentIndex))) {
+    if (assistantSegmentIndex === undefined) return undefined;
+    return turnStats.find((stat) => stat.segmentIndex === assistantSegmentIndex);
+  }
+  return turnStatForNumber(turnStats, turnNumber);
 }
 
 function turnDurationFromScenes(scenes: { scene: Scene }[]): number | undefined {
@@ -197,6 +210,7 @@ export default function ConversationView({
     const result: TurnGroup[] = [];
     let current: TurnGroup | null = null;
     let turnCount = 0;
+    let assistantSegmentCount = 0;
 
     for (let i = 0; i < scenes.length; i++) {
       const scene = scenes[i];
@@ -228,6 +242,7 @@ export default function ConversationView({
             timestamp: scene.timestamp,
             scenes: [],
             turnNumber: turnCount > 0 ? turnCount : undefined,
+            assistantSegmentIndex: assistantSegmentCount++,
           };
         }
         current.scenes.push({ scene, index: i });
@@ -776,16 +791,19 @@ const GroupCard = memo(function GroupCard({
     return getContextScale(turnStats || [], contextLimit).displayMax;
   }, [contextLimit, turnStats]);
 
-  const turnStatsByIndex = useMemo(
-    () => new Map((turnStats || []).map((stat) => [stat.turnIndex, stat])),
-    [turnStats],
-  );
+  const turnStatsByIndex = useMemo(() => {
+    const result = new Map<number, TurnStat>();
+    for (const stat of turnStats || []) {
+      if (!result.has(stat.turnIndex)) result.set(stat.turnIndex, stat);
+    }
+    return result;
+  }, [turnStats]);
 
   // Render every scene in the group — no longer gated by visibleCount.
   // Playback advance still updates currentIndex (used for the focus
   // indicator + scroll-follow), but never hides content.
   const groupScenes = group.scenes;
-  const turnStat = turnStatForNumber(turnStats, group.turnNumber);
+  const turnStat = turnStatForGroup(turnStats, group.turnNumber, group.assistantSegmentIndex);
   const fallbackTurnDurationMs = useMemo(() => turnDurationFromScenes(groupScenes), [groupScenes]);
 
   const groupHasCurrent = groupScenes.some(({ index }) => index === currentIndex);

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -111,7 +111,9 @@ function tokenUsageTitle(usage: NonNullable<TurnStat["tokenUsage"]>): string {
     parts.push(`${usage.cacheReadTokens.toLocaleString("en-US")} cache read`);
   }
   if (usage.cacheCreationTokens > 0) {
-    parts.push(`${usage.cacheCreationTokens.toLocaleString("en-US")} cache write`);
+    parts.push(
+      `${usage.cacheCreationTokens.toLocaleString("en-US")} prompt cache created (not necessarily billable)`,
+    );
   }
   return `Recorded cumulative token usage for this assistant turn: ${parts.join(" · ")}`;
 }
@@ -157,9 +159,6 @@ function AssistantTurnMetrics({
           {usage.outputTokens > 0 && <span>· {formatTokens(usage.outputTokens)} out</span>}
           {usage.cacheReadTokens > 0 && (
             <span>· {formatTokens(usage.cacheReadTokens)} cache read</span>
-          )}
-          {usage.cacheCreationTokens > 0 && (
-            <span>· {formatTokens(usage.cacheCreationTokens)} cache write</span>
           )}
         </span>
       )}

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -57,6 +57,21 @@ const multiTurnScenes: Scene[] = [
   },
 ];
 
+const compactionScenes: Scene[] = [
+  scenes[0],
+  scenes[1],
+  {
+    type: "compaction-summary",
+    content: "Earlier work condensed.",
+    timestamp: "2026-08-30T10:00:05.000Z",
+  },
+  {
+    type: "text-response",
+    content: "Continuing after compaction.",
+    timestamp: "2026-08-30T10:00:06.000Z",
+  },
+];
+
 function prefs(compactAssistant: boolean): EffectivePrefs {
   return {
     hideThinking: false,
@@ -142,6 +157,43 @@ describe("ConversationView assistant metrics", () => {
     expect(screen.getByText(/8\.1s/)).toBeTruthy();
     expect(screen.getByText(/1\.0K\s+in/)).toBeTruthy();
     expect(screen.getByText(/1\.0K\s+out/)).toBeTruthy();
+  });
+
+  it("keeps assistant metrics separate across a compaction boundary", () => {
+    render(
+      <ConversationView
+        scenes={compactionScenes}
+        visibleCount={compactionScenes.length}
+        currentIndex={3}
+        effectivePrefs={prefs(false)}
+        turnStats={[
+          {
+            turnIndex: 0,
+            segmentIndex: 0,
+            tokenUsage: {
+              inputTokens: 100,
+              outputTokens: 10,
+              cacheCreationTokens: 0,
+              cacheReadTokens: 50,
+            },
+          },
+          {
+            turnIndex: 0,
+            segmentIndex: 1,
+            tokenUsage: {
+              inputTokens: 200,
+              outputTokens: 20,
+              cacheCreationTokens: 0,
+              cacheReadTokens: 80,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByLabelText("Cumulative token usage by category")).toHaveLength(2);
+    expect(screen.getByTitle(/150 prompt.*10 output/)).toBeTruthy();
+    expect(screen.getByTitle(/280 prompt.*20 output/)).toBeTruthy();
   });
 
   it("does not fall back by position for sparse indexed stats", () => {

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -86,8 +86,9 @@ describe("ConversationView assistant metrics", () => {
     expect(screen.getByText(/900\s+in/)).toBeTruthy();
     expect(screen.getByText(/800\s+out/)).toBeTruthy();
     expect(screen.getByText(/1\.5K\s+cache read/)).toBeTruthy();
-    expect(screen.getByText(/300\s+cache write/)).toBeTruthy();
+    expect(screen.queryByText(/300\s+cache write/)).toBeNull();
     expect(screen.getByTitle(/2,700 prompt.*800 output/)).toBeTruthy();
+    expect(screen.getByTitle(/300 prompt cache created.*not necessarily billable/)).toBeTruthy();
   });
 
   it("uses scene timestamps for duration when per-turn duration is unavailable", () => {

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -19,7 +19,7 @@ const turnStat: TurnStat = {
   tokenUsage: {
     inputTokens: 900,
     outputTokens: 800,
-    cacheCreationTokens: 0,
+    cacheCreationTokens: 300,
     cacheReadTokens: 1_500,
   },
 };
@@ -83,8 +83,11 @@ describe("ConversationView assistant metrics", () => {
     renderConversation(compact);
 
     expect(screen.getByText(/4\.2s/)).toBeTruthy();
-    expect(screen.getByText(/3\.2K tok/)).toBeTruthy();
-    expect(screen.getByTitle(/2,400 prompt.*800 output/)).toBeTruthy();
+    expect(screen.getByText(/900\s+in/)).toBeTruthy();
+    expect(screen.getByText(/800\s+out/)).toBeTruthy();
+    expect(screen.getByText(/1\.5K\s+cache read/)).toBeTruthy();
+    expect(screen.getByText(/300\s+cache write/)).toBeTruthy();
+    expect(screen.getByTitle(/2,700 prompt.*800 output/)).toBeTruthy();
   });
 
   it("uses scene timestamps for duration when per-turn duration is unavailable", () => {
@@ -136,7 +139,8 @@ describe("ConversationView assistant metrics", () => {
 
     expect(screen.getByText(/4\.2s/)).toBeTruthy();
     expect(screen.getByText(/8\.1s/)).toBeTruthy();
-    expect(screen.getByText(/2\.0K tok/)).toBeTruthy();
+    expect(screen.getByText(/1\.0K\s+in/)).toBeTruthy();
+    expect(screen.getByText(/1\.0K\s+out/)).toBeTruthy();
   });
 
   it("does not fall back by position for sparse indexed stats", () => {

--- a/packages/viewer/src/engine/__tests__/context-chart.test.ts
+++ b/packages/viewer/src/engine/__tests__/context-chart.test.ts
@@ -128,6 +128,23 @@ describe("turn-stat joins and context drops", () => {
     ]);
   });
 
+  it("reports a context drop across assistant segments split by compaction", () => {
+    expect(
+      findContextDrops([
+        ts({ turnIndex: 0, segmentIndex: 0, contextTokens: 1000 }),
+        ts({ turnIndex: 0, segmentIndex: 1, contextTokens: 400 }),
+      ]),
+    ).toEqual([
+      {
+        position: 0,
+        beforeTurnIndex: 0,
+        afterTurnIndex: 0,
+        before: 1000,
+        after: 400,
+      },
+    ]);
+  });
+
   it("uses the configured limit as the semantic limit while keeping an over-limit peak visible", () => {
     expect(getContextScale([ts({ contextTokens: 415_242 })], 272_000)).toEqual({
       peak: 415_242,

--- a/packages/viewer/src/engine/context-chart.ts
+++ b/packages/viewer/src/engine/context-chart.ts
@@ -13,10 +13,13 @@ export interface ContextDrop {
  * Return turn stats in their semantic prompt order without mutating the
  * provider-owned array. Older providers may omit turns, so callers must use
  * `turnIndex` rather than the array position when joining these stats to
- * rendered prompts.
+ * rendered prompts. Providers that expose `segmentIndex` use that for
+ * ordering continuation segments within one user prompt.
  */
 export function orderedTurnStats(turnStats: readonly TurnStat[]): TurnStat[] {
-  return [...turnStats].sort((a, b) => a.turnIndex - b.turnIndex);
+  return [...turnStats].sort(
+    (a, b) => (a.segmentIndex ?? a.turnIndex) - (b.segmentIndex ?? b.turnIndex),
+  );
 }
 
 /** Look up a turn's metrics without assuming that every turn has a stat row. */
@@ -42,14 +45,13 @@ export function findContextDrops(turnStats: readonly TurnStat[]): ContextDrop[] 
     const next = ordered[i + 1];
     const before = current.contextTokens || 0;
     const after = next.contextTokens || 0;
-    // Do not infer across an omitted turn. The missing row may contain the
-    // actual reset or may make two unrelated observations look adjacent.
-    if (
-      next.turnIndex === current.turnIndex + 1 &&
-      before > 0 &&
-      after > 0 &&
-      after < before * 0.5
-    ) {
+    // Do not infer across an omitted turn/segment. The missing row may contain
+    // the actual reset or may make two unrelated observations look adjacent.
+    const adjacent =
+      current.segmentIndex !== undefined && next.segmentIndex !== undefined
+        ? next.segmentIndex === current.segmentIndex + 1
+        : next.turnIndex === current.turnIndex + 1;
+    if (adjacent && before > 0 && after > 0 && after < before * 0.5) {
       drops.push({
         position: i,
         beforeTurnIndex: current.turnIndex,


### PR DESCRIPTION
## Summary

- Replace the single aggregate token badge on Assistant cards with separate `in`, `out`, `cache read`, and `cache write` values.
- Keep the full cumulative usage explanation in the hover tooltip.
- Update ConversationView coverage for all usage categories.

## Why

The aggregate usage combines provider-reported tokens across model requests, while tool badges only estimate individual tool-result size. Cache reads can dominate the aggregate, so showing the categories makes prompt reuse and model output easier to interpret.

## Validation

- `pnpm --filter @vibe-replay/viewer test`
- `pnpm build`
- `pnpm lint:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage now shows separate input, output, and cache-read counts.
  * Tooltips identify cumulative usage, updated prompt totals, and prompt cache creation details.
* **Bug Fixes**
  * Improved token usage visibility when cache-related counts are present.
  * Cache creation tokens are now presented with clearer billing context rather than as a standalone count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->