### PR TITLE
Move SSH session-data consent to Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ The CLI auto-discovers sessions on your machine, parses conversation data from a
   requests to the configured local or remote API root.
 - **Ask Replay** — ask read-only questions about local sessions, replay scenes, usage, and
   insights from the Dashboard or Editor. Answers include citations and explicit navigation actions;
-  SSH-backed data stays hidden unless you enable the per-chat consent toggle.
+  SSH-backed data stays hidden unless you enable it in Settings. The setting is browser-local and
+  can be changed at any time.
 - **Quick preview** — open in browser instantly
 - **Publish to Gist** — shareable link on [vibe-replay.com](https://vibe-replay.com)
 - **Export for GitHub** — markdown + animated SVG for PRs

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ npx vibe-replay --session ~/.claude/projects/<project>/<session>.jsonl
   AI Studio Manage Providers dialog for OpenAI, ChatGPT/Codex, OpenRouter, OpenCode Zen, and
   user-configured OpenAI-compatible proxies such as LiteLLM
 - Read-only Ask Replay assistant for local sessions, replays, scenes, usage, and insights, with
-  citations, navigation actions, bounded tool access, and explicit SSH-data consent
+  citations, navigation actions, bounded tool access, and a browser-local SSH-data consent setting
 
 AI Studio stores provider keys and OAuth refresh tokens outside replay files in
 `~/.vibe-replay/ai-auth.json` (override with `VIBE_REPLAY_AI_AUTH`). Custom endpoint metadata is

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -466,6 +466,7 @@ export default function LocalChatAssistant({ context }: Props) {
     : "Set up an AI provider";
   const remoteSession = Boolean(context.currentSession?.targetId);
   const remoteDataAvailable = remoteSession || hasConfiguredRemoteSource;
+  const remoteDataEnabled = allowRemoteData && remoteDataAvailable;
   const retryProviderSetup = useCallback(async () => {
     try {
       await refreshAiProviders?.();
@@ -596,14 +597,14 @@ export default function LocalChatAssistant({ context }: Props) {
       const params = new URLSearchParams(window.location.search);
       const body = {
         messages: nextMessages
-          .filter((message) => allowRemoteData || !message.remoteDataUsed)
+          .filter((message) => remoteDataEnabled || !message.remoteDataUsed)
           .map(({ role, content: messageContent }) => ({
             role,
             content: messageContent,
           })),
         context: {
           ...context,
-          allowRemoteData,
+          allowRemoteData: remoteDataEnabled,
           tab: params.get("tab") || undefined,
           project: params.get("project") || undefined,
         },
@@ -696,13 +697,13 @@ export default function LocalChatAssistant({ context }: Props) {
     }
   }, [
     context,
-    allowRemoteData,
     input,
     messages,
     providerReady,
     chatModelId,
     chatProviderId,
     running,
+    remoteDataEnabled,
   ]);
 
   const cancel = () => controllerRef.current?.abort();
@@ -1071,7 +1072,7 @@ export default function LocalChatAssistant({ context }: Props) {
                 </button>
               )}
             </div>
-            {providerReady && remoteDataAvailable && !allowRemoteData && (
+            {providerReady && remoteDataAvailable && !remoteDataEnabled && (
               <div className="mt-2 flex items-start justify-between gap-3 rounded-lg border border-terminal-yellow/25 bg-terminal-yellow-subtle px-2.5 py-2 text-[9px] leading-relaxed font-mono text-terminal-yellow">
                 <span>
                   {remoteSession
@@ -1094,10 +1095,8 @@ export default function LocalChatAssistant({ context }: Props) {
                   ? "provider setup required"
                   : remoteSourcesLoading && !remoteSession
                     ? "checking source settings"
-                    : allowRemoteData
-                      ? remoteDataAvailable
-                        ? "SSH data enabled"
-                        : "local sessions only"
+                    : remoteDataEnabled
+                      ? "SSH data enabled"
                       : remoteDataAvailable
                         ? "SSH data hidden"
                         : "local sessions only"}

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -1,6 +1,7 @@
 import { marked } from "marked";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAiProviderSettings } from "../hooks/useAiProviderSettings";
+import { useRemoteDataConsent } from "../hooks/useRemoteDataConsent";
 import { navigateTo } from "./dashboard-utils";
 import { sanitizeHtml } from "../utils/sanitize";
 
@@ -416,7 +417,6 @@ export default function LocalChatAssistant({ context }: Props) {
   const [activeTool, setActiveTool] = useState<string | null>(null);
   const [providerLabel, setProviderLabel] = useState<string | null>(null);
   const [switchOpen, setSwitchOpen] = useState(false);
-  const [allowRemoteData, setAllowRemoteData] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [panelSize, setPanelSize] = useState<PanelSize>(DEFAULT_PANEL_SIZE);
   const [resizing, setResizing] = useState(false);
@@ -427,6 +427,8 @@ export default function LocalChatAssistant({ context }: Props) {
   >(undefined);
   const scrollRef = useRef<HTMLDivElement>(null);
   const providerSettings = useAiProviderSettings(true);
+  const { allowRemoteData, hasConfiguredRemoteSource, remoteSourcesLoading } =
+    useRemoteDataConsent(true);
   const { refreshAiProviders } = providerSettings;
   const availableProviders = providerSettings.aiProviders.filter(
     (provider) => provider.configured && provider.models.length > 0,
@@ -463,6 +465,7 @@ export default function LocalChatAssistant({ context }: Props) {
     ? "Open provider settings"
     : "Set up an AI provider";
   const remoteSession = Boolean(context.currentSession?.targetId);
+  const remoteDataAvailable = remoteSession || hasConfiguredRemoteSource;
   const retryProviderSetup = useCallback(async () => {
     try {
       await refreshAiProviders?.();
@@ -548,7 +551,6 @@ export default function LocalChatAssistant({ context }: Props) {
   }, [chatModelId, chatProviderId]);
 
   useEffect(() => {
-    setAllowRemoteData(false);
     setSwitchOpen(false);
   }, [context.currentSession?.slug, context.currentSession?.targetId]);
 
@@ -1069,31 +1071,36 @@ export default function LocalChatAssistant({ context }: Props) {
                 </button>
               )}
             </div>
-            {providerReady && (remoteSession || context.mode === "dashboard") && (
-              <label className="mt-2 flex items-start gap-2 rounded-lg border border-terminal-yellow/25 bg-terminal-yellow-subtle px-2.5 py-2 text-[9px] leading-relaxed font-mono text-terminal-yellow">
-                <input
-                  type="checkbox"
-                  checked={allowRemoteData}
-                  onChange={(event) => setAllowRemoteData(event.target.checked)}
-                  className="mt-0.5 accent-terminal-yellow"
-                />
+            {providerReady && remoteDataAvailable && !allowRemoteData && (
+              <div className="mt-2 flex items-start justify-between gap-3 rounded-lg border border-terminal-yellow/25 bg-terminal-yellow-subtle px-2.5 py-2 text-[9px] leading-relaxed font-mono text-terminal-yellow">
                 <span>
                   {remoteSession
-                    ? "This replay came from SSH. Allow its session content to be sent to your configured AI provider for this chat."
-                    : "Allow SSH session metadata and content to be sent to your configured AI provider for this chat."}
+                    ? "This SSH replay is hidden from Ask Replay until SSH data is enabled in Settings."
+                    : "SSH session data is hidden from Ask Replay until enabled in Settings."}
                 </span>
-              </label>
+                <button
+                  type="button"
+                  onClick={openProviderSettings}
+                  className="shrink-0 cursor-pointer font-semibold underline underline-offset-2 transition-colors hover:text-terminal-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-terminal-green/50"
+                >
+                  Open Settings
+                </button>
+              </div>
             )}
             <div className="mt-2 flex items-center justify-between text-[9px] font-mono text-terminal-dimmer">
               <span>
                 Read-only ·{" "}
                 {!providerReady
                   ? "provider setup required"
-                  : allowRemoteData
-                    ? "SSH consent granted"
-                    : remoteSession
-                      ? "SSH consent required"
-                      : "local sessions only"}
+                  : remoteSourcesLoading && !remoteSession
+                    ? "checking source settings"
+                    : allowRemoteData
+                      ? remoteDataAvailable
+                        ? "SSH data enabled"
+                        : "local sessions only"
+                      : remoteDataAvailable
+                        ? "SSH data hidden"
+                        : "local sessions only"}
               </span>
               <button
                 type="button"

--- a/packages/viewer/src/components/SettingsPanel.tsx
+++ b/packages/viewer/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from "react"
 import { navigateTo, providerDisplayName } from "./dashboard-utils";
 import { AiProviderSettings } from "./AiProviderSettings";
 import { useAiProviderSettings } from "../hooks/useAiProviderSettings";
+import { notifyRemoteSourcesChanged, useRemoteDataConsent } from "../hooks/useRemoteDataConsent";
 
 type RemoteProvider = "claude-code" | "codex" | "pi";
 
@@ -235,6 +236,7 @@ function sourceForDraft(draft: RemoteSourceDraft): { source?: RemoteSource; erro
 export default function SettingsPanel() {
   const aiProviderSettings = useAiProviderSettings(true);
   const [sources, setSources] = useState<RemoteSource[]>([]);
+  const { allowRemoteData, setAllowRemoteData } = useRemoteDataConsent(true, sources.length);
   const [draft, setDraft] = useState<RemoteSourceDraft | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -288,7 +290,9 @@ export default function SettingsPanel() {
       } | null;
       if (!response.ok) throw new Error(data?.error || "Settings could not be loaded");
       if (requestVersion === sourceRequestVersion.current) {
-        setSources(parseRemoteSources(data?.remoteSources));
+        const nextSources = parseRemoteSources(data?.remoteSources);
+        setSources(nextSources);
+        notifyRemoteSourcesChanged(nextSources.length > 0);
       }
     } catch (err) {
       if (requestVersion === sourceRequestVersion.current) {
@@ -407,7 +411,9 @@ export default function SettingsPanel() {
       } | null;
       if (!response.ok) throw new Error(data?.error || "SSH settings could not be saved");
       if (requestVersion === sourceRequestVersion.current) {
-        setSources(parseRemoteSources(data?.remoteSources));
+        const nextSources = parseRemoteSources(data?.remoteSources);
+        setSources(nextSources);
+        notifyRemoteSourcesChanged(nextSources.length > 0);
         setTestResults({});
         setMessage(successMessage);
         setDraft(null);
@@ -496,6 +502,7 @@ export default function SettingsPanel() {
         setMessage("Source discovery finished. Sessions and Insights will use the new catalog.");
         const refreshedSettings = parseRemoteSources(data?.remoteSources);
         setSources(refreshedSettings);
+        notifyRemoteSourcesChanged(refreshedSettings.length > 0);
       }
     } catch (err) {
       if (requestVersion === sourceRequestVersion.current) {
@@ -571,6 +578,36 @@ export default function SettingsPanel() {
                 + Add SSH source
               </button>
             </div>
+
+            {!loading && sources.length > 0 && (
+              <div className="mt-5 rounded-lg border border-terminal-yellow/25 bg-terminal-yellow-subtle/60 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-sans font-semibold text-terminal-text">
+                      Ask Replay SSH data
+                    </h3>
+                    <p className="mt-1 max-w-2xl text-xs font-sans leading-relaxed text-terminal-dim">
+                      Allow Ask Replay to include SSH session metadata and content in requests to
+                      your configured AI provider. This applies to the dashboard and SSH replays.
+                    </p>
+                  </div>
+                  <label className="flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border border-terminal-yellow/30 bg-terminal-bg px-3 py-2 text-xs font-mono text-terminal-yellow">
+                    <input
+                      type="checkbox"
+                      aria-label="Allow SSH session data to be sent to the configured AI provider"
+                      checked={allowRemoteData}
+                      onChange={(event) => setAllowRemoteData(event.target.checked)}
+                      className="accent-terminal-yellow"
+                    />
+                    Allow SSH data
+                  </label>
+                </div>
+                <p className="mt-3 text-[10px] font-sans leading-relaxed text-terminal-dimmer">
+                  When disabled, SSH-backed sessions stay hidden from Ask Replay. You can change
+                  this at any time from Settings.
+                </p>
+              </div>
+            )}
 
             {loading ? (
               <div className="mt-5 rounded-lg bg-terminal-bg px-4 py-5 text-xs font-mono text-terminal-dimmer">

--- a/packages/viewer/src/components/__tests__/local-chat-assistant.test.tsx
+++ b/packages/viewer/src/components/__tests__/local-chat-assistant.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LocalChatAssistant from "../LocalChatAssistant";
+
+const providerSettings = vi.hoisted(() => ({
+  aiProviders: [
+    {
+      id: "openai",
+      name: "OpenAI",
+      configured: true,
+      authMethods: [],
+      models: [
+        {
+          id: "test-model",
+          name: "Test model",
+          api: "openai-responses",
+          reasoning: false,
+          input: ["text"],
+        },
+      ],
+    },
+  ],
+  aiProviderId: "openai",
+  aiModelId: "test-model",
+  setAiProviderId: vi.fn(),
+  setAiModelId: vi.fn(),
+  refreshAiProviders: vi.fn(async () => {}),
+  authenticateAiProvider: null,
+  cancelAiAuthentication: null,
+  logoutAiProvider: null,
+  configureAiCustomProvider: null,
+  removeAiCustomProvider: null,
+  aiProvidersLoading: false,
+  aiProvidersError: null,
+  defaultAiProviderId: null,
+  defaultAiModelId: null,
+  saveAiSelectionAsDefault: vi.fn(),
+}));
+
+vi.mock("../../hooks/useAiProviderSettings", () => ({
+  useAiProviderSettings: () => providerSettings,
+}));
+
+function settingsResponse(remoteSources: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({ remoteSources }),
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/api/settings")) return settingsResponse([]);
+      throw new Error(`Unexpected request: ${String(input)}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("LocalChatAssistant SSH consent UI", () => {
+  it("does not show SSH consent when no SSH source is configured", async () => {
+    render(<LocalChatAssistant context={{ mode: "dashboard" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ask Replay" }));
+
+    await waitFor(() => expect(screen.getByText("What would you like to find?")).toBeDefined());
+    expect(screen.queryByText(/SSH session data is hidden/)).toBeNull();
+    expect(screen.queryByText(/Allow SSH session metadata and content/)).toBeNull();
+  });
+
+  it("shows a Settings link when an SSH source exists but consent is off", async () => {
+    vi.mocked(fetch).mockImplementationOnce(
+      async () => settingsResponse([{ id: "remote-dev" }]) as unknown as Response,
+    );
+    render(<LocalChatAssistant context={{ mode: "dashboard" }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ask Replay" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("SSH session data is hidden from Ask Replay until enabled in Settings."),
+      ).toBeDefined(),
+    );
+    expect(screen.getByRole("button", { name: "Open Settings" })).toBeDefined();
+  });
+});

--- a/packages/viewer/src/components/__tests__/settings-panel.test.tsx
+++ b/packages/viewer/src/components/__tests__/settings-panel.test.tsx
@@ -11,6 +11,8 @@ const source = {
   connectTimeoutMs: 10_000,
 };
 
+let configuredSources = [source];
+
 function jsonResponse(data: unknown, ok = true) {
   return {
     ok,
@@ -19,12 +21,13 @@ function jsonResponse(data: unknown, ok = true) {
 }
 
 beforeEach(() => {
+  configuredSources = [source];
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/api/settings")) {
-        return jsonResponse({ remoteSources: [source] });
+        return jsonResponse({ remoteSources: configuredSources });
       }
       if (url.endsWith("/api/ai/providers")) {
         return jsonResponse({
@@ -70,6 +73,33 @@ describe("SettingsPanel", () => {
     expect(screen.getByText("Codex")).toBeDefined();
     expect(screen.getByText("AI providers")).toBeDefined();
     expect(screen.getByLabelText("Custom AI endpoint")).toBeDefined();
+    expect(
+      screen.getByLabelText("Allow SSH session data to be sent to the configured AI provider"),
+    ).toBeDefined();
+  });
+
+  it("hides the SSH data setting when no SSH source is configured", async () => {
+    configuredSources = [];
+    render(<SettingsPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No remote SSH sources configured.")).toBeDefined(),
+    );
+    expect(
+      screen.queryByLabelText("Allow SSH session data to be sent to the configured AI provider"),
+    ).toBeNull();
+  });
+
+  it("persists the SSH data setting from Settings", async () => {
+    render(<SettingsPanel />);
+    await waitFor(() => expect(screen.getByText("ROS devspace")).toBeDefined());
+
+    const consent = screen.getByLabelText(
+      "Allow SSH session data to be sent to the configured AI provider",
+    );
+    expect((consent as HTMLInputElement).checked).toBe(false);
+    fireEvent.click(consent);
+    expect((consent as HTMLInputElement).checked).toBe(true);
   });
 
   it("follows the settings section URL and updates it from the left menu", async () => {

--- a/packages/viewer/src/hooks/__tests__/useRemoteDataConsent.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useRemoteDataConsent.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { REMOTE_DATA_CONSENT_STORAGE_KEY, useRemoteDataConsent } from "../useRemoteDataConsent";
+
+function settingsResponse(remoteSources: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({ remoteSources }),
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/api/settings")) return settingsResponse([{ id: "remote-dev" }]);
+      throw new Error(`Unexpected request: ${String(input)}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("useRemoteDataConsent", () => {
+  it("loads remote-source availability and persists the consent choice", async () => {
+    const { result } = renderHook(() => useRemoteDataConsent(true));
+
+    await waitFor(() => expect(result.current.remoteSourcesLoading).toBe(false));
+    expect(result.current.hasConfiguredRemoteSource).toBe(true);
+    expect(result.current.allowRemoteData).toBe(false);
+
+    act(() => result.current.setAllowRemoteData(true));
+
+    expect(result.current.allowRemoteData).toBe(true);
+    expect(localStorage.getItem(REMOTE_DATA_CONSENT_STORAGE_KEY)).toBe("1");
+  });
+
+  it("synchronizes consent changes across mounted surfaces", async () => {
+    const first = renderHook(() => useRemoteDataConsent(true));
+    const second = renderHook(() => useRemoteDataConsent(true));
+
+    await waitFor(() => {
+      expect(first.result.current.hasConfiguredRemoteSource).toBe(true);
+      expect(second.result.current.hasConfiguredRemoteSource).toBe(true);
+    });
+
+    act(() => first.result.current.setAllowRemoteData(true));
+    await waitFor(() => expect(second.result.current.allowRemoteData).toBe(true));
+
+    first.unmount();
+    second.unmount();
+  });
+
+  it("fails closed when no remote source is configured", async () => {
+    vi.mocked(fetch).mockImplementationOnce(
+      async () => settingsResponse([]) as unknown as Response,
+    );
+    const { result } = renderHook(() => useRemoteDataConsent(true));
+
+    await waitFor(() => expect(result.current.remoteSourcesLoading).toBe(false));
+    expect(result.current.hasConfiguredRemoteSource).toBe(false);
+  });
+});

--- a/packages/viewer/src/hooks/useRemoteDataConsent.ts
+++ b/packages/viewer/src/hooks/useRemoteDataConsent.ts
@@ -104,7 +104,11 @@ export function useRemoteDataConsent(
     let cancelled = false;
     setRemoteSourcesLoading(true);
     void fetch(apiUrl("/api/settings"), { cache: "no-store" })
-      .then((response) => response.json().catch(() => null))
+      .then(async (response) => {
+        const data = await response.json().catch(() => null);
+        if (!response.ok) throw new Error("Settings could not be loaded");
+        return data;
+      })
       .then((data) => {
         if (cancelled) return;
         const hasSource = parseHasConfiguredRemoteSource(data);

--- a/packages/viewer/src/hooks/useRemoteDataConsent.ts
+++ b/packages/viewer/src/hooks/useRemoteDataConsent.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiUrl } from "../utils/api";
+import { safeStorageGet, safeStorageSet } from "../utils/safe-storage";
+
+export const REMOTE_DATA_CONSENT_STORAGE_KEY = "vibe-replay-ssh-data-consent-v1";
+export const REMOTE_DATA_CONSENT_CHANGE_EVENT = "vibe-replay-ssh-data-consent-change";
+export const REMOTE_SOURCES_CHANGE_EVENT = "vibe-replay-remote-sources-change";
+
+export interface RemoteDataConsentActions {
+  allowRemoteData: boolean;
+  setAllowRemoteData: (allowed: boolean) => void;
+  hasConfiguredRemoteSource: boolean;
+  remoteSourcesLoading: boolean;
+}
+
+function readAllowRemoteData(): boolean {
+  return safeStorageGet(localStorage, REMOTE_DATA_CONSENT_STORAGE_KEY) === "1";
+}
+
+export function notifyRemoteSourcesChanged(hasConfiguredRemoteSource: boolean): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<boolean>(REMOTE_SOURCES_CHANGE_EVENT, {
+      detail: hasConfiguredRemoteSource,
+    }),
+  );
+}
+
+function parseHasConfiguredRemoteSource(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const remoteSources = (value as { remoteSources?: unknown }).remoteSources;
+  return Array.isArray(remoteSources) && remoteSources.length > 0;
+}
+
+/**
+ * Shared browser-local SSH data consent for Ask Replay and Settings.
+ * Remote-source discovery is fetched here for surfaces that do not already
+ * own the Settings source list; Settings can pass its loaded source count.
+ */
+export function useRemoteDataConsent(
+  enabled: boolean,
+  configuredRemoteSourceCount?: number,
+): RemoteDataConsentActions {
+  const [allowRemoteData, setAllowRemoteDataState] = useState(readAllowRemoteData);
+  const [hasConfiguredRemoteSource, setHasConfiguredRemoteSource] = useState(
+    configuredRemoteSourceCount !== undefined ? configuredRemoteSourceCount > 0 : false,
+  );
+  const [remoteSourcesLoading, setRemoteSourcesLoading] = useState(
+    enabled && configuredRemoteSourceCount === undefined,
+  );
+
+  const setAllowRemoteData = useCallback((allowed: boolean) => {
+    safeStorageSet(localStorage, REMOTE_DATA_CONSENT_STORAGE_KEY, allowed ? "1" : "0");
+    setAllowRemoteDataState(allowed);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent<boolean>(REMOTE_DATA_CONSENT_CHANGE_EVENT, { detail: allowed }),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+
+    const onConsentChange = (event: Event) => {
+      const allowed = (event as CustomEvent<boolean>).detail;
+      if (typeof allowed === "boolean") setAllowRemoteDataState(allowed);
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== REMOTE_DATA_CONSENT_STORAGE_KEY) return;
+      setAllowRemoteDataState(event.newValue === "1");
+    };
+    const onRemoteSourcesChange = (event: Event) => {
+      if (configuredRemoteSourceCount !== undefined) return;
+      const hasSource = (event as CustomEvent<boolean>).detail;
+      if (typeof hasSource === "boolean") {
+        setHasConfiguredRemoteSource(hasSource);
+        setRemoteSourcesLoading(false);
+      }
+    };
+
+    window.addEventListener(REMOTE_DATA_CONSENT_CHANGE_EVENT, onConsentChange);
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(REMOTE_SOURCES_CHANGE_EVENT, onRemoteSourcesChange);
+    return () => {
+      window.removeEventListener(REMOTE_DATA_CONSENT_CHANGE_EVENT, onConsentChange);
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(REMOTE_SOURCES_CHANGE_EVENT, onRemoteSourcesChange);
+    };
+  }, [configuredRemoteSourceCount, enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setHasConfiguredRemoteSource(false);
+      setRemoteSourcesLoading(false);
+      return;
+    }
+    if (configuredRemoteSourceCount !== undefined) {
+      setHasConfiguredRemoteSource(configuredRemoteSourceCount > 0);
+      setRemoteSourcesLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setRemoteSourcesLoading(true);
+    void fetch(apiUrl("/api/settings"), { cache: "no-store" })
+      .then((response) => response.json().catch(() => null))
+      .then((data) => {
+        if (cancelled) return;
+        const hasSource = parseHasConfiguredRemoteSource(data);
+        setHasConfiguredRemoteSource(hasSource);
+        setRemoteSourcesLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Fail closed: an unavailable Settings endpoint must not surface a
+        // prompt that suggests SSH data can be sent.
+        setHasConfiguredRemoteSource(false);
+        setRemoteSourcesLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [configuredRemoteSourceCount, enabled]);
+
+  return {
+    allowRemoteData,
+    setAllowRemoteData,
+    hasConfiguredRemoteSource,
+    remoteSourcesLoading,
+  };
+}


### PR DESCRIPTION
## Summary
- persist the SSH session-data consent choice in browser-local Settings
- hide the consent UI when no SSH source is configured
- keep Ask Replay read-only and show a Settings link only when SSH data is unavailable
- add focused coverage and update privacy docs

## Verification
- `pnpm verify`
