### PR TITLE
refactor(hermes): remove redundant file path cast

### DIFF
--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -162,7 +162,7 @@ function hintedDbPath(paths: string[], sessionInfo?: SessionInfo): string | unde
       if (dbPath) return dbPath;
     }
   }
-  const fp = (sessionInfo as unknown as { filePath?: string })?.filePath;
+  const fp = sessionInfo?.filePath;
   if (typeof fp === "string" && fp.includes("#session:")) {
     return fp.split("#session:")[0];
   }


### PR DESCRIPTION
## Summary

- Use the declared `SessionInfo.filePath` field directly in Hermes database hint resolution.
- Diff: +1 -1.

## Motivation

`SessionInfo.filePath` is already a required string, so removing the double assertion preserves the same optional-chain lookup and runtime behavior while restoring type safety.

## Test plan

- [x] `pnpm test` passed (via `pnpm verify`)
- [x] `pnpm lint:check` passed with zero warnings/errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` equivalent passed as part of the stricter workspace-wide `pnpm typecheck`
- [x] `pnpm build` succeeded
- [x] E2E not run: this is a one-line type-only cleanup with no UI or runtime behavior change

> 🤖 Daily auto-quality routine. Self-merged after AI review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal session path handling while preserving existing behavior.
  * No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->