### PR TITLE
fix: expand CLI tilde paths on Windows

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,7 +41,7 @@ import { startDashboard, startServer } from "./server.js";
 import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
 import { transformToReplay } from "./transform.js";
 import type { ParseWarning, ReplaySession, SessionInfo } from "./types.js";
-import { normalizeTitle } from "./utils.js";
+import { expandUserPath, normalizeTitle } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
 setFileCacheAppVersion(CLI_VERSION);
@@ -281,7 +281,7 @@ program
     let providerName: string;
 
     if (opts.session) {
-      sessionPaths = opts.session;
+      sessionPaths = expandUserPath(opts.session);
       providerName = opts.provider;
     } else {
       // ─── Top-level menu ─────────────────────────────────
@@ -1077,7 +1077,7 @@ program
     let outputDir: string;
 
     if (pathArg) {
-      const abs = resolve(pathArg);
+      const abs = resolve(expandUserPath(pathArg));
       if (!existsSync(abs)) {
         console.error(chalk.red(`\n  ✗ Path not found: ${abs}\n`));
         process.exit(1);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,9 +1,24 @@
 import { homedir } from "node:os";
+import { posix, win32 } from "node:path";
 
 /** Replace $HOME prefix with `~` for display. */
 export function shortenPath(path: string): string {
   const home = homedir();
   if (path.startsWith(home)) return `~${path.slice(home.length)}`;
+  return path;
+}
+
+/** Expand a user-home path passed directly by a shell or CLI client. */
+export function expandUserPath(
+  path: string,
+  home = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (path === "~") return home;
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    const joinPath = platform === "win32" ? win32.join : posix.join;
+    return joinPath(home, path.slice(2));
+  }
   return path;
 }
 

--- a/packages/cli/test/utils.test.ts
+++ b/packages/cli/test/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { expandUserPath } from "../src/utils.js";
+
+describe("expandUserPath", () => {
+  it.each(["~/sessions/replay.jsonl", "~\\sessions\\replay.jsonl"])(
+    "expands %s with the supplied home directory",
+    (path) => {
+      expect(expandUserPath(path, "C:\\Users\\TuoLei", "win32")).toBe(
+        "C:\\Users\\TuoLei\\sessions\\replay.jsonl",
+      );
+    },
+  );
+
+  it("expands the home directory by itself", () => {
+    expect(expandUserPath("~", "C:\\Users\\TuoLei", "win32")).toBe("C:\\Users\\TuoLei");
+  });
+
+  it("uses POSIX separators for POSIX home paths", () => {
+    expect(expandUserPath("~/sessions/replay.jsonl", "/home/TuoLei", "linux")).toBe(
+      "/home/TuoLei/sessions/replay.jsonl",
+    );
+  });
+
+  it.each(["C:\\sessions\\replay.jsonl", "/tmp/replay.jsonl", "~other/replay.jsonl"])(
+    "leaves non-home paths unchanged: %s",
+    (path) => {
+      expect(expandUserPath(path, "C:\\Users\\TuoLei")).toBe(path);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Expand `~/...` and `~\...` paths before parsing an explicit `--session` argument.
- Expand tilde paths before resolving the optional `share [path]` argument.
- Add platform-specific unit coverage for Windows, POSIX, bare `~`, and non-home paths.

## Test plan
- `pnpm --filter vibe-replay exec vitest run test/utils.test.ts` — 7 passed
- `pnpm --filter vibe-replay test` — 530 passed; the only two failures are the known local Git-symlink materialization assertions
- `pnpm typecheck`
- `pnpm lint:check`
- CLI smoke with `--session ~\definitely-missing-vibe-replay-session.jsonl` confirmed Node attempted `C:\Users\TuoLei\definitely-missing-vibe-replay-session.jsonl`, not a repository-relative path