### PR TITLE
fix: redact Windows home paths safely

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,12 +1,6 @@
 import { homedir } from "node:os";
 import { posix, win32 } from "node:path";
-
-/** Replace $HOME prefix with `~` for display. */
-export function shortenPath(path: string): string {
-  const home = homedir();
-  if (path.startsWith(home)) return `~${path.slice(home.length)}`;
-  return path;
-}
+export { shortenPath } from "@vibe-replay/provider-core/utils";
 
 /** Expand a user-home path passed directly by a shell or CLI client. */
 export function expandUserPath(

--- a/packages/provider-core/src/utils.ts
+++ b/packages/provider-core/src/utils.ts
@@ -2,11 +2,22 @@ import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 
-/** Replace $HOME prefix with `~` for display. */
-export function shortenPath(path: string): string {
-  const home = homedir();
-  if (path.startsWith(home)) return `~${path.slice(home.length)}`;
-  return path;
+/** Replace an OS home-directory prefix with `~` for display. */
+export function shortenPath(
+  path: string,
+  home = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const normalizedHome = home.replaceAll("\\", "/").replace(/\/+$/, "");
+  if (!normalizedHome) return path;
+
+  const escapedHome = normalizedHome
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("/", platform === "win32" ? "[\\\\/]" : "/");
+  const flags = platform === "win32" ? "gi" : "g";
+  const homePattern = new RegExp(`(^|[^A-Za-z0-9._-])${escapedHome}(?![A-Za-z0-9._-])`, flags);
+
+  return path.replace(homePattern, (_match, prefix: string) => `${prefix}~`);
 }
 
 const MAX_TITLE_CHARS = 120;

--- a/packages/provider-core/test/utils.test.ts
+++ b/packages/provider-core/test/utils.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { normalizeGitUrl, readGitRepo } from "../src/utils.js";
+import { normalizeGitUrl, readGitRepo, shortenPath } from "../src/utils.js";
 
 describe("normalizeGitUrl", () => {
   it.each([
@@ -51,5 +51,27 @@ describe("readGitRepo", () => {
     );
 
     await expect(readGitRepo(project)).resolves.toBe("org/worktree-repo");
+  });
+});
+
+describe("shortenPath", () => {
+  it("redacts Windows home paths across separators and casing", () => {
+    const home = "C:\\Users\\TuoLei";
+
+    expect(shortenPath("C:/Users/TuoLei/project", home, "win32")).toBe("~/project");
+    expect(shortenPath("c:\\users\\tuolei\\project", home, "win32")).toBe("~\\project");
+  });
+
+  it("does not redact a Windows sibling path with the same prefix", () => {
+    const home = "C:\\Users\\TuoLei";
+
+    expect(shortenPath("C:/Users/TuoLei2/project", home, "win32")).toBe("C:/Users/TuoLei2/project");
+  });
+
+  it("preserves POSIX case sensitivity and separators", () => {
+    const home = "/home/TuoLei";
+
+    expect(shortenPath("/home/TuoLei/project", home, "linux")).toBe("~/project");
+    expect(shortenPath("/home/tuolei/project", home, "linux")).toBe("/home/tuolei/project");
   });
 });

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { getTimestampBounds } from "@vibe-replay/provider-core/duration";
+import { shortenPath } from "@vibe-replay/provider-core/utils";
 import { estimateCostIfKnown, estimateCostSimpleIfKnown, getModelContextLimit } from "./pricing.js";
 import { normalizeSubAgentType, type ProviderParseResult } from "@vibe-replay/provider-contract";
 import { compactWarningSample } from "@vibe-replay/provider-contract/warnings";
@@ -22,8 +23,7 @@ const HOME = homedir();
 
 /** Replace absolute home dir path with ~ to avoid leaking username */
 function redactPath(s: string): string {
-  if (!HOME) return s;
-  return s.replaceAll(HOME, "~");
+  return shortenPath(s);
 }
 
 /**

--- a/packages/replay-core/test/transform-security.test.ts
+++ b/packages/replay-core/test/transform-security.test.ts
@@ -61,6 +61,43 @@ function transformRemote(parsed: ProviderParseResult, remoteHome: string): Repla
 // ---------------------------------------------------------------------------
 
 describe("path redaction", () => {
+  it.skipIf(process.platform !== "win32")(
+    "redacts Windows home paths across separators and casing",
+    () => {
+      const forwardSlashHome = HOME.replaceAll("\\", "/");
+      const lowerCaseHome = forwardSlashHome.toLowerCase();
+      const parsed = makeParsed([
+        {
+          role: "user",
+          blocks: [
+            {
+              type: "text",
+              text: `${forwardSlashHome}/project ${lowerCaseHome}\\other`,
+            },
+          ],
+        },
+      ]);
+      const replay = transform(parsed);
+      const scene = replay.scenes.find((s) => s.type === "user-prompt")!;
+
+      expect(scene.content).toContain("~/project");
+      expect(scene.content).toContain("~\\other");
+    },
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "does not redact a Windows sibling path with the same prefix",
+    () => {
+      const forwardSlashHome = HOME.replaceAll("\\", "/");
+      const sibling = `${forwardSlashHome}2/project`;
+      const parsed = makeParsed([{ role: "user", blocks: [{ type: "text", text: sibling }] }]);
+      const replay = transform(parsed);
+      const scene = replay.scenes.find((s) => s.type === "user-prompt")!;
+
+      expect(scene.content).toBe(sibling);
+    },
+  );
+
   it("redacts home dir in user prompt content", () => {
     const parsed = makeParsed([
       { role: "user", blocks: [{ type: "text", text: `Look at ${HOME}/secret/project` }] },


### PR DESCRIPTION
## Summary
- Harden the shared home-directory shortening helper for Windows slash styles, case differences, and sibling-path boundaries.
- Reuse the hardened helper for CLI project labels and replay content/path redaction.
- Add Windows and POSIX regression coverage, including a replay privacy check.

## Test plan
- `pnpm --filter @vibe-replay/provider-core test` — 43 passed
- `pnpm --filter @vibe-replay/replay-core test` — 131 passed
- `pnpm --filter vibe-replay test` — 530 passed; the only two failures are the known local Git-symlink materialization assertions
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm build`