### PR TITLE
fix: normalize Windows project paths in CLI

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,7 +41,7 @@ import { startDashboard, startServer } from "./server.js";
 import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
 import { transformToReplay } from "./transform.js";
 import type { ParseWarning, ReplaySession, SessionInfo } from "./types.js";
-import { expandUserPath, normalizeTitle } from "./utils.js";
+import { expandUserPath, normalizeTitle, shortenPath } from "./utils.js";
 import { CLI_VERSION } from "./version.js";
 
 setFileCacheAppVersion(CLI_VERSION);
@@ -521,9 +521,7 @@ program
       spinner.text = "Transforming to replay...";
 
       const rawProject = sessionInfo?.project || parsed.cwd;
-      const project = rawProject.startsWith(home)
-        ? `~${rawProject.slice(home.length)}`
-        : rawProject;
+      const project = shortenPath(rawProject, home);
       const gitRepo =
         sessionInfo?.gitRepo ||
         (sessionInfo?.location?.kind === "ssh" ? undefined : await readGitRepo(rawProject));

--- a/packages/cli/src/server-core.ts
+++ b/packages/cli/src/server-core.ts
@@ -1,6 +1,6 @@
-import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import { basename } from "node:path";
+import { shortenPath } from "@vibe-replay/provider-core/utils";
 import type { ReplaySession, SessionInfo, SessionLocation } from "./types.js";
 
 /** Sanitize slug to prevent path traversal — rejects anything that isn't a simple name */
@@ -25,8 +25,7 @@ export function getErrorMessage(err: unknown): string {
 }
 
 function normalizeProjectPath(project: string): string {
-  const home = homedir();
-  return project.startsWith(home) ? `~${project.slice(home.length)}` : project;
+  return shortenPath(project);
 }
 
 // Keep cloud sync requests comfortably below the current D1 bind / batch ceiling.

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -18,7 +18,7 @@ import { streamSSE } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import open from "open";
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
-import { readGitRepo } from "@vibe-replay/provider-core/utils";
+import { readGitRepo, shortenPath } from "@vibe-replay/provider-core/utils";
 import { classifyProject } from "@vibe-replay/types";
 import { readFileCache, writeFileCache } from "./cache.js";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
@@ -704,17 +704,17 @@ interface PersistedInsightsCache {
 }
 
 function normalizeSessionProjectsForHome(sessions: SessionInfo[], home: string): SessionInfo[] {
-  return sessions.map((session) =>
-    session.project.startsWith(home)
-      ? { ...session, project: `~${session.project.slice(home.length)}` }
-      : { ...session },
-  );
+  return sessions.map((session) => ({
+    ...session,
+    project: shortenPath(session.project, home),
+  }));
 }
 
 function isFilesystemProjectKey(project: string): boolean {
   return (
     project === "~" ||
     project.startsWith("~/") ||
+    project.startsWith("~\\") ||
     project.startsWith("/") ||
     /^[A-Za-z]:[\\/]/.test(project)
   );
@@ -831,9 +831,7 @@ async function buildSourcesResult(
 ): Promise<SourceSummaryRecord[]> {
   // Normalize project paths: /Users/xxx/... → ~/...
   for (const s of merged) {
-    if (s.project.startsWith(home)) {
-      s.project = `~${s.project.slice(home.length)}`;
-    }
+    s.project = shortenPath(s.project, home);
   }
 
   // Check which project directories still exist on disk + are git repos
@@ -1716,9 +1714,7 @@ export async function startServer(
         // Normalize project paths
         const home = homedir();
         for (const s of merged) {
-          if (s.project.startsWith(home)) {
-            s.project = `~${s.project.slice(home.length)}`;
-          }
+          s.project = shortenPath(s.project, home);
         }
         lastDiscoveredMergedSessions = merged.map((session) => ({ ...session }));
 
@@ -2094,8 +2090,7 @@ export async function startServer(
       }
 
       const home = homedir();
-      const projectFor = (info: SessionInfo): string =>
-        info.project.startsWith(home) ? `~${info.project.slice(home.length)}` : info.project;
+      const projectFor = (info: SessionInfo): string => shortenPath(info.project, home);
 
       const watchers: FSWatcher[] = [];
       const watchedPaths = new Set<string>();
@@ -2790,9 +2785,7 @@ export async function startServer(
 
       const home = homedir();
       const rawProject = body.sessionProject || parsed.cwd;
-      const project = rawProject.startsWith(home)
-        ? `~${rawProject.slice(home.length)}`
-        : rawProject;
+      const project = shortenPath(rawProject, home);
       const gitRepo =
         resolved.value.sessionInfo?.gitRepo ||
         (resolved.value.sessionInfo?.location?.kind === "ssh"
@@ -2924,9 +2917,7 @@ export async function startServer(
         const paths = [...sessionInfo.filePaths, ...(sessionInfo.toolPaths || [])];
         const parsed = await provider.parse(paths, sessionInfo);
         const home = homedir();
-        const project = sessionInfo.project.startsWith(home)
-          ? `~${sessionInfo.project.slice(home.length)}`
-          : sessionInfo.project;
+        const project = shortenPath(sessionInfo.project, home);
 
         const replay = transformToReplay(parsed, providerName, project, {
           generator: {
@@ -4062,7 +4053,9 @@ export const __testables = {
   getStaleSourceProviders,
   findReplayForSource,
   isSameOriginSettingsRequest,
+  isFilesystemProjectKey,
   mergeSourceCatalogSessionUpdates,
+  normalizeSessionProjectsForHome,
   normalizeSourceSessionCatalogCache,
   pickSourceRecordForSession,
   providerSessionKey,

--- a/packages/cli/test/server-core.test.ts
+++ b/packages/cli/test/server-core.test.ts
@@ -1,5 +1,29 @@
+import { homedir } from "node:os";
 import { describe, expect, it } from "vitest";
-import { getErrorMessage, requireSlug, safeSlug } from "../src/server-core.js";
+import type { SessionInfo } from "@vibe-replay/provider-contract";
+import {
+  getErrorMessage,
+  requireSlug,
+  resolveGenerateInputs,
+  safeSlug,
+} from "../src/server-core.js";
+
+function session(project: string): SessionInfo {
+  return {
+    provider: "cursor",
+    sessionId: "session-1",
+    slug: "session-1",
+    project,
+    cwd: project,
+    version: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    lineCount: 1,
+    fileSize: 1,
+    filePath: "session.jsonl",
+    filePaths: ["session.jsonl"],
+    firstPrompt: "prompt",
+  };
+}
 
 describe("server core helpers", () => {
   it("accepts simple slugs and rejects path traversal", () => {
@@ -21,4 +45,25 @@ describe("server core helpers", () => {
     expect(getErrorMessage("plain failure")).toBe("plain failure");
     expect(getErrorMessage({ message: "not an Error" })).toBe("Unknown error");
   });
+
+  it.skipIf(process.platform !== "win32")(
+    "matches a Windows session project despite slash and casing differences",
+    () => {
+      const home = homedir();
+      const discovered = session("~/Code/vibe-replay");
+      const requestedProject = `${home.replaceAll("\\", "/").toLowerCase()}/Code/vibe-replay`;
+      const result = resolveGenerateInputs(
+        {
+          provider: "cursor",
+          filePaths: [],
+          toolPaths: [],
+          sessionSlug: "session-1",
+          sessionProject: requestedProject,
+        },
+        [discovered],
+      );
+
+      expect(result).toMatchObject({ ok: true, value: { sessionInfo: discovered } });
+    },
+  );
 });

--- a/packages/cli/test/server-project-path.test.ts
+++ b/packages/cli/test/server-project-path.test.ts
@@ -1,0 +1,39 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "@vibe-replay/provider-contract";
+import { __testables } from "../src/server.js";
+
+function session(project: string): SessionInfo {
+  return {
+    provider: "cursor",
+    sessionId: "session-1",
+    slug: "session-1",
+    project,
+    cwd: project,
+    version: "",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    lineCount: 1,
+    fileSize: 1,
+    filePath: "session.jsonl",
+    filePaths: ["session.jsonl"],
+    firstPrompt: "prompt",
+  };
+}
+
+describe("server project path normalization", () => {
+  it.skipIf(process.platform !== "win32")(
+    "redacts Windows home paths regardless of separator or casing",
+    () => {
+      const home = homedir();
+      const project = `${home.replaceAll("\\", "/").toLowerCase()}/Code/vibe-replay`;
+      const [normalized] = __testables.normalizeSessionProjectsForHome([session(project)], home);
+
+      expect(normalized.project).toBe("~/Code/vibe-replay");
+    },
+  );
+
+  it("recognizes both tilde separator styles as filesystem project keys", () => {
+    expect(__testables.isFilesystemProjectKey("~/Code/vibe-replay")).toBe(true);
+    expect(__testables.isFilesystemProjectKey("~\\Code\\vibe-replay")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Reuse the separator- and case-aware home-path helper when generating replays and normalizing dashboard/session projects.
- Match server generation requests against Windows project paths and recognize `~\...` project-memory keys.
- Add Windows-specific coverage for server normalization and project matching.

## Test plan
- `pnpm --filter vibe-replay exec vitest run test/server-project-path.test.ts test/server-core.test.ts` — 6 passed
- `pnpm --filter vibe-replay test` — 533 passed; the only two failures are the known local Git-symlink materialization assertions
- `pnpm --filter @vibe-replay/provider-core test` — 43 passed
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project path display by consistently shortening home-directory paths to `~`.
  * Improved Windows path matching across differences in slash direction and letter casing.
  * Recognized both Windows and Unix-style separators in shortened project paths.

* **Tests**
  * Added coverage for Windows-specific project path normalization and session matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->