### PR TITLE
feat(insights): visualize measured turn activity timing

### DIFF
--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -14,6 +14,7 @@ interface PendingTool {
   timestamp?: string;
   mcpServer?: string;
   mcpTool?: string;
+  durationAnchor?: "end";
 }
 
 interface ToolResult {
@@ -182,6 +183,7 @@ export function parseCodexLines(
             name: "exec_command",
             input: p.command || p.action || {},
             timestamp: obj.timestamp,
+            durationAnchor: "end",
           });
         }
         mergeToolResult(toolResults, p.call_id, {
@@ -451,6 +453,7 @@ export function parseCodexLines(
           ...(tr ? { _result: tr.result } : {}),
           ...(tr?.isError ? { _isError: true } : {}),
           ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
+          ...(tool.durationAnchor ? { _durationAnchor: tool.durationAnchor } : {}),
           ...(tool.mcpServer ? { _mcpServer: tool.mcpServer } : {}),
           ...(tool.mcpTool ? { _mcpTool: tool.mcpTool } : {}),
         },

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -150,6 +150,38 @@ describe("Codex parser", () => {
     });
   });
 
+  it("anchors an orphan exec completion duration at its result timestamp", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T05:10:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-orphan-exec", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T05:10:05.000Z",
+          type: "event_msg",
+          payload: {
+            type: "exec_command_end",
+            call_id: "orphan-exec",
+            aggregated_output: "done",
+            exit_code: 0,
+            duration: { secs: 5, nanos: 0 },
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      _durationMs: 5000,
+      _durationAnchor: "end",
+    });
+  });
+
   it("records malformed JSONL lines as parse warnings", () => {
     const result = parseCodexLines([...lines.slice(0, 2), "{not-json", ...lines.slice(2)]);
 

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -251,6 +251,8 @@ export type ContentBlock =
       _isError?: boolean;
       _subAgent?: SubAgent;
       _durationMs?: number;
+      /** Whether the internal duration is anchored at the tool start or result timestamp. */
+      _durationAnchor?: "start" | "end";
       _isPendingMarker?: boolean;
       /** Provider attribution retained for usage indexing; omitted from replay output. */
       _mcpServer?: string;

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -255,6 +255,7 @@ export function transformToReplay(
         scene.isError = !!block._isError;
         scene.hasResult = block._hasResult ?? block._result !== undefined;
         if (block._durationMs) scene.durationMs = block._durationMs;
+        if (block._durationAnchor) scene.durationAnchor = block._durationAnchor;
         // Attach subagent data for Agent tool calls
         if (block.name === "Agent" && block._subAgent) {
           const sa = block._subAgent;
@@ -725,6 +726,7 @@ function redactSubAgentScene(s: Scene): Scene {
       timestamp: s.timestamp,
       isError: s.isError || false,
       ...(s.durationMs ? { durationMs: s.durationMs } : {}),
+      ...(s.durationAnchor ? { durationAnchor: s.durationAnchor } : {}),
       ...(resultTokens > 0 ? { resultTokens } : {}),
     };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -204,6 +204,8 @@ export type Scene =
       subAgent?: SubAgent;
       /** Tool execution duration in ms (assistant timestamp → tool_result timestamp) */
       durationMs?: number;
+      /** Whether durationMs is anchored at the tool start or result timestamp. */
+      durationAnchor?: "start" | "end";
       /**
        * Estimated tokens of the tool result that was injected back into the
        * model's context (chars/4 heuristic on the un-truncated result).

--- a/packages/viewer/src/components/Controls.tsx
+++ b/packages/viewer/src/components/Controls.tsx
@@ -15,6 +15,8 @@ interface Props {
   onOpenSearch: () => void;
   onOpenOutline?: () => void;
   onShowHelp?: () => void;
+  /** Reserve room for the fixed Ask Replay launcher in editor mode. */
+  reserveAssistantSpace?: boolean;
 }
 
 const SPEEDS = [1, 5, 10];
@@ -33,6 +35,7 @@ export default function Controls({
   onOpenSearch,
   onOpenOutline,
   onShowHelp,
+  reserveAssistantSpace = false,
 }: Props) {
   const isPlaying = state === "playing";
   const playIcon = isPlaying ? "\u23F8" : "\u25B6";
@@ -56,7 +59,11 @@ export default function Controls({
   return (
     <>
       {/* Mobile controls — evenly distributed */}
-      <div className="flex md:hidden items-center justify-between px-3 py-1.5">
+      <div
+        className={`flex md:hidden items-center justify-between py-1.5 pl-3 ${
+          reserveAssistantSpace ? "pr-20" : "pr-3"
+        }`}
+      >
         <button
           onClick={() => {
             flash("play");
@@ -157,7 +164,11 @@ export default function Controls({
       </div>
 
       {/* Desktop controls */}
-      <div className="hidden md:flex items-center justify-between px-5 py-2.5">
+      <div
+        className={`hidden md:flex items-center justify-between py-2.5 pl-5 ${
+          reserveAssistantSpace ? "pr-32" : "pr-5"
+        }`}
+      >
         <div className="flex items-center gap-2">
           <button
             onClick={() => {

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1559,7 +1559,7 @@ function ReplayCard({
         )}
         {compactionCount > 0 && (
           <span
-            className="text-terminal-orange"
+            className="text-terminal-context"
             title={`${compactionCount} context compaction${compactionCount !== 1 ? "s" : ""}`}
           >
             {compactionCount} compact{compactionCount !== 1 ? "s" : ""}
@@ -3252,7 +3252,7 @@ function SessionsPanel() {
             onClick={handleToggleCompactionsOnly}
             className={`w-full rounded-lg px-3 py-2.5 text-left text-sm font-sans shadow-layer-sm transition-colors ${
               compactionsOnly
-                ? "bg-terminal-orange-subtle text-terminal-orange"
+                ? "bg-terminal-context-subtle text-terminal-context"
                 : "bg-terminal-surface text-terminal-dim"
             }`}
           >
@@ -3918,7 +3918,7 @@ function SessionsPanel() {
                       )}
                       {compactionCount > 0 && (
                         <span
-                          className="text-terminal-orange"
+                          className="text-terminal-context"
                           title={`${compactionCount} context compaction${compactionCount !== 1 ? "s" : ""}`}
                         >
                           {compactionCount} compact{compactionCount !== 1 ? "s" : ""}
@@ -4978,7 +4978,7 @@ function ReplaysPanel() {
             onClick={handleToggleCompactionsOnly}
             className={`w-full rounded-lg px-3 py-2.5 text-left text-sm font-sans shadow-layer-sm transition-colors ${
               compactionsOnly
-                ? "bg-terminal-orange-subtle text-terminal-orange"
+                ? "bg-terminal-context-subtle text-terminal-context"
                 : "bg-terminal-surface text-terminal-dim"
             }`}
           >

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -149,8 +149,12 @@ export function TokenBreakdownChart({
     turnCount && turnCount > 0 ? breakdown.output / turnCount : undefined;
 
   return (
-    <div className="space-y-4">
-      <div className="h-4 rounded-full bg-terminal-surface-2 overflow-hidden flex">
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-[10px] font-mono text-terminal-dimmer">
+        <span>Total</span>
+        <span className="font-bold text-terminal-text">{formatTokenCount(total)}</span>
+      </div>
+      <div className="h-3 rounded-full bg-terminal-surface-2 overflow-hidden flex">
         {visibleItems.map((item) => (
           <div
             key={item.key}
@@ -159,46 +163,23 @@ export function TokenBreakdownChart({
           />
         ))}
       </div>
-      <div className="grid grid-cols-2 gap-2 border-y border-terminal-border/20 py-3 sm:grid-cols-4">
-        <div title="Uncached input + cache writes. Providers do not expose a universal miss counter.">
-          <div className="text-[11px] font-mono font-bold text-terminal-context">
-            {formatTokenCount(tokenMetrics.cacheMissTokens)}
-          </div>
-          <div className="text-[10px] font-mono text-terminal-dimmer">uncached / miss</div>
-        </div>
-        <div title="Input + cache read + cache write tokens for the prompt context.">
-          <div className="text-[11px] font-mono font-bold text-terminal-user">
-            {formatTokenCount(tokenMetrics.promptTokens)}
-          </div>
-          <div className="text-[10px] font-mono text-terminal-dimmer">prompt footprint</div>
-        </div>
-        <div title="Tokens served from the provider cache.">
-          <div className="text-[11px] font-mono font-bold text-terminal-context">
-            {formatTokenCount(breakdown.cacheRead)}
-          </div>
-          <div className="text-[10px] font-mono text-terminal-dimmer">cache read</div>
-        </div>
-        <div title="Cache read divided by the prompt footprint; this is a cache-read share, not a provider billing guarantee.">
-          <div className="text-[11px] font-mono font-bold text-terminal-context">
-            {tokenMetrics.cacheReadShare !== undefined
-              ? `${Math.round(tokenMetrics.cacheReadShare * 1000) / 10}%`
-              : "—"}
-          </div>
-          <div className="text-[10px] font-mono text-terminal-dimmer">read share</div>
-        </div>
-      </div>
-      <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-4">
         {items.map((item) => (
-          <div key={item.key} className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <div className={`w-2.5 h-2.5 rounded-sm ${item.color}`} style={{ opacity: 0.7 }} />
-              <span className="text-[11px] font-mono text-terminal-dim">{item.label}</span>
+          <div
+            key={item.key}
+            className="min-w-0"
+            title={`${item.label}: ${formatTokenCount(item.value)} (${item.pct.toFixed(1)}%)`}
+          >
+            <div className="flex items-center gap-1.5">
+              <div
+                className={`h-2 w-2 shrink-0 rounded-sm ${item.color}`}
+                style={{ opacity: 0.7 }}
+              />
+              <span className="truncate text-[10px] font-mono text-terminal-dim">{item.label}</span>
             </div>
-            <div className="flex items-center gap-3">
-              <span className="text-[11px] font-mono text-terminal-text tabular-nums">
-                {formatTokenCount(item.value)}
-              </span>
-              <span className="text-[10px] font-mono text-terminal-dimmer tabular-nums w-10 text-right">
+            <div className="mt-0.5 text-[11px] font-mono text-terminal-text tabular-nums">
+              {formatTokenCount(item.value)}
+              <span className="ml-1 text-[9px] text-terminal-dimmer">
                 {item.value === 0
                   ? "0%"
                   : item.pct < 0.1
@@ -212,27 +193,15 @@ export function TokenBreakdownChart({
         ))}
       </div>
       {averagePromptPerTurn !== undefined && averageOutputPerTurn !== undefined && (
-        <div className="grid grid-cols-2 gap-2 rounded-lg border border-terminal-border/20 bg-terminal-surface-2/40 px-3 py-2.5">
-          <div title="Aggregate prompt footprint divided by recorded turns.">
-            <div className="text-[11px] font-mono font-bold text-terminal-context">
-              ~{formatTokenCount(averagePromptPerTurn)}
-            </div>
-            <div className="text-[9px] font-mono text-terminal-dimmer">prompt / turn</div>
-          </div>
-          <div title="Aggregate output tokens divided by recorded turns.">
-            <div className="text-[11px] font-mono font-bold text-terminal-response">
-              ~{formatTokenCount(averageOutputPerTurn)}
-            </div>
-            <div className="text-[9px] font-mono text-terminal-dimmer">output / turn</div>
-          </div>
+        <div className="flex gap-3 text-[9px] font-mono text-terminal-dimmer">
+          <span title="Aggregate prompt footprint divided by recorded turns.">
+            ~{formatTokenCount(averagePromptPerTurn)} prompt/turn
+          </span>
+          <span title="Aggregate output tokens divided by recorded turns.">
+            ~{formatTokenCount(averageOutputPerTurn)} output/turn
+          </span>
         </div>
       )}
-      <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
-        <span className="text-[10px] font-mono text-terminal-dimmer">Total</span>
-        <span className="text-[11px] font-mono text-terminal-text font-bold tabular-nums">
-          {formatTokenCount(total)}
-        </span>
-      </div>
     </div>
   );
 }

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -41,7 +41,7 @@ export function TurnDurationChart({ histogram }: { histogram: TurnDurationHistog
               <div className="absolute bottom-full mb-1 hidden group-hover:block z-10">
                 <div className="bg-terminal-surface-2 border border-terminal-border-subtle rounded-lg px-2 py-1 shadow-layer-md whitespace-nowrap">
                   <div className="text-[10px] font-mono text-terminal-dim">{bucket.label}</div>
-                  <div className="text-[10px] font-mono text-terminal-green font-bold">
+                  <div className="text-[10px] font-mono text-terminal-response font-bold">
                     {bucket.count} turn{bucket.count !== 1 ? "s" : ""} ({bucket.pct}%)
                   </div>
                 </div>
@@ -52,7 +52,7 @@ export function TurnDurationChart({ histogram }: { histogram: TurnDurationHistog
                 </div>
               )}
               <div
-                className="w-full rounded-md bg-terminal-green hover:opacity-90 transition-all"
+                className="w-full rounded-md bg-gradient-to-t from-terminal-response to-terminal-context hover:opacity-90 transition-all"
                 style={{
                   height: `${heightPct}%`,
                   minHeight: bucket.count > 0 ? "4px" : "0",
@@ -100,15 +100,18 @@ export function TurnDurationChart({ histogram }: { histogram: TurnDurationHistog
           {histogram.totalTurns.toLocaleString()} turns
         </span>
       </div>
+      <div className="text-[9px] font-mono text-terminal-dimmer">
+        Timing quality varies by provider; this combines recorded and estimated turn durations.
+      </div>
     </div>
   );
 }
 
 const TOKEN_COLORS = [
-  { key: "cacheRead", label: "Cache Read", color: "bg-terminal-purple" },
-  { key: "cacheCreation", label: "Cache Write", color: "bg-terminal-orange" },
-  { key: "output", label: "Output", color: "bg-terminal-green" },
-  { key: "input", label: "Input (uncached)", color: "bg-terminal-blue" },
+  { key: "cacheRead", label: "Cache Read", color: "bg-terminal-context" },
+  { key: "cacheCreation", label: "Cache Write", color: "bg-terminal-context-emphasis" },
+  { key: "output", label: "Output", color: "bg-terminal-response" },
+  { key: "input", label: "Input (uncached)", color: "bg-terminal-user" },
 ] as const;
 
 function formatTokenCount(value: number): string {
@@ -117,7 +120,14 @@ function formatTokenCount(value: number): string {
   return value.toString();
 }
 
-export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownData }) {
+export function TokenBreakdownChart({
+  breakdown,
+  turnCount,
+}: {
+  breakdown: TokenBreakdownData;
+  /** Number of recorded turns used to calculate the optional average. */
+  turnCount?: number;
+}) {
   const total = breakdown.input + breakdown.output + breakdown.cacheRead + breakdown.cacheCreation;
   if (total === 0) return null;
   const tokenMetrics = deriveTokenUsageMetrics({
@@ -133,6 +143,10 @@ export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownDa
     pct: (breakdown[token.key] / total) * 100,
   }));
   const visibleItems = items.filter((item) => item.value > 0);
+  const averagePromptPerTurn =
+    turnCount && turnCount > 0 ? tokenMetrics.promptTokens / turnCount : undefined;
+  const averageOutputPerTurn =
+    turnCount && turnCount > 0 ? breakdown.output / turnCount : undefined;
 
   return (
     <div className="space-y-4">
@@ -147,25 +161,25 @@ export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownDa
       </div>
       <div className="grid grid-cols-2 gap-2 border-y border-terminal-border/20 py-3 sm:grid-cols-4">
         <div title="Uncached input + cache writes. Providers do not expose a universal miss counter.">
-          <div className="text-[11px] font-mono font-bold text-terminal-orange">
+          <div className="text-[11px] font-mono font-bold text-terminal-context">
             {formatTokenCount(tokenMetrics.cacheMissTokens)}
           </div>
           <div className="text-[10px] font-mono text-terminal-dimmer">uncached / miss</div>
         </div>
         <div title="Input + cache read + cache write tokens for the prompt context.">
-          <div className="text-[11px] font-mono font-bold text-terminal-blue">
+          <div className="text-[11px] font-mono font-bold text-terminal-user">
             {formatTokenCount(tokenMetrics.promptTokens)}
           </div>
           <div className="text-[10px] font-mono text-terminal-dimmer">prompt footprint</div>
         </div>
         <div title="Tokens served from the provider cache.">
-          <div className="text-[11px] font-mono font-bold text-terminal-purple">
+          <div className="text-[11px] font-mono font-bold text-terminal-context">
             {formatTokenCount(breakdown.cacheRead)}
           </div>
           <div className="text-[10px] font-mono text-terminal-dimmer">cache read</div>
         </div>
         <div title="Cache read divided by the prompt footprint; this is a cache-read share, not a provider billing guarantee.">
-          <div className="text-[11px] font-mono font-bold text-terminal-green">
+          <div className="text-[11px] font-mono font-bold text-terminal-context">
             {tokenMetrics.cacheReadShare !== undefined
               ? `${Math.round(tokenMetrics.cacheReadShare * 1000) / 10}%`
               : "—"}
@@ -197,6 +211,22 @@ export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownDa
           </div>
         ))}
       </div>
+      {averagePromptPerTurn !== undefined && averageOutputPerTurn !== undefined && (
+        <div className="grid grid-cols-2 gap-2 rounded-lg border border-terminal-border/20 bg-terminal-surface-2/40 px-3 py-2.5">
+          <div title="Aggregate prompt footprint divided by recorded turns.">
+            <div className="text-[11px] font-mono font-bold text-terminal-context">
+              ~{formatTokenCount(averagePromptPerTurn)}
+            </div>
+            <div className="text-[9px] font-mono text-terminal-dimmer">prompt / turn</div>
+          </div>
+          <div title="Aggregate output tokens divided by recorded turns.">
+            <div className="text-[11px] font-mono font-bold text-terminal-response">
+              ~{formatTokenCount(averageOutputPerTurn)}
+            </div>
+            <div className="text-[9px] font-mono text-terminal-dimmer">output / turn</div>
+          </div>
+        </div>
+      )}
       <div className="flex items-center justify-between pt-2 border-t border-terminal-border/20">
         <span className="text-[10px] font-mono text-terminal-dimmer">Total</span>
         <span className="text-[11px] font-mono text-terminal-text font-bold tabular-nums">

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -1,5 +1,3 @@
-import { deriveTokenUsageMetrics } from "@vibe-replay/types";
-
 export interface TurnDurationHistogramData {
   buckets: Array<{ label: string; count: number; pct: number }>;
   percentiles: { p50Ms: number; p75Ms: number; p90Ms: number };
@@ -120,33 +118,15 @@ function formatTokenCount(value: number): string {
   return value.toString();
 }
 
-export function TokenBreakdownChart({
-  breakdown,
-  turnCount,
-}: {
-  breakdown: TokenBreakdownData;
-  /** Number of recorded turns used to calculate the optional average. */
-  turnCount?: number;
-}) {
+export function TokenBreakdownChart({ breakdown }: { breakdown: TokenBreakdownData }) {
   const total = breakdown.input + breakdown.output + breakdown.cacheRead + breakdown.cacheCreation;
   if (total === 0) return null;
-  const tokenMetrics = deriveTokenUsageMetrics({
-    inputTokens: breakdown.input,
-    outputTokens: breakdown.output,
-    cacheReadTokens: breakdown.cacheRead,
-    cacheCreationTokens: breakdown.cacheCreation,
-  });
-
   const items = TOKEN_COLORS.map((token) => ({
     ...token,
     value: breakdown[token.key],
     pct: (breakdown[token.key] / total) * 100,
   }));
   const visibleItems = items.filter((item) => item.value > 0);
-  const averagePromptPerTurn =
-    turnCount && turnCount > 0 ? tokenMetrics.promptTokens / turnCount : undefined;
-  const averageOutputPerTurn =
-    turnCount && turnCount > 0 ? breakdown.output / turnCount : undefined;
 
   return (
     <div className="space-y-3">
@@ -192,16 +172,6 @@ export function TokenBreakdownChart({
           </div>
         ))}
       </div>
-      {averagePromptPerTurn !== undefined && averageOutputPerTurn !== undefined && (
-        <div className="flex gap-3 text-[9px] font-mono text-terminal-dimmer">
-          <span title="Aggregate prompt footprint divided by recorded turns.">
-            ~{formatTokenCount(averagePromptPerTurn)} prompt/turn
-          </span>
-          <span title="Aggregate output tokens divided by recorded turns.">
-            ~{formatTokenCount(averageOutputPerTurn)} output/turn
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -1110,6 +1110,7 @@ export default function Player({
               onOpenSearch={() => setSearchOpen(true)}
               onOpenOutline={() => setMobileDrawerOpen(true)}
               onShowHelp={() => setShowHelp(true)}
+              reserveAssistantSpace={viewerMode === "editor"}
             />
           </div>
         )}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -313,10 +313,8 @@ export default function SummaryView({ session }: Props) {
   }, [scenes, meta]);
 
   const hasTurnStats = meta.stats.turnStats && meta.stats.turnStats.length > 1;
-  const recordedTurnCount = useMemo(
-    () => new Set(meta.stats.turnStats?.map((turn) => turn.turnIndex)).size,
-    [meta.stats.turnStats],
-  );
+  const hasTokenUsage =
+    !!stats.tokenUsage && Object.values(stats.tokenUsage).some((value) => value > 0);
   // Build turn labels (user prompt snippets) for chart tooltips
   const turnLabels = useMemo(
     () => stats.turns.map((t) => t.text.slice(0, 60) + (t.text.length > 60 ? "…" : "")),
@@ -563,23 +561,22 @@ export default function SummaryView({ session }: Props) {
 
         {/* === Time Series Charts (grouped) === */}
         <TurnActivityTimeline scenes={scenes} />
+        {hasTokenUsage && (
+          <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
+            <div className="ui-section-title-strong mb-3">Tokens</div>
+            <TokenBreakdownChart
+              breakdown={{
+                input: stats.tokenUsage!.inputTokens,
+                output: stats.tokenUsage!.outputTokens,
+                cacheRead: stats.tokenUsage!.cacheReadTokens,
+                cacheCreation: stats.tokenUsage!.cacheCreationTokens,
+              }}
+            />
+          </div>
+        )}
         {hasTurnStats && (
           <div className="space-y-5">
             <div className="ui-section-title">Per-Turn Metrics</div>
-            {stats.tokenUsage && recordedTurnCount > 0 && (
-              <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
-                <div className="ui-section-title-strong mb-3">Tokens</div>
-                <TokenBreakdownChart
-                  breakdown={{
-                    input: stats.tokenUsage.inputTokens,
-                    output: stats.tokenUsage.outputTokens,
-                    cacheRead: stats.tokenUsage.cacheReadTokens,
-                    cacheCreation: stats.tokenUsage.cacheCreationTokens,
-                  }}
-                  turnCount={recordedTurnCount}
-                />
-              </div>
-            )}
             <TokenBurnCurve
               turnStats={meta.stats.turnStats!}
               costEstimate={meta.stats.costEstimate}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -562,7 +562,7 @@ export default function SummaryView({ session }: Props) {
         </div>
 
         {/* === Time Series Charts (grouped) === */}
-        <TurnActivityTimeline scenes={scenes} turnStats={meta.stats.turnStats} />
+        <TurnActivityTimeline scenes={scenes} />
         {hasTurnStats && (
           <div className="space-y-5">
             <div className="ui-section-title">Per-Turn Metrics</div>

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -16,7 +16,9 @@ import {
   getSessionDataQualityNotes,
   getSessionMetricQuality,
 } from "./DataQualityIndicator";
+import { TokenBreakdownChart } from "./InsightCharts";
 import { fmtNum, formatDuration, StatCard } from "./StatsPanel";
+import TurnActivityTimeline from "./TurnActivityTimeline";
 
 interface Props {
   session: ReplaySession;
@@ -311,6 +313,10 @@ export default function SummaryView({ session }: Props) {
   }, [scenes, meta]);
 
   const hasTurnStats = meta.stats.turnStats && meta.stats.turnStats.length > 1;
+  const recordedTurnCount = useMemo(
+    () => new Set(meta.stats.turnStats?.map((turn) => turn.turnIndex)).size,
+    [meta.stats.turnStats],
+  );
   // Build turn labels (user prompt snippets) for chart tooltips
   const turnLabels = useMemo(
     () => stats.turns.map((t) => t.text.slice(0, 60) + (t.text.length > 60 ? "…" : "")),
@@ -556,9 +562,27 @@ export default function SummaryView({ session }: Props) {
         </div>
 
         {/* === Time Series Charts (grouped) === */}
+        <TurnActivityTimeline scenes={scenes} turnStats={meta.stats.turnStats} />
         {hasTurnStats && (
           <div className="space-y-5">
             <div className="ui-section-title">Per-Turn Metrics</div>
+            {stats.tokenUsage && recordedTurnCount > 0 && (
+              <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
+                <div className="ui-section-title-strong mb-1">Turn Token Footprint</div>
+                <p className="mb-4 text-[10px] font-mono text-terminal-dimmer">
+                  Aggregate token usage with average prompt and output per recorded turn.
+                </p>
+                <TokenBreakdownChart
+                  breakdown={{
+                    input: stats.tokenUsage.inputTokens,
+                    output: stats.tokenUsage.outputTokens,
+                    cacheRead: stats.tokenUsage.cacheReadTokens,
+                    cacheCreation: stats.tokenUsage.cacheCreationTokens,
+                  }}
+                  turnCount={recordedTurnCount}
+                />
+              </div>
+            )}
             <TokenBurnCurve
               turnStats={meta.stats.turnStats!}
               costEstimate={meta.stats.costEstimate}

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -568,10 +568,7 @@ export default function SummaryView({ session }: Props) {
             <div className="ui-section-title">Per-Turn Metrics</div>
             {stats.tokenUsage && recordedTurnCount > 0 && (
               <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
-                <div className="ui-section-title-strong mb-1">Turn Token Footprint</div>
-                <p className="mb-4 text-[10px] font-mono text-terminal-dimmer">
-                  Aggregate token usage with average prompt and output per recorded turn.
-                </p>
+                <div className="ui-section-title-strong mb-3">Tokens</div>
                 <TokenBreakdownChart
                   breakdown={{
                     input: stats.tokenUsage.inputTokens,

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -62,6 +62,11 @@ function formatActivityPercent(value: number, total: number): string {
   return percent < 1 ? "<1%" : `${Math.round(percent)}%`;
 }
 
+function boundaryStyle(elapsedMs: number, totalMs: number): { left?: string; right?: number } {
+  if (totalMs <= 0 || elapsedMs >= totalMs) return { right: 0 };
+  return { left: `${Math.max(0, (elapsedMs / totalMs) * 100)}%` };
+}
+
 function intervalTitle(interval: ActivityInterval): string {
   const meta = ACTIVITY_META[interval.kind];
   const source =
@@ -125,7 +130,7 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         `${ACTIVITY_META[kind].label}: ${formatActivityDuration(durationMs)}`,
     ),
     `Compaction/context boundaries: ${timing.contextBoundaries.length}`,
-    `${timing.thinkingCount} thinking blocks folded into model activity`,
+    `${timing.thinkingCount} thinking blocks included in LLM wait; no separate duration persisted`,
   ].join(". ");
 
   return (
@@ -174,9 +179,7 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
               key={`context-${boundary.sceneIndex}`}
               aria-hidden="true"
               className="absolute inset-y-0 w-0.5 bg-terminal-context"
-              style={{
-                left: `${timing.totalMs > 0 ? (boundary.elapsedMs / timing.totalMs) * 100 : 0}%`,
-              }}
+              style={boundaryStyle(boundary.elapsedMs, timing.totalMs)}
               title={
                 boundary.type === "compaction-summary" && boundary.durationMs !== undefined
                   ? `Compaction boundary; ~${formatActivityDuration(boundary.durationMs)} estimated from the preceding timestamp gap`
@@ -225,10 +228,15 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="h-2 w-2 shrink-0 rounded-sm bg-terminal-thinking" />
-            <span className="truncate text-[10px] font-mono text-terminal-thinking">Thinking</span>
+            <span
+              className="truncate text-[10px] font-mono text-terminal-thinking"
+              title="Thinking blocks are included in LLM wait; their separate wall-clock duration is not persisted."
+            >
+              Thinking blocks
+            </span>
           </div>
           <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
-            {timing.thinkingCount > 0 ? `${timing.thinkingCount} folded` : "—"}
+            {timing.thinkingCount > 0 ? `${timing.thinkingCount} blocks` : "—"}
           </div>
         </div>
       </div>

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -12,7 +12,6 @@ const ACTIVITY_META: Record<
   TimedActivityKind,
   { label: string; color: string; textColor: string }
 > = {
-  "user-idle": { label: "User / idle", color: "bg-terminal-user", textColor: "text-terminal-user" },
   "llm-wait": {
     label: "LLM wait",
     color: "bg-terminal-response",
@@ -126,8 +125,8 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         <div>
           <div className="ui-section-title-strong">Activity timeline</div>
           <p id={descriptionId} className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-            Timestamp gaps and provider-recorded tool runtimes, left to right. Gap roles are
-            inferred; exact TTFT and compaction duration are not persisted.
+            Timestamp gaps and provider-recorded tool runtimes, excluding user idle, left to right.
+            Gap roles are inferred; exact TTFT and compaction duration are not persisted.
           </p>
         </div>
         {timing.totalMs > 0 && (

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -1,63 +1,44 @@
-import { useMemo } from "react";
-import { sceneDuration } from "../engine/scene-timing";
-import type { Scene, TurnStat } from "../types";
+import { useId, useMemo } from "react";
+import {
+  buildActivityTiming,
+  type ActivityInterval,
+  type ToolCategory,
+} from "../engine/activity-timing";
+import type { Scene } from "../types";
 
-type ActivityKind = "user" | "tool" | "response" | "context" | "thinking";
+type TimedActivityKind = ActivityInterval["kind"];
 
-interface ActivitySegment {
-  kind: Exclude<ActivityKind, "thinking">;
-  durationMs: number;
-  sceneIndex: number;
-  recorded: boolean;
-}
-
-interface ActivityTotal {
-  durationMs: number;
-  count: number;
-  recordedMs: number;
-  estimatedMs: number;
-}
-
-interface ContextMarker {
-  sceneIndex: number;
-  elapsedMs: number;
-}
-
-const ACTIVITY_META: Record<ActivityKind, { label: string; color: string; textColor: string }> = {
-  user: { label: "User / idle", color: "bg-terminal-user", textColor: "text-terminal-user" },
-  tool: { label: "Tool execution", color: "bg-terminal-tool", textColor: "text-terminal-tool" },
-  response: {
-    label: "LLM wait / response",
+const ACTIVITY_META: Record<
+  TimedActivityKind,
+  { label: string; color: string; textColor: string }
+> = {
+  "user-idle": { label: "User / idle", color: "bg-terminal-user", textColor: "text-terminal-user" },
+  "llm-wait": {
+    label: "LLM wait",
     color: "bg-terminal-response",
     textColor: "text-terminal-response",
   },
-  context: {
-    label: "Compaction / context",
-    color: "bg-terminal-context",
-    textColor: "text-terminal-context",
+  response: {
+    label: "Response / generation",
+    color: "bg-terminal-response-emphasis",
+    textColor: "text-terminal-response",
   },
-  thinking: {
-    label: "Thinking",
-    color: "bg-terminal-thinking",
-    textColor: "text-terminal-thinking",
+  tool: { label: "Tool execution", color: "bg-terminal-tool", textColor: "text-terminal-tool" },
+  unknown: {
+    label: "Unattributed gap",
+    color: "bg-terminal-surface-2",
+    textColor: "text-terminal-dim",
   },
 };
 
-function emptyTotals(): Record<ActivityKind, ActivityTotal> {
-  return {
-    user: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
-    tool: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
-    response: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
-    context: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
-    thinking: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
-  };
-}
-
-function timestampMs(scene: Scene): number | undefined {
-  if (!scene.timestamp) return undefined;
-  const parsed = Date.parse(scene.timestamp);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
+const TOOL_CATEGORY_LABELS: Record<ToolCategory, string> = {
+  test: "test",
+  lint: "lint",
+  build: "build",
+  check: "check",
+  file: "file",
+  other: "other",
+};
 
 function formatActivityDuration(durationMs: number): string {
   if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
@@ -77,144 +58,130 @@ function formatActivityPercent(value: number, total: number): string {
   return percent < 1 ? "<1%" : `${Math.round(percent)}%`;
 }
 
-function addTotal(
-  totals: Record<ActivityKind, ActivityTotal>,
-  kind: ActivityKind,
-  durationMs: number,
-  recorded: boolean,
-): void {
-  totals[kind].durationMs += durationMs;
-  totals[kind].count++;
-  if (recorded) totals[kind].recordedMs += durationMs;
-  else totals[kind].estimatedMs += durationMs;
+function intervalTitle(interval: ActivityInterval): string {
+  const meta = ACTIVITY_META[interval.kind];
+  const source =
+    interval.source === "tool-duration"
+      ? "provider-recorded tool duration"
+      : interval.note === "context-boundary"
+        ? "timestamp gap before context boundary; compaction duration unknown"
+        : interval.note === "unmeasured-tool"
+          ? "timestamp gap includes a tool with no recorded duration"
+          : "timestamp gap; activity role inferred";
+  const tool = interval.toolName
+    ? ` · ${interval.toolName}${interval.toolCategory ? ` (${TOOL_CATEGORY_LABELS[interval.toolCategory]})` : ""}`
+    : "";
+  return `${meta.label} · ${formatActivityDuration(interval.durationMs)}${tool} · ${source}`;
 }
 
-export default function TurnActivityTimeline({
-  scenes,
-  turnStats,
-}: {
-  scenes: readonly Scene[];
-  turnStats?: readonly TurnStat[];
-}) {
-  const { segments, totals, totalMs, measuredMs, contextMarkers, thinkingCount, turnOverheadMs } =
-    useMemo(() => {
-      const nextTotals = emptyTotals();
-      const nextSegments: ActivitySegment[] = [];
-      const nextContextMarkers: ContextMarker[] = [];
-      let cursorMs: number | undefined;
-      let measuredMs = 0;
-      let elapsedMs = 0;
-      let thinkingCount = 0;
+function categorySummary(
+  category: ToolCategory,
+  durationMs: number,
+  count: number,
+): string | undefined {
+  if (count === 0) return undefined;
+  return `${TOOL_CATEGORY_LABELS[category]} ${formatActivityDuration(durationMs)}`;
+}
 
-      const addSegment = (
-        kind: Exclude<ActivityKind, "thinking">,
-        durationMs: number,
-        sceneIndex: number,
-        recorded: boolean,
-      ) => {
-        const safeDurationMs = Math.max(1, durationMs);
-        nextSegments.push({ kind, durationMs: safeDurationMs, sceneIndex, recorded });
-        addTotal(nextTotals, kind, safeDurationMs, recorded);
-        elapsedMs += safeDurationMs;
-        if (recorded) measuredMs += safeDurationMs;
-      };
+export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scene[] }) {
+  const descriptionId = useId();
+  const timing = useMemo(() => buildActivityTiming(scenes), [scenes]);
+  const visibleKinds = useMemo(
+    () =>
+      (Object.keys(ACTIVITY_META) as TimedActivityKind[]).filter((kind) =>
+        timing.intervals.some((interval) => interval.kind === kind),
+      ),
+    [timing.intervals],
+  );
+  const toolCategorySummaries = (Object.keys(TOOL_CATEGORY_LABELS) as ToolCategory[])
+    .map((category) =>
+      categorySummary(
+        category,
+        timing.toolCategories[category].durationMs,
+        timing.toolCategories[category].count,
+      ),
+    )
+    .filter((summary): summary is string => summary !== undefined);
 
-      scenes.forEach((scene, sceneIndex) => {
-        const atMs = timestampMs(scene);
+  if (timing.totalMs <= 0 && timing.contextBoundaries.length === 0) return null;
 
-        // A gap ending at a user prompt is user idle/input time. A gap ending at
-        // an assistant event is model/network wait plus response generation; the
-        // persisted record does not expose exact first-token timing.
-        if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
-          const kind: Exclude<ActivityKind, "thinking"> =
-            scene.type === "user-prompt"
-              ? "user"
-              : scene.type === "compaction-summary" || scene.type === "context-injection"
-                ? "context"
-                : "response";
-          addSegment(kind, atMs - cursorMs, sceneIndex, true);
-        }
-
-        if (scene.type === "tool-call") {
-          const recorded = scene.durationMs !== undefined && scene.durationMs > 0;
-          const durationMs = recorded ? scene.durationMs! : sceneDuration(scene, 1);
-          addSegment("tool", durationMs, sceneIndex, recorded);
-          if (atMs !== undefined) {
-            const startMs = Math.max(cursorMs ?? atMs, atMs);
-            cursorMs = startMs + durationMs;
-          }
-        } else {
-          if (scene.type === "thinking") thinkingCount++;
-          if (scene.type === "compaction-summary" || scene.type === "context-injection") {
-            nextContextMarkers.push({ sceneIndex, elapsedMs });
-          }
-          if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
-        }
-      });
-
-      return {
-        segments: nextSegments,
-        totals: nextTotals,
-        totalMs: elapsedMs,
-        measuredMs,
-        contextMarkers: nextContextMarkers,
-        thinkingCount,
-        turnOverheadMs:
-          turnStats && turnStats.some((turn) => turn.durationMs !== undefined)
-            ? Math.max(
-                0,
-                turnStats.reduce((sum, turn) => sum + (turn.durationMs || 0), 0) -
-                  nextTotals.tool.recordedMs,
-              )
-            : undefined,
-      };
-    }, [scenes, turnStats]);
-
-  if (segments.length === 0 || totalMs <= 0) return null;
+  const totals = visibleKinds.map((kind) => ({
+    kind,
+    durationMs: timing.intervals
+      .filter((interval) => interval.kind === kind)
+      .reduce((sum, interval) => sum + interval.durationMs, 0),
+  }));
+  const accessibleSummary = [
+    ...totals.map(
+      ({ kind, durationMs }) =>
+        `${ACTIVITY_META[kind].label}: ${formatActivityDuration(durationMs)}`,
+    ),
+    `Compaction/context boundaries: ${timing.contextBoundaries.length}`,
+    `${timing.thinkingCount} thinking blocks folded into model activity`,
+  ].join(". ");
 
   return (
     <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="ui-section-title-strong">Activity timeline</div>
-          <p className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-            Recorded event gaps and tool runtimes, left to right. LLM wait is not exact TTFT.
+          <p id={descriptionId} className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+            Timestamp gaps and provider-recorded tool runtimes, left to right. Gap roles are
+            inferred; exact TTFT and compaction duration are not persisted.
           </p>
         </div>
-        <span className="shrink-0 text-[10px] font-mono text-terminal-dim tabular-nums">
-          {formatActivityDuration(totalMs)} timeline span
-        </span>
+        {timing.totalMs > 0 && (
+          <span className="shrink-0 text-[10px] font-mono text-terminal-dim tabular-nums">
+            {formatActivityDuration(timing.totalMs)} represented
+          </span>
+        )}
       </div>
 
-      <div
-        className="relative mt-4 flex h-5 overflow-hidden rounded-full bg-terminal-surface-2"
-        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- composite timeline visualization, not an image asset
-        role="img"
-        aria-label="Activity timeline showing user idle, tool execution, LLM wait, and context gaps"
-      >
-        {segments.map((segment) => (
-          <div
-            key={`${segment.sceneIndex}-${segment.kind}`}
-            className={`${ACTIVITY_META[segment.kind].color} min-w-0 transition-opacity hover:opacity-80`}
-            style={{ flex: `${segment.durationMs} 1 0%`, opacity: segment.recorded ? 0.9 : 0.35 }}
-            title={`${ACTIVITY_META[segment.kind].label} · ${formatActivityDuration(segment.durationMs)}${segment.recorded ? " · measured" : " · estimated tool fallback"}`}
-          />
-        ))}
-        {contextMarkers.map((marker) => (
-          <div
-            key={`context-${marker.sceneIndex}`}
-            className="absolute inset-y-0 w-0.5 bg-terminal-context"
-            style={{ left: `${totalMs > 0 ? (marker.elapsedMs / totalMs) * 100 : 0}%` }}
-            title="Compaction/context boundary; duration not persisted"
-          />
-        ))}
-      </div>
+      {timing.totalMs > 0 ? (
+        <div
+          className="relative mt-4 flex h-5 overflow-hidden rounded-full bg-terminal-surface-2"
+          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- composite timeline visualization, not an image asset
+          role="img"
+          aria-describedby={descriptionId}
+          aria-label="Activity timeline"
+        >
+          {timing.intervals.map((interval, index) => (
+            <div
+              key={`${interval.sceneIndex}-${interval.kind}-${index}`}
+              aria-hidden="true"
+              className={`${ACTIVITY_META[interval.kind].color} min-w-0 transition-opacity hover:opacity-80`}
+              style={{
+                flex: `${interval.durationMs} 1 0%`,
+                opacity: interval.confidence === "measured" ? 0.9 : 0.55,
+              }}
+              title={intervalTitle(interval)}
+            />
+          ))}
+          {timing.contextBoundaries.map((boundary) => (
+            <div
+              key={`context-${boundary.sceneIndex}`}
+              aria-hidden="true"
+              className="absolute inset-y-0 w-0.5 bg-terminal-context"
+              style={{
+                left: `${timing.totalMs > 0 ? (boundary.elapsedMs / timing.totalMs) * 100 : 0}%`,
+              }}
+              title={`${boundary.type === "compaction-summary" ? "Compaction" : "Context"} boundary; duration not persisted`}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-lg border border-terminal-context/30 bg-terminal-context-subtle/30 px-3 py-2 text-[10px] font-mono text-terminal-context">
+          Context boundaries were recorded, but no timestamp interval is available to size the
+          activity strip.
+        </div>
+      )}
 
-      <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-5">
-        {(Object.keys(ACTIVITY_META) as ActivityKind[]).map((kind) => {
+      <span className="sr-only">{accessibleSummary}</span>
+
+      <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-6">
+        {visibleKinds.map((kind) => {
           const meta = ACTIVITY_META[kind];
-          const total = totals[kind];
-          const hasTime = total.durationMs > 0;
+          const durationMs = totals.find((total) => total.kind === kind)?.durationMs || 0;
           return (
             <div key={kind} className="min-w-0">
               <div className="flex items-center gap-1.5">
@@ -224,36 +191,56 @@ export default function TurnActivityTimeline({
                 </span>
               </div>
               <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
-                {hasTime
-                  ? formatActivityDuration(total.durationMs)
-                  : kind === "context" && contextMarkers.length > 0
-                    ? "marker only"
-                    : kind === "thinking" && thinkingCount > 0
-                      ? "folded"
-                      : "—"}
-                {hasTime && (
-                  <span className="ml-1 text-[9px] text-terminal-dimmer">
-                    {formatActivityPercent(total.durationMs, totalMs)}
-                  </span>
-                )}
+                {formatActivityDuration(durationMs)}
+                <span className="ml-1 text-[9px] text-terminal-dimmer">
+                  {formatActivityPercent(durationMs, timing.totalMs)}
+                </span>
               </div>
             </div>
           );
         })}
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="h-2 w-2 shrink-0 rounded-sm bg-terminal-context" />
+            <span className="truncate text-[10px] font-mono text-terminal-context">
+              Compaction / context
+            </span>
+          </div>
+          <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
+            {timing.contextBoundaries.length > 0
+              ? `${timing.contextBoundaries.length} marker${timing.contextBoundaries.length === 1 ? "" : "s"}`
+              : "—"}
+          </div>
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="h-2 w-2 shrink-0 rounded-sm bg-terminal-thinking" />
+            <span className="truncate text-[10px] font-mono text-terminal-thinking">Thinking</span>
+          </div>
+          <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
+            {timing.thinkingCount > 0 ? `${timing.thinkingCount} folded` : "—"}
+          </div>
+        </div>
       </div>
 
       <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[9px] font-mono text-terminal-dimmer">
-        <span>{segments.length} timed segments</span>
-        <span>{totals.tool.count} tool calls</span>
-        <span>{formatActivityDuration(measuredMs)} timestamp/tool time</span>
-        {turnOverheadMs !== undefined && (
-          <span>{formatActivityDuration(turnOverheadMs)} non-tool turn overhead</span>
+        <span>{timing.intervals.length} timed segments</span>
+        <span>{timing.toolCalls} tool calls</span>
+        <span>{formatActivityDuration(timing.timestampGapMs)} from timestamp gaps</span>
+        <span>{formatActivityDuration(timing.toolDurationMs)} provider-recorded tool time</span>
+        {timing.localToolMs > 0 && (
+          <span>local tools {formatActivityDuration(timing.localToolMs)}</span>
         )}
-        {totals.tool.estimatedMs > 0 && (
-          <span>{formatActivityDuration(totals.tool.estimatedMs)} estimated tool fallback</span>
+        {timing.remoteToolMs > 0 && (
+          <span>remote tools {formatActivityDuration(timing.remoteToolMs)}</span>
         )}
-        {thinkingCount > 0 && <span>{thinkingCount} thinking blocks folded into LLM wait</span>}
-        {contextMarkers.length > 0 && <span>{contextMarkers.length} context boundaries</span>}
+        {toolCategorySummaries.length > 0 && <span>{toolCategorySummaries.join(" · ")}</span>}
+        {timing.unmeasuredToolCalls > 0 && (
+          <span>{timing.unmeasuredToolCalls} tool calls without recorded duration</span>
+        )}
+        {timing.contextBoundaries.length > 0 && (
+          <span>{timing.contextBoundaries.length} context boundaries (marker only)</span>
+        )}
       </div>
     </div>
   );

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -160,7 +160,11 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
               className={`${ACTIVITY_META[interval.kind].color} min-w-0 transition-opacity hover:opacity-80`}
               style={{
                 flex: `${interval.durationMs} 1 0%`,
-                opacity: interval.confidence === "measured" ? 0.9 : 0.55,
+                // Keep the context role on one cyan/teal color. Its estimate
+                // status is conveyed by the ~ label and tooltip instead of a
+                // second, dimmer teal shade.
+                opacity:
+                  interval.kind === "context" ? 1 : interval.confidence === "measured" ? 0.9 : 0.55,
               }}
               title={intervalTitle(interval)}
             />

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -23,6 +23,11 @@ const ACTIVITY_META: Record<
     textColor: "text-terminal-response",
   },
   tool: { label: "Tool execution", color: "bg-terminal-tool", textColor: "text-terminal-tool" },
+  context: {
+    label: "Compaction / context",
+    color: "bg-terminal-context",
+    textColor: "text-terminal-context",
+  },
   unknown: {
     label: "Unattributed gap",
     color: "bg-terminal-surface-2",
@@ -62,11 +67,13 @@ function intervalTitle(interval: ActivityInterval): string {
   const source =
     interval.source === "tool-duration"
       ? "provider-recorded tool duration"
-      : interval.note === "context-boundary"
-        ? "timestamp gap before context boundary; compaction duration unknown"
-        : interval.note === "unmeasured-tool"
-          ? "timestamp gap includes a tool with no recorded duration"
-          : "timestamp gap; activity role inferred";
+      : interval.note === "compaction-duration-estimate"
+        ? "timestamp gap to compaction record; duration estimated, start not persisted"
+        : interval.note === "context-boundary"
+          ? "timestamp gap before context boundary; compaction duration unknown"
+          : interval.note === "unmeasured-tool"
+            ? "timestamp gap includes a tool with no recorded duration"
+            : "timestamp gap; activity role inferred";
   const tool = interval.toolName
     ? ` · ${interval.toolName}${interval.toolCategory ? ` (${TOOL_CATEGORY_LABELS[interval.toolCategory]})` : ""}`
     : "";
@@ -85,13 +92,15 @@ function categorySummary(
 export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scene[] }) {
   const descriptionId = useId();
   const timing = useMemo(() => buildActivityTiming(scenes), [scenes]);
-  const visibleKinds = useMemo(
-    () =>
-      (Object.keys(ACTIVITY_META) as TimedActivityKind[]).filter((kind) =>
-        timing.intervals.some((interval) => interval.kind === kind),
-      ),
-    [timing.intervals],
-  );
+  const visibleKinds = useMemo(() => {
+    const kinds = (Object.keys(ACTIVITY_META) as TimedActivityKind[]).filter((kind) =>
+      timing.intervals.some((interval) => interval.kind === kind),
+    );
+    if (timing.contextBoundaries.length > 0 && !kinds.includes("context")) {
+      kinds.push("context");
+    }
+    return kinds;
+  }, [timing.contextBoundaries.length, timing.intervals]);
   const toolCategorySummaries = (Object.keys(TOOL_CATEGORY_LABELS) as ToolCategory[])
     .map((category) =>
       categorySummary(
@@ -126,7 +135,7 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
           <div className="ui-section-title-strong">Activity timeline</div>
           <p id={descriptionId} className="mt-1 text-[10px] font-mono text-terminal-dimmer">
             Timestamp gaps and provider-recorded tool runtimes, excluding user idle, left to right.
-            Gap roles are inferred; exact TTFT and compaction duration are not persisted.
+            Gap roles are inferred; compaction time is estimated from its preceding gap.
           </p>
         </div>
         {timing.totalMs > 0 && (
@@ -164,7 +173,11 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
               style={{
                 left: `${timing.totalMs > 0 ? (boundary.elapsedMs / timing.totalMs) * 100 : 0}%`,
               }}
-              title={`${boundary.type === "compaction-summary" ? "Compaction" : "Context"} boundary; duration not persisted`}
+              title={
+                boundary.type === "compaction-summary" && boundary.durationMs !== undefined
+                  ? `Compaction boundary; ~${formatActivityDuration(boundary.durationMs)} estimated from the preceding timestamp gap`
+                  : `${boundary.type === "compaction-summary" ? "Compaction" : "Context"} boundary; duration not persisted`
+              }
             />
           ))}
         </div>
@@ -181,6 +194,7 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         {visibleKinds.map((kind) => {
           const meta = ACTIVITY_META[kind];
           const durationMs = totals.find((total) => total.kind === kind)?.durationMs || 0;
+          const contextMarkerOnly = kind === "context" && durationMs === 0;
           return (
             <div key={kind} className="min-w-0">
               <div className="flex items-center gap-1.5">
@@ -190,27 +204,20 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
                 </span>
               </div>
               <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
-                {formatActivityDuration(durationMs)}
-                <span className="ml-1 text-[9px] text-terminal-dimmer">
-                  {formatActivityPercent(durationMs, timing.totalMs)}
-                </span>
+                {contextMarkerOnly
+                  ? `${timing.contextBoundaries.length} marker${timing.contextBoundaries.length === 1 ? "" : "s"}`
+                  : kind === "context"
+                    ? `~${formatActivityDuration(durationMs)}`
+                    : formatActivityDuration(durationMs)}
+                {!contextMarkerOnly && (
+                  <span className="ml-1 text-[9px] text-terminal-dimmer">
+                    {formatActivityPercent(durationMs, timing.totalMs)}
+                  </span>
+                )}
               </div>
             </div>
           );
         })}
-        <div className="min-w-0">
-          <div className="flex items-center gap-1.5">
-            <span className="h-2 w-2 shrink-0 rounded-sm bg-terminal-context" />
-            <span className="truncate text-[10px] font-mono text-terminal-context">
-              Compaction / context
-            </span>
-          </div>
-          <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
-            {timing.contextBoundaries.length > 0
-              ? `${timing.contextBoundaries.length} marker${timing.contextBoundaries.length === 1 ? "" : "s"}`
-              : "—"}
-          </div>
-        </div>
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <span className="h-2 w-2 shrink-0 rounded-sm bg-terminal-thinking" />
@@ -233,12 +240,19 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         {timing.remoteToolMs > 0 && (
           <span>remote tools {formatActivityDuration(timing.remoteToolMs)}</span>
         )}
+        {timing.compactionDurationMs > 0 && (
+          <span>
+            ~{formatActivityDuration(timing.compactionDurationMs)} estimated compaction time
+          </span>
+        )}
         {toolCategorySummaries.length > 0 && <span>{toolCategorySummaries.join(" · ")}</span>}
         {timing.unmeasuredToolCalls > 0 && (
           <span>{timing.unmeasuredToolCalls} tool calls without recorded duration</span>
         )}
         {timing.contextBoundaries.length > 0 && (
-          <span>{timing.contextBoundaries.length} context boundaries (marker only)</span>
+          <span>
+            {timing.contextBoundaries.length} context boundaries; exact start/end not persisted
+          </span>
         )}
       </div>
     </div>

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -1,0 +1,260 @@
+import { useMemo } from "react";
+import { sceneDuration } from "../engine/scene-timing";
+import type { Scene, TurnStat } from "../types";
+
+type ActivityKind = "user" | "tool" | "response" | "context" | "thinking";
+
+interface ActivitySegment {
+  kind: Exclude<ActivityKind, "thinking">;
+  durationMs: number;
+  sceneIndex: number;
+  recorded: boolean;
+}
+
+interface ActivityTotal {
+  durationMs: number;
+  count: number;
+  recordedMs: number;
+  estimatedMs: number;
+}
+
+interface ContextMarker {
+  sceneIndex: number;
+  elapsedMs: number;
+}
+
+const ACTIVITY_META: Record<ActivityKind, { label: string; color: string; textColor: string }> = {
+  user: { label: "User / idle", color: "bg-terminal-user", textColor: "text-terminal-user" },
+  tool: { label: "Tool execution", color: "bg-terminal-tool", textColor: "text-terminal-tool" },
+  response: {
+    label: "LLM wait / response",
+    color: "bg-terminal-response",
+    textColor: "text-terminal-response",
+  },
+  context: {
+    label: "Compaction / context",
+    color: "bg-terminal-context",
+    textColor: "text-terminal-context",
+  },
+  thinking: {
+    label: "Thinking",
+    color: "bg-terminal-thinking",
+    textColor: "text-terminal-thinking",
+  },
+};
+
+function emptyTotals(): Record<ActivityKind, ActivityTotal> {
+  return {
+    user: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
+    tool: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
+    response: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
+    context: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
+    thinking: { durationMs: 0, count: 0, recordedMs: 0, estimatedMs: 0 },
+  };
+}
+
+function timestampMs(scene: Scene): number | undefined {
+  if (!scene.timestamp) return undefined;
+  const parsed = Date.parse(scene.timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function formatActivityDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  const totalSeconds = Math.round(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function formatActivityPercent(value: number, total: number): string {
+  if (total <= 0 || value <= 0) return "0%";
+  const percent = (value / total) * 100;
+  return percent < 1 ? "<1%" : `${Math.round(percent)}%`;
+}
+
+function addTotal(
+  totals: Record<ActivityKind, ActivityTotal>,
+  kind: ActivityKind,
+  durationMs: number,
+  recorded: boolean,
+): void {
+  totals[kind].durationMs += durationMs;
+  totals[kind].count++;
+  if (recorded) totals[kind].recordedMs += durationMs;
+  else totals[kind].estimatedMs += durationMs;
+}
+
+export default function TurnActivityTimeline({
+  scenes,
+  turnStats,
+}: {
+  scenes: readonly Scene[];
+  turnStats?: readonly TurnStat[];
+}) {
+  const { segments, totals, totalMs, measuredMs, contextMarkers, thinkingCount, turnOverheadMs } =
+    useMemo(() => {
+      const nextTotals = emptyTotals();
+      const nextSegments: ActivitySegment[] = [];
+      const nextContextMarkers: ContextMarker[] = [];
+      let cursorMs: number | undefined;
+      let measuredMs = 0;
+      let elapsedMs = 0;
+      let thinkingCount = 0;
+
+      const addSegment = (
+        kind: Exclude<ActivityKind, "thinking">,
+        durationMs: number,
+        sceneIndex: number,
+        recorded: boolean,
+      ) => {
+        const safeDurationMs = Math.max(1, durationMs);
+        nextSegments.push({ kind, durationMs: safeDurationMs, sceneIndex, recorded });
+        addTotal(nextTotals, kind, safeDurationMs, recorded);
+        elapsedMs += safeDurationMs;
+        if (recorded) measuredMs += safeDurationMs;
+      };
+
+      scenes.forEach((scene, sceneIndex) => {
+        const atMs = timestampMs(scene);
+
+        // A gap ending at a user prompt is user idle/input time. A gap ending at
+        // an assistant event is model/network wait plus response generation; the
+        // persisted record does not expose exact first-token timing.
+        if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
+          const kind: Exclude<ActivityKind, "thinking"> =
+            scene.type === "user-prompt"
+              ? "user"
+              : scene.type === "compaction-summary" || scene.type === "context-injection"
+                ? "context"
+                : "response";
+          addSegment(kind, atMs - cursorMs, sceneIndex, true);
+        }
+
+        if (scene.type === "tool-call") {
+          const recorded = scene.durationMs !== undefined && scene.durationMs > 0;
+          const durationMs = recorded ? scene.durationMs! : sceneDuration(scene, 1);
+          addSegment("tool", durationMs, sceneIndex, recorded);
+          if (atMs !== undefined) {
+            const startMs = Math.max(cursorMs ?? atMs, atMs);
+            cursorMs = startMs + durationMs;
+          }
+        } else {
+          if (scene.type === "thinking") thinkingCount++;
+          if (scene.type === "compaction-summary" || scene.type === "context-injection") {
+            nextContextMarkers.push({ sceneIndex, elapsedMs });
+          }
+          if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
+        }
+      });
+
+      return {
+        segments: nextSegments,
+        totals: nextTotals,
+        totalMs: elapsedMs,
+        measuredMs,
+        contextMarkers: nextContextMarkers,
+        thinkingCount,
+        turnOverheadMs:
+          turnStats && turnStats.some((turn) => turn.durationMs !== undefined)
+            ? Math.max(
+                0,
+                turnStats.reduce((sum, turn) => sum + (turn.durationMs || 0), 0) -
+                  nextTotals.tool.recordedMs,
+              )
+            : undefined,
+      };
+    }, [scenes, turnStats]);
+
+  if (segments.length === 0 || totalMs <= 0) return null;
+
+  return (
+    <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="ui-section-title-strong">Activity timeline</div>
+          <p className="mt-1 text-[10px] font-mono text-terminal-dimmer">
+            Recorded event gaps and tool runtimes, left to right. LLM wait is not exact TTFT.
+          </p>
+        </div>
+        <span className="shrink-0 text-[10px] font-mono text-terminal-dim tabular-nums">
+          {formatActivityDuration(totalMs)} timeline span
+        </span>
+      </div>
+
+      <div
+        className="relative mt-4 flex h-5 overflow-hidden rounded-full bg-terminal-surface-2"
+        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- composite timeline visualization, not an image asset
+        role="img"
+        aria-label="Activity timeline showing user idle, tool execution, LLM wait, and context gaps"
+      >
+        {segments.map((segment) => (
+          <div
+            key={`${segment.sceneIndex}-${segment.kind}`}
+            className={`${ACTIVITY_META[segment.kind].color} min-w-0 transition-opacity hover:opacity-80`}
+            style={{ flex: `${segment.durationMs} 1 0%`, opacity: segment.recorded ? 0.9 : 0.35 }}
+            title={`${ACTIVITY_META[segment.kind].label} · ${formatActivityDuration(segment.durationMs)}${segment.recorded ? " · measured" : " · estimated tool fallback"}`}
+          />
+        ))}
+        {contextMarkers.map((marker) => (
+          <div
+            key={`context-${marker.sceneIndex}`}
+            className="absolute inset-y-0 w-0.5 bg-terminal-context"
+            style={{ left: `${totalMs > 0 ? (marker.elapsedMs / totalMs) * 100 : 0}%` }}
+            title="Compaction/context boundary; duration not persisted"
+          />
+        ))}
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-5">
+        {(Object.keys(ACTIVITY_META) as ActivityKind[]).map((kind) => {
+          const meta = ACTIVITY_META[kind];
+          const total = totals[kind];
+          const hasTime = total.durationMs > 0;
+          return (
+            <div key={kind} className="min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className={`h-2 w-2 shrink-0 rounded-sm ${meta.color}`} />
+                <span className={`truncate text-[10px] font-mono ${meta.textColor}`}>
+                  {meta.label}
+                </span>
+              </div>
+              <div className="mt-1 text-[11px] font-mono text-terminal-text tabular-nums">
+                {hasTime
+                  ? formatActivityDuration(total.durationMs)
+                  : kind === "context" && contextMarkers.length > 0
+                    ? "marker only"
+                    : kind === "thinking" && thinkingCount > 0
+                      ? "folded"
+                      : "—"}
+                {hasTime && (
+                  <span className="ml-1 text-[9px] text-terminal-dimmer">
+                    {formatActivityPercent(total.durationMs, totalMs)}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[9px] font-mono text-terminal-dimmer">
+        <span>{segments.length} timed segments</span>
+        <span>{totals.tool.count} tool calls</span>
+        <span>{formatActivityDuration(measuredMs)} timestamp/tool time</span>
+        {turnOverheadMs !== undefined && (
+          <span>{formatActivityDuration(turnOverheadMs)} non-tool turn overhead</span>
+        )}
+        {totals.tool.estimatedMs > 0 && (
+          <span>{formatActivityDuration(totals.tool.estimatedMs)} estimated tool fallback</span>
+        )}
+        {thinkingCount > 0 && <span>{thinkingCount} thinking blocks folded into LLM wait</span>}
+        {contextMarkers.length > 0 && <span>{contextMarkers.length} context boundaries</span>}
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -14,12 +14,12 @@ const ACTIVITY_META: Record<
 > = {
   "llm-wait": {
     label: "LLM wait",
-    color: "bg-terminal-response",
-    textColor: "text-terminal-response",
+    color: "bg-terminal-thinking",
+    textColor: "text-terminal-thinking",
   },
   response: {
     label: "Response / generation",
-    color: "bg-terminal-response-emphasis",
+    color: "bg-terminal-response",
     textColor: "text-terminal-response",
   },
   tool: { label: "Tool execution", color: "bg-terminal-tool", textColor: "text-terminal-tool" },
@@ -134,8 +134,8 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         <div>
           <div className="ui-section-title-strong">Activity timeline</div>
           <p id={descriptionId} className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-            Timestamp gaps and provider-recorded tool runtimes, excluding user idle, left to right.
-            Gap roles are inferred; compaction time is estimated from its preceding gap.
+            Agent time only: user idle is excluded; prompt-to-assistant gaps are LLM wait. Other gap
+            roles are inferred; compaction time is estimated from its preceding gap.
           </p>
         </div>
         {timing.totalMs > 0 && (

--- a/packages/viewer/src/components/__tests__/insight-charts.test.tsx
+++ b/packages/viewer/src/components/__tests__/insight-charts.test.tsx
@@ -14,10 +14,8 @@ describe("InsightCharts", () => {
       />,
     );
 
-    expect(screen.getByText("prompt / turn")).toBeDefined();
-    expect(screen.getByText("~155")).toBeDefined();
-    expect(screen.getByText("output / turn")).toBeDefined();
-    expect(screen.getByText("~25")).toBeDefined();
+    expect(screen.getByText("~155 prompt/turn")).toBeDefined();
+    expect(screen.getByText("~25 output/turn")).toBeDefined();
   });
 
   it("renders duration percentiles alongside the turn distribution", () => {

--- a/packages/viewer/src/components/__tests__/insight-charts.test.tsx
+++ b/packages/viewer/src/components/__tests__/insight-charts.test.tsx
@@ -6,16 +6,18 @@ import { TokenBreakdownChart, TurnDurationChart } from "../InsightCharts";
 afterEach(cleanup);
 
 describe("InsightCharts", () => {
-  it("shows average prompt and output tokens per recorded turn", () => {
+  it("shows a compact total and token category breakdown", () => {
     render(
       <TokenBreakdownChart
         breakdown={{ input: 100, output: 50, cacheRead: 200, cacheCreation: 10 }}
-        turnCount={2}
       />,
     );
 
-    expect(screen.getByText("~155 prompt/turn")).toBeDefined();
-    expect(screen.getByText("~25 output/turn")).toBeDefined();
+    expect(screen.getByText("Total")).toBeDefined();
+    expect(screen.getByText("Cache Read")).toBeDefined();
+    expect(screen.getByText("Cache Write")).toBeDefined();
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(screen.getByText("Input (uncached)")).toBeDefined();
   });
 
   it("renders duration percentiles alongside the turn distribution", () => {

--- a/packages/viewer/src/components/__tests__/insight-charts.test.tsx
+++ b/packages/viewer/src/components/__tests__/insight-charts.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TokenBreakdownChart, TurnDurationChart } from "../InsightCharts";
+
+afterEach(cleanup);
+
+describe("InsightCharts", () => {
+  it("shows average prompt and output tokens per recorded turn", () => {
+    render(
+      <TokenBreakdownChart
+        breakdown={{ input: 100, output: 50, cacheRead: 200, cacheCreation: 10 }}
+        turnCount={2}
+      />,
+    );
+
+    expect(screen.getByText("prompt / turn")).toBeDefined();
+    expect(screen.getByText("~155")).toBeDefined();
+    expect(screen.getByText("output / turn")).toBeDefined();
+    expect(screen.getByText("~25")).toBeDefined();
+  });
+
+  it("renders duration percentiles alongside the turn distribution", () => {
+    render(
+      <TurnDurationChart
+        histogram={{
+          buckets: [
+            { label: "<30s", count: 1, pct: 50 },
+            { label: "30s-1m", count: 1, pct: 50 },
+          ],
+          percentiles: { p50Ms: 20_000, p75Ms: 30_000, p90Ms: 40_000 },
+          totalTurns: 2,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("P50")).toBeDefined();
+    expect(screen.getByText("P75")).toBeDefined();
+    expect(screen.getByText("P90")).toBeDefined();
+    expect(screen.getByText(/recorded and estimated turn durations/)).toBeDefined();
+  });
+});

--- a/packages/viewer/src/components/__tests__/project-performance.test.tsx
+++ b/packages/viewer/src/components/__tests__/project-performance.test.tsx
@@ -53,7 +53,8 @@ describe("ProjectPerformance", () => {
     expect(screen.getByText("P90")).toBeDefined();
     expect(screen.getByText("8s")).toBeDefined();
     expect(screen.getByText("Cache Read")).toBeDefined();
-    expect(screen.getAllByText("1k")).toHaveLength(4);
+    expect(screen.getByText("Total")).toBeDefined();
+    expect(screen.getAllByText("1k")).toHaveLength(2);
   });
 
   it("keeps zero token categories visible", () => {

--- a/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
+++ b/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
@@ -45,7 +45,7 @@ describe("TurnActivityTimeline", () => {
     expect(screen.getByRole("img", { name: /Activity timeline/ })).toBeDefined();
     expect(screen.getByText("Tool execution")).toBeDefined();
     expect(screen.getByText("Compaction / context")).toBeDefined();
-    expect(screen.getByText(/timestamp\/tool time/)).toBeDefined();
-    expect(screen.getByText(/Recorded event gaps and tool runtimes/)).toBeDefined();
+    expect(screen.getByText(/from timestamp gaps/)).toBeDefined();
+    expect(screen.getByText(/Timestamp gaps and provider-recorded tool runtimes/)).toBeDefined();
   });
 });

--- a/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
+++ b/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import TurnActivityTimeline from "../TurnActivityTimeline";
+
+afterEach(cleanup);
+
+describe("TurnActivityTimeline", () => {
+  it("shows a left-to-right duration strip with semantic activity categories", () => {
+    render(
+      <TurnActivityTimeline
+        scenes={[
+          {
+            type: "user-prompt",
+            content: "Inspect the issue",
+            timestamp: "2026-08-31T00:00:00.000Z",
+          },
+          {
+            type: "tool-call",
+            toolName: "Bash",
+            input: { command: "pnpm test" },
+            result: "passed",
+            durationMs: 2_000,
+            timestamp: "2026-08-31T00:00:02.000Z",
+          },
+          {
+            type: "compaction-summary",
+            content: "Earlier context condensed.",
+            timestamp: "2026-08-31T00:00:05.000Z",
+          },
+          {
+            type: "text-response",
+            content: "The issue is fixed.",
+            timestamp: "2026-08-31T00:00:05.500Z",
+          },
+          {
+            type: "thinking",
+            content: "Checking the result.",
+            timestamp: "2026-08-31T00:00:05.500Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: /Activity timeline/ })).toBeDefined();
+    expect(screen.getByText("Tool execution")).toBeDefined();
+    expect(screen.getByText("Compaction / context")).toBeDefined();
+    expect(screen.getByText(/timestamp\/tool time/)).toBeDefined();
+    expect(screen.getByText(/Recorded event gaps and tool runtimes/)).toBeDefined();
+  });
+});

--- a/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
+++ b/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
@@ -46,7 +46,9 @@ describe("TurnActivityTimeline", () => {
     expect(screen.getByText("Tool execution")).toBeDefined();
     expect(screen.getByText("Compaction / context")).toBeDefined();
     expect(screen.getByText(/from timestamp gaps/)).toBeDefined();
-    expect(screen.getByText(/Timestamp gaps and provider-recorded tool runtimes/)).toBeDefined();
+    expect(screen.getByText(/prompt-to-assistant gaps are LLM wait/)).toBeDefined();
     expect(screen.getByText(/estimated compaction time/)).toBeDefined();
+    expect(screen.getAllByTitle(/LLM wait/)[0].className).toContain("bg-terminal-thinking");
+    expect(screen.getByTitle(/Compaction boundary/).className).toContain("bg-terminal-context");
   });
 });

--- a/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
+++ b/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
@@ -47,5 +47,6 @@ describe("TurnActivityTimeline", () => {
     expect(screen.getByText("Compaction / context")).toBeDefined();
     expect(screen.getByText(/from timestamp gaps/)).toBeDefined();
     expect(screen.getByText(/Timestamp gaps and provider-recorded tool runtimes/)).toBeDefined();
+    expect(screen.getByText(/estimated compaction time/)).toBeDefined();
   });
 });

--- a/packages/viewer/src/engine/__tests__/activity-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/activity-timing.test.ts
@@ -35,7 +35,7 @@ describe("buildActivityTiming", () => {
     expect(result.toolCategories.test).toEqual({ durationMs: 2_000, count: 1 });
   });
 
-  it("does not pretend a context boundary has a duration", () => {
+  it("estimates compaction time from the preceding gap", () => {
     const result = buildActivityTiming([
       { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
       { type: "text-response", content: "Before", timestamp: timestamp(1) },
@@ -44,15 +44,35 @@ describe("buildActivityTiming", () => {
     ]);
 
     expect(result.contextBoundaries).toEqual([
-      { sceneIndex: 2, elapsedMs: 5_000, type: "compaction-summary" },
+      { sceneIndex: 2, elapsedMs: 5_000, type: "compaction-summary", durationMs: 4_000 },
     ]);
     expect(
       result.intervals.map((interval) => [interval.kind, interval.durationMs, interval.note]),
     ).toEqual([
       ["llm-wait", 1_000, undefined],
-      ["unknown", 4_000, "context-boundary"],
+      ["context", 4_000, "compaction-duration-estimate"],
       ["llm-wait", 1_000, undefined],
     ]);
+    expect(result.compactionDurationMs).toBe(4_000);
+  });
+
+  it("keeps context injections as marker-only boundaries", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
+      { type: "text-response", content: "Before", timestamp: timestamp(1) },
+      { type: "context-injection", content: "Injected context", timestamp: timestamp(5) },
+      { type: "text-response", content: "After", timestamp: timestamp(6) },
+    ]);
+
+    expect(result.contextBoundaries).toEqual([
+      { sceneIndex: 2, elapsedMs: 5_000, type: "context-injection" },
+    ]);
+    expect(result.compactionDurationMs).toBe(0);
+    expect(result.intervals[1]).toMatchObject({
+      kind: "unknown",
+      durationMs: 4_000,
+      note: "context-boundary",
+    });
   });
 
   it("does not double-count a gap after a tool with no recorded duration", () => {

--- a/packages/viewer/src/engine/__tests__/activity-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/activity-timing.test.ts
@@ -99,6 +99,98 @@ describe("buildActivityTiming", () => {
     ]);
   });
 
+  it("excludes idle time after an unmeasured tool before a later user prompt", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm test" },
+        result: "ok",
+        timestamp: timestamp(1),
+      },
+      { type: "user-prompt", content: "Continue", timestamp: timestamp(30) },
+    ]);
+
+    expect(result.totalMs).toBe(1_000);
+    expect(result.excludedIdleMs).toBe(29_000);
+    expect(result.intervals).toHaveLength(1);
+    expect(result.intervals[0].kind).toBe("llm-wait");
+  });
+
+  it("merges overlapping parallel tool durations instead of serializing them", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Run both", timestamp: timestamp(0) },
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm test" },
+        result: "one",
+        timestamp: timestamp(1),
+        durationMs: 5_000,
+      },
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm lint" },
+        result: "two",
+        timestamp: timestamp(1),
+        durationMs: 5_000,
+      },
+      { type: "text-response", content: "Done", timestamp: timestamp(7) },
+    ]);
+
+    expect(result.toolCalls).toBe(2);
+    expect(result.toolDurationMs).toBe(5_000);
+    expect(result.totalMs).toBe(7_000);
+  });
+
+  it("anchors result-only tool durations at their end timestamp", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Run command", timestamp: timestamp(0) },
+      {
+        type: "tool-call",
+        toolName: "exec_command",
+        input: { command: "pnpm test" },
+        result: "ok",
+        timestamp: timestamp(5),
+        durationMs: 5_000,
+        durationAnchor: "end",
+      },
+      { type: "text-response", content: "Done", timestamp: timestamp(6) },
+    ]);
+
+    expect(result.intervals.map((interval) => [interval.kind, interval.durationMs])).toEqual([
+      ["tool", 5_000],
+      ["llm-wait", 1_000],
+    ]);
+    expect(result.totalMs).toBe(6_000);
+  });
+
+  it("classifies file tools and canonical web tools in scope totals", () => {
+    const result = buildActivityTiming([
+      {
+        type: "tool-call",
+        toolName: "cat",
+        input: { command: "cat package.json" },
+        result: "{}",
+        timestamp: timestamp(0),
+        durationMs: 1_000,
+      },
+      {
+        type: "tool-call",
+        toolName: "WebFetch",
+        input: { url: "https://example.com" },
+        result: "ok",
+        timestamp: timestamp(2),
+        durationMs: 1_000,
+      },
+    ]);
+
+    expect(result.toolCategories.file).toEqual({ durationMs: 1_000, count: 1 });
+    expect(result.remoteToolMs).toBe(1_000);
+  });
+
   it("keeps known tool time when no scene timestamps exist", () => {
     const result = buildActivityTiming([
       {

--- a/packages/viewer/src/engine/__tests__/activity-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/activity-timing.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { buildActivityTiming } from "../activity-timing";
+
+const timestamp = (seconds: number) =>
+  `2026-08-31T00:00:${seconds.toString().padStart(2, "0")}.000Z`;
+
+describe("buildActivityTiming", () => {
+  it("keeps user idle, model gaps, tool time, and response gaps non-overlapping", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm test" },
+        result: "ok",
+        timestamp: timestamp(1),
+        durationMs: 2_000,
+      },
+      { type: "thinking", content: "Reason", timestamp: timestamp(4) },
+      { type: "text-response", content: "Done", timestamp: timestamp(5) },
+      { type: "user-prompt", content: "Thanks", timestamp: timestamp(10) },
+    ]);
+
+    expect(result.intervals.map((interval) => [interval.kind, interval.durationMs])).toEqual([
+      ["llm-wait", 1_000],
+      ["tool", 2_000],
+      ["llm-wait", 1_000],
+      ["response", 1_000],
+      ["user-idle", 5_000],
+    ]);
+    expect(result.totalMs).toBe(10_000);
+    expect(result.timestampGapMs).toBe(8_000);
+    expect(result.toolDurationMs).toBe(2_000);
+    expect(result.localToolMs).toBe(2_000);
+    expect(result.toolCategories.test).toEqual({ durationMs: 2_000, count: 1 });
+  });
+
+  it("does not pretend a context boundary has a duration", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
+      { type: "text-response", content: "Before", timestamp: timestamp(1) },
+      { type: "compaction-summary", content: "Summary", timestamp: timestamp(5) },
+      { type: "text-response", content: "After", timestamp: timestamp(6) },
+    ]);
+
+    expect(result.contextBoundaries).toEqual([
+      { sceneIndex: 2, elapsedMs: 5_000, type: "compaction-summary" },
+    ]);
+    expect(
+      result.intervals.map((interval) => [interval.kind, interval.durationMs, interval.note]),
+    ).toEqual([
+      ["llm-wait", 1_000, undefined],
+      ["unknown", 4_000, "context-boundary"],
+      ["llm-wait", 1_000, undefined],
+    ]);
+  });
+
+  it("does not double-count a gap after a tool with no recorded duration", () => {
+    const result = buildActivityTiming([
+      { type: "user-prompt", content: "Start", timestamp: timestamp(0) },
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm test" },
+        result: "ok",
+        timestamp: timestamp(1),
+      },
+      { type: "text-response", content: "Done", timestamp: timestamp(5) },
+    ]);
+
+    expect(result.totalMs).toBe(5_000);
+    expect(result.toolDurationMs).toBe(0);
+    expect(result.unmeasuredToolCalls).toBe(1);
+    expect(
+      result.intervals.map((interval) => [interval.kind, interval.durationMs, interval.note]),
+    ).toEqual([
+      ["llm-wait", 1_000, undefined],
+      ["unknown", 4_000, "unmeasured-tool"],
+    ]);
+  });
+
+  it("keeps known tool time when no scene timestamps exist", () => {
+    const result = buildActivityTiming([
+      {
+        type: "tool-call",
+        toolName: "Bash",
+        input: { command: "pnpm lint" },
+        result: "ok",
+        durationMs: 3_000,
+      },
+      { type: "text-response", content: "Done" },
+    ]);
+
+    expect(result.totalMs).toBe(3_000);
+    expect(result.toolDurationMs).toBe(3_000);
+    expect(result.timestampGapMs).toBe(0);
+    expect(result.toolCategories.lint).toEqual({ durationMs: 3_000, count: 1 });
+  });
+});

--- a/packages/viewer/src/engine/__tests__/activity-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/activity-timing.test.ts
@@ -26,10 +26,10 @@ describe("buildActivityTiming", () => {
       ["tool", 2_000],
       ["llm-wait", 1_000],
       ["response", 1_000],
-      ["user-idle", 5_000],
     ]);
-    expect(result.totalMs).toBe(10_000);
-    expect(result.timestampGapMs).toBe(8_000);
+    expect(result.totalMs).toBe(5_000);
+    expect(result.timestampGapMs).toBe(3_000);
+    expect(result.excludedIdleMs).toBe(5_000);
     expect(result.toolDurationMs).toBe(2_000);
     expect(result.localToolMs).toBe(2_000);
     expect(result.toolCategories.test).toEqual({ durationMs: 2_000, count: 1 });

--- a/packages/viewer/src/engine/activity-timing.ts
+++ b/packages/viewer/src/engine/activity-timing.ts
@@ -1,0 +1,303 @@
+import type { Scene } from "../types";
+
+/** Categories used to identify the local work represented by a tool call. */
+export type ToolCategory = "test" | "lint" | "build" | "check" | "file" | "other";
+
+export type ToolScope = "local" | "remote" | "unknown";
+
+/**
+ * A timed interval that can be represented without inventing a wall-clock
+ * duration. Timestamp gaps have a real recorded length, but their activity
+ * role is inferred from the surrounding replay events.
+ */
+export interface ActivityInterval {
+  kind: "user-idle" | "llm-wait" | "response" | "tool" | "unknown";
+  durationMs: number;
+  sceneIndex: number;
+  source: "timestamp-gap" | "tool-duration";
+  confidence: "inferred" | "measured";
+  note?: "unmeasured-tool" | "context-boundary";
+  toolName?: string;
+  toolCategory?: ToolCategory;
+  toolScope?: ToolScope;
+}
+
+export interface ContextBoundary {
+  sceneIndex: number;
+  elapsedMs: number;
+  type: "compaction-summary" | "context-injection";
+}
+
+export interface ToolCategoryTotal {
+  durationMs: number;
+  count: number;
+}
+
+export interface ActivityTimingResult {
+  intervals: ActivityInterval[];
+  contextBoundaries: ContextBoundary[];
+  thinkingCount: number;
+  totalMs: number;
+  timestampGapMs: number;
+  toolDurationMs: number;
+  toolCalls: number;
+  recordedToolCalls: number;
+  unmeasuredToolCalls: number;
+  localToolMs: number;
+  remoteToolMs: number;
+  unknownToolMs: number;
+  toolCategories: Record<ToolCategory, ToolCategoryTotal>;
+}
+
+type PreviousEvent = "user" | "assistant" | "tool" | "context";
+
+interface ToolDescriptor {
+  category: ToolCategory;
+  scope: ToolScope;
+  command?: string;
+}
+
+const EMPTY_TOOL_CATEGORIES: Record<ToolCategory, ToolCategoryTotal> = {
+  test: { durationMs: 0, count: 0 },
+  lint: { durationMs: 0, count: 0 },
+  build: { durationMs: 0, count: 0 },
+  check: { durationMs: 0, count: 0 },
+  file: { durationMs: 0, count: 0 },
+  other: { durationMs: 0, count: 0 },
+};
+
+const LOCAL_TOOL_NAMES = new Set([
+  "apply_patch",
+  "bash",
+  "cat",
+  "edit",
+  "exec_command",
+  "file",
+  "find",
+  "glob",
+  "grep",
+  "ls",
+  "multiedit",
+  "read",
+  "run_in_terminal",
+  "run_terminal_cmd",
+  "shell",
+  "terminal",
+  "write",
+]);
+
+const REMOTE_TOOL_PREFIXES = ["browser", "fetch", "http", "mcp", "search", "web"];
+
+const FILE_TOOL_NAMES = new Set([
+  "apply_patch",
+  "edit",
+  "file",
+  "glob",
+  "grep",
+  "ls",
+  "read",
+  "write",
+]);
+
+function emptyToolCategories(): Record<ToolCategory, ToolCategoryTotal> {
+  return Object.fromEntries(
+    Object.entries(EMPTY_TOOL_CATEGORIES).map(([category, total]) => [category, { ...total }]),
+  ) as Record<ToolCategory, ToolCategoryTotal>;
+}
+
+function timestampMs(scene: Scene): number | undefined {
+  if (!scene.timestamp) return undefined;
+  const parsed = Date.parse(scene.timestamp);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizedToolName(toolName: string): string {
+  return toolName
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function inputString(input: Record<string, any>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function commandCategory(toolName: string, input: Record<string, any>): ToolCategory {
+  const name = normalizedToolName(toolName);
+  const command = inputString(input, ["command", "cmd", "script", "action"]);
+  const text = `${name} ${command || ""}`.toLowerCase();
+
+  if (/\b(test|tests|jest|vitest|pytest|unittest|spec)\b/.test(text)) return "test";
+  if (/\b(lint|linting|format|fmt|prettier|oxlint|eslint)\b/.test(text)) return "lint";
+  if (/\b(build|compile|bundle|webpack|vite|tsc)\b/.test(text)) return "build";
+  if (/\b(typecheck|check|verify)\b/.test(text)) return "check";
+  if (FILE_TOOL_NAMES.has(name)) return "file";
+  return "other";
+}
+
+function toolDescriptor(toolName: string, input: Record<string, any>): ToolDescriptor {
+  const name = normalizedToolName(toolName);
+  const command = inputString(input, ["command", "cmd", "script", "action"]);
+  if (LOCAL_TOOL_NAMES.has(name)) {
+    return {
+      category: commandCategory(toolName, input),
+      scope: "local",
+      ...(command ? { command } : {}),
+    };
+  }
+  if (REMOTE_TOOL_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix}_`))) {
+    return {
+      category: commandCategory(toolName, input),
+      scope: "remote",
+      ...(command ? { command } : {}),
+    };
+  }
+  return {
+    category: commandCategory(toolName, input),
+    scope: "unknown",
+    ...(command ? { command } : {}),
+  };
+}
+
+function addToolCategory(
+  categories: Record<ToolCategory, ToolCategoryTotal>,
+  category: ToolCategory,
+  durationMs: number,
+): void {
+  categories[category].durationMs += durationMs;
+  categories[category].count++;
+}
+
+function gapKind(
+  scene: Scene,
+  previous: PreviousEvent | undefined,
+  hasUnmeasuredTool: boolean,
+): { kind: ActivityInterval["kind"]; note?: ActivityInterval["note"] } {
+  if (scene.type === "compaction-summary" || scene.type === "context-injection") {
+    // The boundary timestamp proves that context changed, not how long the
+    // compaction itself took. Keep the preceding gap unattributed.
+    return { kind: "unknown", note: "context-boundary" };
+  }
+  if (hasUnmeasuredTool) {
+    // A gap after a tool without a provider duration may contain both tool
+    // execution and the following model request. Do not call all of it LLM
+    // latency or all of it local execution.
+    return { kind: "unknown", note: "unmeasured-tool" };
+  }
+  if (scene.type === "user-prompt") return { kind: "user-idle" };
+  if (previous === "assistant") return { kind: "response" };
+  return { kind: "llm-wait" };
+}
+
+/**
+ * Build non-overlapping, confidence-labeled activity intervals from replay
+ * scenes. The function intentionally does not use playback heuristics for
+ * response or user time: missing timestamps remain unassigned.
+ */
+export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingResult {
+  const intervals: ActivityInterval[] = [];
+  const contextBoundaries: ContextBoundary[] = [];
+  const toolCategories = emptyToolCategories();
+  let cursorMs: number | undefined;
+  let elapsedMs = 0;
+  let timestampGapMs = 0;
+  let toolDurationMs = 0;
+  let thinkingCount = 0;
+  let toolCalls = 0;
+  let recordedToolCalls = 0;
+  let unmeasuredToolCalls = 0;
+  let localToolMs = 0;
+  let remoteToolMs = 0;
+  let unknownToolMs = 0;
+  let previous: PreviousEvent | undefined;
+  let hasUnmeasuredTool = false;
+
+  const addInterval = (
+    interval: Omit<ActivityInterval, "durationMs"> & { durationMs: number },
+  ): void => {
+    if (interval.durationMs <= 0) return;
+    intervals.push(interval);
+    elapsedMs += interval.durationMs;
+    if (interval.source === "timestamp-gap") timestampGapMs += interval.durationMs;
+    else toolDurationMs += interval.durationMs;
+  };
+
+  for (const [sceneIndex, scene] of scenes.entries()) {
+    const atMs = timestampMs(scene);
+
+    if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
+      const durationMs = atMs - cursorMs;
+      const gap = gapKind(scene, previous, hasUnmeasuredTool);
+      addInterval({
+        kind: gap.kind,
+        durationMs,
+        sceneIndex,
+        source: "timestamp-gap",
+        confidence: "inferred",
+        ...(gap.note ? { note: gap.note } : {}),
+      });
+      cursorMs = atMs;
+      hasUnmeasuredTool = false;
+    }
+
+    if (scene.type === "compaction-summary" || scene.type === "context-injection") {
+      contextBoundaries.push({ sceneIndex, elapsedMs, type: scene.type });
+      if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
+      previous = "context";
+    } else if (scene.type === "tool-call") {
+      toolCalls++;
+      const descriptor = toolDescriptor(scene.toolName, scene.input);
+      const hasDuration = scene.durationMs !== undefined && scene.durationMs > 0;
+
+      if (hasDuration) {
+        const durationMs = scene.durationMs!;
+        const startMs = atMs !== undefined ? Math.max(cursorMs ?? atMs, atMs) : cursorMs;
+        addInterval({
+          kind: "tool",
+          durationMs,
+          sceneIndex,
+          source: "tool-duration",
+          confidence: "measured",
+          toolName: scene.toolName,
+          toolCategory: descriptor.category,
+          toolScope: descriptor.scope,
+        });
+        recordedToolCalls++;
+        addToolCategory(toolCategories, descriptor.category, durationMs);
+        if (descriptor.scope === "local") localToolMs += durationMs;
+        else if (descriptor.scope === "remote") remoteToolMs += durationMs;
+        else unknownToolMs += durationMs;
+        if (startMs !== undefined) cursorMs = startMs + durationMs;
+      } else {
+        unmeasuredToolCalls++;
+        hasUnmeasuredTool = true;
+      }
+      if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
+      previous = "tool";
+    } else {
+      if (scene.type === "thinking") thinkingCount++;
+      if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
+      previous = scene.type === "user-prompt" ? "user" : "assistant";
+    }
+  }
+
+  return {
+    intervals,
+    contextBoundaries,
+    thinkingCount,
+    totalMs: elapsedMs,
+    timestampGapMs,
+    toolDurationMs,
+    toolCalls,
+    recordedToolCalls,
+    unmeasuredToolCalls,
+    localToolMs,
+    remoteToolMs,
+    unknownToolMs,
+    toolCategories,
+  };
+}

--- a/packages/viewer/src/engine/activity-timing.ts
+++ b/packages/viewer/src/engine/activity-timing.ts
@@ -11,12 +11,12 @@ export type ToolScope = "local" | "remote" | "unknown";
  * role is inferred from the surrounding replay events.
  */
 export interface ActivityInterval {
-  kind: "llm-wait" | "response" | "tool" | "unknown";
+  kind: "llm-wait" | "response" | "tool" | "context" | "unknown";
   durationMs: number;
   sceneIndex: number;
   source: "timestamp-gap" | "tool-duration";
   confidence: "inferred" | "measured";
-  note?: "unmeasured-tool" | "context-boundary";
+  note?: "unmeasured-tool" | "context-boundary" | "compaction-duration-estimate";
   toolName?: string;
   toolCategory?: ToolCategory;
   toolScope?: ToolScope;
@@ -26,6 +26,8 @@ export interface ContextBoundary {
   sceneIndex: number;
   elapsedMs: number;
   type: "compaction-summary" | "context-injection";
+  /** Estimated from the preceding timestamp gap when this is a compaction. */
+  durationMs?: number;
 }
 
 export interface ToolCategoryTotal {
@@ -39,6 +41,8 @@ export interface ActivityTimingResult {
   thinkingCount: number;
   totalMs: number;
   timestampGapMs: number;
+  /** Estimated compaction time derived from timestamp gaps. */
+  compactionDurationMs: number;
   /** User-away gaps are intentionally excluded from the activity timeline. */
   excludedIdleMs: number;
   toolDurationMs: number;
@@ -179,16 +183,21 @@ function gapKind(
   previous: PreviousEvent | undefined,
   hasUnmeasuredTool: boolean,
 ): { kind: ActivityInterval["kind"] | "user-idle"; note?: ActivityInterval["note"] } {
-  if (scene.type === "compaction-summary" || scene.type === "context-injection") {
-    // The boundary timestamp proves that context changed, not how long the
-    // compaction itself took. Keep the preceding gap unattributed.
-    return { kind: "unknown", note: "context-boundary" };
-  }
   if (hasUnmeasuredTool) {
     // A gap after a tool without a provider duration may contain both tool
     // execution and the following model request. Do not call all of it LLM
     // latency or all of it local execution.
     return { kind: "unknown", note: "unmeasured-tool" };
+  }
+  if (scene.type === "compaction-summary") {
+    // Pi persists the completed compaction timestamp, but not a start event.
+    // The preceding gap is therefore useful as an estimate, not an exact
+    // compaction duration.
+    return { kind: "context", note: "compaction-duration-estimate" };
+  }
+  if (scene.type === "context-injection") {
+    // A context injection has no persisted processing interval of its own.
+    return { kind: "unknown", note: "context-boundary" };
   }
   if (scene.type === "user-prompt") return { kind: "user-idle" };
   if (previous === "assistant") return { kind: "response" };
@@ -208,6 +217,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
   let elapsedMs = 0;
   let timestampGapMs = 0;
   let excludedIdleMs = 0;
+  let compactionDurationMs = 0;
   let toolDurationMs = 0;
   let thinkingCount = 0;
   let toolCalls = 0;
@@ -235,12 +245,14 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
       const durationMs = atMs - cursorMs;
       const gap = gapKind(scene, previous, hasUnmeasuredTool);
+      const compactionGapMs = gap.kind === "context" ? durationMs : undefined;
       if (gap.kind === "user-idle") {
         // Time between turns mostly measures how long the user was away from
         // the computer, not how the agent spent the session. Keep the cursor
         // moving but leave this interval out of the activity visualization.
         excludedIdleMs += durationMs;
       } else {
+        if (compactionGapMs !== undefined) compactionDurationMs += compactionGapMs;
         addInterval({
           kind: gap.kind,
           durationMs,
@@ -255,7 +267,19 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     }
 
     if (scene.type === "compaction-summary" || scene.type === "context-injection") {
-      contextBoundaries.push({ sceneIndex, elapsedMs, type: scene.type });
+      const precedingInterval = intervals.at(-1);
+      const durationMs =
+        scene.type === "compaction-summary" &&
+        precedingInterval?.sceneIndex === sceneIndex &&
+        precedingInterval.kind === "context"
+          ? precedingInterval.durationMs
+          : undefined;
+      contextBoundaries.push({
+        sceneIndex,
+        elapsedMs,
+        type: scene.type,
+        ...(durationMs !== undefined ? { durationMs } : {}),
+      });
       if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
       previous = "context";
     } else if (scene.type === "tool-call") {
@@ -302,6 +326,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     totalMs: elapsedMs,
     timestampGapMs,
     excludedIdleMs,
+    compactionDurationMs,
     toolDurationMs,
     toolCalls,
     recordedToolCalls,

--- a/packages/viewer/src/engine/activity-timing.ts
+++ b/packages/viewer/src/engine/activity-timing.ts
@@ -83,26 +83,44 @@ const LOCAL_TOOL_NAMES = new Set([
   "glob",
   "grep",
   "ls",
+  "delete",
+  "delete_file",
   "multiedit",
+  "multi_edit",
+  "notebookedit",
+  "notebook_edit",
   "read",
+  "read_file",
   "run_in_terminal",
   "run_terminal_cmd",
   "shell",
   "terminal",
   "write",
+  "write_file",
 ]);
 
 const REMOTE_TOOL_PREFIXES = ["browser", "fetch", "http", "mcp", "search", "web"];
+const REMOTE_TOOL_NAMES = new Set(["webfetch", "websearch"]);
 
 const FILE_TOOL_NAMES = new Set([
   "apply_patch",
+  "cat",
+  "delete",
+  "delete_file",
   "edit",
   "file",
+  "find",
   "glob",
   "grep",
   "ls",
+  "multiedit",
+  "multi_edit",
+  "notebookedit",
+  "notebook_edit",
   "read",
+  "read_file",
   "write",
+  "write_file",
 ]);
 
 function emptyToolCategories(): Record<ToolCategory, ToolCategoryTotal> {
@@ -115,6 +133,19 @@ function timestampMs(scene: Scene): number | undefined {
   if (!scene.timestamp) return undefined;
   const parsed = Date.parse(scene.timestamp);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function activityStartMs(scene: Scene, atMs: number | undefined): number | undefined {
+  if (
+    scene.type === "tool-call" &&
+    scene.durationAnchor === "end" &&
+    scene.durationMs !== undefined &&
+    scene.durationMs > 0 &&
+    atMs !== undefined
+  ) {
+    return atMs - scene.durationMs;
+  }
+  return atMs;
 }
 
 function normalizedToolName(toolName: string): string {
@@ -155,7 +186,10 @@ function toolDescriptor(toolName: string, input: Record<string, any>): ToolDescr
       ...(command ? { command } : {}),
     };
   }
-  if (REMOTE_TOOL_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix}_`))) {
+  if (
+    REMOTE_TOOL_NAMES.has(name) ||
+    REMOTE_TOOL_PREFIXES.some((prefix) => name === prefix || name.startsWith(`${prefix}_`))
+  ) {
     return {
       category: commandCategory(toolName, input),
       scope: "remote",
@@ -183,6 +217,7 @@ function gapKind(
   previous: PreviousEvent | undefined,
   hasUnmeasuredTool: boolean,
 ): { kind: ActivityInterval["kind"] | "user-idle"; note?: ActivityInterval["note"] } {
+  if (scene.type === "user-prompt") return { kind: "user-idle" };
   if (hasUnmeasuredTool) {
     // A gap after a tool without a provider duration may contain both tool
     // execution and the following model request. Do not call all of it LLM
@@ -199,7 +234,6 @@ function gapKind(
     // A context injection has no persisted processing interval of its own.
     return { kind: "unknown", note: "context-boundary" };
   }
-  if (scene.type === "user-prompt") return { kind: "user-idle" };
   if (previous === "assistant") return { kind: "response" };
   return { kind: "llm-wait" };
 }
@@ -241,9 +275,10 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
 
   for (const [sceneIndex, scene] of scenes.entries()) {
     const atMs = timestampMs(scene);
+    const startAtMs = activityStartMs(scene, atMs);
 
-    if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
-      const durationMs = atMs - cursorMs;
+    if (startAtMs !== undefined && cursorMs !== undefined && startAtMs > cursorMs) {
+      const durationMs = startAtMs - cursorMs;
       const gap = gapKind(scene, previous, hasUnmeasuredTool);
       const compactionGapMs = gap.kind === "context" ? durationMs : undefined;
       if (gap.kind === "user-idle") {
@@ -262,7 +297,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
           ...(gap.note ? { note: gap.note } : {}),
         });
       }
-      cursorMs = atMs;
+      cursorMs = startAtMs;
       hasUnmeasuredTool = false;
     }
 
@@ -289,28 +324,47 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
 
       if (hasDuration) {
         const durationMs = scene.durationMs!;
-        const startMs = atMs !== undefined ? Math.max(cursorMs ?? atMs, atMs) : cursorMs;
-        addInterval({
-          kind: "tool",
-          durationMs,
-          sceneIndex,
-          source: "tool-duration",
-          confidence: "measured",
-          toolName: scene.toolName,
-          toolCategory: descriptor.category,
-          toolScope: descriptor.scope,
-        });
+        const endMs =
+          scene.durationAnchor === "end" && atMs !== undefined
+            ? atMs
+            : startAtMs !== undefined
+              ? startAtMs + durationMs
+              : undefined;
+        const representedStartMs =
+          startAtMs !== undefined ? Math.max(cursorMs ?? startAtMs, startAtMs) : undefined;
+        const representedDurationMs =
+          endMs !== undefined && representedStartMs !== undefined
+            ? Math.max(0, endMs - representedStartMs)
+            : durationMs;
+        if (representedDurationMs > 0) {
+          addInterval({
+            kind: "tool",
+            durationMs: representedDurationMs,
+            sceneIndex,
+            source: "tool-duration",
+            confidence: "measured",
+            toolName: scene.toolName,
+            toolCategory: descriptor.category,
+            toolScope: descriptor.scope,
+          });
+        }
         recordedToolCalls++;
-        addToolCategory(toolCategories, descriptor.category, durationMs);
-        if (descriptor.scope === "local") localToolMs += durationMs;
-        else if (descriptor.scope === "remote") remoteToolMs += durationMs;
-        else unknownToolMs += durationMs;
-        if (startMs !== undefined) cursorMs = startMs + durationMs;
+        addToolCategory(toolCategories, descriptor.category, representedDurationMs);
+        if (descriptor.scope === "local") localToolMs += representedDurationMs;
+        else if (descriptor.scope === "remote") remoteToolMs += representedDurationMs;
+        else unknownToolMs += representedDurationMs;
+        if (endMs !== undefined) {
+          cursorMs = Math.max(cursorMs ?? endMs, endMs);
+        } else if (cursorMs !== undefined) {
+          cursorMs += durationMs;
+        }
       } else {
         unmeasuredToolCalls++;
         hasUnmeasuredTool = true;
       }
-      if (atMs !== undefined) cursorMs = Math.max(cursorMs ?? atMs, atMs);
+      if (!hasDuration && atMs !== undefined) {
+        cursorMs = Math.max(cursorMs ?? atMs, atMs);
+      }
       previous = "tool";
     } else {
       if (scene.type === "thinking") thinkingCount++;

--- a/packages/viewer/src/engine/activity-timing.ts
+++ b/packages/viewer/src/engine/activity-timing.ts
@@ -11,7 +11,7 @@ export type ToolScope = "local" | "remote" | "unknown";
  * role is inferred from the surrounding replay events.
  */
 export interface ActivityInterval {
-  kind: "user-idle" | "llm-wait" | "response" | "tool" | "unknown";
+  kind: "llm-wait" | "response" | "tool" | "unknown";
   durationMs: number;
   sceneIndex: number;
   source: "timestamp-gap" | "tool-duration";
@@ -39,6 +39,8 @@ export interface ActivityTimingResult {
   thinkingCount: number;
   totalMs: number;
   timestampGapMs: number;
+  /** User-away gaps are intentionally excluded from the activity timeline. */
+  excludedIdleMs: number;
   toolDurationMs: number;
   toolCalls: number;
   recordedToolCalls: number;
@@ -176,7 +178,7 @@ function gapKind(
   scene: Scene,
   previous: PreviousEvent | undefined,
   hasUnmeasuredTool: boolean,
-): { kind: ActivityInterval["kind"]; note?: ActivityInterval["note"] } {
+): { kind: ActivityInterval["kind"] | "user-idle"; note?: ActivityInterval["note"] } {
   if (scene.type === "compaction-summary" || scene.type === "context-injection") {
     // The boundary timestamp proves that context changed, not how long the
     // compaction itself took. Keep the preceding gap unattributed.
@@ -205,6 +207,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
   let cursorMs: number | undefined;
   let elapsedMs = 0;
   let timestampGapMs = 0;
+  let excludedIdleMs = 0;
   let toolDurationMs = 0;
   let thinkingCount = 0;
   let toolCalls = 0;
@@ -232,14 +235,21 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     if (atMs !== undefined && cursorMs !== undefined && atMs > cursorMs) {
       const durationMs = atMs - cursorMs;
       const gap = gapKind(scene, previous, hasUnmeasuredTool);
-      addInterval({
-        kind: gap.kind,
-        durationMs,
-        sceneIndex,
-        source: "timestamp-gap",
-        confidence: "inferred",
-        ...(gap.note ? { note: gap.note } : {}),
-      });
+      if (gap.kind === "user-idle") {
+        // Time between turns mostly measures how long the user was away from
+        // the computer, not how the agent spent the session. Keep the cursor
+        // moving but leave this interval out of the activity visualization.
+        excludedIdleMs += durationMs;
+      } else {
+        addInterval({
+          kind: gap.kind,
+          durationMs,
+          sceneIndex,
+          source: "timestamp-gap",
+          confidence: "inferred",
+          ...(gap.note ? { note: gap.note } : {}),
+        });
+      }
       cursorMs = atMs;
       hasUnmeasuredTool = false;
     }
@@ -291,6 +301,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     thinkingCount,
     totalMs: elapsedMs,
     timestampGapMs,
+    excludedIdleMs,
     toolDurationMs,
     toolCalls,
     recordedToolCalls,


### PR DESCRIPTION
## Summary

- Add a left-to-right per-session activity timeline in the replay Summary view.
- Focus the timeline on agent-relevant activity: inferred LLM wait, response/generation gaps, provider-recorded tool runtimes, and compaction/context.
- Exclude user-away/idle gaps from the strip and its represented-time denominator.
- Estimate compaction time from the timestamp gap before each persisted compaction record; keep context injections marker-only when no duration is available.
- Classify local tool time for test, lint, build, checks, and file operations, with explicit unattributed gaps when timing is missing.
- Keep the token card compact: total, stacked breakdown, and four token categories.
- Use semantic colors for activity and token charts, and reserve space for the fixed Ask Replay launcher.

## Validation

- `pnpm verify`
- 40 viewer test files / 402 tests
- GitHub CI checks passed

Timing labels intentionally avoid claiming exact TTFT or exact compaction start/end: provider records expose event gaps and tool durations with different levels of precision.