### PR TITLE
feat(insights): improve Cursor and Codex timing coverage

### DIFF
--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -22,6 +22,7 @@ interface ToolResult {
   isError?: boolean;
   timestamp?: string;
   durationMs?: number;
+  durationSource?: "timestamp";
 }
 
 interface CodexTokenInfo {
@@ -177,6 +178,12 @@ export function parseCodexLines(
         continue;
       }
       if (p.type === "exec_command_end" && p.call_id) {
+        const existingTool = tools.get(p.call_id);
+        const explicitDurationMs = durationToMs(p.duration);
+        const inferredDurationMs =
+          explicitDurationMs === undefined && existingTool?.timestamp
+            ? durationBetweenTimestamps(existingTool.timestamp, obj.timestamp)
+            : undefined;
         if (!tools.has(p.call_id)) {
           tools.set(p.call_id, {
             id: p.call_id,
@@ -190,7 +197,11 @@ export function parseCodexLines(
           result: formatExecResult(p),
           isError: typeof p.exit_code === "number" ? p.exit_code !== 0 : undefined,
           timestamp: obj.timestamp,
-          durationMs: durationToMs(p.duration),
+          ...(explicitDurationMs !== undefined
+            ? { durationMs: explicitDurationMs }
+            : inferredDurationMs !== undefined
+              ? { durationMs: inferredDurationMs, durationSource: "timestamp" as const }
+              : {}),
         });
         continue;
       }
@@ -414,6 +425,11 @@ export function parseCodexLines(
       p.type === "tool_search_output"
     ) {
       if (p.call_id) {
+        const existingTool = tools.get(p.call_id);
+        const inferredDurationMs =
+          existingTool?.timestamp && obj.timestamp
+            ? durationBetweenTimestamps(existingTool.timestamp, obj.timestamp)
+            : undefined;
         if (!tools.has(p.call_id)) {
           // Preserve orphan completions as an unknown ordinary tool rather
           // than silently losing a concrete provider event.
@@ -430,6 +446,9 @@ export function parseCodexLines(
           {
             result: formatOutputPayload(p),
             timestamp: obj.timestamp,
+            ...(inferredDurationMs !== undefined
+              ? { durationMs: inferredDurationMs, durationSource: "timestamp" as const }
+              : {}),
           },
           { preferExistingResult: true },
         );
@@ -453,6 +472,7 @@ export function parseCodexLines(
           ...(tr ? { _result: tr.result } : {}),
           ...(tr?.isError ? { _isError: true } : {}),
           ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
+          ...(tr?.durationSource ? { _durationSource: tr.durationSource } : {}),
           ...(tool.durationAnchor ? { _durationAnchor: tool.durationAnchor } : {}),
           ...(tool.mcpServer ? { _mcpServer: tool.mcpServer } : {}),
           ...(tool.mcpTool ? { _mcpTool: tool.mcpTool } : {}),
@@ -755,7 +775,18 @@ function mergeToolResult(
         : next.result || previous.result,
     isError: next.isError ?? previous.isError,
     timestamp: next.timestamp || previous.timestamp,
-    durationMs: next.durationMs ?? previous.durationMs,
+    durationMs:
+      next.durationSource === "timestamp" &&
+      previous.durationMs !== undefined &&
+      previous.durationSource === undefined
+        ? previous.durationMs
+        : (next.durationMs ?? previous.durationMs),
+    durationSource:
+      next.durationSource === "timestamp" &&
+      previous.durationMs !== undefined &&
+      previous.durationSource === undefined
+        ? undefined
+        : (next.durationSource ?? previous.durationSource),
   });
 }
 
@@ -859,6 +890,13 @@ function durationToMs(duration: any): number | undefined {
   const nanos = typeof duration.nanos === "number" ? duration.nanos : 0;
   const ms = secs * 1000 + Math.round(nanos / 1_000_000);
   return ms > 0 ? ms : undefined;
+}
+
+function durationBetweenTimestamps(start: string, end: string): number | undefined {
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  const durationMs = endMs - startMs;
+  return durationMs > 0 && durationMs < 12 * 60 * 60 * 1000 ? durationMs : undefined;
 }
 
 function tokenUsageFromSnapshots(snapshots: CodexTokenSnapshot[]): TokenUsage | undefined {

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -182,6 +182,46 @@ describe("Codex parser", () => {
     });
   });
 
+  it("infers custom tool duration from paired call and output timestamps", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T05:20:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-custom-duration", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T05:20:01.000Z",
+          type: "response_item",
+          payload: {
+            type: "custom_tool_call",
+            call_id: "custom-1",
+            name: "custom_local_tool",
+            input: { command: "pnpm test" },
+          },
+        },
+        {
+          timestamp: "2026-04-26T05:20:04.500Z",
+          type: "response_item",
+          payload: {
+            type: "custom_tool_call_output",
+            call_id: "custom-1",
+            output: "passed",
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const tool = result.turns
+      .flatMap((turn) => turn.blocks)
+      .find((block) => block.type === "tool_use");
+    expect(tool).toMatchObject({
+      type: "tool_use",
+      _durationMs: 3500,
+      _durationSource: "timestamp",
+    });
+  });
+
   it("records malformed JSONL lines as parse warnings", () => {
     const result = parseCodexLines([...lines.slice(0, 2), "{not-json", ...lines.slice(2)]);
 

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -251,6 +251,8 @@ export type ContentBlock =
       _isError?: boolean;
       _subAgent?: SubAgent;
       _durationMs?: number;
+      /** Whether the internal duration came from a provider value or timestamp inference. */
+      _durationSource?: "provider" | "timestamp";
       /** Whether the internal duration is anchored at the tool start or result timestamp. */
       _durationAnchor?: "start" | "end";
       _isPendingMarker?: boolean;

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -2319,6 +2319,7 @@ function parseToolFormerBlock(
   const paramsRaw = parsedParams ?? toolFormerData.params ?? {};
   const result = extractToolResultText(toolFormerData.result);
   const hasResult = Object.prototype.hasOwnProperty.call(toolFormerData, "result");
+  const executionTimeMs = extractToolExecutionTimeMs(toolFormerData.result);
 
   return {
     type: "tool_use",
@@ -2329,6 +2330,7 @@ function parseToolFormerBlock(
     input: mapToolArgs(name, paramsRaw, result),
     _hasResult: hasResult,
     ...(hasResult ? { _result: result } : {}),
+    ...(executionTimeMs !== undefined ? { _durationMs: executionTimeMs } : {}),
     ...(hasToolError(toolFormerData.result) ? { _isError: true } : {}),
   };
 }

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -255,6 +255,7 @@ export function transformToReplay(
         scene.isError = !!block._isError;
         scene.hasResult = block._hasResult ?? block._result !== undefined;
         if (block._durationMs) scene.durationMs = block._durationMs;
+        if (block._durationSource) scene.durationSource = block._durationSource;
         if (block._durationAnchor) scene.durationAnchor = block._durationAnchor;
         // Attach subagent data for Agent tool calls
         if (block.name === "Agent" && block._subAgent) {
@@ -726,6 +727,7 @@ function redactSubAgentScene(s: Scene): Scene {
       timestamp: s.timestamp,
       isError: s.isError || false,
       ...(s.durationMs ? { durationMs: s.durationMs } : {}),
+      ...(s.durationSource ? { durationSource: s.durationSource } : {}),
       ...(s.durationAnchor ? { durationAnchor: s.durationAnchor } : {}),
       ...(resultTokens > 0 ? { resultTokens } : {}),
     };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -204,6 +204,8 @@ export type Scene =
       subAgent?: SubAgent;
       /** Tool execution duration in ms (assistant timestamp → tool_result timestamp) */
       durationMs?: number;
+      /** Whether the duration came from an explicit provider value or timestamp inference. */
+      durationSource?: "provider" | "timestamp";
       /** Whether durationMs is anchored at the tool start or result timestamp. */
       durationAnchor?: "start" | "end";
       /**

--- a/packages/viewer/src/components/SummaryView.tsx
+++ b/packages/viewer/src/components/SummaryView.tsx
@@ -560,7 +560,11 @@ export default function SummaryView({ session }: Props) {
         </div>
 
         {/* === Time Series Charts (grouped) === */}
-        <TurnActivityTimeline scenes={scenes} />
+        <TurnActivityTimeline
+          scenes={scenes}
+          provider={meta.provider}
+          turnStats={meta.stats.turnStats}
+        />
         {hasTokenUsage && (
           <div className="rounded-xl bg-terminal-surface p-4 shadow-layer-sm">
             <div className="ui-section-title-strong mb-3">Tokens</div>

--- a/packages/viewer/src/components/TurnActivityTimeline.tsx
+++ b/packages/viewer/src/components/TurnActivityTimeline.tsx
@@ -2,9 +2,10 @@ import { useId, useMemo } from "react";
 import {
   buildActivityTiming,
   type ActivityInterval,
+  type ActivityTimingOptions,
   type ToolCategory,
 } from "../engine/activity-timing";
-import type { Scene } from "../types";
+import type { Scene, TurnStat } from "../types";
 
 type TimedActivityKind = ActivityInterval["kind"];
 
@@ -27,6 +28,11 @@ const ACTIVITY_META: Record<
     label: "Compaction / context",
     color: "bg-terminal-context",
     textColor: "text-terminal-context",
+  },
+  "agent-turn": {
+    label: "Agent turn (not split)",
+    color: "bg-terminal-surface-2",
+    textColor: "text-terminal-dim",
   },
   unknown: {
     label: "Unattributed gap",
@@ -71,14 +77,18 @@ function intervalTitle(interval: ActivityInterval): string {
   const meta = ACTIVITY_META[interval.kind];
   const source =
     interval.source === "tool-duration"
-      ? "provider-recorded tool duration"
+      ? interval.durationSource === "timestamp"
+        ? "call/output timestamp gap; duration inferred"
+        : "recorded tool duration"
       : interval.note === "compaction-duration-estimate"
         ? "timestamp gap to compaction record; duration estimated, start not persisted"
-        : interval.note === "context-boundary"
-          ? "timestamp gap before context boundary; compaction duration unknown"
-          : interval.note === "unmeasured-tool"
-            ? "timestamp gap includes a tool with no recorded duration"
-            : "timestamp gap; activity role inferred";
+        : interval.note === "provider-turn-duration"
+          ? "provider turn duration; local tool vs LLM time is not split"
+          : interval.note === "context-boundary"
+            ? "timestamp gap before context boundary; compaction duration unknown"
+            : interval.note === "unmeasured-tool"
+              ? "timestamp gap includes a tool with no recorded duration"
+              : "timestamp gap; activity role inferred";
   const tool = interval.toolName
     ? ` · ${interval.toolName}${interval.toolCategory ? ` (${TOOL_CATEGORY_LABELS[interval.toolCategory]})` : ""}`
     : "";
@@ -94,9 +104,21 @@ function categorySummary(
   return `${TOOL_CATEGORY_LABELS[category]} ${formatActivityDuration(durationMs)}`;
 }
 
-export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scene[] }) {
+export default function TurnActivityTimeline({
+  scenes,
+  provider,
+  turnStats,
+}: {
+  scenes: readonly Scene[];
+  provider?: string;
+  turnStats?: readonly TurnStat[];
+}) {
   const descriptionId = useId();
-  const timing = useMemo(() => buildActivityTiming(scenes), [scenes]);
+  const timingOptions: ActivityTimingOptions = useMemo(
+    () => ({ provider, turnStats }),
+    [provider, turnStats],
+  );
+  const timing = useMemo(() => buildActivityTiming(scenes, timingOptions), [scenes, timingOptions]);
   const visibleKinds = useMemo(() => {
     const kinds = (Object.keys(ACTIVITY_META) as TimedActivityKind[]).filter((kind) =>
       timing.intervals.some((interval) => interval.kind === kind),
@@ -131,6 +153,9 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
     ),
     `Compaction/context boundaries: ${timing.contextBoundaries.length}`,
     `${timing.thinkingCount} thinking blocks included in LLM wait; no separate duration persisted`,
+    ...(timing.timingMode === "provider-turns"
+      ? ["Only whole-turn timing is available; local tool and LLM time are not split"]
+      : []),
   ].join(". ");
 
   return (
@@ -139,8 +164,9 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         <div>
           <div className="ui-section-title-strong">Activity timeline</div>
           <p id={descriptionId} className="mt-1 text-[10px] font-mono text-terminal-dimmer">
-            Agent time only: user idle is excluded; prompt-to-assistant gaps are LLM wait. Other gap
-            roles are inferred; compaction time is estimated from its preceding gap.
+            {timing.timingMode === "provider-turns"
+              ? "Whole-turn timing only: local tool and LLM time cannot be split for this provider."
+              : "Agent time only: user idle is excluded; prompt-to-assistant gaps are LLM wait. Other gap roles are inferred; compaction time is estimated from its preceding gap."}
           </p>
         </div>
         {timing.totalMs > 0 && (
@@ -245,7 +271,12 @@ export default function TurnActivityTimeline({ scenes }: { scenes: readonly Scen
         <span>{timing.intervals.length} timed segments</span>
         <span>{timing.toolCalls} tool calls</span>
         <span>{formatActivityDuration(timing.timestampGapMs)} from timestamp gaps</span>
-        <span>{formatActivityDuration(timing.toolDurationMs)} provider-recorded tool time</span>
+        <span>{formatActivityDuration(timing.toolDurationMs)} recorded tool time</span>
+        {timing.timingMode === "provider-turns" && timing.providerTurnDurationMs > 0 && (
+          <span>
+            {formatActivityDuration(timing.providerTurnDurationMs)} whole-turn timing; not split
+          </span>
+        )}
         {timing.localToolMs > 0 && (
           <span>local tools {formatActivityDuration(timing.localToolMs)}</span>
         )}

--- a/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
+++ b/packages/viewer/src/components/__tests__/turn-activity-timeline.test.tsx
@@ -51,4 +51,28 @@ describe("TurnActivityTimeline", () => {
     expect(screen.getAllByTitle(/LLM wait/)[0].className).toContain("bg-terminal-thinking");
     expect(screen.getByTitle(/Compaction boundary/).className).toContain("bg-terminal-context");
   });
+
+  it("shows whole-turn timing without pretending to split Cursor work", () => {
+    render(
+      <TurnActivityTimeline
+        provider="cursor"
+        turnStats={[{ turnIndex: 0, durationMs: 3_000 }]}
+        scenes={[
+          { type: "user-prompt", content: "Inspect", timestamp: "2026-08-31T00:00:00.000Z" },
+          {
+            type: "tool-call",
+            toolName: "run_terminal_command_v2",
+            input: { command: "pnpm test" },
+            result: "ok",
+            timestamp: "2026-08-31T00:00:01.000Z",
+          },
+          { type: "text-response", content: "Done", timestamp: "2026-08-31T00:00:10.000Z" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Agent turn (not split)")).toBeDefined();
+    expect(screen.getByText(/Whole-turn timing only/)).toBeDefined();
+    expect(screen.getByText(/whole-turn timing; not split/)).toBeDefined();
+  });
 });

--- a/packages/viewer/src/engine/__tests__/activity-timing.test.ts
+++ b/packages/viewer/src/engine/__tests__/activity-timing.test.ts
@@ -191,6 +191,34 @@ describe("buildActivityTiming", () => {
     expect(result.remoteToolMs).toBe(1_000);
   });
 
+  it("uses whole-turn timing instead of misleading unknown gaps for Cursor/Codex", () => {
+    const result = buildActivityTiming(
+      [
+        { type: "user-prompt", content: "Inspect", timestamp: timestamp(0) },
+        {
+          type: "tool-call",
+          toolName: "run_terminal_command_v2",
+          input: { command: "pnpm test" },
+          result: "ok",
+          timestamp: timestamp(1),
+        },
+        { type: "text-response", content: "Done", timestamp: timestamp(10) },
+      ],
+      { provider: "cursor", turnStats: [{ turnIndex: 0, durationMs: 3_000 }] },
+    );
+
+    expect(result.timingMode).toBe("provider-turns");
+    expect(result.providerTurnDurationMs).toBe(3_000);
+    expect(result.totalMs).toBe(3_000);
+    expect(result.intervals).toEqual([
+      expect.objectContaining({
+        kind: "agent-turn",
+        durationMs: 3_000,
+        source: "turn-duration",
+      }),
+    ]);
+  });
+
   it("keeps known tool time when no scene timestamps exist", () => {
     const result = buildActivityTiming([
       {

--- a/packages/viewer/src/engine/activity-timing.ts
+++ b/packages/viewer/src/engine/activity-timing.ts
@@ -1,4 +1,4 @@
-import type { Scene } from "../types";
+import type { Scene, TurnStat } from "../types";
 
 /** Categories used to identify the local work represented by a tool call. */
 export type ToolCategory = "test" | "lint" | "build" | "check" | "file" | "other";
@@ -11,12 +11,17 @@ export type ToolScope = "local" | "remote" | "unknown";
  * role is inferred from the surrounding replay events.
  */
 export interface ActivityInterval {
-  kind: "llm-wait" | "response" | "tool" | "context" | "unknown";
+  kind: "llm-wait" | "response" | "tool" | "context" | "agent-turn" | "unknown";
   durationMs: number;
   sceneIndex: number;
-  source: "timestamp-gap" | "tool-duration";
+  source: "timestamp-gap" | "tool-duration" | "turn-duration";
   confidence: "inferred" | "measured";
-  note?: "unmeasured-tool" | "context-boundary" | "compaction-duration-estimate";
+  durationSource?: "provider" | "timestamp";
+  note?:
+    | "unmeasured-tool"
+    | "context-boundary"
+    | "compaction-duration-estimate"
+    | "provider-turn-duration";
   toolName?: string;
   toolCategory?: ToolCategory;
   toolScope?: ToolScope;
@@ -53,6 +58,13 @@ export interface ActivityTimingResult {
   remoteToolMs: number;
   unknownToolMs: number;
   toolCategories: Record<ToolCategory, ToolCategoryTotal>;
+  timingMode: "scene-events" | "provider-turns";
+  providerTurnDurationMs: number;
+}
+
+export interface ActivityTimingOptions {
+  provider?: string;
+  turnStats?: readonly TurnStat[];
 }
 
 type PreviousEvent = "user" | "assistant" | "tool" | "context";
@@ -243,7 +255,10 @@ function gapKind(
  * scenes. The function intentionally does not use playback heuristics for
  * response or user time: missing timestamps remain unassigned.
  */
-export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingResult {
+export function buildActivityTiming(
+  scenes: readonly Scene[],
+  options: ActivityTimingOptions = {},
+): ActivityTimingResult {
   const intervals: ActivityInterval[] = [];
   const contextBoundaries: ContextBoundary[] = [];
   const toolCategories = emptyToolCategories();
@@ -342,7 +357,8 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
             durationMs: representedDurationMs,
             sceneIndex,
             source: "tool-duration",
-            confidence: "measured",
+            confidence: scene.durationSource === "timestamp" ? "inferred" : "measured",
+            ...(scene.durationSource ? { durationSource: scene.durationSource } : {}),
             toolName: scene.toolName,
             toolCategory: descriptor.category,
             toolScope: descriptor.scope,
@@ -373,6 +389,56 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     }
   }
 
+  const providerTurnIntervals = (options.turnStats || [])
+    .filter(
+      (turn): turn is TurnStat & { durationMs: number } =>
+        turn.durationMs !== undefined && turn.durationMs > 0,
+    )
+    .map<ActivityInterval>((turn, index) => ({
+      kind: "agent-turn",
+      durationMs: turn.durationMs,
+      sceneIndex: -(index + 1),
+      source: "turn-duration",
+      confidence: "inferred",
+      note: "provider-turn-duration",
+    }));
+  const providerTurnDurationMs = providerTurnIntervals.reduce(
+    (sum, interval) => sum + interval.durationMs,
+    0,
+  );
+  const unknownMs = intervals
+    .filter((interval) => interval.kind === "unknown")
+    .reduce((sum, interval) => sum + interval.durationMs, 0);
+  const useProviderTurnFallback =
+    (options.provider === "cursor" || options.provider === "codex") &&
+    providerTurnIntervals.length > 0 &&
+    toolDurationMs === 0 &&
+    (unknownMs > 0 || intervals.length === 0);
+
+  if (useProviderTurnFallback) {
+    return {
+      intervals: providerTurnIntervals,
+      // Scene timestamps cannot be safely aligned with these whole-turn
+      // durations, so do not position stale context markers against them.
+      contextBoundaries: [],
+      thinkingCount,
+      totalMs: providerTurnDurationMs,
+      timestampGapMs: 0,
+      excludedIdleMs,
+      compactionDurationMs: 0,
+      toolDurationMs: 0,
+      toolCalls,
+      recordedToolCalls: 0,
+      unmeasuredToolCalls,
+      localToolMs: 0,
+      remoteToolMs: 0,
+      unknownToolMs: 0,
+      toolCategories: emptyToolCategories(),
+      timingMode: "provider-turns",
+      providerTurnDurationMs,
+    };
+  }
+
   return {
     intervals,
     contextBoundaries,
@@ -389,5 +455,7 @@ export function buildActivityTiming(scenes: readonly Scene[]): ActivityTimingRes
     remoteToolMs,
     unknownToolMs,
     toolCategories,
+    timingMode: "scene-events",
+    providerTurnDurationMs,
   };
 }


### PR DESCRIPTION
## Summary

- Infer Codex tool duration from paired call/output timestamps when explicit duration is absent.
- Preserve explicit provider durations over inferred follow-up events.
- Use Cursor/Codex whole-turn timing as an honest fallback when per-tool timing is unavailable instead of rendering large misleading unknown gaps.
- Preserve Cursor tool execution durations when they are present in global-state payloads.
- Clarify the UI when timing is whole-turn-only and label inferred tool timing.

## Validation

- Audited 20 unique sessions across Pi, Cursor, Codex, and Claude Code.
- Regenerated representative replays and inspected Summary screenshots.
- `pnpm verify`
- 40 viewer test files / 404 tests

## Data semantics

Cursor global-state sessions still cannot be split into local-tool versus LLM time without a tool end timestamp; they now show provider whole-turn timing instead. Codex timestamp-derived durations are labeled inferred.