### PR TITLE
feat(viewer): show replay generation progress

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -597,6 +597,7 @@ export function SessionDetailPopup({
   onDeleteReplay,
   onRawData,
   isGenerating,
+  generationInProgress = false,
   isArchived,
 }: {
   session: SourceSession;
@@ -609,6 +610,7 @@ export function SessionDetailPopup({
   onDeleteReplay: (slug: string, location?: SessionLocation) => void;
   onRawData?: (session: SourceSession, scanData: SessionScanData | null) => void;
   isGenerating: boolean;
+  generationInProgress?: boolean;
   isArchived: boolean;
 }) {
   const [scanData, setScanData] = useState<SessionScanData | null>(initialScanData);
@@ -1179,8 +1181,12 @@ export function SessionDetailPopup({
               <>
                 <button
                   onClick={() => onGenerate(s, titleValue)}
-                  disabled={isGenerating || !!transcriptStatus}
-                  title={transcriptStatusHelp}
+                  disabled={isGenerating || generationInProgress || !!transcriptStatus}
+                  title={
+                    generationInProgress
+                      ? "Another replay is being generated"
+                      : transcriptStatusHelp
+                  }
                   className="h-11 px-5 text-sm font-sans font-semibold rounded-xl bg-terminal-blue-subtle text-terminal-blue hover:bg-terminal-blue-emphasis transition-all duration-200 flex items-center gap-2 disabled:opacity-50"
                 >
                   {isGenerating ? (
@@ -1227,8 +1233,10 @@ export function SessionDetailPopup({
             {!s.replay && (
               <button
                 onClick={handleGenerate}
-                disabled={isGenerating || !!transcriptStatus}
-                title={transcriptStatusHelp}
+                disabled={isGenerating || generationInProgress || !!transcriptStatus}
+                title={
+                  generationInProgress ? "Another replay is being generated" : transcriptStatusHelp
+                }
                 className="h-12 px-8 text-sm font-sans font-bold rounded-xl bg-terminal-green text-terminal-bg hover:brightness-110 transition-all duration-200 flex items-center gap-2 shadow-lg shadow-terminal-green/20 disabled:opacity-50"
               >
                 {isGenerating ? (

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -105,6 +105,11 @@ function RemoteSourceFailureNotice({ failures }: { failures: string[] }) {
   );
 }
 
+function formatGenerationElapsed(ms: number): string {
+  if (ms < 60_000) return `${Math.max(1, Math.floor(ms / 1000))}s`;
+  return formatCompactDuration(ms);
+}
+
 // ─── Data Fetching ───────────────────────────────────────────────────
 
 function useDashboardData() {
@@ -595,7 +600,7 @@ function RecentSessionsList({
         }`}
       >
         {isGenerating ? (
-          <span className="animate-pulse">{featured ? "Generating..." : "..."}</span>
+          <span className="animate-pulse">{featured ? "Generating..." : "Working..."}</span>
         ) : hasError ? (
           "Failed"
         ) : transcriptStatus ? (
@@ -979,6 +984,8 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const insights = useMemo(() => computeInsights(sources, replays), [sources, replays]);
   const { userInsights } = useScanInsightsContext();
   const [generatingSessionKey, setGeneratingSessionKey] = useState<string | null>(null);
+  const [generationStartedAt, setGenerationStartedAt] = useState<number | null>(null);
+  const [generationElapsedMs, setGenerationElapsedMs] = useState(0);
   const [generateErrorSessionKey, setGenerateErrorSessionKey] = useState<string | null>(null);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [selectedSessionKey, setSelectedSessionKey] = useState<string | null>(null);
@@ -1005,6 +1012,23 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     ? archiveSessionKey(selectedSession.slug, selectedSession.location)
     : null;
   const selectedIsArchived = selectedArchiveKey ? archivedSlugs.has(selectedArchiveKey) : false;
+  const generatingSource = generatingSessionKey
+    ? (sources.find((source) => sessionIdentityKey(source) === generatingSessionKey) ?? null)
+    : null;
+  const generatingTitle = generatingSource
+    ? sourceSuggestedTitle(generatingSource)
+    : "selected session";
+
+  useEffect(() => {
+    if (generationStartedAt === null) {
+      setGenerationElapsedMs(0);
+      return;
+    }
+    const updateElapsed = () => setGenerationElapsedMs(Date.now() - generationStartedAt);
+    updateElapsed();
+    const timer = setInterval(updateElapsed, 1000);
+    return () => clearInterval(timer);
+  }, [generationStartedAt]);
   useEffect(() => {
     let mounted = true;
     void fetch("/api/archived")
@@ -1074,6 +1098,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const handleGenerate = async (source: SourceSession) => {
     const identity = sessionIdentityKey(source);
     setGeneratingSessionKey(identity);
+    setGenerationStartedAt(Date.now());
     setGenerateErrorSessionKey(null);
     try {
       const title = sourceSuggestedTitle(source);
@@ -1106,6 +1131,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
       );
     } finally {
       setGeneratingSessionKey(null);
+      setGenerationStartedAt(null);
     }
   };
 
@@ -1114,6 +1140,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     setSelectedSessionKey(null);
     const identity = sessionIdentityKey(source);
     setGeneratingSessionKey(identity);
+    setGenerationStartedAt(Date.now());
     setGenerateErrorSessionKey(null);
     try {
       const resp = await fetchWithRetry("/api/generate", {
@@ -1145,6 +1172,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
       );
     } finally {
       setGeneratingSessionKey(null);
+      setGenerationStartedAt(null);
     }
   };
 
@@ -1548,6 +1576,13 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                 ? "Home is using cached data while local providers refresh in the background."
                 : "Recent sessions will update in place as titles, prompt previews, counts, and metrics become available."
             }
+          />
+        )}
+
+        {generatingSessionKey && (
+          <SessionLoadingBanner
+            title="Generating replay"
+            description={`${generatingTitle} — parsing the session and building the replay. Large sessions may take a while. Elapsed ${formatGenerationElapsed(generationElapsedMs)}. The replay will open automatically when it is ready.`}
           />
         )}
 

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -539,6 +539,7 @@ function RecentSessionsList({
   onViewReplay,
   onSessionClick,
   generatingSessionKey,
+  generationInProgress,
   generateErrorSessionKey,
 }: {
   sessions: SourceSession[];
@@ -548,6 +549,7 @@ function RecentSessionsList({
   onViewReplay: (slug: string, location?: SessionLocation) => void;
   onSessionClick: (source: SourceSession) => void;
   generatingSessionKey: string | null;
+  generationInProgress: boolean;
   generateErrorSessionKey: string | null;
 }) {
   if (sessions.length === 0) {
@@ -564,6 +566,7 @@ function RecentSessionsList({
     const hasReplay = !!s.existingReplay;
     const identity = sessionIdentityKey(s);
     const isGenerating = generatingSessionKey === identity;
+    const anotherGenerationInProgress = generationInProgress && !isGenerating;
     const hasError = generateErrorSessionKey === identity;
     const transcriptStatus = s.transcriptStatus;
     const sizeClass = featured ? "h-8 px-3.5" : "h-7 px-3";
@@ -591,8 +594,12 @@ function RecentSessionsList({
           e.stopPropagation();
           onGenerate(s);
         }}
-        disabled={isGenerating || !!transcriptStatus}
-        title={transcriptStatusDescription(transcriptStatus)}
+        disabled={isGenerating || anotherGenerationInProgress || !!transcriptStatus}
+        title={
+          anotherGenerationInProgress
+            ? "Another replay is being generated"
+            : transcriptStatusDescription(transcriptStatus)
+        }
         className={`${sizeClass} text-xs font-sans font-semibold rounded-md transition-all duration-200 disabled:opacity-50 flex items-center gap-1 shrink-0 ${
           hasError
             ? "bg-terminal-red-subtle text-terminal-red"
@@ -998,6 +1005,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   const [, setTick] = useState(0);
   const [activityWindow, setActivityWindow] = useState<ActivityWindow>("today");
   const requestedEnrichmentSignatureRef = useRef("");
+  const activeGenerationRequestRef = useRef<number | null>(null);
   const syncPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const syncPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const legacySelectedSlugMatches = selectedSlug
@@ -1096,7 +1104,10 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
   };
 
   const handleGenerate = async (source: SourceSession) => {
+    if (activeGenerationRequestRef.current !== null) return;
     const identity = sessionIdentityKey(source);
+    const requestId = Date.now();
+    activeGenerationRequestRef.current = requestId;
     setGeneratingSessionKey(identity);
     setGenerationStartedAt(Date.now());
     setGenerateErrorSessionKey(null);
@@ -1130,15 +1141,21 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
         2000,
       );
     } finally {
-      setGeneratingSessionKey(null);
-      setGenerationStartedAt(null);
+      if (activeGenerationRequestRef.current === requestId) {
+        activeGenerationRequestRef.current = null;
+        setGeneratingSessionKey(null);
+        setGenerationStartedAt(null);
+      }
     }
   };
 
   const submitGenerateFromPopup = async (source: SourceSession, title: string) => {
+    if (activeGenerationRequestRef.current !== null) return;
     setSelectedSlug(null);
     setSelectedSessionKey(null);
     const identity = sessionIdentityKey(source);
+    const requestId = Date.now();
+    activeGenerationRequestRef.current = requestId;
     setGeneratingSessionKey(identity);
     setGenerationStartedAt(Date.now());
     setGenerateErrorSessionKey(null);
@@ -1171,8 +1188,11 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
         2000,
       );
     } finally {
-      setGeneratingSessionKey(null);
-      setGenerationStartedAt(null);
+      if (activeGenerationRequestRef.current === requestId) {
+        activeGenerationRequestRef.current = null;
+        setGeneratingSessionKey(null);
+        setGenerationStartedAt(null);
+      }
     }
   };
 
@@ -1611,6 +1631,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
                   setSelectedSessionKey(sessionIdentityKey(s));
                 }}
                 generatingSessionKey={generatingSessionKey}
+                generationInProgress={generatingSessionKey !== null}
                 generateErrorSessionKey={generateErrorSessionKey}
               />
             </div>
@@ -1737,6 +1758,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           onTitleSave={handleTitleSave}
           onDeleteReplay={handleDeleteReplay}
           isGenerating={generatingSessionKey === sessionIdentityKey(selectedSession)}
+          generationInProgress={generatingSessionKey !== null}
           isArchived={selectedIsArchived}
         />
       )}


### PR DESCRIPTION
## Summary

- Show a persistent page-level progress banner after Generate/Regenerate is clicked.
- Keep the user informed while `/api/generate` parses large sessions and builds the replay.
- Show the selected session title, elapsed time, indeterminate progress, and an explicit automatic-open message.
- Keep row and popup actions in a working state with `Generating...` / `Working...` labels.

## Validation

- `pnpm verify`
- 40 viewer test files / 404 tests

The server currently exposes generation as one request without phase events, so the UI intentionally uses an indeterminate progress indicator rather than pretending to know a percentage.