### PR TITLE
fix: avoid duplicate dashboard discovery

### DIFF
--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -57,7 +57,7 @@ import {
   resolveCursorLiveWatchPaths,
 } from "./providers/cursor/sqlite-reader.js";
 import { getAllProviders, getProvider } from "./providers/index.js";
-import { discoverProvidersSafely } from "./provider-discovery.js";
+import { discoverProvidersSafely, type SafeProviderDiscoveryResult } from "./provider-discovery.js";
 import { getApiUrl, loadSavedCloudInfo, publishCloudWithOverlays } from "./publishers/cloud.js";
 import {
   checkPublishStatus,
@@ -1172,6 +1172,42 @@ export async function startServer(
   let lastDiscoveredMergedSessions: SessionInfo[] = [];
   let latestSourceFailures: string[] | undefined;
   let remoteConfigChangedAt: number | undefined;
+  type DiscoverySubscriber = (session: SessionInfo) => Promise<void> | void;
+  let localDiscoveryRun: {
+    promise: Promise<SafeProviderDiscoveryResult>;
+    subscribers: Set<DiscoverySubscriber>;
+  } | null = null;
+
+  /** Share one local/SSH provider discovery across the dashboard and scanner. */
+  const discoverAllProviders = (
+    subscriber?: DiscoverySubscriber,
+  ): Promise<SafeProviderDiscoveryResult> => {
+    let run = localDiscoveryRun;
+    if (!run) {
+      const subscribers = new Set<DiscoverySubscriber>();
+      const promise = discoverProvidersSafely(getAllProviders(), async (session) => {
+        await Promise.all(
+          [...subscribers].map(async (listener) => {
+            try {
+              await listener(session);
+            } catch {
+              // A disconnected SSE client must not abort discovery for everyone else.
+            }
+          }),
+        );
+      }).finally(() => {
+        if (localDiscoveryRun?.promise === promise) localDiscoveryRun = null;
+      });
+      run = { promise, subscribers };
+      localDiscoveryRun = run;
+    }
+
+    if (subscriber) run.subscribers.add(subscriber);
+    const activeRun = run;
+    return activeRun.promise.finally(() => {
+      if (subscriber) activeRun.subscribers.delete(subscriber);
+    });
+  };
 
   const enrichCursorStatsInBackground = (
     merged: SessionInfo[],
@@ -1708,7 +1744,14 @@ export async function startServer(
     void (async () => {
       try {
         // Discover all sessions
-        const discovery = await discoverProvidersSafely(getAllProviders());
+        const discovery = await discoverAllProviders(async () => {
+          scanState = {
+            ...scanState,
+            phase: "discovering",
+            scanned: scanState.scanned + 1,
+            total: 0,
+          };
+        });
         const merged = mergeSameSessions(discovery.sessions);
         scanState.failedProviders = discovery.failedProviders;
 
@@ -1756,7 +1799,11 @@ export async function startServer(
           hints,
         );
 
-        scanState.total = scanInputs.length;
+        scanState = {
+          ...scanState,
+          scanned: 0,
+          total: scanInputs.length,
+        };
 
         const freshResults = await runBackgroundScan(scanInputs, (progress) => {
           scanState = {
@@ -2625,7 +2672,7 @@ export async function startServer(
 
   const getSourceSessions = async (c: Context) => {
     try {
-      const discovery = await discoverProvidersSafely(getAllProviders());
+      const discovery = await discoverAllProviders();
       latestSourceFailures = discovery.failedProviders;
       const merged = mergeSameSessions(discovery.sessions);
       lastDiscoveredMergedSessions = normalizeSessionProjectsForHome(merged, homedir());
@@ -2705,7 +2752,7 @@ export async function startServer(
     return streamSSE(c, async (stream) => {
       try {
         let scanned = 0;
-        const discovery = await discoverProvidersSafely(getAllProviders(), async () => {
+        const discovery = await discoverAllProviders(async () => {
           scanned++;
           // Emit progress every 5 sessions to avoid overwhelming the client
           if (scanned % 5 === 0 || scanned === 1) {
@@ -2857,7 +2904,7 @@ export async function startServer(
 
     // Discover all sessions across all providers and configured SSH sources.
     const allProviders = getAllProviders();
-    const allSessions = mergeSameSessions((await discoverProvidersSafely(allProviders)).sessions);
+    const allSessions = mergeSameSessions((await discoverAllProviders()).sessions);
 
     let entries: string[];
     try {

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -5518,7 +5518,9 @@ function ScanToast() {
 
   const label =
     displayStatus.phase === "discovering"
-      ? "Discovering sessions..."
+      ? displayStatus.scanned > 0
+        ? `Discovering sessions (${displayStatus.scanned} found)...`
+        : "Discovering sessions..."
       : displayStatus.total > 0
         ? `Scanning ${displayStatus.scanned}/${displayStatus.total}`
         : "Preparing scan...";

--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -120,7 +120,7 @@ function useDashboardData() {
   const [loadingReplays, setLoadingReplays] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [failedRemoteSources, setFailedRemoteSources] = useState<string[]>([]);
-  const [, setScanProgress] = useState<number | null>(null);
+  const [discoveryProgress, setDiscoveryProgress] = useState<number | null>(null);
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const wasEnrichingRef = useRef(false);
   const lastSourcesCachedAtRef = useRef<string | undefined>(undefined);
@@ -167,24 +167,24 @@ function useDashboardData() {
         // Use SSE stream for discovery with progress reporting
         refreshPromises.push(
           new Promise<void>((resolve) => {
-            setScanProgress(0);
+            setDiscoveryProgress(0);
             const es = new EventSource("/api/sources/stream");
             es.onmessage = (evt) => {
               try {
                 const msg = JSON.parse(evt.data);
                 if (msg.type === "progress") {
-                  setScanProgress(msg.scanned);
+                  setDiscoveryProgress(msg.scanned);
                 } else if (msg.type === "complete") {
                   setSources(msg.sessions);
                   setFailedRemoteSources(remoteSourceFailureLabels(msg));
-                  setScanProgress(null);
+                  setDiscoveryProgress(null);
                   es.close();
                   resolve();
                 } else if (msg.type === "error") {
                   if (!cachedSources?.sessions.length) {
                     setError(msg.message || "Failed to load sessions");
                   }
-                  setScanProgress(null);
+                  setDiscoveryProgress(null);
                   es.close();
                   resolve();
                 }
@@ -195,7 +195,7 @@ function useDashboardData() {
             es.onerror = () => {
               // SSE failed — fall back to regular fetch
               es.close();
-              setScanProgress(null);
+              setDiscoveryProgress(null);
               fetchWithRetry("/api/sources")
                 .then((r) => {
                   if (!r.ok) throw new Error("Failed to load sources");
@@ -303,6 +303,7 @@ function useDashboardData() {
     replays,
     loading,
     loadingSources,
+    discoveryProgress,
     loadingReplays,
     enrichmentStatus,
     error,
@@ -983,6 +984,7 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     replays,
     loading,
     loadingSources,
+    discoveryProgress,
     loadingReplays,
     enrichmentStatus,
     error,
@@ -1593,8 +1595,15 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
             }
             description={
               loadingSources
-                ? "Home is using cached data while local providers refresh in the background."
+                ? discoveryProgress === null
+                  ? "Home is using cached data while local providers refresh in the background."
+                  : `Discovered ${discoveryProgress} sessions so far. Home is using cached data while the refresh continues.`
                 : "Recent sessions will update in place as titles, prompt previews, counts, and metrics become available."
+            }
+            progress={
+              loadingSources && discoveryProgress !== null
+                ? { current: discoveryProgress }
+                : undefined
             }
           />
         )}

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -274,13 +274,16 @@ export function SessionLoadingRibbon({
   status,
   title,
   description,
+  progress,
 }: {
   status?: SourcesEnrichmentStatus | null;
   title: string;
   description: string;
+  progress?: { current: number; total?: number };
 }) {
-  const total = status?.total ?? 0;
-  const processed = status?.processed ?? 0;
+  const total = status?.total ?? progress?.total ?? 0;
+  const processed = status?.processed ?? progress?.current ?? 0;
+  const progressLabel = total > 0 ? `${processed}/${total}` : `${processed} discovered`;
 
   return (
     <div className="rounded-lg border border-terminal-blue/20 bg-terminal-blue-subtle/95 px-3 py-2 text-terminal-blue shadow-layer-md backdrop-blur-sm">
@@ -289,9 +292,9 @@ export function SessionLoadingRibbon({
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-3">
             <div className="text-xs font-mono truncate">{title}</div>
-            {total > 0 && (
+            {(status || progress) && (
               <div className="text-[10px] font-mono tabular-nums text-terminal-blue/75">
-                {processed}/{total}
+                {progressLabel}
               </div>
             )}
           </div>
@@ -319,6 +322,7 @@ export function SessionLoadingBanner(props: {
   status?: SourcesEnrichmentStatus | null;
   title: string;
   description: string;
+  progress?: { current: number; total?: number };
 }) {
   return (
     <div

--- a/packages/viewer/src/components/__tests__/session-data-progress.test.tsx
+++ b/packages/viewer/src/components/__tests__/session-data-progress.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SessionLoadingBanner } from "../SessionDataProgress";
+
+describe("SessionLoadingBanner", () => {
+  it("shows discovery progress when the total is not known yet", () => {
+    render(
+      <SessionLoadingBanner
+        title="Refreshing local session list"
+        description="Discovering sessions"
+        progress={{ current: 17 }}
+      />,
+    );
+
+    expect(screen.getByText("17 discovered")).toBeTruthy();
+  });
+
+  it("shows processed and total counts for enrichment progress", () => {
+    render(
+      <SessionLoadingBanner
+        title="Loading more local session details"
+        description="Enriching sessions"
+        status={{ running: true, processed: 3, total: 10, updated: 0 }}
+      />,
+    );
+
+    expect(screen.getByText("3/10")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- share in-flight local/SSH provider discovery between Dashboard Home, source catalog refresh, and Insights scanning
- expose discovered-session progress while provider discovery is still running
- add regression coverage for the loading progress UI

## Validation
- `pnpm verify` (Node 22.22.3)
- `pnpm test:e2e`
- targeted Dashboard/progress tests

This addresses the Dashboard state where `Discovering sessions...` appeared stuck while Home and the scanner were independently reading the same provider stores.