### PR TITLE
fix: remove duplicate discovery banner

### DIFF
--- a/packages/viewer/src/components/DashboardHome.tsx
+++ b/packages/viewer/src/components/DashboardHome.tsx
@@ -120,7 +120,6 @@ function useDashboardData() {
   const [loadingReplays, setLoadingReplays] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [failedRemoteSources, setFailedRemoteSources] = useState<string[]>([]);
-  const [discoveryProgress, setDiscoveryProgress] = useState<number | null>(null);
   const [enrichmentStatus, setEnrichmentStatus] = useState<SourcesEnrichmentStatus | null>(null);
   const wasEnrichingRef = useRef(false);
   const lastSourcesCachedAtRef = useRef<string | undefined>(undefined);
@@ -167,24 +166,19 @@ function useDashboardData() {
         // Use SSE stream for discovery with progress reporting
         refreshPromises.push(
           new Promise<void>((resolve) => {
-            setDiscoveryProgress(0);
             const es = new EventSource("/api/sources/stream");
             es.onmessage = (evt) => {
               try {
                 const msg = JSON.parse(evt.data);
-                if (msg.type === "progress") {
-                  setDiscoveryProgress(msg.scanned);
-                } else if (msg.type === "complete") {
+                if (msg.type === "complete") {
                   setSources(msg.sessions);
                   setFailedRemoteSources(remoteSourceFailureLabels(msg));
-                  setDiscoveryProgress(null);
                   es.close();
                   resolve();
                 } else if (msg.type === "error") {
                   if (!cachedSources?.sessions.length) {
                     setError(msg.message || "Failed to load sessions");
                   }
-                  setDiscoveryProgress(null);
                   es.close();
                   resolve();
                 }
@@ -195,7 +189,6 @@ function useDashboardData() {
             es.onerror = () => {
               // SSE failed — fall back to regular fetch
               es.close();
-              setDiscoveryProgress(null);
               fetchWithRetry("/api/sources")
                 .then((r) => {
                   if (!r.ok) throw new Error("Failed to load sources");
@@ -303,7 +296,6 @@ function useDashboardData() {
     replays,
     loading,
     loadingSources,
-    discoveryProgress,
     loadingReplays,
     enrichmentStatus,
     error,
@@ -984,7 +976,6 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
     replays,
     loading,
     loadingSources,
-    discoveryProgress,
     loadingReplays,
     enrichmentStatus,
     error,
@@ -1585,26 +1576,11 @@ export default function DashboardHome({ onNavigate }: DashboardHomeProps) {
           </div>
         </div>
 
-        {(loadingSources || (enrichmentStatus?.running && enrichmentStatus.total > 0)) && (
+        {enrichmentStatus?.running && enrichmentStatus.total > 0 && (
           <SessionLoadingBanner
-            status={enrichmentStatus?.running ? enrichmentStatus : null}
-            title={
-              loadingSources
-                ? "Refreshing local session list"
-                : "Loading more local session details"
-            }
-            description={
-              loadingSources
-                ? discoveryProgress === null
-                  ? "Home is using cached data while local providers refresh in the background."
-                  : `Discovered ${discoveryProgress} sessions so far. Home is using cached data while the refresh continues.`
-                : "Recent sessions will update in place as titles, prompt previews, counts, and metrics become available."
-            }
-            progress={
-              loadingSources && discoveryProgress !== null
-                ? { current: discoveryProgress }
-                : undefined
-            }
+            status={enrichmentStatus}
+            title="Loading more local session details"
+            description="Recent sessions will update in place as titles, prompt previews, counts, and metrics become available."
           />
         )}
 

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -274,16 +274,13 @@ export function SessionLoadingRibbon({
   status,
   title,
   description,
-  progress,
 }: {
   status?: SourcesEnrichmentStatus | null;
   title: string;
   description: string;
-  progress?: { current: number; total?: number };
 }) {
-  const total = status?.total ?? progress?.total ?? 0;
-  const processed = status?.processed ?? progress?.current ?? 0;
-  const progressLabel = total > 0 ? `${processed}/${total}` : `${processed} discovered`;
+  const total = status?.total ?? 0;
+  const processed = status?.processed ?? 0;
 
   return (
     <div className="rounded-lg border border-terminal-blue/20 bg-terminal-blue-subtle/95 px-3 py-2 text-terminal-blue shadow-layer-md backdrop-blur-sm">
@@ -292,9 +289,9 @@ export function SessionLoadingRibbon({
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-3">
             <div className="text-xs font-mono truncate">{title}</div>
-            {(status || progress) && (
+            {total > 0 && (
               <div className="text-[10px] font-mono tabular-nums text-terminal-blue/75">
-                {progressLabel}
+                {processed}/{total}
               </div>
             )}
           </div>
@@ -322,7 +319,6 @@ export function SessionLoadingBanner(props: {
   status?: SourcesEnrichmentStatus | null;
   title: string;
   description: string;
-  progress?: { current: number; total?: number };
 }) {
   return (
     <div

--- a/packages/viewer/src/components/__tests__/session-data-progress.test.tsx
+++ b/packages/viewer/src/components/__tests__/session-data-progress.test.tsx
@@ -4,18 +4,6 @@ import { describe, expect, it } from "vitest";
 import { SessionLoadingBanner } from "../SessionDataProgress";
 
 describe("SessionLoadingBanner", () => {
-  it("shows discovery progress when the total is not known yet", () => {
-    render(
-      <SessionLoadingBanner
-        title="Refreshing local session list"
-        description="Discovering sessions"
-        progress={{ current: 17 }}
-      />,
-    );
-
-    expect(screen.getByText("17 discovered")).toBeTruthy();
-  });
-
   it("shows processed and total counts for enrichment progress", () => {
     render(
       <SessionLoadingBanner


### PR DESCRIPTION
## Summary
- keep the global top-right discovery indicator as the single discovery progress surface
- remove the duplicate Home-level discovery banner while preserving enrichment and replay-generation banners
- keep the loading UI focused on one source of truth

## Validation
- `pnpm --filter @vibe-replay/viewer test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint:check`

The screenshot showed the same discovery represented by both the top-right toast and the Home banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed source-discovery progress tracking from the dashboard.
  - The session loading banner now appears only while enrichment is running, rather than during local session list refreshes.
  - Progress counters are shown only when a total is available, using enrichment status data.
  - Discovery-specific progress messaging, including “discovered” counts, is no longer displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->