### PR TITLE
fix: index skill file activations

### DIFF
--- a/docs/session-observability-audit.md
+++ b/docs/session-observability-audit.md
@@ -18,7 +18,9 @@ separately in the **Insights → Coverage** section.
 - `cacheReadShare = cacheReadTokens / promptTokens`.
 - “Uncached / miss” is derived. There is no provider-independent cache-miss
   counter, so it must not be presented as an exact billing field.
-- Invocation counts are one event per concrete tool call. MCP calls are removed
+- Invocation counts are one event per concrete tool call or skill activation.
+  A concrete read of a provider's `SKILL.md` is skill activation evidence;
+  injected lists of available skills are not activations. MCP calls are removed
   from the ordinary-tool facet and counted under their server; named MCP tools
   are measured separately from server-only calls.
 - A completed index with zero invocations is valid evidence of zero calls. It is

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -72,7 +72,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v34: persist provider/session diagnostic events and Pi compaction evidence.
 // v35: retain Pi usage from assistant records without visible replay content.
 // v36: index privacy-safe provider context composition metadata.
-export const SCANNER_VERSION = 36;
+// v37: count concrete SKILL.md reads as skill activations across providers.
+export const SCANNER_VERSION = 37;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -333,15 +334,85 @@ function parseMcpUsage(rawName: string, input?: Record<string, unknown>): McpUsa
   return undefined;
 }
 
+const SKILL_PATH_ROOTS = new Set(["skills", "skills-cursor"]);
+const SKILL_INPUT_KEYS = new Set([
+  "command",
+  "cmd",
+  "file_path",
+  "file_paths",
+  "filepath",
+  "filePath",
+  "path",
+  "paths",
+]);
+
+function skillNameFromPath(value: string): string | undefined {
+  const segments = value.replaceAll("\\", "/").split("/").filter(Boolean);
+  for (let index = segments.length - 1; index >= 0; index--) {
+    if (segments[index]?.toLowerCase() !== "skill.md") continue;
+
+    let candidateIndex = index - 1;
+    if (candidateIndex < 0) continue;
+    // rbx-skills snapshots store skills as skills/<name>/<commit>/SKILL.md.
+    if (/^[0-9a-f]{20,}$/i.test(segments[candidateIndex] || "")) candidateIndex--;
+    const candidate = segments[candidateIndex]?.trim();
+    if (
+      !candidate ||
+      candidate === "**" ||
+      candidate === "*" ||
+      candidate.startsWith("<") ||
+      candidate === "." ||
+      candidate === ".."
+    ) {
+      continue;
+    }
+
+    // Prefer the explicit skills root. This handles both normal installations
+    // and nested snapshot/backup directories without treating every README
+    // that happens to be named SKILL.md as a skill.
+    for (let rootIndex = candidateIndex - 1; rootIndex >= 0; rootIndex--) {
+      if (SKILL_PATH_ROOTS.has(segments[rootIndex]?.toLowerCase() || "")) return candidate;
+    }
+
+    // Glob patterns such as **/ros-cli/SKILL.md do not contain a skills root,
+    // but still name one concrete skill. Keep the fallback narrow so a bare
+    // **/SKILL.md search is not counted.
+    if (index - candidateIndex >= 1 && candidateIndex < index - 1) return candidate;
+    if (candidateIndex === index - 1 && candidateIndex > 0) {
+      const previous = segments[candidateIndex - 1];
+      if (previous === "**" || previous === "*") return candidate;
+    }
+  }
+  return undefined;
+}
+
+function skillNameFromInput(input: Record<string, unknown>): string | undefined {
+  for (const [key, value] of Object.entries(input)) {
+    if (!SKILL_INPUT_KEYS.has(key)) continue;
+    const values = Array.isArray(value) ? value : [value];
+    for (const candidate of values) {
+      if (typeof candidate !== "string") continue;
+      const skillName = skillNameFromPath(candidate);
+      if (skillName) return skillName;
+    }
+  }
+  return undefined;
+}
+
 function skillNameFromTool(block: Extract<ContentBlock, { type: "tool_use" }>): string | undefined {
   if (block._skillName?.trim()) return block._skillName.trim();
   const normalizedName = block.name.trim().toLowerCase();
-  if (normalizedName !== "skill" && normalizedName !== "skill_view") return undefined;
-  for (const key of ["name", "skill", "skillName", "skill_name", "slug"]) {
-    const value = block.input?.[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
+  if (normalizedName === "skill" || normalizedName === "skill_view") {
+    for (const key of ["name", "skill", "skillName", "skill_name", "slug"]) {
+      const value = block.input?.[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
   }
-  return undefined;
+  // Cursor, Codex, and Pi commonly activate a skill by reading its SKILL.md
+  // with their ordinary file/shell tools rather than emitting a provider-native
+  // Skill tool. The input is concrete invocation evidence; injected lists of
+  // available skills are not scanned here and therefore do not inflate counts.
+  return skillNameFromInput(block.input);
 }
 
 /** Results that still need the rich Cursor pass before usage facets are complete. */

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -335,6 +335,7 @@ function parseMcpUsage(rawName: string, input?: Record<string, unknown>): McpUsa
 }
 
 const SKILL_PATH_ROOTS = new Set(["skills", "skills-cursor"]);
+const SKILL_READ_COMMANDS = new Set(["cat", "head", "less", "more", "sed", "tail"]);
 const SKILL_INPUT_KEYS = new Set([
   "command",
   "cmd",
@@ -386,13 +387,32 @@ function skillNameFromPath(value: string): string | undefined {
   return undefined;
 }
 
+function skillNameFromCommand(command: string): string | undefined {
+  const tokens = [...command.matchAll(/'([^']*)'|"([^"]*)"|([^\s]+)/g)].map(
+    (match) => match[1] ?? match[2] ?? match[3] ?? "",
+  );
+  const executable = tokens[0]?.split("/").pop()?.toLowerCase();
+  if (!executable || !SKILL_READ_COMMANDS.has(executable)) return undefined;
+
+  for (const token of tokens.slice(1)) {
+    const argument = token.replace(/^[;|&]+|[;|&]+$/g, "");
+    if (!argument || argument === "--" || argument.startsWith("-")) continue;
+    const skillName = skillNameFromPath(argument);
+    if (skillName) return skillName;
+  }
+  return undefined;
+}
+
 function skillNameFromInput(input: Record<string, unknown>): string | undefined {
   for (const [key, value] of Object.entries(input)) {
     if (!SKILL_INPUT_KEYS.has(key)) continue;
     const values = Array.isArray(value) ? value : [value];
     for (const candidate of values) {
       if (typeof candidate !== "string") continue;
-      const skillName = skillNameFromPath(candidate);
+      const skillName =
+        key === "command" || key === "cmd"
+          ? skillNameFromCommand(candidate)
+          : skillNameFromPath(candidate);
       if (skillName) return skillName;
     }
   }

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -541,6 +541,69 @@ describe("scanSession", () => {
     expect(JSON.stringify(result.usageEvents)).not.toContain("/secret/path.ts");
   });
 
+  it("counts concrete SKILL.md reads as skill activations", async () => {
+    const path = join(tmpDir, "usage-skill-reads.jsonl");
+    await writeFile(
+      path,
+      makeLine({
+        type: "assistant",
+        timestamp: "2025-03-20T10:00:00Z",
+        message: {
+          role: "assistant",
+          id: "skill-read-message",
+          content: [
+            {
+              type: "tool_use",
+              id: "skill-read-1",
+              name: "Read",
+              input: { file_path: "/Users/test/.claude/skills/ros-cli/SKILL.md" },
+            },
+            {
+              type: "tool_use",
+              id: "skill-read-2",
+              name: "Bash",
+              input: { command: "cat /Users/test/.pi/agent/skills/mcp-adaptor/SKILL.md" },
+            },
+            {
+              type: "tool_use",
+              id: "skill-read-3",
+              name: "Glob",
+              input: { glob_pattern: "**/replay/SKILL.md" },
+            },
+            {
+              type: "tool_use",
+              id: "skill-read-4",
+              name: "Read",
+              input: {
+                file_path:
+                  "/Users/test/.local/share/rbx-skills/snapshots/Roblox/skills/gdrive/0123456789abcdef0123456789abcdef01234567/SKILL.md",
+              },
+            },
+          ],
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "usage-skill-reads",
+      provider: "claude-code",
+      project: "~/test/project",
+      slug: "usage-skill-reads",
+      filePaths: [path],
+    });
+
+    // Locating a skill with a glob is still an ordinary tool call; only a
+    // concrete SKILL.md path read is counted as activation evidence.
+    expect(result.usageSummary?.tools).toEqual({ Glob: 1 });
+    expect(result.usageSummary?.skills).toEqual({
+      "mcp-adaptor": 1,
+      "ros-cli": 1,
+      gdrive: 1,
+    });
+    expect(result.usageEvents?.filter((event) => event.kind === "skill")).toHaveLength(3);
+  });
+
   it("preserves repeated rich-provider skill activations and MCP attribution", async () => {
     const path = join(tmpDir, "usage-rich-attribution.jsonl");
     await writeFile(

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -572,6 +572,12 @@ describe("scanSession", () => {
             },
             {
               type: "tool_use",
+              id: "skill-read-echo",
+              name: "Bash",
+              input: { command: "echo /Users/test/.pi/agent/skills/not-a-skill/SKILL.md" },
+            },
+            {
+              type: "tool_use",
               id: "skill-read-4",
               name: "Read",
               input: {
@@ -595,7 +601,7 @@ describe("scanSession", () => {
 
     // Locating a skill with a glob is still an ordinary tool call; only a
     // concrete SKILL.md path read is counted as activation evidence.
-    expect(result.usageSummary?.tools).toEqual({ Glob: 1 });
+    expect(result.usageSummary?.tools).toEqual({ Bash: 1, Glob: 1 });
     expect(result.usageSummary?.skills).toEqual({
       "mcp-adaptor": 1,
       "ros-cli": 1,


### PR DESCRIPTION
## Summary
- count concrete `SKILL.md` reads from ordinary provider tools as skill activations
- keep skill discovery/glob searches and injected available-skill lists out of activation counts
- bump the scanner version so existing usage caches are rescanned
- add regression coverage for Claude, Pi, snapshot, and glob-shaped inputs

## Why
The Insights usage rollup only recognized provider-native `Skill`/metadata records. Cursor and Pi commonly activate skills by reading `SKILL.md` through `Read` or shell tools, so the dashboard reported only a handful of activations despite substantial skill usage.

## Validation
- `pnpm test`
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm --filter vibe-replay build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified invocation-counting rules for session observability.
  * Concrete tool calls and skill activations are counted as individual events.
  * Reading a skill’s `SKILL.md` counts as activation evidence, while injected skill lists and glob-based discovery do not.

* **Bug Fixes**
  * Improved detection of skill activations across supported file-reading and command-based tools.
  * Recognized skill paths from common path formats and snapshot layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->