### PR TITLE
fix(viewer): make project timeline the default

### DIFF
--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -2,9 +2,9 @@
  * ProjectsPanel — full-page Projects tab.
  *
  * Layout mirrors Sessions / Replays: a left sidebar listing projects, and a
- * right pane showing the selected project's content. View tabs (Overview /
- * Timeline / Hot Files) live in the right pane and adapt to whether one
- * project is selected or "All projects".
+ * right pane showing the selected project's content. View tabs (Timeline /
+ * Overview / Hot Files) live in the right pane and keep the same navigation
+ * whether one project or "All projects" is selected.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -32,8 +32,8 @@ interface ProjectsPanelProps {
 type PanelMode = "overview" | "timeline" | "files";
 
 const PROJECT_VIEW_TABS: { id: PanelMode; label: string }[] = [
-  { id: "overview", label: "Overview" },
   { id: "timeline", label: "Timeline" },
+  { id: "overview", label: "Overview" },
   { id: "files", label: "Hot Files" },
 ];
 
@@ -465,7 +465,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     loading: insightsLoading,
   } = useScanInsightsContext();
   const [selectedProjectKey, setSelectedProjectKey] = useState<string>(ALL_PROJECTS);
-  const [mode, setMode] = useState<PanelMode>("overview");
+  const [mode, setMode] = useState<PanelMode>("timeline");
   const [showAgentRuns, setShowAgentRuns] = useState(
     () => new URLSearchParams(window.location.search).get("agentRuns") === "true",
   );
@@ -567,12 +567,13 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     lastActivity: p.lastActivity,
   }));
 
-  // Single-project Overview already embeds the timeline; the standalone tab
-  // is redundant and dropped. Hot Files stays as its own tab.
+  const selectProject = (projectKey: string) => {
+    setSelectedProjectKey(projectKey);
+    setMode("timeline");
+  };
+
   const isSingleProject = selectedProjectKey !== ALL_PROJECTS;
-  const visibleTabs = isSingleProject
-    ? PROJECT_VIEW_TABS.filter((t) => t.id !== "timeline")
-    : PROJECT_VIEW_TABS;
+  const visibleTabs = PROJECT_VIEW_TABS;
   const activeMode = visibleTabs.some((t) => t.id === mode) ? mode : "overview";
   const projectFilterArg = isSingleProject ? selectedProject : undefined;
 
@@ -582,10 +583,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
       <ProjectSidebar
         projects={sidebarProjects}
         selected={selectedProjectKey}
-        onSelect={(projectKey) => {
-          setSelectedProjectKey(projectKey);
-          setMode("overview");
-        }}
+        onSelect={selectProject}
       />
 
       {/* ─── Right pane: header + tabs + content ─── */}
@@ -596,8 +594,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
             aria-label="Select project"
             value={selectedProjectKey}
             onChange={(e) => {
-              setSelectedProjectKey(e.target.value);
-              setMode("overview");
+              selectProject(e.target.value);
             }}
             className="w-full bg-terminal-surface rounded-lg px-3 py-2.5 text-sm font-sans text-terminal-text outline-none shadow-layer-sm"
           >
@@ -632,7 +629,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 onClick={() => {
                   const next = !showAgentRuns;
                   setShowAgentRuns(next);
-                  setSelectedProjectKey(ALL_PROJECTS);
+                  selectProject(ALL_PROJECTS);
                   navigateTo({ agentRuns: next ? "true" : null }, { notify: false });
                 }}
                 className="mt-1 text-[10px] font-mono text-terminal-dimmer hover:text-terminal-text transition-colors"
@@ -666,7 +663,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
         {/* Tab content */}
         <div className="px-4 md:px-6 pb-6 space-y-4">
           {activeMode === "overview" && selectedProjectKey === ALL_PROJECTS && (
-            <ProjectsGrid projects={projects} onProjectClick={setSelectedProjectKey} />
+            <ProjectsGrid projects={projects} onProjectClick={selectProject} />
           )}
           {activeMode === "overview" && selectedInsight && (
             <>
@@ -676,11 +673,6 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 onOpenSessions={() => openSessionsForProject(selectedInsight.project)}
               />
               <ProjectPerformance insights={detailedInsight} loading={insightsLoading} />
-              <SessionRelationshipsView
-                view="timeline"
-                projectFilter={projectFilterArg}
-                projectLocation={selectedLocation}
-              />
             </>
           )}
           {activeMode === "timeline" && (

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -732,11 +732,23 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                 const rowHeight = p.totalRowHeightPx;
                 const accentColor = color.solid;
                 return (
-                  <div key={p.key} className="flex items-stretch rounded-xl group">
+                  <div
+                    key={p.key}
+                    className="group flex items-stretch overflow-hidden rounded-xl border transition-colors"
+                    style={{
+                      borderColor: hexToRgba(accentColor, 0.2),
+                      backgroundColor: hexToRgba(accentColor, 0.025),
+                    }}
+                  >
                     {/* Project label */}
                     <div
-                      className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
-                      style={{ width: LABEL_WIDTH, height: rowHeight }}
+                      className="flex shrink-0 flex-col justify-center overflow-hidden border-l-2 py-1 pr-3"
+                      style={{
+                        width: LABEL_WIDTH,
+                        height: rowHeight,
+                        borderLeftColor: accentColor,
+                        backgroundColor: hexToRgba(accentColor, 0.055),
+                      }}
                     >
                       <div className="flex min-w-0 items-center gap-1.5">
                         <span
@@ -777,8 +789,11 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
 
                     {/* Lane area */}
                     <div
-                      className="relative flex-1 overflow-hidden rounded-xl bg-terminal-surface/45 shadow-layer-sm transition-colors group-hover:bg-terminal-surface-hover/70"
-                      style={{ height: rowHeight }}
+                      className="relative flex-1 overflow-hidden rounded-r-xl border-l border-terminal-border/20 shadow-inner"
+                      style={{
+                        height: rowHeight,
+                        backgroundColor: hexToRgba(accentColor, 0.035),
+                      }}
                     >
                       {/* Grid lines */}
                       {ticks.map((t, i) => (
@@ -836,7 +851,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                           >
                             {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
                               <span
-                                className={`pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
+                                className={`relative z-[1] pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
                                   lineClamp === 1
                                     ? "truncate leading-[18px]"
                                     : "overflow-hidden pt-1"
@@ -858,7 +873,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 track is the visual bar; the bright segment marks
                                 the actual active interval, including right-anchored
                                 sessions and bars widened for readable hit targets. */}
-                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-white/20">
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-[3px] bg-white/20">
                               <span
                                 className="absolute bottom-0 h-full min-w-[2px] rounded-full bg-white/85"
                                 style={{

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -742,11 +742,10 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                   >
                     {/* Project label */}
                     <div
-                      className="flex shrink-0 flex-col justify-center overflow-hidden border-l-2 py-1 pr-3"
+                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pr-3"
                       style={{
                         width: LABEL_WIDTH,
                         height: rowHeight,
-                        borderLeftColor: accentColor,
                         backgroundColor: hexToRgba(accentColor, 0.055),
                       }}
                     >
@@ -789,7 +788,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
 
                     {/* Lane area */}
                     <div
-                      className="relative flex-1 overflow-hidden rounded-r-xl border-l border-terminal-border/20 shadow-inner"
+                      className="relative flex-1 overflow-hidden rounded-r-xl shadow-inner"
                       style={{
                         height: rowHeight,
                         backgroundColor: hexToRgba(accentColor, 0.035),

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { matchesProjectFacet } from "../engine/dashboard-filtering";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
 import { plural } from "../utils/format";
@@ -629,18 +630,26 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       {/* Range selector + automated toggle */}
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
-          <div className="text-sm font-sans font-semibold text-terminal-text">Work Timeline</div>
+          <div className="flex items-center gap-2">
+            <span className="h-1.5 w-1.5 rounded-full bg-terminal-green shadow-[0_0_8px_rgba(34,197,94,0.55)]" />
+            <div className="text-sm font-sans font-semibold text-terminal-text">Work Timeline</div>
+          </div>
           <div className="text-xs font-mono text-terminal-dimmer">
             {totalSessions} {plural(totalSessions, "session")} · rows are projects · bar position
             and width show active time
             {estimatedTimingCount > 0 ? ` · ${estimatedTimingCount} estimated` : ""}
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1 text-[10px] font-mono text-terminal-dimmer">
+            <span>Hover for details</span>
+            <span className="text-terminal-border">·</span>
+            <span>Click a session to inspect it</span>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[10px] font-mono">
           {hiddenAutomatedCount > 0 && !showAutomated && (
             <button
               onClick={() => setShowAutomated(true)}
-              className="text-terminal-dimmer hover:text-terminal-text transition-colors"
+              className="rounded-lg bg-terminal-orange-subtle px-2.5 py-1 text-terminal-orange transition-colors hover:bg-terminal-orange-emphasis"
               title="Scheduled / automated sessions are hidden by default"
             >
               + {hiddenAutomatedCount} automated hidden ▸
@@ -649,7 +658,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           {showAutomated && (
             <button
               onClick={() => setShowAutomated(false)}
-              className="text-terminal-purple hover:underline"
+              className="rounded-lg bg-terminal-purple-subtle px-2.5 py-1 text-terminal-purple transition-colors hover:bg-terminal-purple-emphasis"
             >
               hide automated
             </button>
@@ -659,6 +668,8 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
               <button
                 key={opt.value}
                 onClick={() => setRange(opt.value)}
+                aria-pressed={range === opt.value}
+                title={`Show ${opt.label} timeline`}
                 className={`rounded-lg px-2.5 py-1 text-xs font-sans font-semibold transition-all duration-200 ease-material ${
                   range === opt.value
                     ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
@@ -719,8 +730,16 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                       className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
                       style={{ width: LABEL_WIDTH, height: rowHeight }}
                     >
-                      <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                        {projectDisplayName(p.project, p.sessions[0]?.session.projectIdentity)}
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span
+                          className="h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: accentColor }}
+                        />
+                        <div
+                          className={`min-w-0 text-xs font-sans font-medium truncate ${color.text}`}
+                        >
+                          {projectDisplayName(p.project, p.sessions[0]?.session.projectIdentity)}
+                        </div>
                       </div>
                       <div className="text-[9px] font-mono text-terminal-dimmer truncate">
                         {p.sessions.length} {plural(p.sessions.length, "session")}
@@ -860,70 +879,75 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
         </div>
       )}
 
-      {/* Tooltip */}
-      {tooltip && (
-        <div
-          className="fixed pointer-events-none w-80 rounded-xl border border-terminal-border bg-terminal-surface p-3 text-xs font-mono shadow-layer-xl"
-          style={{
-            // Keep the tooltip above hovered timeline bars.
-            zIndex: 1000,
-            left: Math.min(tooltip.x + 12, window.innerWidth - 336),
-            top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
-          }}
-        >
-          <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
-            {sessionTitle(tooltip.session)}
-          </div>
-          <div className="mb-2 flex flex-wrap gap-1">
-            {sessionBadges(tooltip.session).map((badge) => (
-              <span
-                key={badge}
-                className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] text-terminal-dim"
-              >
-                {badge}
-              </span>
-            ))}
-          </div>
-          <div className="text-terminal-dimmer space-y-0.5">
-            {tooltip.session.startTime &&
-              (() => {
-                const startMs = new Date(tooltip.session.startTime).getTime();
-                const endMs = activeEndMs(startMs, tooltip.session);
-                const startISO = tooltip.session.startTime;
-                const endISO = new Date(endMs).toISOString();
-                const sameDay = fmtDate(startISO) === fmtDate(endISO);
-                return (
-                  <div>
-                    {fmtDate(startISO)} {fmtShortTime(startISO)}
-                    {endMs !== startMs && (
-                      <span>
-                        {" → "}
-                        {sameDay ? "" : `${fmtDate(endISO)} `}
-                        {fmtShortTime(endISO)}
-                      </span>
-                    )}
-                  </div>
-                );
-              })()}
-            {tooltip.session.durationMs && (
-              <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
-            )}
-            <div>
-              {tooltip.session.promptCount}p · {tooltip.session.editCount}{" "}
-              {plural(tooltip.session.editCount, "edit")} · {tooltip.session.toolCallCount}{" "}
-              {plural(tooltip.session.toolCallCount, "tool")}
+      {/* Portal the fixed tooltip out of the scrollable timeline pane. A fixed
+          child can still expand an ancestor's scrollable overflow, which makes
+          the pane jump when hover state toggles. */}
+      {tooltip &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className="fixed pointer-events-none w-80 rounded-xl border border-terminal-border bg-terminal-surface p-3 text-xs font-mono shadow-layer-xl"
+            style={{
+              // Keep the tooltip above hovered timeline bars.
+              zIndex: 1000,
+              left: Math.min(tooltip.x + 12, window.innerWidth - 336),
+              top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
+            }}
+          >
+            <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
+              {sessionTitle(tooltip.session)}
             </div>
-            {tooltip.session.gitBranch && (
-              <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
-            )}
-            {(tooltip.session.costEstimate ?? 0) > 0 && (
-              <div className="text-terminal-orange">
-                ${tooltip.session.costEstimate!.toFixed(3)}
+            <div className="mb-2 flex flex-wrap gap-1">
+              {sessionBadges(tooltip.session).map((badge) => (
+                <span
+                  key={badge}
+                  className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] text-terminal-dim"
+                >
+                  {badge}
+                </span>
+              ))}
+            </div>
+            <div className="text-terminal-dimmer space-y-0.5">
+              {tooltip.session.startTime &&
+                (() => {
+                  const startMs = new Date(tooltip.session.startTime).getTime();
+                  const endMs = activeEndMs(startMs, tooltip.session);
+                  const startISO = tooltip.session.startTime;
+                  const endISO = new Date(endMs).toISOString();
+                  const sameDay = fmtDate(startISO) === fmtDate(endISO);
+                  return (
+                    <div>
+                      {fmtDate(startISO)} {fmtShortTime(startISO)}
+                      {endMs !== startMs && (
+                        <span>
+                          {" → "}
+                          {sameDay ? "" : `${fmtDate(endISO)} `}
+                          {fmtShortTime(endISO)}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })()}
+              {tooltip.session.durationMs && (
+                <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
+              )}
+              <div>
+                {tooltip.session.promptCount}p · {tooltip.session.editCount}{" "}
+                {plural(tooltip.session.editCount, "edit")} · {tooltip.session.toolCallCount}{" "}
+                {plural(tooltip.session.toolCallCount, "tool")}
               </div>
-            )}
-          </div>
-        </div>
-      )}
+              {tooltip.session.gitBranch && (
+                <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
+              )}
+              {(tooltip.session.costEstimate ?? 0) > 0 && (
+                <div className="text-terminal-orange">
+                  ${tooltip.session.costEstimate!.toFixed(3)}
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -704,7 +704,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           )}
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+        <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 py-3 shadow-inner">
           <div className="min-w-[760px]">
             {/* Time axis header */}
             <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
@@ -742,7 +742,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                   >
                     {/* Project label */}
                     <div
-                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pr-3"
+                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pl-3 pr-3"
                       style={{
                         width: LABEL_WIDTH,
                         height: rowHeight,

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -858,9 +858,9 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 track is the visual bar; the bright segment marks
                                 the actual active interval, including right-anchored
                                 sessions and bars widened for readable hit targets. */}
-                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/15">
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-white/20">
                               <span
-                                className="absolute bottom-0 h-full rounded-full bg-white/75"
+                                className="absolute bottom-0 h-full min-w-[2px] rounded-full bg-white/85"
                                 style={{
                                   left: `${ts.actualStartFraction * 100}%`,
                                   right: `${(1 - ts.actualEndFraction) * 100}%`,

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -104,8 +104,6 @@ function rangeEmptyLabel(range: TimelineRange): string {
       return "the last 7 days";
     case "30d":
       return "the last 30 days";
-    case "all":
-      return "this scan";
   }
 }
 
@@ -247,7 +245,9 @@ interface TimelineSession {
   heightPx: number;
   fillAlpha: number;
   opacity: number;
-  realDurationFraction: number;
+  /** Actual active interval within the rendered visual bar, 0–1. */
+  actualStartFraction: number;
+  actualEndFraction: number;
   /**
    * True when the bar would overflow the lane's right edge if rendered from
    * its leftPct. Right-anchored bars hug the right edge with their full
@@ -486,9 +486,17 @@ function buildTimeline(
       const leftPct = Math.max(0, rawLeftPct);
       const widthPct = Math.max(0, rawRightPct - leftPct);
       const minWidthPx = minWidthFor(it.score);
-      const realWidthPx = (widthPct / 100) * APPROX_TIMELINE_WIDTH_PX;
-      const visualWidthPx = Math.max(realWidthPx, minWidthPx);
-      const realDurationFraction = visualWidthPx > 0 ? Math.min(1, realWidthPx / visualWidthPx) : 1;
+      const visualStartMs = Math.max(it.startMs, rangeStart);
+      const visualEndMs = Math.min(it.endMs, rangeEnd);
+      const visualDurationMs = Math.max(1, visualEndMs - visualStartMs);
+      const actualStartFraction = Math.max(
+        0,
+        Math.min(1, (Math.max(it.realStartMs, visualStartMs) - visualStartMs) / visualDurationMs),
+      );
+      const actualEndFraction = Math.max(
+        actualStartFraction,
+        Math.min(1, (Math.min(it.realEndMs, visualEndMs) - visualStartMs) / visualDurationMs),
+      );
       tSessions.push({
         session: it.original,
         leftPct,
@@ -499,7 +507,8 @@ function buildTimeline(
         heightPx: heightFor(it.score),
         fillAlpha: fillAlphaFor(it.score),
         opacity: opacityFor(it.score),
-        realDurationFraction,
+        actualStartFraction,
+        actualEndFraction,
         rightAnchored: it.rightAnchored,
       });
     }
@@ -570,18 +579,17 @@ function buildTimeline(
   return { projects, ticks, minMs, maxMs, totalSessions, hiddenAutomatedCount };
 }
 
-type TimelineRange = "1d" | "7d" | "30d" | "all";
+type TimelineRange = "1d" | "7d" | "30d";
 
-const RANGE_OPTIONS: { value: TimelineRange; label: string; days?: number }[] = [
+const RANGE_OPTIONS: { value: TimelineRange; label: string; days: number }[] = [
   { value: "1d", label: "1D", days: 1 },
   { value: "7d", label: "7D", days: 7 },
   { value: "30d", label: "30D", days: 30 },
-  { value: "all", label: "All" },
 ];
 
 function rangeWindow(range: TimelineRange): { start?: number; end?: number } {
   const opt = RANGE_OPTIONS.find((o) => o.value === range);
-  if (!opt || opt.days == null) return {};
+  if (!opt) return {};
   const end = Date.now();
   const start = end - opt.days * 86400000;
   return { start, end };
@@ -686,12 +694,12 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       {projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-40 gap-2 text-terminal-dimmer text-sm font-mono">
           <div>No sessions in {rangeEmptyLabel(range)}.</div>
-          {range !== "all" && (
+          {range !== "30d" && (
             <button
-              onClick={() => setRange("all")}
+              onClick={() => setRange("30d")}
               className="text-terminal-green hover:underline text-xs"
             >
-              Show all sessions →
+              Show 30 days →
             </button>
           )}
         </div>
@@ -794,10 +802,6 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                             (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
                           ),
                         );
-                        // Right-anchored bars no longer have their left edge
-                        // at startTime, so a left-aligned wick would be
-                        // misleading. Use the tooltip for exact timing instead.
-                        const showWick = !ts.rightAnchored && ts.realDurationFraction < 0.85;
                         return (
                           <button
                             type="button"
@@ -850,23 +854,20 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 {sessionTitle(ts.session)}
                               </span>
                             )}
-                            {showWick && (
-                              <>
-                                {/* Bottom strip + end-tick mark the actual session
-                                    duration inside the min-width-padded bar. */}
-                                <span
-                                  className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
-                                  style={{ width: `${ts.realDurationFraction * 100}%` }}
-                                  title="actual duration"
-                                />
-                                <span
-                                  className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
-                                  style={{
-                                    left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
-                                  }}
-                                />
-                              </>
-                            )}
+                            {/* Every bar gets the same duration rail. The muted
+                                track is the visual bar; the bright segment marks
+                                the actual active interval, including right-anchored
+                                sessions and bars widened for readable hit targets. */}
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/15">
+                              <span
+                                className="absolute bottom-0 h-full rounded-full bg-white/75"
+                                style={{
+                                  left: `${ts.actualStartFraction * 100}%`,
+                                  right: `${(1 - ts.actualEndFraction) * 100}%`,
+                                }}
+                                title="actual duration"
+                              />
+                            </span>
                           </button>
                         );
                       })}

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -64,7 +64,7 @@ describe("ProjectsPanel project insights", () => {
 
     render(<ProjectsPanel onNavigate={vi.fn()} />);
 
-    const timelineTab = screen.getByRole("button", { name: "Timeline", exact: true });
+    const timelineTab = screen.getByRole("button", { name: "Timeline" });
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
 
     fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -58,6 +58,20 @@ function contextValue(): ReturnType<typeof InsightsPanel.useScanInsightsContext>
 }
 
 describe("ProjectsPanel project insights", () => {
+  it("opens the Timeline view by default and when selecting a project", () => {
+    const context = contextValue();
+    vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);
+
+    render(<ProjectsPanel onNavigate={vi.fn()} />);
+
+    const timelineTab = screen.getByRole("button", { name: "Timeline", exact: true });
+    expect(timelineTab.className).toContain("bg-terminal-green-subtle");
+
+    fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);
+
+    expect(timelineTab.className).toContain("bg-terminal-green-subtle");
+  });
+
   it("fetches detailed insights only after selecting a project", () => {
     const context = contextValue();
     vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -67,8 +67,13 @@ describe("ProjectsPanel project insights", () => {
     const timelineTab = screen.getByRole("button", { name: "Timeline" });
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
 
+    const overviewTab = screen.getByRole("button", { name: "Overview" });
+    fireEvent.click(overviewTab);
+    expect(overviewTab.className).toContain("bg-terminal-green-subtle");
+
     fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);
 
+    expect(screen.getByRole("heading", { name: /example/i })).toBeDefined();
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
   });
 

--- a/packages/viewer/src/components/__tests__/session-relationships-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/session-relationships-view.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SessionRelationshipsView from "../SessionRelationshipsView";
+import { useRelationshipData, type ScanResultSession } from "../../hooks/useRelationshipData";
+
+vi.mock("../../hooks/useRelationshipData", () => ({
+  useRelationshipData: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function session(): ScanResultSession {
+  const startTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  return {
+    sessionId: "hover-session",
+    provider: "claude-code",
+    project: "~/project",
+    slug: "hover-session",
+    title: "Hover session",
+    startTime,
+    endTime: startTime,
+    durationMs: 60_000,
+    promptCount: 1,
+    toolCallCount: 1,
+    editCount: 0,
+    filesModified: [],
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
+  };
+}
+
+describe("SessionRelationshipsView timeline tooltip", () => {
+  it("renders the hover card outside the scrollable timeline pane", () => {
+    vi.mocked(useRelationshipData).mockReturnValue({
+      sessions: [session()],
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(<SessionRelationshipsView view="timeline" />);
+    const timelinePane = container.querySelector("div.overflow-y-auto");
+    const bar = screen.getByRole("button", { name: "Open Hover session" });
+
+    expect(timelinePane).not.toBeNull();
+    fireEvent.mouseEnter(bar, { clientX: 100, clientY: 100 });
+
+    const tooltip = document.body.querySelector(".fixed");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toContain("Hover session");
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(timelinePane?.contains(tooltip)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- make Projects open on Timeline by default
- keep Timeline as the first-class view when selecting a project
- remove the redundant embedded timeline from single-project Overview
- replace inconsistent duration wicks with a consistent active-duration rail
- remove the project accent stripe and use full-lane color treatment instead
- remove the unbounded All range; keep 1D, 7D, and 30D
- portal hover tooltips outside the scroll container to prevent jitter

## Design notes
- Project identity is expressed through full-row tint, outline, label color, and a small dot — not a decorative left-edge stripe.
- The duration rail is rendered behind labels and uses a minimum visible marker for very short sessions.

## Validation
- `pnpm verify`
- Playwright smoke validation at a 1525x997 viewport
- Verified Timeline is active by default and after project selection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects now use consistent Timeline, Overview, and Hot Files tabs across individual and all-project views.
  - Selecting a project opens its Timeline view.
  - Timeline session bars now show active durations more clearly.
  - Timeline tooltips remain visible and accessible while scrolling.

- **Improvements**
  - Timeline filtering now offers 1-day, 7-day, and 30-day ranges.
  - Empty timelines provide a direct option to show the past 30 days.
  - Updated timeline controls and project indicators improve visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->