### PR TITLE
feat(insights): add session and per-turn percentile distributions

### DIFF
--- a/packages/cli/src/insights-rollup.ts
+++ b/packages/cli/src/insights-rollup.ts
@@ -1,6 +1,6 @@
 import type { ReplaySummary } from "./server-types.js";
 import type { SessionScanResult } from "./scanner.js";
-import type { ProjectIdentity, SessionLocation } from "@vibe-replay/types";
+import type { ProjectIdentity, SessionLocation, TurnMetric } from "@vibe-replay/types";
 
 export interface InsightsRollupSession {
   project: string;
@@ -22,6 +22,7 @@ export interface InsightsRollupSession {
     cacheCreationTokens: number;
   };
   turnDurations?: number[];
+  turnMetrics?: TurnMetric[];
 }
 
 export interface InsightsRollupReplay {
@@ -65,6 +66,7 @@ export function buildInsightsRollup(
         session.model = scan.model;
         session.tokenUsage = scan.tokenUsage;
         session.turnDurations = scan.turnDurations;
+        session.turnMetrics = scan.turnMetrics;
       }
       return session;
     }),

--- a/packages/cli/src/insights.ts
+++ b/packages/cli/src/insights.ts
@@ -119,6 +119,7 @@ export function scanResultToInsight(scan: SessionScanResult): SessionInsight {
     toolCallCount: scan.toolCallCount,
     editCount: scan.editCount,
     filesModified: scan.filesModified?.length ? scan.filesModified : undefined,
+    turnMetrics: scan.turnMetrics,
     tokenUsage: scan.tokenUsage,
     costEstimate: scan.costEstimate,
     contextBreakdown: scan.contextBreakdown,

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1594,9 +1594,20 @@ function turnToolCallCount(blocks: ContentBlock[]): number {
   for (const block of blocks) {
     if (block.type !== "tool_use") continue;
     count++;
-    const nestedEvents = (block as { _subAgent?: { usageEvents?: UsageEvent[] } })._subAgent
-      ?.usageEvents;
-    if (nestedEvents) count += nestedEvents.filter((event) => event.kind === "tool").length;
+    const subAgent = (
+      block as {
+        _subAgent?: {
+          usageEvents?: UsageEvent[];
+          scenes?: Array<{ type?: string }>;
+        };
+      }
+    )._subAgent;
+    const nestedEvents = subAgent?.usageEvents;
+    if (nestedEvents?.length) {
+      count += nestedEvents.filter((event) => event.kind === "tool").length;
+    } else if (subAgent?.scenes) {
+      count += subAgent.scenes.filter((scene) => scene.type === "tool-call").length;
+    }
   }
   return count;
 }
@@ -1607,7 +1618,7 @@ function addTurnTokenTotal(metric: TurnMetric, usage: TokenUsage): void {
   metric.tokens = (metric.tokens || 0) + total;
 }
 
-function buildTurnMetrics(
+export function buildTurnMetrics(
   turns: ProviderParseResult["turns"],
   turnStats: ProviderParseResult["turnStats"],
 ): TurnMetric[] | undefined {
@@ -1632,6 +1643,7 @@ function buildTurnMetrics(
 
   for (const stat of turnStats || []) {
     if (!Number.isInteger(stat.turnIndex) || stat.turnIndex < 0) continue;
+    if (stat.turnIndex >= metrics.length) continue;
     const metric = ensureMetric(stat.turnIndex);
     if (typeof stat.durationMs === "number" && stat.durationMs > 0) {
       metric.durationMs = (metric.durationMs || 0) + stat.durationMs;

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -44,6 +44,7 @@ import type {
   SessionTranscriptStatus,
   SessionUsageSummary,
   TokenUsage,
+  TurnMetric,
   UsageEvent,
 } from "./types.js";
 import { localDayKey, shortenPath } from "./utils.js";
@@ -73,7 +74,8 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v35: retain Pi usage from assistant records without visible replay content.
 // v36: index privacy-safe provider context composition metadata.
 // v37: count concrete SKILL.md reads as skill activations across providers.
-export const SCANNER_VERSION = 37;
+// v38: retain compact per-turn duration/tool/token metrics for distributions.
+export const SCANNER_VERSION = 38;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -144,6 +146,8 @@ export interface SessionScanResult {
   turnStatCount?: number;
   /** Per-turn durations in ms — used for median time-to-intervention */
   turnDurations?: number[];
+  /** Compact numeric metrics used for per-turn distributions. */
+  turnMetrics?: TurnMetric[];
 }
 
 interface ScanCacheEntry {
@@ -1576,6 +1580,68 @@ async function scanCursorSession(input: ScanInput): Promise<SessionScanResult> {
   return buildScanResultFromParsed(input, parsed);
 }
 
+function isMetricUserPrompt(turn: ProviderParseResult["turns"][number]): boolean {
+  if (turn.role !== "user" || turn.subtype) return false;
+  return turn.blocks.some(
+    (block) =>
+      (block.type === "text" && block.text.trim().length > 0) ||
+      (block.type === "_user_images" && block.images.length > 0),
+  );
+}
+
+function turnToolCallCount(blocks: ContentBlock[]): number {
+  let count = 0;
+  for (const block of blocks) {
+    if (block.type !== "tool_use") continue;
+    count++;
+    const nestedEvents = (block as { _subAgent?: { usageEvents?: UsageEvent[] } })._subAgent
+      ?.usageEvents;
+    if (nestedEvents) count += nestedEvents.filter((event) => event.kind === "tool").length;
+  }
+  return count;
+}
+
+function addTurnTokenTotal(metric: TurnMetric, usage: TokenUsage): void {
+  const total =
+    usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreationTokens;
+  metric.tokens = (metric.tokens || 0) + total;
+}
+
+function buildTurnMetrics(
+  turns: ProviderParseResult["turns"],
+  turnStats: ProviderParseResult["turnStats"],
+): TurnMetric[] | undefined {
+  const metrics: TurnMetric[] = [];
+  let currentTurnIndex = -1;
+
+  const ensureMetric = (turnIndex: number): TurnMetric => {
+    while (metrics.length <= turnIndex) metrics.push({ toolCalls: 0 });
+    return metrics[turnIndex]!;
+  };
+
+  for (const turn of turns) {
+    if (isMetricUserPrompt(turn)) {
+      currentTurnIndex++;
+      ensureMetric(currentTurnIndex);
+      continue;
+    }
+    if (turn.role === "assistant" && currentTurnIndex >= 0) {
+      ensureMetric(currentTurnIndex).toolCalls += turnToolCallCount(turn.blocks);
+    }
+  }
+
+  for (const stat of turnStats || []) {
+    if (!Number.isInteger(stat.turnIndex) || stat.turnIndex < 0) continue;
+    const metric = ensureMetric(stat.turnIndex);
+    if (typeof stat.durationMs === "number" && stat.durationMs > 0) {
+      metric.durationMs = (metric.durationMs || 0) + stat.durationMs;
+    }
+    if (stat.tokenUsage) addTurnTokenTotal(metric, stat.tokenUsage);
+  }
+
+  return metrics.length > 0 ? metrics : undefined;
+}
+
 function buildLightweightCursorScanResult(input: ScanInput): SessionScanResult {
   const firstPrompt = scanFallbackPrompt(input);
   const hasPrompt = typeof firstPrompt === "string" && firstPrompt.trim().length > 0;
@@ -1871,6 +1937,7 @@ function buildScanResultFromParsed(
   const fallbackStart = parsed.startTime || input.timestamp;
   const durationMs = parsed.totalDurationMs;
   const normalizedEndTime = ensureEndCoversDuration(fallbackStart, parsed.endTime, durationMs);
+  const turnMetrics = buildTurnMetrics(parsed.turns, parsed.turnStats);
   const firstPrompt = input.transcriptStatus
     ? ""
     : firstUserPrompt(parsed.turns) || input.firstPrompt || parsed.title;
@@ -1948,6 +2015,7 @@ function buildScanResultFromParsed(
     turnDurations: parsed.turnStats
       ?.map((t) => t.durationMs)
       .filter((d): d is number => d != null && d > 0),
+    turnMetrics,
   };
 }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -25,6 +25,7 @@ export type {
   ProviderCoverage,
   TokenUsage,
   TokenUsageMetrics,
+  TurnMetric,
   TurnStat,
   UsageCoverageReport,
   UsageEvent,

--- a/packages/cli/test/insights-rollup.test.ts
+++ b/packages/cli/test/insights-rollup.test.ts
@@ -71,6 +71,10 @@ describe("buildInsightsRollup", () => {
         makeScan({
           model: "claude-sonnet-4",
           turnDurations: [10_000, 45_000],
+          turnMetrics: [
+            { durationMs: 10_000, toolCalls: 2, tokens: 100 },
+            { durationMs: 45_000, toolCalls: 3, tokens: 200 },
+          ],
         }),
       ],
       [],
@@ -87,6 +91,10 @@ describe("buildInsightsRollup", () => {
         cacheCreationTokens: 40,
       },
       turnDurations: [10_000, 45_000],
+      turnMetrics: [
+        { durationMs: 10_000, toolCalls: 2, tokens: 100 },
+        { durationMs: 45_000, toolCalls: 3, tokens: 200 },
+      ],
     });
     expect(JSON.stringify(payload)).not.toContain("private");
   });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   aggregateProjectInsights,
   aggregateUserInsights,
+  buildTurnMetrics,
   countPendingCursorUsageIndexes,
   type SessionScanResult,
   isPartialScanResult,
@@ -184,6 +185,29 @@ describe("scanSession", () => {
     );
   });
 
+  it("counts fallback sub-agent scenes without expanding malformed turn indexes", () => {
+    const metrics = buildTurnMetrics(
+      [
+        { role: "user", blocks: [{ type: "text", text: "Delegate this" }] },
+        {
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool_use",
+              id: "agent-1",
+              name: "Agent",
+              input: {},
+              _subAgent: { scenes: [{ type: "tool-call" }] },
+            } as any,
+          ],
+        },
+      ],
+      [{ turnIndex: 1_000_000 }],
+    );
+
+    expect(metrics).toEqual([{ toolCalls: 2 }]);
+  });
+
   it.each(["no-prompts", "unreadable"] as const)(
     "does not use a metadata title as a prompt for %s sources",
     async (transcriptStatus) => {
@@ -220,7 +244,7 @@ describe("scanSession", () => {
     expect(result.startTime).toBe("2025-03-20T10:00:00Z");
     expect(result.model).toBe("claude-sonnet-4-20250514");
     expect(result.turnMetrics).toMatchObject([
-      { durationMs: 9_000, toolCalls: 2 },
+      { durationMs: 9_000, toolCalls: 2, tokens: 10_700 },
       { toolCalls: 0 },
     ]);
   });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -219,6 +219,10 @@ describe("scanSession", () => {
     expect(result.title).toBe("Fix login bug in auth module");
     expect(result.startTime).toBe("2025-03-20T10:00:00Z");
     expect(result.model).toBe("claude-sonnet-4-20250514");
+    expect(result.turnMetrics).toMatchObject([
+      { durationMs: 9_000, toolCalls: 2 },
+      { toolCalls: 0 },
+    ]);
   });
 
   it("persists structured Pi compaction diagnostics in scan results", async () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -104,6 +104,16 @@ export interface TurnStat {
   contextTokens?: number;
 }
 
+/** Privacy-safe numeric metrics for one user turn. */
+export interface TurnMetric {
+  /** Active/provider-recorded time for the turn, in milliseconds. */
+  durationMs?: number;
+  /** All recorded tool invocations attributed to the turn. */
+  toolCalls: number;
+  /** Input + output + cache read/write tokens attributed to the turn. */
+  tokens?: number;
+}
+
 /**
  * A privacy-preserving event used to explain provider/session failures.
  *
@@ -478,6 +488,7 @@ export interface SessionInsight {
   toolCallCount: number;
   editCount: number;
   filesModified?: Array<{ file: string; count: number }>;
+  turnMetrics?: TurnMetric[];
 
   // Cost
   tokenUsage?: TokenUsage;
@@ -567,6 +578,7 @@ export interface SessionScanWireData {
   dataQualityNotes?: string[];
   turnStatCount?: number;
   turnDurations?: number[];
+  turnMetrics?: TurnMetric[];
 }
 
 export interface ReplaySession {

--- a/packages/viewer/src/components/InsightCharts.tsx
+++ b/packages/viewer/src/components/InsightCharts.tsx
@@ -1,3 +1,8 @@
+import type {
+  PerTurnDistributions,
+  SessionMetricDistribution,
+  SessionMetricDistributions,
+} from "../engine/insights-rollup";
 import type { ContextBreakdown, ContextComponentId } from "../types";
 
 export interface TurnDurationHistogramData {
@@ -104,6 +109,188 @@ export function TurnDurationChart({ histogram }: { histogram: TurnDurationHistog
         Timing quality varies by provider; this combines recorded and estimated turn durations.
       </div>
     </div>
+  );
+}
+
+type DistributionKey = "durationMs" | "toolCalls" | "turns" | "tokens";
+type DistributionMap = Partial<Record<DistributionKey, SessionMetricDistribution>>;
+type PercentileKey = "p25" | "p50" | "p75" | "p95" | "p99";
+
+const PERCENTILES: PercentileKey[] = ["p25", "p50", "p75", "p95", "p99"];
+
+const SESSION_METRIC_PRESENTATION: Array<{
+  key: DistributionKey;
+  label: string;
+  color: string;
+}> = [
+  { key: "durationMs", label: "Session duration", color: "bg-terminal-response" },
+  { key: "toolCalls", label: "Tool calls", color: "bg-terminal-tool" },
+  { key: "turns", label: "Turns", color: "bg-terminal-green" },
+  { key: "tokens", label: "Tokens", color: "bg-terminal-context" },
+];
+
+const PER_TURN_METRIC_PRESENTATION: Array<{
+  key: DistributionKey;
+  label: string;
+  color: string;
+}> = [
+  { key: "durationMs", label: "Time", color: "bg-terminal-response" },
+  { key: "toolCalls", label: "Tool calls", color: "bg-terminal-tool" },
+  { key: "tokens", label: "Tokens", color: "bg-terminal-context" },
+];
+
+function formatCountPercentile(value: number): string {
+  return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(1);
+}
+
+function formatDistributionValue(key: DistributionKey, value: number): string {
+  if (key === "durationMs") return formatDurationShort(value);
+  if (key === "tokens") return formatTokenCount(value);
+  return formatCountPercentile(value);
+}
+
+function formatSampleCount(
+  sampleCount: number,
+  totalSamples: number | undefined,
+  unit: string,
+): string {
+  if (totalSamples !== undefined && sampleCount < totalSamples) {
+    return `${sampleCount.toLocaleString()}/${totalSamples.toLocaleString()} ${unit}`;
+  }
+  return `${sampleCount.toLocaleString()} ${unit}`;
+}
+
+function DistributionMetricGrid({
+  distributions,
+  metrics,
+  totalSamples,
+  sampleUnit,
+}: {
+  distributions: DistributionMap;
+  metrics: Array<{ key: DistributionKey; label: string; color: string }>;
+  totalSamples?: number;
+  sampleUnit: string;
+}) {
+  const availableMetrics = metrics.flatMap((metric) => {
+    const distribution = distributions[metric.key];
+    return distribution ? [{ ...metric, distribution }] : [];
+  });
+
+  if (availableMetrics.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-x-6 gap-y-5 md:grid-cols-2">
+        {availableMetrics.map(({ key, label, color, distribution }) => {
+          const maxPct = Math.max(...distribution.buckets.map((bucket) => bucket.pct), 1);
+          return (
+            <div key={key} aria-label={`${label} distribution`} className="min-w-0">
+              <div className="mb-2 flex items-baseline justify-between gap-2">
+                <span className="text-xs font-sans font-semibold text-terminal-text">{label}</span>
+                <span className="shrink-0 text-[10px] font-mono text-terminal-dimmer">
+                  {formatSampleCount(distribution.sampleCount, totalSamples, sampleUnit)}
+                </span>
+              </div>
+              <div className="flex h-20 items-end gap-1">
+                {distribution.buckets.map((bucket) => {
+                  const heightPct = Math.max((bucket.pct / maxPct) * 100, bucket.count > 0 ? 7 : 0);
+                  return (
+                    <div
+                      key={bucket.label}
+                      className="group relative flex h-full min-w-0 flex-1 flex-col items-center justify-end"
+                      title={`${bucket.label}: ${bucket.count.toLocaleString()} ${sampleUnit} (${bucket.pct}%)`}
+                    >
+                      <div
+                        className={`w-full rounded-sm ${color} transition-opacity group-hover:opacity-100`}
+                        style={{
+                          height: `${heightPct}%`,
+                          minHeight: bucket.count > 0 ? "3px" : "0",
+                          opacity: bucket.count > 0 ? 0.7 : 0.12,
+                        }}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="mt-1 flex gap-1">
+                {distribution.buckets.map((bucket) => (
+                  <div
+                    key={bucket.label}
+                    className="min-w-0 flex-1 truncate text-center text-[9px] font-mono text-terminal-dimmer"
+                    title={bucket.label}
+                  >
+                    {bucket.label}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-2 grid grid-cols-5 gap-1 border-t border-terminal-border/20 pt-2">
+                {PERCENTILES.map((percentile) => (
+                  <div key={percentile} className="min-w-0">
+                    <div
+                      className={`text-[10px] font-mono uppercase ${
+                        percentile === "p99"
+                          ? "text-terminal-orange"
+                          : percentile === "p95"
+                            ? "text-terminal-response"
+                            : "text-terminal-dimmer"
+                      }`}
+                    >
+                      {percentile}
+                    </div>
+                    <div
+                      className={`mt-0.5 truncate text-xs font-mono font-semibold tabular-nums ${
+                        percentile === "p99" ? "text-terminal-orange" : "text-terminal-text"
+                      }`}
+                    >
+                      {formatDistributionValue(key, distribution.percentiles[percentile])}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="text-[9px] font-mono leading-relaxed text-terminal-dimmer">
+        P50 is the median; P25/P75 bound the middle 50%; P95/P99 expose the long tail. Each cutoff
+        is the value at or below which that share of observations falls. P99 is most useful with a
+        larger sample. Missing duration or token observations are excluded; the sample count shows
+        coverage. Token values include input, output, cache read, and cache write.
+      </div>
+    </div>
+  );
+}
+
+export function SessionDistributionChart({
+  distributions,
+  totalSessions,
+}: {
+  distributions: SessionMetricDistributions;
+  totalSessions?: number;
+}) {
+  return (
+    <DistributionMetricGrid
+      distributions={distributions}
+      metrics={SESSION_METRIC_PRESENTATION}
+      totalSamples={totalSessions}
+      sampleUnit="sessions"
+    />
+  );
+}
+
+export function PerTurnDistributionChart({
+  distributions,
+}: {
+  distributions: PerTurnDistributions;
+}) {
+  const totalTurns = distributions.toolCalls?.sampleCount;
+  return (
+    <DistributionMetricGrid
+      distributions={distributions}
+      metrics={PER_TURN_METRIC_PRESENTATION}
+      totalSamples={totalTurns}
+      sampleUnit="turns"
+    />
   );
 }
 

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -35,7 +35,12 @@ import type {
 } from "../types";
 import { localDayKey } from "../utils/date";
 import { DataQualityIndicator } from "./DataQualityIndicator";
-import { TokenBreakdownChart, TurnDurationChart } from "./InsightCharts";
+import {
+  PerTurnDistributionChart,
+  SessionDistributionChart,
+  TokenBreakdownChart,
+  TurnDurationChart,
+} from "./InsightCharts";
 import {
   formatCompactAge,
   formatCompactDuration,
@@ -1876,10 +1881,11 @@ export default function InsightsPage() {
     };
   }, [userInsights, range, homePageCounts, insightsRollupPayload]);
 
-  const rangeBreakdown = useMemo<InsightsRangeBreakdown | null>(() => {
-    if (range === "all" || !insightsRollupPayload) return null;
+  const rollupBreakdown = useMemo<InsightsRangeBreakdown | null>(() => {
+    if (!insightsRollupPayload) return null;
     return rollupInsightsBreakdown(insightsRollupPayload, { since: rangeSince(range) });
   }, [insightsRollupPayload, range]);
+  const rangeBreakdown = range === "all" ? null : rollupBreakdown;
 
   const rolledTopProjects = useMemo(
     () => rollupTopProjects(userInsights?.topProjects || []),
@@ -1893,6 +1899,8 @@ export default function InsightsPage() {
     range === "all" ? userInsights?.tokenBreakdown : rangeBreakdown?.tokenBreakdown;
   const turnDurationHistogram =
     range === "all" ? userInsights?.turnDurationHistogram : rangeBreakdown?.turnDurationHistogram;
+  const sessionMetricDistributions = rollupBreakdown?.sessionMetricDistributions;
+  const perTurnDistributions = rollupBreakdown?.perTurnDistributions;
 
   const usagePayload = useUsageRollupSessions(
     scanStatus?.finishedAt,
@@ -1923,7 +1931,15 @@ export default function InsightsPage() {
     updateActiveSection();
     root.addEventListener("scroll", updateActiveSection, { passive: true });
     return () => root.removeEventListener("scroll", updateActiveSection);
-  }, [userInsights, range, usage.sessionCount, turnDurationHistogram, tokenBreakdown]);
+  }, [
+    userInsights,
+    range,
+    usage.sessionCount,
+    turnDurationHistogram,
+    tokenBreakdown,
+    sessionMetricDistributions,
+    perTurnDistributions,
+  ]);
 
   if (!userInsights && (loading || isInitialScan || scanStatus?.phase === "discovering")) {
     return (
@@ -2160,7 +2176,7 @@ export default function InsightsPage() {
               id="usage"
               eyebrow="03 / Usage"
               title="How your agents work"
-              description="Invocation counts are kept separate: ordinary tools, MCP servers and tools, and skill activations."
+              description="Compare per-session and per-turn duration, tools, and token usage by percentile, while keeping ordinary tools, MCP, and skills separate."
               meta={
                 usage.sessionCount > 0 ? (
                   <span className="text-[10px] font-mono tabular-nums text-terminal-dimmer">
@@ -2171,15 +2187,35 @@ export default function InsightsPage() {
               }
             >
               <div className="space-y-4">
-                {/* Turn Duration Distribution + Token Breakdown */}
-                {(turnDurationHistogram || tokenBreakdown) && (
+                {sessionMetricDistributions && (
+                  <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                    <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                      <h3 className="ui-section-title-strong">Per-session distributions</h3>
+                      <span className="text-[10px] font-mono text-terminal-dimmer">
+                        P50 median · P95/P99 tail
+                      </span>
+                    </div>
+                    <SessionDistributionChart
+                      distributions={sessionMetricDistributions}
+                      totalSessions={stats.sessions}
+                    />
+                  </div>
+                )}
+
+                {/* Per-turn distributions + Token Breakdown */}
+                {(perTurnDistributions || turnDurationHistogram || tokenBreakdown) && (
                   <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                    {turnDurationHistogram && (
+                    {perTurnDistributions ? (
+                      <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
+                        <h3 className="ui-section-title-strong mb-4">Per-turn distributions</h3>
+                        <PerTurnDistributionChart distributions={perTurnDistributions} />
+                      </div>
+                    ) : turnDurationHistogram ? (
                       <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
                         <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
                         <TurnDurationChart histogram={turnDurationHistogram} />
                       </div>
-                    )}
+                    ) : null}
                     {tokenBreakdown && (
                       <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
                         <h3 className="ui-section-title-strong mb-4">Token Usage</h3>

--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -322,6 +322,14 @@ function rangeLabel(range: TimeRange): string {
   return "All Time";
 }
 
+/** Keep the legacy duration chart visible when per-turn timing is incomplete. */
+export function shouldShowLegacyTurnDuration(
+  perTurnDistributions: InsightsRangeBreakdown["perTurnDistributions"],
+  turnDurationHistogram: InsightsRangeBreakdown["turnDurationHistogram"],
+): boolean {
+  return Boolean(turnDurationHistogram && !perTurnDistributions?.durationMs);
+}
+
 type InsightsSectionId = "overview" | "activity" | "usage" | "coverage" | "workspace";
 
 const INSIGHTS_SECTIONS: Array<{
@@ -2210,7 +2218,9 @@ export default function InsightsPage() {
                         <h3 className="ui-section-title-strong mb-4">Per-turn distributions</h3>
                         <PerTurnDistributionChart distributions={perTurnDistributions} />
                       </div>
-                    ) : turnDurationHistogram ? (
+                    ) : null}
+                    {shouldShowLegacyTurnDuration(perTurnDistributions, turnDurationHistogram) &&
+                    turnDurationHistogram ? (
                       <div className={`${INSIGHTS_CARD_CLASS} p-5 md:p-6`}>
                         <h3 className="ui-section-title-strong mb-4">Turn Duration Distribution</h3>
                         <TurnDurationChart histogram={turnDurationHistogram} />

--- a/packages/viewer/src/components/ProjectsPanel.tsx
+++ b/packages/viewer/src/components/ProjectsPanel.tsx
@@ -2,9 +2,9 @@
  * ProjectsPanel — full-page Projects tab.
  *
  * Layout mirrors Sessions / Replays: a left sidebar listing projects, and a
- * right pane showing the selected project's content. View tabs (Overview /
- * Timeline / Hot Files) live in the right pane and adapt to whether one
- * project is selected or "All projects".
+ * right pane showing the selected project's content. View tabs (Timeline /
+ * Overview / Hot Files) live in the right pane and keep the same navigation
+ * whether one project or "All projects" is selected.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -32,8 +32,8 @@ interface ProjectsPanelProps {
 type PanelMode = "overview" | "timeline" | "files";
 
 const PROJECT_VIEW_TABS: { id: PanelMode; label: string }[] = [
-  { id: "overview", label: "Overview" },
   { id: "timeline", label: "Timeline" },
+  { id: "overview", label: "Overview" },
   { id: "files", label: "Hot Files" },
 ];
 
@@ -465,7 +465,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     loading: insightsLoading,
   } = useScanInsightsContext();
   const [selectedProjectKey, setSelectedProjectKey] = useState<string>(ALL_PROJECTS);
-  const [mode, setMode] = useState<PanelMode>("overview");
+  const [mode, setMode] = useState<PanelMode>("timeline");
   const [showAgentRuns, setShowAgentRuns] = useState(
     () => new URLSearchParams(window.location.search).get("agentRuns") === "true",
   );
@@ -567,12 +567,13 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
     lastActivity: p.lastActivity,
   }));
 
-  // Single-project Overview already embeds the timeline; the standalone tab
-  // is redundant and dropped. Hot Files stays as its own tab.
+  const selectProject = (projectKey: string) => {
+    setSelectedProjectKey(projectKey);
+    setMode("timeline");
+  };
+
   const isSingleProject = selectedProjectKey !== ALL_PROJECTS;
-  const visibleTabs = isSingleProject
-    ? PROJECT_VIEW_TABS.filter((t) => t.id !== "timeline")
-    : PROJECT_VIEW_TABS;
+  const visibleTabs = PROJECT_VIEW_TABS;
   const activeMode = visibleTabs.some((t) => t.id === mode) ? mode : "overview";
   const projectFilterArg = isSingleProject ? selectedProject : undefined;
 
@@ -582,10 +583,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
       <ProjectSidebar
         projects={sidebarProjects}
         selected={selectedProjectKey}
-        onSelect={(projectKey) => {
-          setSelectedProjectKey(projectKey);
-          setMode("overview");
-        }}
+        onSelect={selectProject}
       />
 
       {/* ─── Right pane: header + tabs + content ─── */}
@@ -596,8 +594,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
             aria-label="Select project"
             value={selectedProjectKey}
             onChange={(e) => {
-              setSelectedProjectKey(e.target.value);
-              setMode("overview");
+              selectProject(e.target.value);
             }}
             className="w-full bg-terminal-surface rounded-lg px-3 py-2.5 text-sm font-sans text-terminal-text outline-none shadow-layer-sm"
           >
@@ -632,7 +629,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 onClick={() => {
                   const next = !showAgentRuns;
                   setShowAgentRuns(next);
-                  setSelectedProjectKey(ALL_PROJECTS);
+                  selectProject(ALL_PROJECTS);
                   navigateTo({ agentRuns: next ? "true" : null }, { notify: false });
                 }}
                 className="mt-1 text-[10px] font-mono text-terminal-dimmer hover:text-terminal-text transition-colors"
@@ -666,7 +663,7 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
         {/* Tab content */}
         <div className="px-4 md:px-6 pb-6 space-y-4">
           {activeMode === "overview" && selectedProjectKey === ALL_PROJECTS && (
-            <ProjectsGrid projects={projects} onProjectClick={setSelectedProjectKey} />
+            <ProjectsGrid projects={projects} onProjectClick={selectProject} />
           )}
           {activeMode === "overview" && selectedInsight && (
             <>
@@ -676,11 +673,6 @@ export default function ProjectsPanel({ onNavigate }: ProjectsPanelProps) {
                 onOpenSessions={() => openSessionsForProject(selectedInsight.project)}
               />
               <ProjectPerformance insights={detailedInsight} loading={insightsLoading} />
-              <SessionRelationshipsView
-                view="timeline"
-                projectFilter={projectFilterArg}
-                projectLocation={selectedLocation}
-              />
             </>
           )}
           {activeMode === "timeline" && (

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -732,11 +732,23 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                 const rowHeight = p.totalRowHeightPx;
                 const accentColor = color.solid;
                 return (
-                  <div key={p.key} className="flex items-stretch rounded-xl group">
+                  <div
+                    key={p.key}
+                    className="group flex items-stretch overflow-hidden rounded-xl border transition-colors"
+                    style={{
+                      borderColor: hexToRgba(accentColor, 0.2),
+                      backgroundColor: hexToRgba(accentColor, 0.025),
+                    }}
+                  >
                     {/* Project label */}
                     <div
-                      className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
-                      style={{ width: LABEL_WIDTH, height: rowHeight }}
+                      className="flex shrink-0 flex-col justify-center overflow-hidden border-l-2 py-1 pr-3"
+                      style={{
+                        width: LABEL_WIDTH,
+                        height: rowHeight,
+                        borderLeftColor: accentColor,
+                        backgroundColor: hexToRgba(accentColor, 0.055),
+                      }}
                     >
                       <div className="flex min-w-0 items-center gap-1.5">
                         <span
@@ -777,8 +789,11 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
 
                     {/* Lane area */}
                     <div
-                      className="relative flex-1 overflow-hidden rounded-xl bg-terminal-surface/45 shadow-layer-sm transition-colors group-hover:bg-terminal-surface-hover/70"
-                      style={{ height: rowHeight }}
+                      className="relative flex-1 overflow-hidden rounded-r-xl border-l border-terminal-border/20 shadow-inner"
+                      style={{
+                        height: rowHeight,
+                        backgroundColor: hexToRgba(accentColor, 0.035),
+                      }}
                     >
                       {/* Grid lines */}
                       {ticks.map((t, i) => (
@@ -836,7 +851,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                           >
                             {ts.heightPx >= LABEL_VISIBLE_MIN_HEIGHT_PX && (
                               <span
-                                className={`pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
+                                className={`relative z-[1] pointer-events-none block min-w-0 px-1.5 text-[10px] font-mono leading-tight ${color.text} ${
                                   lineClamp === 1
                                     ? "truncate leading-[18px]"
                                     : "overflow-hidden pt-1"
@@ -858,7 +873,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 track is the visual bar; the bright segment marks
                                 the actual active interval, including right-anchored
                                 sessions and bars widened for readable hit targets. */}
-                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-white/20">
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-[3px] bg-white/20">
                               <span
                                 className="absolute bottom-0 h-full min-w-[2px] rounded-full bg-white/85"
                                 style={{

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -742,11 +742,10 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                   >
                     {/* Project label */}
                     <div
-                      className="flex shrink-0 flex-col justify-center overflow-hidden border-l-2 py-1 pr-3"
+                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pr-3"
                       style={{
                         width: LABEL_WIDTH,
                         height: rowHeight,
-                        borderLeftColor: accentColor,
                         backgroundColor: hexToRgba(accentColor, 0.055),
                       }}
                     >
@@ -789,7 +788,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
 
                     {/* Lane area */}
                     <div
-                      className="relative flex-1 overflow-hidden rounded-r-xl border-l border-terminal-border/20 shadow-inner"
+                      className="relative flex-1 overflow-hidden rounded-r-xl shadow-inner"
                       style={{
                         height: rowHeight,
                         backgroundColor: hexToRgba(accentColor, 0.035),

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { matchesProjectFacet } from "../engine/dashboard-filtering";
 import { type ScanResultSession, useRelationshipData } from "../hooks/useRelationshipData";
 import { plural } from "../utils/format";
@@ -629,18 +630,26 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       {/* Range selector + automated toggle */}
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-1">
-          <div className="text-sm font-sans font-semibold text-terminal-text">Work Timeline</div>
+          <div className="flex items-center gap-2">
+            <span className="h-1.5 w-1.5 rounded-full bg-terminal-green shadow-[0_0_8px_rgba(34,197,94,0.55)]" />
+            <div className="text-sm font-sans font-semibold text-terminal-text">Work Timeline</div>
+          </div>
           <div className="text-xs font-mono text-terminal-dimmer">
             {totalSessions} {plural(totalSessions, "session")} · rows are projects · bar position
             and width show active time
             {estimatedTimingCount > 0 ? ` · ${estimatedTimingCount} estimated` : ""}
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1 text-[10px] font-mono text-terminal-dimmer">
+            <span>Hover for details</span>
+            <span className="text-terminal-border">·</span>
+            <span>Click a session to inspect it</span>
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-[10px] font-mono">
           {hiddenAutomatedCount > 0 && !showAutomated && (
             <button
               onClick={() => setShowAutomated(true)}
-              className="text-terminal-dimmer hover:text-terminal-text transition-colors"
+              className="rounded-lg bg-terminal-orange-subtle px-2.5 py-1 text-terminal-orange transition-colors hover:bg-terminal-orange-emphasis"
               title="Scheduled / automated sessions are hidden by default"
             >
               + {hiddenAutomatedCount} automated hidden ▸
@@ -649,7 +658,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           {showAutomated && (
             <button
               onClick={() => setShowAutomated(false)}
-              className="text-terminal-purple hover:underline"
+              className="rounded-lg bg-terminal-purple-subtle px-2.5 py-1 text-terminal-purple transition-colors hover:bg-terminal-purple-emphasis"
             >
               hide automated
             </button>
@@ -659,6 +668,8 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
               <button
                 key={opt.value}
                 onClick={() => setRange(opt.value)}
+                aria-pressed={range === opt.value}
+                title={`Show ${opt.label} timeline`}
                 className={`rounded-lg px-2.5 py-1 text-xs font-sans font-semibold transition-all duration-200 ease-material ${
                   range === opt.value
                     ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"
@@ -719,8 +730,16 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                       className="flex flex-col justify-center shrink-0 py-1 pr-3 overflow-hidden"
                       style={{ width: LABEL_WIDTH, height: rowHeight }}
                     >
-                      <div className={`text-xs font-sans font-medium truncate ${color.text}`}>
-                        {projectDisplayName(p.project, p.sessions[0]?.session.projectIdentity)}
+                      <div className="flex min-w-0 items-center gap-1.5">
+                        <span
+                          className="h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: accentColor }}
+                        />
+                        <div
+                          className={`min-w-0 text-xs font-sans font-medium truncate ${color.text}`}
+                        >
+                          {projectDisplayName(p.project, p.sessions[0]?.session.projectIdentity)}
+                        </div>
                       </div>
                       <div className="text-[9px] font-mono text-terminal-dimmer truncate">
                         {p.sessions.length} {plural(p.sessions.length, "session")}
@@ -860,70 +879,75 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
         </div>
       )}
 
-      {/* Tooltip */}
-      {tooltip && (
-        <div
-          className="fixed pointer-events-none w-80 rounded-xl border border-terminal-border bg-terminal-surface p-3 text-xs font-mono shadow-layer-xl"
-          style={{
-            // Keep the tooltip above hovered timeline bars.
-            zIndex: 1000,
-            left: Math.min(tooltip.x + 12, window.innerWidth - 336),
-            top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
-          }}
-        >
-          <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
-            {sessionTitle(tooltip.session)}
-          </div>
-          <div className="mb-2 flex flex-wrap gap-1">
-            {sessionBadges(tooltip.session).map((badge) => (
-              <span
-                key={badge}
-                className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] text-terminal-dim"
-              >
-                {badge}
-              </span>
-            ))}
-          </div>
-          <div className="text-terminal-dimmer space-y-0.5">
-            {tooltip.session.startTime &&
-              (() => {
-                const startMs = new Date(tooltip.session.startTime).getTime();
-                const endMs = activeEndMs(startMs, tooltip.session);
-                const startISO = tooltip.session.startTime;
-                const endISO = new Date(endMs).toISOString();
-                const sameDay = fmtDate(startISO) === fmtDate(endISO);
-                return (
-                  <div>
-                    {fmtDate(startISO)} {fmtShortTime(startISO)}
-                    {endMs !== startMs && (
-                      <span>
-                        {" → "}
-                        {sameDay ? "" : `${fmtDate(endISO)} `}
-                        {fmtShortTime(endISO)}
-                      </span>
-                    )}
-                  </div>
-                );
-              })()}
-            {tooltip.session.durationMs && (
-              <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
-            )}
-            <div>
-              {tooltip.session.promptCount}p · {tooltip.session.editCount}{" "}
-              {plural(tooltip.session.editCount, "edit")} · {tooltip.session.toolCallCount}{" "}
-              {plural(tooltip.session.toolCallCount, "tool")}
+      {/* Portal the fixed tooltip out of the scrollable timeline pane. A fixed
+          child can still expand an ancestor's scrollable overflow, which makes
+          the pane jump when hover state toggles. */}
+      {tooltip &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className="fixed pointer-events-none w-80 rounded-xl border border-terminal-border bg-terminal-surface p-3 text-xs font-mono shadow-layer-xl"
+            style={{
+              // Keep the tooltip above hovered timeline bars.
+              zIndex: 1000,
+              left: Math.min(tooltip.x + 12, window.innerWidth - 336),
+              top: Math.max(8, Math.min(tooltip.y - 8, window.innerHeight - 200)),
+            }}
+          >
+            <div className="text-terminal-text font-medium mb-1.5 break-words leading-snug">
+              {sessionTitle(tooltip.session)}
             </div>
-            {tooltip.session.gitBranch && (
-              <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
-            )}
-            {(tooltip.session.costEstimate ?? 0) > 0 && (
-              <div className="text-terminal-orange">
-                ${tooltip.session.costEstimate!.toFixed(3)}
+            <div className="mb-2 flex flex-wrap gap-1">
+              {sessionBadges(tooltip.session).map((badge) => (
+                <span
+                  key={badge}
+                  className="rounded-md bg-terminal-surface-2 px-1.5 py-0.5 text-[10px] text-terminal-dim"
+                >
+                  {badge}
+                </span>
+              ))}
+            </div>
+            <div className="text-terminal-dimmer space-y-0.5">
+              {tooltip.session.startTime &&
+                (() => {
+                  const startMs = new Date(tooltip.session.startTime).getTime();
+                  const endMs = activeEndMs(startMs, tooltip.session);
+                  const startISO = tooltip.session.startTime;
+                  const endISO = new Date(endMs).toISOString();
+                  const sameDay = fmtDate(startISO) === fmtDate(endISO);
+                  return (
+                    <div>
+                      {fmtDate(startISO)} {fmtShortTime(startISO)}
+                      {endMs !== startMs && (
+                        <span>
+                          {" → "}
+                          {sameDay ? "" : `${fmtDate(endISO)} `}
+                          {fmtShortTime(endISO)}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })()}
+              {tooltip.session.durationMs && (
+                <div className="text-terminal-blue">{fmtDuration(tooltip.session.durationMs)}</div>
+              )}
+              <div>
+                {tooltip.session.promptCount}p · {tooltip.session.editCount}{" "}
+                {plural(tooltip.session.editCount, "edit")} · {tooltip.session.toolCallCount}{" "}
+                {plural(tooltip.session.toolCallCount, "tool")}
               </div>
-            )}
-          </div>
-        </div>
-      )}
+              {tooltip.session.gitBranch && (
+                <div className="text-terminal-purple">{tooltip.session.gitBranch}</div>
+              )}
+              {(tooltip.session.costEstimate ?? 0) > 0 && (
+                <div className="text-terminal-orange">
+                  ${tooltip.session.costEstimate!.toFixed(3)}
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -704,7 +704,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
           )}
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 p-3 shadow-inner">
+        <div className="overflow-x-auto rounded-2xl bg-terminal-bg/35 py-3 shadow-inner">
           <div className="min-w-[760px]">
             {/* Time axis header */}
             <div className="flex" style={{ paddingLeft: LABEL_WIDTH }}>
@@ -742,7 +742,7 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                   >
                     {/* Project label */}
                     <div
-                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pr-3"
+                      className="flex shrink-0 flex-col justify-center overflow-hidden py-1 pl-3 pr-3"
                       style={{
                         width: LABEL_WIDTH,
                         height: rowHeight,

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -858,9 +858,9 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 track is the visual bar; the bright segment marks
                                 the actual active interval, including right-anchored
                                 sessions and bars widened for readable hit targets. */}
-                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/15">
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] bg-white/20">
                               <span
-                                className="absolute bottom-0 h-full rounded-full bg-white/75"
+                                className="absolute bottom-0 h-full min-w-[2px] rounded-full bg-white/85"
                                 style={{
                                   left: `${ts.actualStartFraction * 100}%`,
                                   right: `${(1 - ts.actualEndFraction) * 100}%`,

--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -104,8 +104,6 @@ function rangeEmptyLabel(range: TimelineRange): string {
       return "the last 7 days";
     case "30d":
       return "the last 30 days";
-    case "all":
-      return "this scan";
   }
 }
 
@@ -247,7 +245,9 @@ interface TimelineSession {
   heightPx: number;
   fillAlpha: number;
   opacity: number;
-  realDurationFraction: number;
+  /** Actual active interval within the rendered visual bar, 0–1. */
+  actualStartFraction: number;
+  actualEndFraction: number;
   /**
    * True when the bar would overflow the lane's right edge if rendered from
    * its leftPct. Right-anchored bars hug the right edge with their full
@@ -486,9 +486,17 @@ function buildTimeline(
       const leftPct = Math.max(0, rawLeftPct);
       const widthPct = Math.max(0, rawRightPct - leftPct);
       const minWidthPx = minWidthFor(it.score);
-      const realWidthPx = (widthPct / 100) * APPROX_TIMELINE_WIDTH_PX;
-      const visualWidthPx = Math.max(realWidthPx, minWidthPx);
-      const realDurationFraction = visualWidthPx > 0 ? Math.min(1, realWidthPx / visualWidthPx) : 1;
+      const visualStartMs = Math.max(it.startMs, rangeStart);
+      const visualEndMs = Math.min(it.endMs, rangeEnd);
+      const visualDurationMs = Math.max(1, visualEndMs - visualStartMs);
+      const actualStartFraction = Math.max(
+        0,
+        Math.min(1, (Math.max(it.realStartMs, visualStartMs) - visualStartMs) / visualDurationMs),
+      );
+      const actualEndFraction = Math.max(
+        actualStartFraction,
+        Math.min(1, (Math.min(it.realEndMs, visualEndMs) - visualStartMs) / visualDurationMs),
+      );
       tSessions.push({
         session: it.original,
         leftPct,
@@ -499,7 +507,8 @@ function buildTimeline(
         heightPx: heightFor(it.score),
         fillAlpha: fillAlphaFor(it.score),
         opacity: opacityFor(it.score),
-        realDurationFraction,
+        actualStartFraction,
+        actualEndFraction,
         rightAnchored: it.rightAnchored,
       });
     }
@@ -570,18 +579,17 @@ function buildTimeline(
   return { projects, ticks, minMs, maxMs, totalSessions, hiddenAutomatedCount };
 }
 
-type TimelineRange = "1d" | "7d" | "30d" | "all";
+type TimelineRange = "1d" | "7d" | "30d";
 
-const RANGE_OPTIONS: { value: TimelineRange; label: string; days?: number }[] = [
+const RANGE_OPTIONS: { value: TimelineRange; label: string; days: number }[] = [
   { value: "1d", label: "1D", days: 1 },
   { value: "7d", label: "7D", days: 7 },
   { value: "30d", label: "30D", days: 30 },
-  { value: "all", label: "All" },
 ];
 
 function rangeWindow(range: TimelineRange): { start?: number; end?: number } {
   const opt = RANGE_OPTIONS.find((o) => o.value === range);
-  if (!opt || opt.days == null) return {};
+  if (!opt) return {};
   const end = Date.now();
   const start = end - opt.days * 86400000;
   return { start, end };
@@ -686,12 +694,12 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
       {projects.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-40 gap-2 text-terminal-dimmer text-sm font-mono">
           <div>No sessions in {rangeEmptyLabel(range)}.</div>
-          {range !== "all" && (
+          {range !== "30d" && (
             <button
-              onClick={() => setRange("all")}
+              onClick={() => setRange("30d")}
               className="text-terminal-green hover:underline text-xs"
             >
-              Show all sessions →
+              Show 30 days →
             </button>
           )}
         </div>
@@ -794,10 +802,6 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                             (ts.heightPx - LABEL_VERTICAL_PADDING_PX) / LABEL_LINE_HEIGHT_PX,
                           ),
                         );
-                        // Right-anchored bars no longer have their left edge
-                        // at startTime, so a left-aligned wick would be
-                        // misleading. Use the tooltip for exact timing instead.
-                        const showWick = !ts.rightAnchored && ts.realDurationFraction < 0.85;
                         return (
                           <button
                             type="button"
@@ -850,23 +854,20 @@ function TimelineSwimlaneView({ groups }: { groups: ProjectGroup[] }) {
                                 {sessionTitle(ts.session)}
                               </span>
                             )}
-                            {showWick && (
-                              <>
-                                {/* Bottom strip + end-tick mark the actual session
-                                    duration inside the min-width-padded bar. */}
-                                <span
-                                  className="pointer-events-none absolute bottom-0 left-0 h-[2px] rounded-r-full bg-white/85"
-                                  style={{ width: `${ts.realDurationFraction * 100}%` }}
-                                  title="actual duration"
-                                />
-                                <span
-                                  className="pointer-events-none absolute bottom-0 h-[6px] w-[2px] bg-white/90"
-                                  style={{
-                                    left: `calc(${ts.realDurationFraction * 100}% - 2px)`,
-                                  }}
-                                />
-                              </>
-                            )}
+                            {/* Every bar gets the same duration rail. The muted
+                                track is the visual bar; the bright segment marks
+                                the actual active interval, including right-anchored
+                                sessions and bars widened for readable hit targets. */}
+                            <span className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-white/15">
+                              <span
+                                className="absolute bottom-0 h-full rounded-full bg-white/75"
+                                style={{
+                                  left: `${ts.actualStartFraction * 100}%`,
+                                  right: `${(1 - ts.actualEndFraction) * 100}%`,
+                                }}
+                                title="actual duration"
+                              />
+                            </span>
                           </button>
                         );
                       })}

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -11,6 +11,8 @@ import {
   UsageBarList,
   UsageCoverage,
 } from "../InsightsPage";
+import { PerTurnDistributionChart, SessionDistributionChart } from "../InsightCharts";
+import type { SessionMetricDistributions } from "../../engine/insights-rollup";
 import { getInsightsRangeFromUrl, getMultiFromUrl } from "../../hooks/usePanelFilters";
 
 afterEach(() => {
@@ -123,6 +125,55 @@ describe("Insights sections", () => {
 
     fireEvent.click(usageButton);
     expect(onSelect).toHaveBeenCalledWith("usage");
+  });
+
+  it("renders session metric distributions with coverage-aware samples", () => {
+    const distribution: SessionMetricDistributions = {
+      durationMs: {
+        buckets: [{ label: "<30s", count: 2, pct: 100 }],
+        percentiles: { p25: 1_000, p50: 2_000, p75: 3_000, p95: 4_000, p99: 5_000 },
+        sampleCount: 2,
+      },
+      turns: {
+        buckets: [{ label: "1-2", count: 3, pct: 100 }],
+        percentiles: { p25: 1, p50: 1, p75: 2, p95: 2, p99: 2 },
+        sampleCount: 3,
+      },
+    };
+
+    render(<SessionDistributionChart distributions={distribution} totalSessions={3} />);
+
+    expect(screen.getByLabelText("Session duration distribution")).toBeDefined();
+    expect(screen.getByText("2/3 sessions")).toBeDefined();
+    expect(screen.getByLabelText("Turns distribution")).toBeDefined();
+    expect(screen.getAllByText("p95")).toHaveLength(2);
+    expect(screen.getAllByText("p99")).toHaveLength(2);
+  });
+
+  it("renders per-turn time, tool, and token distributions", () => {
+    const distribution: SessionMetricDistributions = {
+      durationMs: {
+        buckets: [{ label: "<30s", count: 2, pct: 100 }],
+        percentiles: { p25: 1, p50: 2, p75: 3, p95: 4, p99: 5 },
+        sampleCount: 2,
+      },
+      toolCalls: {
+        buckets: [{ label: "0", count: 2, pct: 100 }],
+        percentiles: { p25: 0, p50: 0, p75: 1, p95: 1, p99: 1 },
+        sampleCount: 2,
+      },
+      tokens: {
+        buckets: [{ label: "<1k", count: 2, pct: 100 }],
+        percentiles: { p25: 10, p50: 20, p75: 30, p95: 40, p99: 50 },
+        sampleCount: 2,
+      },
+    };
+
+    render(<PerTurnDistributionChart distributions={distribution} />);
+
+    expect(screen.getByLabelText("Time distribution")).toBeDefined();
+    expect(screen.getByLabelText("Tool calls distribution")).toBeDefined();
+    expect(screen.getByLabelText("Tokens distribution")).toBeDefined();
   });
 
   it("communicates incomplete invocation-index coverage", () => {

--- a/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
+++ b/packages/viewer/src/components/__tests__/insights-usage-list.test.tsx
@@ -8,6 +8,7 @@ import {
   TopProjectsList,
   CoverageAudit,
   formatCompactNum,
+  shouldShowLegacyTurnDuration,
   UsageBarList,
   UsageCoverage,
 } from "../InsightsPage";
@@ -174,6 +175,32 @@ describe("Insights sections", () => {
     expect(screen.getByLabelText("Time distribution")).toBeDefined();
     expect(screen.getByLabelText("Tool calls distribution")).toBeDefined();
     expect(screen.getByLabelText("Tokens distribution")).toBeDefined();
+  });
+
+  it("keeps legacy turn timing when per-turn timing is unavailable", () => {
+    const histogram = {
+      buckets: [],
+      percentiles: { p50Ms: 1_000, p75Ms: 2_000, p90Ms: 3_000 },
+      totalTurns: 2,
+    };
+    const partial = {
+      toolCalls: {
+        buckets: [],
+        percentiles: { p25: 0, p50: 1, p75: 2, p95: 3, p99: 4 },
+        sampleCount: 2,
+      },
+    };
+    const complete = {
+      ...partial,
+      durationMs: {
+        buckets: [],
+        percentiles: { p25: 1, p50: 2, p75: 3, p95: 4, p99: 5 },
+        sampleCount: 2,
+      },
+    };
+
+    expect(shouldShowLegacyTurnDuration(partial, histogram)).toBe(true);
+    expect(shouldShowLegacyTurnDuration(complete, histogram)).toBe(false);
   });
 
   it("communicates incomplete invocation-index coverage", () => {

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -64,7 +64,7 @@ describe("ProjectsPanel project insights", () => {
 
     render(<ProjectsPanel onNavigate={vi.fn()} />);
 
-    const timelineTab = screen.getByRole("button", { name: "Timeline", exact: true });
+    const timelineTab = screen.getByRole("button", { name: "Timeline" });
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
 
     fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -58,6 +58,20 @@ function contextValue(): ReturnType<typeof InsightsPanel.useScanInsightsContext>
 }
 
 describe("ProjectsPanel project insights", () => {
+  it("opens the Timeline view by default and when selecting a project", () => {
+    const context = contextValue();
+    vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);
+
+    render(<ProjectsPanel onNavigate={vi.fn()} />);
+
+    const timelineTab = screen.getByRole("button", { name: "Timeline", exact: true });
+    expect(timelineTab.className).toContain("bg-terminal-green-subtle");
+
+    fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);
+
+    expect(timelineTab.className).toContain("bg-terminal-green-subtle");
+  });
+
   it("fetches detailed insights only after selecting a project", () => {
     const context = contextValue();
     vi.spyOn(InsightsPanel, "useScanInsightsContext").mockReturnValue(context);

--- a/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
+++ b/packages/viewer/src/components/__tests__/projects-lazy-insights.test.tsx
@@ -67,8 +67,13 @@ describe("ProjectsPanel project insights", () => {
     const timelineTab = screen.getByRole("button", { name: "Timeline" });
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
 
+    const overviewTab = screen.getByRole("button", { name: "Overview" });
+    fireEvent.click(overviewTab);
+    expect(overviewTab.className).toContain("bg-terminal-green-subtle");
+
     fireEvent.click(screen.getAllByRole("button", { name: /example/i })[0]);
 
+    expect(screen.getByRole("heading", { name: /example/i })).toBeDefined();
     expect(timelineTab.className).toContain("bg-terminal-green-subtle");
   });
 

--- a/packages/viewer/src/components/__tests__/session-relationships-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/session-relationships-view.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SessionRelationshipsView from "../SessionRelationshipsView";
+import { useRelationshipData, type ScanResultSession } from "../../hooks/useRelationshipData";
+
+vi.mock("../../hooks/useRelationshipData", () => ({
+  useRelationshipData: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function session(): ScanResultSession {
+  const startTime = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  return {
+    sessionId: "hover-session",
+    provider: "claude-code",
+    project: "~/project",
+    slug: "hover-session",
+    title: "Hover session",
+    startTime,
+    endTime: startTime,
+    durationMs: 60_000,
+    promptCount: 1,
+    toolCallCount: 1,
+    editCount: 0,
+    filesModified: [],
+    subAgentCount: 0,
+    apiErrorCount: 0,
+    compactionCount: 0,
+  };
+}
+
+describe("SessionRelationshipsView timeline tooltip", () => {
+  it("renders the hover card outside the scrollable timeline pane", () => {
+    vi.mocked(useRelationshipData).mockReturnValue({
+      sessions: [session()],
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(<SessionRelationshipsView view="timeline" />);
+    const timelinePane = container.querySelector("div.overflow-y-auto");
+    const bar = screen.getByRole("button", { name: "Open Hover session" });
+
+    expect(timelinePane).not.toBeNull();
+    fireEvent.mouseEnter(bar, { clientX: 100, clientY: 100 });
+
+    const tooltip = document.body.querySelector(".fixed");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toContain("Hover session");
+    expect(tooltip?.parentElement).toBe(document.body);
+    expect(timelinePane?.contains(tooltip)).toBe(false);
+  });
+});

--- a/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
+++ b/packages/viewer/src/engine/__tests__/insights-rollup.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPerTurnDistributions,
+  buildSessionMetricDistributions,
   isInInsightsRange,
   rangeSince,
   rollupInsights,
@@ -344,5 +346,120 @@ describe("rollupInsights", () => {
   it("excludes undated sessions from bounded secondary breakdowns", () => {
     expect(isInInsightsRange(undefined, "2026-08-15T00:00:00Z")).toBe(false);
     expect(isInInsightsRange(undefined)).toBe(true);
+  });
+});
+
+describe("session metric distributions", () => {
+  it("computes per-session percentiles and keeps zero-count sessions", () => {
+    const distributions = buildSessionMetricDistributions([
+      {
+        project: "~/code/a",
+        durationMs: 100,
+        prompts: 1,
+        edits: 0,
+        toolCalls: 0,
+        tokenUsage: {
+          inputTokens: 25,
+          outputTokens: 25,
+          cacheReadTokens: 25,
+          cacheCreationTokens: 25,
+        },
+      },
+      {
+        project: "~/code/b",
+        durationMs: 200,
+        prompts: 3,
+        edits: 0,
+        toolCalls: 10,
+        tokenUsage: {
+          inputTokens: 75,
+          outputTokens: 75,
+          cacheReadTokens: 75,
+          cacheCreationTokens: 75,
+        },
+      },
+      {
+        project: "~/code/c",
+        prompts: 2,
+        edits: 0,
+        toolCalls: 5,
+      },
+    ]);
+
+    expect(distributions?.durationMs).toMatchObject({
+      sampleCount: 2,
+      percentiles: { p25: 125, p50: 150, p75: 175, p95: 195, p99: 199 },
+    });
+    expect(distributions?.toolCalls).toMatchObject({
+      sampleCount: 3,
+      percentiles: { p25: 2.5, p50: 5, p75: 7.5, p95: 9.5, p99: 9.9 },
+    });
+    expect(distributions?.turns?.sampleCount).toBe(3);
+    expect(distributions?.tokens).toMatchObject({
+      sampleCount: 2,
+      percentiles: { p25: 150, p50: 200, p75: 250, p95: 290, p99: 298 },
+    });
+  });
+
+  it("builds time, tool, and token distributions for turns", () => {
+    const distributions = buildPerTurnDistributions([
+      { durationMs: 100, toolCalls: 0, tokens: 100 },
+      { durationMs: 200, toolCalls: 4, tokens: 300 },
+      { toolCalls: 2 },
+    ]);
+
+    expect(distributions).toMatchObject({
+      durationMs: {
+        sampleCount: 2,
+        percentiles: { p50: 150, p99: 199 },
+      },
+      toolCalls: {
+        sampleCount: 3,
+        percentiles: { p50: 2, p99: 3.96 },
+      },
+      tokens: {
+        sampleCount: 2,
+        percentiles: { p50: 200, p99: 298 },
+      },
+    });
+  });
+
+  it("scopes distributions to the selected session range", () => {
+    const result = rollupInsightsBreakdown(
+      {
+        sessions: [
+          {
+            project: "~/code/recent",
+            startTime: "2026-08-20T12:00:00Z",
+            durationMs: 100,
+            prompts: 1,
+            edits: 0,
+            toolCalls: 2,
+            turnMetrics: [{ durationMs: 100, toolCalls: 2, tokens: 50 }],
+          },
+          {
+            project: "~/code/old",
+            startTime: "2026-01-01T00:00:00Z",
+            durationMs: 10_000,
+            prompts: 10,
+            edits: 0,
+            toolCalls: 20,
+          },
+        ],
+        replays: [],
+      },
+      { since: "2026-08-15T00:00:00Z" },
+    );
+
+    expect(result.sessionMetricDistributions).toMatchObject({
+      durationMs: { sampleCount: 1, percentiles: { p50: 100 } },
+      toolCalls: { sampleCount: 1, percentiles: { p50: 2 } },
+      turns: { sampleCount: 1, percentiles: { p50: 1 } },
+    });
+    expect(result.perTurnDistributions).toMatchObject({
+      durationMs: { sampleCount: 1, percentiles: { p50: 100 } },
+      toolCalls: { sampleCount: 1, percentiles: { p50: 2 } },
+      tokens: { sampleCount: 1, percentiles: { p50: 50 } },
+    });
   });
 });

--- a/packages/viewer/src/engine/insights-rollup.ts
+++ b/packages/viewer/src/engine/insights-rollup.ts
@@ -1,5 +1,5 @@
 import { mergeProjectIdentities, projectIdentityKey } from "@vibe-replay/types";
-import type { ProjectIdentity, SessionLocation } from "@vibe-replay/types";
+import type { ProjectIdentity, SessionLocation, TurnMetric } from "@vibe-replay/types";
 
 export interface InsightsMetricSession {
   project: string;
@@ -20,6 +20,7 @@ export interface InsightsMetricSession {
     cacheCreationTokens: number;
   };
   turnDurations?: number[];
+  turnMetrics?: TurnMetric[];
 }
 
 export interface InsightsReplayRef {
@@ -69,12 +70,41 @@ export interface InsightsRangeTurnDurationHistogram {
   totalTurns: number;
 }
 
+export interface SessionMetricDistribution {
+  buckets: Array<{ label: string; count: number; pct: number }>;
+  /** Linear-interpolated percentile cutoffs, in the metric's native unit. */
+  percentiles: { p25: number; p50: number; p75: number; p95: number; p99: number };
+  sampleCount: number;
+}
+
+export interface SessionMetricDistributions {
+  /** Total active duration for each session, in milliseconds. */
+  durationMs?: SessionMetricDistribution;
+  /** All provider-recorded tool invocations for each session. */
+  toolCalls?: SessionMetricDistribution;
+  /** User prompts (turns) for each session. */
+  turns?: SessionMetricDistribution;
+  /** Input + output + cache read/write tokens for each session. */
+  tokens?: SessionMetricDistribution;
+}
+
+export interface PerTurnDistributions {
+  /** Active/provider-recorded time for each turn, in milliseconds. */
+  durationMs?: SessionMetricDistribution;
+  /** All recorded tool invocations attributed to each turn. */
+  toolCalls?: SessionMetricDistribution;
+  /** Input + output + cache read/write tokens for each turn. */
+  tokens?: SessionMetricDistribution;
+}
+
 export interface InsightsRangeBreakdown {
   projects: InsightsRangeProject[];
   models: Record<string, number>;
   providers: Record<string, number>;
   tokenBreakdown?: InsightsRangeTokenBreakdown;
   turnDurationHistogram?: InsightsRangeTurnDurationHistogram;
+  sessionMetricDistributions?: SessionMetricDistributions;
+  perTurnDistributions?: PerTurnDistributions;
 }
 
 export type InsightsRange = "7d" | "30d" | "90d" | "all";
@@ -217,6 +247,143 @@ function buildTurnDurationHistogram(
   };
 }
 
+const SESSION_METRIC_BUCKETS = {
+  durationMs: [
+    { label: "<30s", max: 30_000 },
+    { label: "30s-1m", max: 60_000 },
+    { label: "1-2m", max: 120_000 },
+    { label: "2-5m", max: 300_000 },
+    { label: "5-10m", max: 600_000 },
+    { label: "10m+", max: Number.POSITIVE_INFINITY },
+  ],
+  toolCalls: [
+    { label: "0", max: 1 },
+    { label: "1-5", max: 6 },
+    { label: "6-10", max: 11 },
+    { label: "11-25", max: 26 },
+    { label: "26-50", max: 51 },
+    { label: "51-100", max: 101 },
+    { label: "100+", max: Number.POSITIVE_INFINITY },
+  ],
+  turns: [
+    { label: "0", max: 1 },
+    { label: "1-2", max: 3 },
+    { label: "3-5", max: 6 },
+    { label: "6-10", max: 11 },
+    { label: "11-20", max: 21 },
+    { label: "21-50", max: 51 },
+    { label: "50+", max: Number.POSITIVE_INFINITY },
+  ],
+  tokens: [
+    { label: "<1k", max: 1_000 },
+    { label: "1-10k", max: 10_000 },
+    { label: "10-50k", max: 50_000 },
+    { label: "50-100k", max: 100_000 },
+    { label: "100-250k", max: 250_000 },
+    { label: "250-500k", max: 500_000 },
+    { label: "500k+", max: Number.POSITIVE_INFINITY },
+  ],
+} as const;
+
+type SessionMetricKey = keyof typeof SESSION_METRIC_BUCKETS;
+
+const TURN_METRIC_BUCKETS = {
+  durationMs: SESSION_METRIC_BUCKETS.durationMs,
+  toolCalls: SESSION_METRIC_BUCKETS.toolCalls,
+  tokens: SESSION_METRIC_BUCKETS.tokens,
+} as const;
+
+function buildSessionMetricDistribution(
+  values: readonly number[],
+  buckets: readonly { label: string; max: number }[],
+): SessionMetricDistribution | undefined {
+  const sorted = values
+    .filter((value) => Number.isFinite(value) && value >= 0)
+    .sort((a, b) => a - b);
+  if (sorted.length === 0) return undefined;
+
+  const counts = buckets.map(() => 0);
+  for (const value of sorted) {
+    const bucketIndex = buckets.findIndex((bucket) => value < bucket.max);
+    if (bucketIndex >= 0) counts[bucketIndex]!++;
+  }
+
+  return {
+    buckets: buckets.map((bucket, index) => ({
+      label: bucket.label,
+      count: counts[index]!,
+      pct: Math.round((counts[index]! / sorted.length) * 1000) / 10,
+    })),
+    percentiles: {
+      p25: percentile(sorted, 25),
+      p50: percentile(sorted, 50),
+      p75: percentile(sorted, 75),
+      p95: percentile(sorted, 95),
+      p99: percentile(sorted, 99),
+    },
+    sampleCount: sorted.length,
+  };
+}
+
+export function buildSessionMetricDistributions(
+  sessions: readonly InsightsMetricSession[],
+): SessionMetricDistributions | undefined {
+  const values: Record<SessionMetricKey, number[]> = {
+    durationMs: [],
+    toolCalls: [],
+    turns: [],
+    tokens: [],
+  };
+
+  for (const session of sessions) {
+    if (session.durationMs !== undefined) values.durationMs.push(session.durationMs);
+    values.toolCalls.push(session.toolCalls);
+    values.turns.push(session.prompts);
+    if (session.tokenUsage) {
+      values.tokens.push(
+        session.tokenUsage.inputTokens +
+          session.tokenUsage.outputTokens +
+          session.tokenUsage.cacheReadTokens +
+          session.tokenUsage.cacheCreationTokens,
+      );
+    }
+  }
+
+  const distributions: SessionMetricDistributions = {};
+  for (const key of Object.keys(SESSION_METRIC_BUCKETS) as SessionMetricKey[]) {
+    const distribution = buildSessionMetricDistribution(values[key], SESSION_METRIC_BUCKETS[key]);
+    if (distribution) distributions[key] = distribution;
+  }
+
+  return Object.keys(distributions).length > 0 ? distributions : undefined;
+}
+
+type PerTurnMetricKey = keyof typeof TURN_METRIC_BUCKETS;
+
+export function buildPerTurnDistributions(
+  turnMetrics: readonly TurnMetric[],
+): PerTurnDistributions | undefined {
+  const values: Record<PerTurnMetricKey, number[]> = {
+    durationMs: [],
+    toolCalls: [],
+    tokens: [],
+  };
+
+  for (const turn of turnMetrics) {
+    if (turn.durationMs !== undefined) values.durationMs.push(turn.durationMs);
+    values.toolCalls.push(turn.toolCalls);
+    if (turn.tokens !== undefined) values.tokens.push(turn.tokens);
+  }
+
+  const distributions: PerTurnDistributions = {};
+  for (const key of Object.keys(TURN_METRIC_BUCKETS) as PerTurnMetricKey[]) {
+    const distribution = buildSessionMetricDistribution(values[key], TURN_METRIC_BUCKETS[key]);
+    if (distribution) distributions[key] = distribution;
+  }
+
+  return Object.keys(distributions).length > 0 ? distributions : undefined;
+}
+
 /**
  * Aggregate the non-additive Insights sections for a selected time range.
  * These fields are carried per session by the optional detail projection so
@@ -231,6 +398,7 @@ export function rollupInsightsBreakdown(
   const models: Record<string, number> = {};
   const providers: Record<string, number> = {};
   const durations: number[] = [];
+  const turnMetrics: TurnMetric[] = [];
   let input = 0;
   let output = 0;
   let cacheRead = 0;
@@ -281,6 +449,7 @@ export function rollupInsightsBreakdown(
       cacheCreation += session.tokenUsage.cacheCreationTokens;
     }
     if (session.turnDurations) durations.push(...session.turnDurations);
+    if (session.turnMetrics) turnMetrics.push(...session.turnMetrics);
   }
 
   const tokenTotal = input + output + cacheRead + cacheCreation;
@@ -303,5 +472,7 @@ export function rollupInsightsBreakdown(
           }
         : undefined,
     turnDurationHistogram: buildTurnDurationHistogram(durations),
+    sessionMetricDistributions: buildSessionMetricDistributions(sessions),
+    perTurnDistributions: buildPerTurnDistributions(turnMetrics),
   };
 }


### PR DESCRIPTION
## Summary

- Add per-session distributions for session duration, tool calls, turns, and total token usage.
- Show P25, P50, P75, P95, and P99 cutoffs with clearer percentile presentation and coverage counts.
- Replace the dashboard's turn-duration-only section with per-turn distributions for time, tool calls, and tokens.
- Persist compact numeric per-turn metrics and bump the scanner cache version so existing sessions are rescanned.
- Preserve duration-chart fallback behavior for partial metrics and guard malformed turn indexes and sub-agent scene fallbacks.

## Validation

- `pnpm verify`
- Full unit test suite: 538 CLI tests and 417 viewer tests passed.
