### PR TITLE
docs: refresh README and website product messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/vibe-replay)](https://www.npmjs.com/package/vibe-replay)
 [![license](https://img.shields.io/npm/l/vibe-replay)](./LICENSE)
 
-Turn Claude, Cursor, Codex, OpenCode, Hermes, and Pi sessions into shareable, interactive replays.
+Turn Claude, Cursor, Codex, OpenCode, Hermes, and Pi sessions into shareable, interactive replays — then analyze them with local insights, AI Studio, and Ask Replay.
 
 ### The problem
 
@@ -12,7 +12,7 @@ AI agents write code in long, complex sessions — dozens of tool calls, hundred
 
 ### The fix
 
-One command. One self-contained HTML file. Every prompt, every thought, every tool call — animated and interactive.
+One command. One self-contained HTML file. Every prompt, every thought, every tool call — animated, searchable, and ready to share.
 
 ```bash
 npx vibe-replay
@@ -99,6 +99,15 @@ GitHub-style activity heatmap, streaks, weekly trends, top projects, model usage
   <img src="docs/screenshots/personal-insights.png" alt="Personal insights — GitHub-style heatmap, streaks, session stats, and cost tracking" width="800" />
 </p>
 
+### AI Studio and Ask Replay
+
+Go beyond playback without sending your session history to a hosted service. **AI Studio** uses the
+embedded Pi runtime to analyze a replay, translate it, or adjust its tone with the provider you
+choose — including OpenAI-compatible endpoints and local gateways. **Ask Replay** is a read-only
+assistant for searching sessions, explaining usage and Insights, inspecting scenes and overlays, and
+jumping to stable dashboard or replay links. It never edits files, publishes, or mutates data on its
+own; any requested action is handed back to you for review.
+
 ## Claude Code Plugin
 
 vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/docs/en/plugins). Once installed, your agent learns how to generate replays autonomously — it can find the current session, produce GitHub-ready artifacts, and embed them in PRs, all without you running any CLI commands.
@@ -158,16 +167,18 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 
 ## Features
 
-- **Zero config** — one command, no setup, no account. Works instantly with existing sessions
+- **Local-first** — one command and no account required for local replays; sign in only when you want cloud publishing or synced insights
 - **Cross-platform** — runs on macOS, Linux, and Windows
 - **Single HTML file** — self-contained, works offline, and makes no automatic external requests. Remote image attachments load only after an explicit click
 - **Claude, Cursor, Codex, OpenCode, Hermes, and Pi** — all providers auto-discovered, including multi-file and resumed sessions
 - **Remote SSH sources** — optionally combine remote Codex, Claude Code, and Pi JSONL sessions with local sessions using standard OpenSSH configuration
 - **Local dashboard** — browse and search every session, filter by git repo, tool, MCP server/tool, skill, or context compaction, expand a session for its own tool/MCP/skill counts, with activity heatmaps, per-project analytics, and a personal-insights view (including which tools and MCP servers you lean on) across all your coding
+- **AI Studio** — use the embedded Pi runtime to analyze, translate, and professionalize replays with your selected provider/model, including OpenAI-compatible local or remote endpoints
+- **Ask Replay** — ask read-only questions about sessions, scenes, annotations, overlays, usage, coverage, projects, and Insights; get stable permalinks instead of opaque chat answers
 - **Share & export** — GitHub Gist, animated SVG, GIF, markdown summary, or cloud upload. Secret redaction built in
 - **Sub-agent visualization** — see delegated tool calls and sub-agent trees rendered inline
 - **Comments** — leave notes on any scene. Comments persist in the HTML and travel with the replay
-- **Live mode** — `vibe-replay live` streams a running Claude Code or Codex session into the viewer, pinned to the latest turn as it lands on disk
+- **Live mode** — `vibe-replay live` follows a running local session as new turns land on disk; SSH-backed live mode is intentionally disabled
 
 ## Supported Providers
 
@@ -262,7 +273,7 @@ VIBE_VIEWER_PORT=5175 VIBE_WEBSITE_PORT=4322 pnpm dev:website
 The requested ports must be free and different within the same launcher. If
 only one port is overridden, automatic selection skips that port as well.
 
-CLI usage requires Node.js >= 22.19.0. The `website` package uses Astro 6 and
+CLI usage requires Node.js >= 22.19.0. The `website` package uses Astro 7 and
 requires Node.js >= 22.12.0. Its scripts use a cross-platform Node launcher
 that searches standard nvm-managed installations when needed. If a global
 package-manager shim selects an older Node for child commands, verify

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,8 +1,8 @@
 # vibe-replay
 
-> vibe-replay turns your AI coding sessions — Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi — into interactive, shareable web replays as single self-contained HTML files. One command, no account, free and open source.
+> vibe-replay turns your AI coding sessions — Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi — into local-first interactive, shareable web replays. Then use Insights, embedded AI Studio, and Ask Replay to understand what happened. One command for local use, no account required, free and open source.
 
-vibe-replay is a CLI (npm package: `vibe-replay`) that reads your local AI agent session data (Claude Code `~/.claude/`, Cursor `~/.cursor/` + SQLite stores, Codex, OpenCode `~/.local/share/opencode/opencode.db`, Hermes `~/.hermes/state.db`, Pi `~/.pi/agent/sessions/`), then renders it as a scrubbable timeline showing every prompt, AI response, tool call, file diff, and thinking block. Output is a single HTML file with all assets inlined — no server, no external requests.
+vibe-replay is a CLI (npm package: `vibe-replay`) that reads your local AI agent session data (Claude Code `~/.claude/`, Cursor `~/.cursor/` + SQLite stores, Codex, OpenCode `~/.local/share/opencode/opencode.db`, Hermes `~/.hermes/state.db`, Pi `~/.pi/agent/sessions/`), then renders it as a scrubbable timeline showing every prompt, AI response, tool call, file diff, and thinking block. The local dashboard adds searchable session discovery, usage facets, project analytics, and personal Insights. Output is a single HTML file with all assets inlined — no server, no external requests.
 
 Install: `npx vibe-replay`
 Source: https://github.com/tuo-lei/vibe-replay
@@ -21,9 +21,12 @@ License: MIT
 - **Full replay**: step through every prompt, thinking block, tool call, and code diff with All/Compact/Custom view modes, outline navigation, search, and playback controls.
 - **Session insights**: per-session analytics — token burn and cost per turn, context window usage, cache hit rates, tool call distribution, model breakdown, and data-quality hints.
 - **Personal insights**: GitHub-style activity heatmap, streaks, weekly trends, top projects, model usage, provider breakdown, and cost tracking across all sessions.
+- **AI Studio**: embedded Pi runtime for replay analysis, translation, and tone adjustment with the provider/model selected by the user, including OpenAI-compatible endpoints.
+- **Ask Replay**: a read-only local assistant for sessions, scenes, annotations, overlays, usage, coverage, projects, and Insights. It returns stable navigation permalinks and never performs a mutation itself.
+- **Remote SSH sources**: optionally index Codex, Claude Code, and Pi sessions from OpenSSH-compatible hosts. Remote data is cached locally, remote Live mode is disabled, and remote aggregates stay out of cloud insight sync.
 - **Share & export**: self-contained HTML, animated SVG, GIF, or markdown summary. Publish to GitHub Gist for a shareable link, or upload to the cloud. Secret redaction built in.
 - **Claude Code plugin**: install from the plugin marketplace so your agent generates replays automatically during PR creation. A portable Agent Skills `SKILL.md` is also included for Cursor, Codex, and other compatible agents.
-- **Live mode**: `vibe-replay live` streams a running Claude Code or Codex session into the viewer, pinned to the latest turn as it lands on disk.
+- **Live mode**: `vibe-replay live` follows a running local session as new turns land on disk; SSH-backed live mode is intentionally unavailable.
 
 ## Supported providers
 

--- a/website/scripts/run-with-required-node.mjs
+++ b/website/scripts/run-with-required-node.mjs
@@ -81,7 +81,7 @@ function resolveNodeBinary() {
   if (best) return best.candidate;
 
   throw new Error(
-    `Website scripts require Node.js >= ${MIN_NODE_VERSION} (Astro 6). ` +
+    `Website scripts require Node.js >= ${MIN_NODE_VERSION} (Astro 7). ` +
       "Run: cd website && nvm install 22.12.0 && nvm use 22.12.0",
   );
 }

--- a/website/src/components/CliGuide.astro
+++ b/website/src/components/CliGuide.astro
@@ -26,7 +26,7 @@ const fullSteps = [
   {
     num: "2",
     title: "Open Dashboard",
-    desc: "Browse sessions, view replays, and explore local insights.",
+    desc: "Browse sessions, view replays, explore Insights, and open AI Studio or Ask Replay when you want more context.",
     code: "npx vibe-replay -d",
   },
   {

--- a/website/src/components/Features.astro
+++ b/website/src/components/Features.astro
@@ -2,7 +2,7 @@
 const features = [
   {
     title: "Zero config, one command",
-    desc: "No setup, no account, no config files. Just run npx vibe-replay and pick a session. Works instantly with local Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions — plus remote Codex/Claude Code/Pi hosts over SSH and the embedded AI Studio (no external CLI required).",
+    desc: "No account or setup is required for local replays. Run npx vibe-replay and pick a session. Optional Settings add remote SSH sources, cloud publishing, and the embedded AI Studio — no external coding CLI required.",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" /></svg>`,
   },
   {
@@ -29,6 +29,21 @@ const features = [
     title: "Share & export anywhere",
     desc: "Publish to GitHub Gist for a shareable link. Export as markdown summary or animated SVG for PRs. Add comments that travel with the replay. Secret redaction built in.",
     icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" /></svg>`,
+  },
+  {
+    title: "AI Studio, built in",
+    desc: "Analyze, translate, and professionalize replays with the embedded Pi runtime and the provider/model you choose. Bring OpenAI-compatible local gateways or hosted endpoints — no external coding CLI required.",
+    icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v18m9-9H3m13.5-6.75L7.5 19.5m9-15L7.5 19.5" /></svg>`,
+  },
+  {
+    title: "Ask Replay",
+    desc: "Ask read-only questions about sessions, scenes, tools, MCP usage, coverage, projects, and Insights. Get a stable link back to the exact replay or dashboard view — never an unreviewed mutation.",
+    icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 9.75h7.5m-7.5 3h4.5m-9 6.75l2.25-2.25h10.5A2.25 2.25 0 0018.75 15V6A2.25 2.25 0 0016.5 3.75h-9A2.25 2.25 0 005.25 6v11.25c0 .621.504 1.125 1.125 1.125h.375z" /></svg>`,
+  },
+  {
+    title: "Remote SSH sources",
+    desc: "Add Codex, Claude Code, or Pi sessions from an OpenSSH host using your existing aliases, keys, agents, and ProxyJump setup. Remote data is cached locally and excluded from cloud insight sync.",
+    icon: `<svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 7.5h15m-15 4.5h15m-15 4.5h9m-9 3h15A2.25 2.25 0 0021.75 17.25V6.75A2.25 2.25 0 0019.5 4.5h-15A2.25 2.25 0 002.25 6.75v10.5A2.25 2.25 0 004.5 19.5z" /></svg>`,
   },
 ];
 ---

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -92,8 +92,8 @@ const slides = [
             </div>
             <div id="hero-output" class="mt-4 space-y-1 text-xs sm:text-sm hidden">
               <div class="text-[#8b949e]">Discovering sessions...</div>
-              <div class="text-[#8b949e]">Found <span class="text-[#3fb950]">152 sessions</span> across <span class="text-[#58a6ff]">26 projects</span></div>
-              <div class="text-[#8b949e] mt-1">Generated replay &mdash; <span class="text-[#e6edf3]">512 scenes</span>, <span class="text-[#e6edf3]">537KB</span></div>
+              <div class="text-[#8b949e]">Found local sessions across <span class="text-[#3fb950]">Claude, Cursor, Codex</span> &amp; more</div>
+              <div class="text-[#8b949e] mt-1">Dashboard ready &mdash; <span class="text-[#e6edf3]">replay</span>, <span class="text-[#e6edf3]">analyze</span>, <span class="text-[#e6edf3]">share</span></div>
               <div class="mt-1 text-[#3fb950]">Opening editor at <span class="underline">http://localhost:13456</span></div>
             </div>
           </div>
@@ -265,7 +265,7 @@ const slides = [
   runDemo();
 
   // Rotating words
-  const words = ["Replay", "Analyze", "Track", "Share", "Export"];
+  const words = ["Replay", "Understand", "Analyze", "Track", "Share", "Export"];
   const wordEl = document.getElementById("hero-word");
   if (wordEl) {
     let i = 0;

--- a/website/src/components/HowItWorks.astro
+++ b/website/src/components/HowItWorks.astro
@@ -22,7 +22,7 @@
             <span class="w-8 h-8 rounded-lg bg-gradient-to-br from-accent/10 to-cyan-400/5 flex items-center justify-center text-accent font-mono text-sm font-bold">1</span>
             <h3 class="text-xl font-semibold">All your sessions, one place</h3>
           </div>
-          <p class="text-text-secondary leading-relaxed">A local dashboard shows every session across <span class="text-[#D97706] font-medium">Claude Code</span>, Claude Desktop, Claude Cowork, <span class="text-[#0096FF] font-medium">Cursor</span>, Codex, OpenCode, Hermes, and Pi &mdash; with activity heatmaps, project-level analytics, and cost estimates. Search, filter by git repo, and generate a replay in one click. Runs entirely on your machine.</p>
+          <p class="text-text-secondary leading-relaxed">A local dashboard shows every session across <span class="text-[#D97706] font-medium">Claude Code</span>, Claude Desktop, Claude Cowork, <span class="text-[#0096FF] font-medium">Cursor</span>, Codex, OpenCode, Hermes, and Pi &mdash; with activity heatmaps, project analytics, cost estimates, and filters for repositories, tools, MCP servers, skills, and compactions. Generate a replay in one click, or add remote Codex/Claude Code/Pi sources over SSH.</p>
           <p class="text-text-muted text-sm mt-3 font-mono">$ npx vibe-replay -d</p>
         </div>
         <div class="md:w-3/5">
@@ -69,7 +69,7 @@
             <span class="w-8 h-8 rounded-lg bg-gradient-to-br from-accent/10 to-cyan-400/5 flex items-center justify-center text-accent font-mono text-sm font-bold">3</span>
             <h3 class="text-xl font-semibold">Deep insights for every session</h3>
           </div>
-          <p class="text-text-secondary leading-relaxed">Drill into any session for auto-generated analytics: token burn &amp; cost per turn, context window usage, cache hit rates, tool call distribution, model breakdown, and per-turn breakdowns.</p>
+          <p class="text-text-secondary leading-relaxed">Drill into any session for auto-generated analytics: token burn &amp; cost per turn, context window usage, cache accounting, tool/MCP/skill breakdowns, model distribution, percentile views, coverage, and data-quality notes.</p>
         </div>
         <div class="md:w-3/5">
           <div class="rounded-xl border border-border/50 overflow-hidden shadow-lg shadow-accent/5">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -17,7 +17,7 @@ interface Props {
 
 const {
   title,
-  description = "vibe-replay turns your Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions into interactive, shareable web replays as single self-contained HTML files.",
+  description = "vibe-replay turns Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions into local-first interactive replays, insights, AI Studio analyses, and shareable self-contained HTML files.",
   canonicalPath,
   ogImage: ogImageProp,
   ogType = "website",

--- a/website/src/pages/explore.astro
+++ b/website/src/pages/explore.astro
@@ -10,7 +10,7 @@ const exploreFaq = [
   },
   {
     q: "How do I share my own replay?",
-    a: "Run `npx vibe-replay --gist` (publishes to GitHub Gist) or `npx vibe-replay --cloud` (publishes to vibe-replay cloud). Both produce a public URL you can share. Replays show up here automatically.",
+    a: "Run `npx vibe-replay`, open the replay in the editor, and choose Publish to Gist, or run `npx vibe-replay share` for an unlisted cloud link. You can also use `npx vibe-replay --session <path> --github` for PR-ready markdown, GIF, and SVG artifacts. Public Gist replays appear here automatically.",
   },
   {
     q: "Which agents can I replay?",
@@ -93,10 +93,10 @@ const exploreJsonLd = [
         </p>
         <p class="mt-3">
           Want to share your own? Run
-          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay --gist</code>
-          or
-          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay --cloud</code>
-          and your replay will appear here.
+          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay</code>
+          and publish from the editor, or use
+          <code class="font-mono text-accent bg-surface-2 px-1.5 py-0.5 rounded">npx vibe-replay share</code>
+          for a cloud link.
         </p>
       </section>
 
@@ -110,9 +110,9 @@ const exploreJsonLd = [
         <div class="rounded-xl border border-border bg-surface-1 p-10 max-w-md mx-auto">
           <div class="text-4xl mb-4">&#9654;</div>
           <h2 class="text-lg font-semibold text-text-primary mb-2">No replays yet</h2>
-          <p class="text-text-muted text-sm mb-6">Be the first to share a replay!</p>
+          <p class="text-text-muted text-sm mb-6">Be the first to share a replay from the editor.</p>
           <div class="font-mono text-sm bg-surface-2 rounded-lg px-4 py-3 text-text-secondary">
-            <span class="text-accent">$</span> npx vibe-replay --gist
+            <span class="text-accent">$</span> npx vibe-replay
           </div>
         </div>
       </div>
@@ -285,4 +285,3 @@ const exploreJsonLd = [
 
   // Auth is handled by Nav component
 </script>
-

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -16,7 +16,7 @@ const homeJsonLd = [
     "name": "vibe-replay",
     "url": siteBase,
     "description":
-      "Replay, analyze, and share AI coding sessions as interactive web replays.",
+      "Replay, analyze, and share AI coding sessions with local-first replays, Insights, AI Studio, and Ask Replay.",
     "publisher": {
       "@type": "Organization",
       "name": "vibe-replay",
@@ -33,7 +33,7 @@ const homeJsonLd = [
     "name": "vibe-replay",
     "url": siteBase,
     "description":
-      "Create a self-contained HTML replay with one command. Free and open source.",
+      "Create a self-contained HTML replay with one command, then analyze it locally with Insights, AI Studio, and Ask Replay. Free and open source.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux, Windows",
     "downloadUrl": "https://www.npmjs.com/package/vibe-replay",
@@ -53,8 +53,8 @@ const homeJsonLd = [
 ---
 
 <Layout
-  title="vibe-replay - Turn AI coding sessions into shareable replays"
-  description="Replay, analyze, and share AI coding sessions as interactive web replays. One command creates a self-contained HTML file. Free and open source."
+  title="vibe-replay - Replay, understand, and share AI coding sessions"
+  description="Replay, analyze, and share AI coding sessions with local-first replays, Insights, AI Studio, and Ask Replay. One command creates a self-contained HTML file."
   jsonLd={homeJsonLd}
 >
   <main>


### PR DESCRIPTION
## Summary

Refresh the public product story so the README and Cloudflare-hosted website describe the current product rather than the earlier replay-only positioning:

- position vibe-replay as local-first replay + Insights + AI Studio + Ask Replay
- explain the read-only Ask Replay contract and embedded AI Studio more clearly
- make Remote SSH sources visible as a first-class optional workflow
- replace stale/fake hero demo numbers with provider/product language
- update the Explore page's sharing commands (`npx vibe-replay` / `npx vibe-replay share`)
- update SEO/JSON-LD/`llms.txt` messaging and the Astro 7 development note

## Verification

- `pnpm lint:check` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @vibe-replay/website build` ✅
- `git diff --check` ✅
