### PR TITLE
test(cloudflare): validate D1 migration upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,31 @@ jobs:
       - run: pnpm test
       - run: pnpm test:cloudflare
 
+  database-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Check migration journal and schema drift
+        working-directory: cloudflare
+        run: |
+          pnpm db:check
+          pnpm db:generate
+          if [ -n "$(git -C .. status --short --untracked-files=all -- cloudflare/drizzle)" ]; then
+            echo "Generated or modified migration files are not committed. Run pnpm db:generate locally and commit the result."
+            git -C .. status --short --untracked-files=all -- cloudflare/drizzle
+            exit 1
+          fi
+      - name: Apply all migrations to a clean local D1 database
+        run: pnpm --filter @vibe-replay/cloudflare db:migrate:local
+      - name: Verify a second migration pass is a no-op
+        run: pnpm --filter @vibe-replay/cloudflare db:migrate:local
+
   windows-smoke:
     runs-on: windows-latest
     steps:

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -7,6 +7,7 @@
     "test": "vitest run --config vitest.config.ts",
     "deploy": "wrangler deploy",
     "db:generate": "drizzle-kit generate",
+    "db:check": "drizzle-kit check",
     "db:migrate:local": "wrangler d1 migrations apply vibe-replay-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply vibe-replay-db --remote"
   },

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -1,8 +1,7 @@
-import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
 import { Miniflare } from "miniflare";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/worker";
+import { applyMigrations } from "./migration-utils";
 
 const TEST_USER_ID = "user-test-1";
 const OTHER_USER_ID = "user-test-2";
@@ -55,21 +54,6 @@ async function dispatch(path: string, init: RequestInit = {}, userId = TEST_USER
   );
   await waitOnCtx(ctx);
   return response;
-}
-
-async function applyMigrations(db: D1Database) {
-  const migrationsDir = join(process.cwd(), "drizzle");
-  const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
-  for (const file of files) {
-    const sql = await readFile(join(migrationsDir, file), "utf-8");
-    const statements = sql
-      .split("--> statement-breakpoint")
-      .map((statement) => statement.trim())
-      .filter(Boolean);
-    for (const statement of statements) {
-      await db.prepare(statement).run();
-    }
-  }
 }
 
 async function resetDb() {

--- a/cloudflare/test/migration-upgrade.test.ts
+++ b/cloudflare/test/migration-upgrade.test.ts
@@ -1,0 +1,55 @@
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { applyMigration, applyMigrations } from "./migration-utils";
+
+const LEGACY_USER_ID = "legacy-user";
+
+let mf: Miniflare;
+let db: D1Database;
+
+describe("D1 migration upgrades", () => {
+  beforeAll(async () => {
+    mf = new Miniflare({
+      script: "export default { fetch() { return new Response('ok'); } }",
+      modules: true,
+      compatibilityDate: "2024-12-01",
+      compatibilityFlags: ["nodejs_compat"],
+      d1Databases: ["DB"],
+    });
+    db = (await mf.getBindings()).DB as D1Database;
+  });
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  it("upgrades a populated pre-issuer account table", async () => {
+    await applyMigrations(db, "0008_add_insight_profiles.sql");
+    await db
+      .prepare("INSERT INTO user (id, name, email, email_verified) VALUES (?, ?, ?, ?)")
+      .bind(LEGACY_USER_ID, "Legacy User", "legacy-user", 1)
+      .run();
+    await db
+      .prepare("INSERT INTO account (id, account_id, provider_id, user_id) VALUES (?, ?, ?, ?)")
+      .bind("legacy-account", "github-subject", "github", LEGACY_USER_ID)
+      .run();
+
+    const beforeColumns = await db.prepare("PRAGMA table_info(account)").all<{ name: string }>();
+    expect(beforeColumns.results.map((column) => column.name)).not.toContain("issuer");
+
+    await applyMigration(db, "0009_add_account_issuer.sql");
+
+    const account = await db
+      .prepare("SELECT issuer FROM account WHERE id = ?")
+      .bind("legacy-account")
+      .first<{ issuer: string }>();
+    expect(account?.issuer).toBe("local:oauth:github");
+
+    const issuerIndex = await db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?")
+      .bind("account_issuer_accountId_uidx")
+      .first<{ sql: string }>();
+    expect(issuerIndex?.sql).toContain("issuer");
+    expect(issuerIndex?.sql).toContain("account_id");
+  });
+});

--- a/cloudflare/test/migration-utils.ts
+++ b/cloudflare/test/migration-utils.ts
@@ -1,0 +1,27 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "drizzle");
+
+export async function migrationFiles(): Promise<string[]> {
+  return (await readdir(MIGRATIONS_DIR)).filter((file) => file.endsWith(".sql")).sort();
+}
+
+export async function applyMigrations(db: D1Database, through?: string): Promise<void> {
+  for (const file of await migrationFiles()) {
+    if (through && file > through) break;
+    await applyMigration(db, file);
+  }
+}
+
+export async function applyMigration(db: D1Database, file: string): Promise<void> {
+  const sql = await readFile(join(MIGRATIONS_DIR, file), "utf-8");
+  const statements = sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+  for (const statement of statements) {
+    await db.prepare(statement).run();
+  }
+}


### PR DESCRIPTION
## Summary
- add a populated pre-issuer D1 upgrade regression test
- run the real Wrangler migration chain against a clean local D1 database in CI
- run the migration command twice to verify tracked migrations are idempotently a no-op
- fail CI when Drizzle schema generation produces uncommitted migration changes

## Why
The Better Auth 1.7 incident passed the existing fresh-database API tests because they did not model an upgrade of a populated production database. This adds that missing validation path.

## Validation
- `pnpm lint:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:cloudflare`
- `pnpm db:check`
- clean local D1 migration pass and second no-op pass