### PR TITLE
docs(blog): add Codex, OpenCode, Hermes, and Pi storage guides

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -13,7 +13,7 @@ License: MIT
 - [Homepage](https://vibe-replay.com/): Product overview, install instructions, feature list.
 - [Explore replays](https://vibe-replay.com/explore/): Public AI coding sessions shared by the community (Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi).
 - [Insights dashboard](https://vibe-replay.com/insights/): Personal AI coding analytics — sessions, prompts, tool calls, costs, streaks across machines and providers.
-- [Blog](https://vibe-replay.com/blog/): Deep-dives on Claude Code, Cursor, and AI coding workflows.
+- [Blog](https://vibe-replay.com/blog/): Deep-dives on AI-agent local storage, coding workflows, and replayable sessions.
 
 ## What it does
 
@@ -41,6 +41,10 @@ License: MIT
 ## Blog posts
 
 - [Where Does Cursor's SDK Actually Store Your Agents? A Deep Dive into sdk-agent-store](https://vibe-replay.com/blog/cursor-sdk-deep-dive/): Inside the Cursor SDK's local storage layer — its own schema, event stream, and tool-result format.
+- [What Does OpenCode Store on Your Machine? A Deep Dive into opencode.db](https://vibe-replay.com/blog/opencode-local-storage/): How OpenCode's SQLite session, message, and part tables encode prompts, reasoning, tools, and compaction.
+- [What Does Hermes Store on Your Machine? A Deep Dive into state.db and Profiles](https://vibe-replay.com/blog/hermes-local-storage/): How Hermes stores profile-aware sessions, usage, tools, reasoning, costs, and compaction markers in SQLite.
+- [What Does Pi Coding Agent Store on Your Machine? A Deep Dive into Session JSONL](https://vibe-replay.com/blog/pi-local-storage/): How Pi's parent-linked JSONL tree represents branches, tool results, model changes, and compaction.
+- [What Does Codex Store on Your Machine? A Deep Dive into Rollout JSONL and state_5.sqlite](https://vibe-replay.com/blog/codex-local-storage/): How Codex combines rollout events, the thread catalog, and its append-only session-name index.
 - [Capturing Claude's Autonomous Agent Mode: A Deep Dive into Dispatch](https://vibe-replay.com/blog/dispatch-deep-dive/): How vibe-replay captures Claude Desktop Cowork / autonomous sessions, including the technical challenges and the parser changes required.
 - [878 Sessions, 52.9k Tool Calls — What a Year of Vibe Coding Looks Like](https://vibe-replay.com/blog/personal-insights/): Year-long usage breakdown: prompts, tool calls, model distribution, and what the data reveals about real AI coding habits.
 - [What Actually Happens When Claude Code /simplify Cleans Your Codebase](https://vibe-replay.com/blog/simplify-codebase-with-ai/): Behavioral analysis of Claude Code's `/simplify` slash command and the kinds of refactors it produces.

--- a/website/src/content/blog/codex-local-storage.md
+++ b/website/src/content/blog/codex-local-storage.md
@@ -1,0 +1,153 @@
+---
+title: "What Does Codex Store on Your Machine? A Deep Dive into Rollout JSONL and state_5.sqlite"
+excerpt: "Codex keeps the replay in rollout JSONL, the /resume metadata in SQLite, and renamed threads in an append-only index. Here's how the pieces fit together."
+date: 2026-04-27
+readTime: "7 min read"
+---
+
+Where did that Codex session go?
+
+If you have used Codex from a terminal, the first instinct is usually to look for one transcript file. That gets you part of the answer. Codex keeps the conversation in rollout JSONL, but it also maintains a local SQLite database for thread metadata and a small append-only index for explicit names.
+
+That split explains several familiar surprises:
+
+- a session appears in `/resume` even when its rollout file is unavailable;
+- the title in `/resume` is newer than the title in the transcript;
+- a parser finds the same user message twice because two event families describe it;
+- token counts and task durations live in telemetry records rather than in the visible conversation.
+
+The useful mental model is not “Codex has a transcript.” It is:
+
+```text
+state_5.sqlite        → thread catalog and resume metadata
+session_index.jsonl   → explicit thread-name history
+sessions/**/*.jsonl   → rollout transcript and event stream
+```
+
+That is the layer vibe-replay has to reconcile before it can show a faithful replay.
+
+## Where does Codex store sessions?
+
+Codex uses `~/.codex` by default. `CODEX_HOME` can point the session home somewhere else, and `CODEX_SQLITE_HOME` can place the SQLite catalog in a different directory.
+
+The important files are:
+
+```text
+~/.codex/
+├── sessions/
+│   └── .../*.jsonl
+├── session_index.jsonl
+└── state_5.sqlite
+```
+
+The exact rollout subdirectories and database columns can change between Codex releases. Treat these paths as the current local layout, not a permanent public API.
+
+If you want to inspect a synthetic example without reading the transcript, the catalog query looks like this:
+
+```bash
+sqlite3 "${CODEX_SQLITE_HOME:-$HOME/.codex}/state_5.sqlite" \
+  'select id, title, cwd, updated_at from threads order by updated_at desc limit 10;'
+```
+
+The database is useful for finding threads. It is not the source of every prompt, tool result, or reasoning block.
+
+## What is in `state_5.sqlite`?
+
+The central table is `threads`. A row can contain fields such as:
+
+- a stable thread id;
+- the rollout path;
+- created and updated timestamps;
+- the working directory and Git branch;
+- the title shown by resume UI;
+- the first user message;
+- model and CLI-version metadata;
+- token totals maintained by Codex.
+
+Some installations have older or newer column sets. A reader that selects every modern column unconditionally will eventually meet `no such column` on a perfectly valid local database. A defensive reader probes the table shape first and treats optional columns as optional.
+
+That is also why `state_5.sqlite` should be opened read-only. It is a catalog and metadata source, not a database that a replay tool needs to modify.
+
+## Why is there a second `session_index.jsonl`?
+
+Codex thread names are append-only events. A rename does not need to rewrite the whole thread row; it can append a record to `session_index.jsonl`.
+
+A simplified record looks like this:
+
+```json
+{
+  "id": "thread-demo-001",
+  "thread_name": "Review the session explorer"
+}
+```
+
+The newest valid name for a thread wins. A trailing line can be incomplete while Codex is writing it, so a reader should keep the previous valid name instead of discarding the entire index.
+
+In practice, the precedence is:
+
+1. the latest explicit name from `session_index.jsonl`;
+2. the catalog title from `state_5.sqlite`;
+3. a title or first prompt recovered from the rollout.
+
+That ordering is small, but it makes a session list feel like the tool the user actually used rather than like a raw database dump.
+
+## What is inside a rollout JSONL file?
+
+Codex rollouts are event streams. The same session can contain several event families:
+
+```text
+session_meta       → id, cwd, source, memory mode
+turn_context       → model, approval and sandbox policy
+event_msg          → user text, assistant text, tool completions, token snapshots
+response_item      → messages, reasoning, tool calls, patches, web search, MCP
+compacted          → context compaction records and summaries
+```
+
+The practical parser problem is correlation. A command may start in one record and finish in another. A patch can be announced separately from its changed files. A tool completion can arrive without a matching start record. A user message can be represented by both `event_msg` and `response_item`.
+
+The safe approach is to key pending work by `call_id`, join terminal records back to their starts, and deduplicate repeated message payloads by content plus a small timestamp window. If a completion has no start, keep it as an orphan tool call rather than silently losing evidence that the agent did work.
+
+## What can you learn from Codex telemetry?
+
+Codex can persist more than visible text:
+
+- token snapshots, including cached input and output totals;
+- model context-window limits;
+- task duration records;
+- approval policy and sandbox mode;
+- memory mode;
+- context-compaction events;
+- MCP server and tool names.
+
+These fields are valuable, but they are not all the same kind of measurement. A token snapshot is not necessarily the model context size. A task duration is not necessarily wall-clock time. A missing snapshot is a coverage limitation, not proof that the session used zero tokens.
+
+That distinction matters when you build analytics. Label estimates as estimates and keep provider-reported values separate from locally inferred values.
+
+## How vibe-replay reconstructs Codex sessions
+
+vibe-replay merges the three local surfaces instead of choosing one and pretending it is complete:
+
+1. discover threads from `state_5.sqlite` when the catalog is available;
+2. apply the newest explicit title from `session_index.jsonl`;
+3. scan rollout JSONL for prompts, responses, reasoning, tools, patches, timing, and usage;
+4. use the stable thread id to deduplicate the same session discovered through multiple surfaces;
+5. preserve incomplete or metadata-only sessions with an explicit status rather than generating an empty replay.
+
+The result is a self-contained replay that can show both the conversation and the context around it: model changes, task boundaries, compactions, tool calls, and data-quality notes.
+
+You can compare this with the simpler one-file mental model in [What Does Claude Code Store on Your Machine?](/blog/claude-code-local-storage/), or with Cursor's multi-store design in [What Does Cursor Store on Your Machine?](/blog/cursor-local-storage/).
+
+## A privacy note before you inspect the files
+
+Codex transcripts can contain prompts, file contents, command output, local paths, and links. The catalog can contain working directories and titles. Treat both as private application data.
+
+Before sharing a raw rollout or database export:
+
+- remove prompts and command output you did not intend to publish;
+- replace local paths with synthetic paths;
+- do not upload `state_5.sqlite` just to share a replay;
+- prefer a generated replay after reviewing its redactions.
+
+The easiest safe workflow is to let vibe-replay read the local sources and export the reviewed result, rather than turning the entire Codex home directory into an attachment.
+
+Codex is not hiding one giant transcript in one obvious place. It is maintaining a catalog, an index, and an event stream for different jobs. Once you understand that division, `/resume` behavior becomes less mysterious — and building reliable tooling becomes much easier.

--- a/website/src/content/blog/hermes-local-storage.md
+++ b/website/src/content/blog/hermes-local-storage.md
@@ -1,0 +1,176 @@
+---
+title: "What Does Hermes Store on Your Machine? A Deep Dive into state.db and Profiles"
+excerpt: "Hermes keeps session metadata, token accounting, reasoning, and tool calls in SQLite — with named profiles and two different compaction signals."
+date: 2026-08-05
+readTime: "7 min read"
+---
+
+Hermes sessions look like conversations, but Hermes stores them like a small observability system.
+
+The database knows things a transcript alone usually does not: the session’s model, Git branch, token totals, estimated and actual cost, profile, end reason, and whether the session is pinned. The message table then adds the visible conversation, reasoning, tool calls, and tool results.
+
+The surprising part is that compaction is represented twice, and named profiles are separate databases. A parser that reads only the default file or counts every user row will produce a replay that is technically readable but semantically wrong.
+
+The practical mental model is:
+
+```text
+~/.hermes/state.db
+~/.hermes/profiles/<name>/state.db
+        │
+        ├── sessions       → catalog, usage, cost, Git metadata
+        └── messages       → prompts, reasoning, tool calls, results
+```
+
+vibe-replay discovers those databases together, keeps profile identity out of the prompt text, and renders the result as the same replay format used for other providers.
+
+## Where does Hermes store sessions?
+
+Hermes uses `~/.hermes` by default. `HERMES_HOME` can override the root, with one subtle rule: if it points inside the default Hermes root or inside a named profile, the provider still treats the default root as the installation root and scans sibling profiles.
+
+The common layout is:
+
+```text
+~/.hermes/
+├── state.db
+├── .update_check
+└── profiles/
+    ├── work/state.db
+    └── experiments/state.db
+```
+
+A custom installation outside `~/.hermes` can use that custom directory as its root. This is useful for containers and isolated test environments.
+
+To inspect the layout without reading conversation data:
+
+```bash
+find "${HERMES_HOME:-$HOME/.hermes}" \
+  -maxdepth 4 -name state.db -print
+```
+
+The `.update_check` file can contain the Hermes version. It is useful context when a schema looks different, but it is not part of the session transcript.
+
+## What is in `state.db`?
+
+The `sessions` table is the catalog. Depending on Hermes version, a row can contain:
+
+- session id, title, working directory, and model;
+- start, end, and last-activity timestamps;
+- message and tool-call totals;
+- input, output, cache-read, cache-write, and reasoning tokens;
+- estimated cost and actual cost, with a cost status;
+- Git branch and repository root;
+- parent session and profile name;
+- pin and end-reason flags.
+
+The `messages` table carries the conversation. Hermes uses OpenAI-style roles, which makes the broad shape familiar:
+
+```text
+user       → prompt text or a compaction summary
+assistant   → text, reasoning, and tool_calls JSON
+tool       → tool_name, tool_call_id, and result content
+```
+
+That shape is convenient for a replay reader, but the JSON payloads still need validation. A malformed `tool_calls` value should become a parse warning for one message, not a reason to discard the entire session.
+
+## Why named profiles matter
+
+A profile is more than a UI preference. It has its own `state.db`, and two profiles can contain sessions with the same id shape. Scanning only `~/.hermes/state.db` makes a named profile look empty.
+
+The safe discovery sequence is:
+
+1. resolve the Hermes root;
+2. include the default `state.db` if it exists;
+3. enumerate `profiles/*/state.db`;
+4. open only databases with the expected `sessions` and `messages` tables;
+5. deduplicate session ids while preserving the first resolved database path;
+6. sort the combined result by last activity.
+
+When a session is later opened, the database path is part of the provider marker. That lets the parser find the right profile instead of guessing from the current `HERMES_HOME`.
+
+## Hermes compaction appears in two forms
+
+This is the detail most likely to make aggregate analytics lie.
+
+### 1. Compacted transcript runs
+
+Hermes can mark the pre-compaction history with `compacted = 1`. The rows remain in the database, so a full replay can preserve the history before the summary. A long session may contain several compacted runs.
+
+The correct count is the number of **run boundaries**, not the number of rows with `compacted = 1`:
+
+```text
+normal normal compacted compacted normal compacted compacted
+                    ↑ one boundary             ↑ another boundary
+```
+
+### 2. Summary marker rows
+
+Some stores also contain a user message beginning with a marker such as:
+
+```text
+[CONTEXT COMPACTION ...]
+```
+
+That row is a compaction summary, not a human prompt. It should become a dedicated compaction event in the replay and should be excluded from prompt counts.
+
+Older or summary-only stores may not have the `compacted` column. A robust reader falls back to the marker rows rather than declaring that the session never compacted.
+
+This is a useful general rule: classify events by their provider semantics, not only by the role column they happen to use.
+
+## Where do Hermes costs and tokens come from?
+
+Hermes maintains usage fields on the session row and may also maintain a per-model usage table. The provider can report:
+
+- actual cost when the store has it;
+- estimated cost when actual billing is unavailable;
+- zero when the store says cost is not included or unknown;
+- token categories split by model.
+
+Those values should not be recomputed from a local pricing table if Hermes already reported a total. A local estimate can be useful as a fallback, but it must not replace a provider-owned number or add itself on top of it.
+
+The same caution applies to duration. `started_at` and `last_activity_at` define a broad window; message timestamps help estimate active time, but idle periods are not automatically model work.
+
+## The SQLite WAL caveat
+
+Hermes may be running with a write-ahead log:
+
+```text
+state.db
+state.db-wal
+state.db-shm
+```
+
+The `state.db` file can be structurally valid while the newest messages still live in WAL frames. A portable reader that loads only the database bytes may not see a long-running session until Hermes checkpoints.
+
+That is not a reason to copy or mutate the live database. It is a reason to make the limitation visible: refresh after a checkpoint, keep the last stable cached version, or use the provider’s own export path when one exists.
+
+## How vibe-replay reads Hermes
+
+vibe-replay keeps the fast dashboard pass lightweight and defers full parsing until a session is opened. Discovery reads the catalog fields and aggregate counters; the replay parser then:
+
+1. resolves the session id from a database marker;
+2. prefers the hinted profile database;
+3. falls back to probing known Hermes databases when needed;
+4. reconstructs user prompts, assistant text, reasoning, and parallel tool calls;
+5. joins tool results by `tool_call_id`;
+6. preserves orphan tool results instead of undercounting activity;
+7. emits compaction events and provider-reported usage separately.
+
+The viewer can therefore show a full Hermes session without flattening away profile, cost, model, or compaction semantics.
+
+## A safe way to inspect Hermes history
+
+Start with schema and catalog metadata:
+
+```bash
+DB="${HERMES_HOME:-$HOME/.hermes}/state.db"
+sqlite3 "$DB" 'pragma table_info(sessions);'
+sqlite3 "$DB" \
+  'select id, title, model, last_activity_at
+   from sessions order by last_activity_at desc limit 10;'
+```
+
+Do not publish the database itself. It can contain prompts, reasoning, tool arguments, file contents, tokens, and paths. Use synthetic examples when writing bug reports, and review the generated replay before sharing it.
+
+Hermes is a good example of why “read the transcript” is not a complete storage strategy. The durable truth is a profile-aware SQLite catalog plus an OpenAI-shaped message stream, with compaction and billing metadata that deserve their own logic. Once you model those layers separately, the replay becomes both more accurate and more honest about what the source actually recorded.
+
+For comparison, see [OpenCode’s relational session database](/blog/opencode-local-storage/) and the JSONL tree used by [Pi coding agent](/blog/pi-local-storage/).

--- a/website/src/content/blog/opencode-local-storage.md
+++ b/website/src/content/blog/opencode-local-storage.md
@@ -1,0 +1,191 @@
+---
+title: "What Does OpenCode Store on Your Machine? A Deep Dive into opencode.db"
+excerpt: "OpenCode stores sessions, messages, and tool parts in SQLite instead of a folder of JSONL files. Here's the schema, the compaction trap, and how to read it safely."
+date: 2026-08-03
+readTime: "7 min read"
+---
+
+OpenCode looks like a chat interface, but its local history is closer to an application database.
+
+That matters the first time you try to answer a simple question such as “show me the session where the agent changed the router.” There is no canonical transcript file to open. The answer is distributed across a session row, message rows, and part rows inside SQLite.
+
+The useful mental model is:
+
+```text
+session row   → identity, title, project, timestamps, model, cost
+message rows  → user/assistant boundaries and message metadata
+part rows     → text, reasoning, tools, files, results, compaction markers
+```
+
+vibe-replay treats those rows as one logical conversation and turns them into the same replay vocabulary used for Claude Code, Cursor, Codex, Hermes, and Pi.
+
+## Where does OpenCode store its database?
+
+On macOS and Linux, OpenCode normally uses:
+
+```text
+~/.local/share/opencode/opencode.db
+```
+
+On Windows, the default follows `%LOCALAPPDATA%\opencode\opencode.db`. The `OPENCODE_DATA` environment variable overrides the data directory on every platform.
+
+So the portable way to locate the database is:
+
+```bash
+echo "${OPENCODE_DATA:-$HOME/.local/share/opencode}/opencode.db"
+```
+
+The variable names and schema are implementation details of the local OpenCode build. A future release may add columns or reshape JSON payloads without changing the fact that the database is the source of truth.
+
+If SQLite is installed, a quick inventory is:
+
+```bash
+sqlite3 "${OPENCODE_DATA:-$HOME/.local/share/opencode}/opencode.db" \
+  '.tables'
+```
+
+The tables that matter for replay are usually `session`, `message`, and `part`. Some versions also carry project or auxiliary tables.
+
+## Why are sessions, messages, and parts separate?
+
+OpenCode has a relational conversation model. A session is the container; messages establish roles and timestamps; parts hold the content that makes a message interesting.
+
+A simplified shape looks like this:
+
+```text
+session(id, slug, title, directory, time_created, time_updated, model, cost)
+  └── message(id, session_id, data)
+        └── part(id, message_id, data)
+```
+
+The `data` columns are JSON rather than a single normalized column for every possible event. That lets OpenCode add a new part type without a database migration for every UI feature, but it means a reader must validate JSON and branch on `type`.
+
+Typical message metadata includes:
+
+- `role`: user or assistant;
+- created and completed timestamps;
+- model id;
+- token usage and cache fields;
+- finish reason.
+
+Typical parts include:
+
+- user text;
+- assistant text;
+- reasoning;
+- tool calls and their state;
+- patches or file changes;
+- images and files;
+- compaction markers.
+
+The part boundary is important. A message with a tool call is not the same thing as a message whose text merely mentions a tool. Counting parts gives you tool-call volume; counting user message text gives you prompts.
+
+## The compaction trap: not every user-looking row is a prompt
+
+OpenCode writes context compaction as a synthetic user message with a compaction part. That row may also contain text.
+
+If you count every `role = 'user'` message, the compaction summary becomes an extra human prompt. The dashboard then reports too many turns, and the first-prompt preview can become a summary instead of something the user typed.
+
+The safe query shape is closer to:
+
+```sql
+SELECT m.session_id, COUNT(DISTINCT m.id)
+FROM part p
+JOIN message m ON m.id = p.message_id
+WHERE json_extract(m.data, '$.role') = 'user'
+  AND json_extract(p.data, '$.type') = 'text'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM part compact
+    WHERE compact.message_id = m.id
+      AND json_extract(compact.data, '$.type') = 'compaction'
+  )
+GROUP BY m.session_id;
+```
+
+Real databases need an additional guard around malformed JSON. `json_valid(data)` keeps a damaged or partially-written row from taking down the whole discovery pass.
+
+Compaction is not lost just because it is excluded from prompt counts. vibe-replay keeps it as a distinct replay event so you can see where context was summarized and how the conversation continued.
+
+## Why schema drift is normal here
+
+OpenCode has changed the `session` table over time. Fields such as `agent`, `model`, `cost`, and token columns may be absent in an older database or named differently in a newer one.
+
+A brittle reader does this:
+
+```sql
+SELECT id, title, agent, model, cost, tokens_input
+FROM session;
+```
+
+That query is fine until one optional column is missing. A resilient reader first asks SQLite what exists:
+
+```sql
+PRAGMA table_info(session);
+```
+
+Then it builds a projection from the columns that are actually present. Missing model or cost metadata should lower the quality of one metric, not make every session disappear.
+
+This is a general lesson for local AI-agent storage: the database is real, but it is not necessarily a stable public API. Version-tolerant discovery is part of replay correctness.
+
+## Where do costs and tokens come from?
+
+Some OpenCode versions persist session-level cost and token fields. Assistant message JSON can also contain per-message usage, including cached input and output. Those values have different scopes:
+
+- session cost is a provider-reported total when present;
+- message usage is attached to an assistant response;
+- a missing value means “not recorded,” not “zero.”
+
+vibe-replay preserves provider-reported cost when it exists and keeps token categories separate. It does not silently add a session total to per-message totals, which would double count the bill.
+
+The same principle applies to timing. OpenCode has message timestamps, but idle gaps are not necessarily active model time. A replay can show the timeline while labeling reconstructed duration as an estimate.
+
+## The WAL problem: why a live session may be invisible
+
+SQLite can write recent changes to a write-ahead log next to the main database:
+
+```text
+opencode.db
+opencode.db-wal
+opencode.db-shm
+```
+
+If a process has not checkpointed those frames into `opencode.db`, a reader that opens only the main file may not see the newest session. This is particularly relevant while OpenCode is running for a long time.
+
+A tool should not copy or mutate the live database just to chase those rows. It should report the limitation, retry when the database is checkpointed, or use a provider-supported read path. vibe-replay keeps SQLite reads read-only and uses a lightweight discovery path for database-backed sessions so a large database is not opened once per dashboard card.
+
+## How vibe-replay reads OpenCode
+
+Discovery reads the `session` table and joins aggregate counts from `message` and `part`. Each discovered session gets a marker path in this form:
+
+```text
+<database-path>#session:<session-id>
+```
+
+That is not a file that OpenCode creates. It is a replay-tool pointer that preserves which database and which session should be parsed later.
+
+When you open a replay, the provider:
+
+1. resolves the session id from the marker;
+2. opens the hinted SQLite database with a portable read-only reader;
+3. reads messages in timestamp order;
+4. expands parts into text, reasoning, tool calls, results, images, and compaction events;
+5. maps provider-specific tool names into the shared viewer vocabulary;
+6. records parse warnings instead of hiding malformed rows.
+
+That gives OpenCode sessions the same useful output as a JSONL provider without pretending the underlying storage is JSONL.
+
+## A safe way to inspect OpenCode history
+
+Start with metadata, not a full dump:
+
+```bash
+DB="${OPENCODE_DATA:-$HOME/.local/share/opencode}/opencode.db"
+sqlite3 "$DB" \
+  'select id, title, directory, datetime(time_updated/1000, "unixepoch")
+   from session order by time_updated desc limit 10;'
+```
+
+Do not paste the result into a public issue without checking it. Titles, directories, prompts, tool arguments, and file contents can all be sensitive. Generate a reviewed replay instead of sharing the database.
+
+If Claude Code’s one-file JSONL model is the simple case, OpenCode is the database case: structured, queryable, and more version-sensitive. Once you follow the session → message → part chain, the storage stops looking mysterious — and the replay can preserve the details that a flat session list leaves out.

--- a/website/src/content/blog/pi-local-storage.md
+++ b/website/src/content/blog/pi-local-storage.md
@@ -1,0 +1,175 @@
+---
+title: "What Does Pi Coding Agent Store on Your Machine? A Deep Dive into Session JSONL"
+excerpt: "Pi stores a session as a JSONL tree, not a flat transcript: entries point to parents, branches can be abandoned, and compaction is its own event."
+date: 2026-06-06
+readTime: "7 min read"
+---
+
+Pi’s session files look approachable: they are JSONL, one record per line, inside a directory under your home folder.
+
+Then you try to replay one and discover the important detail: the file is a tree.
+
+Pi can branch, compact, change models, add custom messages, and keep tool results in separate entries. The last line is not necessarily “the whole conversation.” It is a leaf in the active branch.
+
+The useful mental model is:
+
+```text
+session header
+      │
+      ├── message ── message ── message
+      │                    └── alternate branch
+      └── compaction / model change / custom context
+```
+
+That tree is what makes Pi powerful for interactive work — and what makes a line-by-line parser subtly wrong.
+
+## Where does Pi store sessions?
+
+Pi uses the agent directory under `~/.pi/agent` by default:
+
+```text
+~/.pi/agent/
+├── sessions/
+│   └── <encoded-project-directory>/
+│       └── <timestamp>_<session-name>.jsonl
+├── models.json
+└── settings.json
+```
+
+`PI_CODING_AGENT_DIR` overrides the agent directory. `PI_CODING_AGENT_SESSION_DIR` overrides the sessions directory directly, which is useful for isolated environments and tests.
+
+The project directory is encoded into the folder name. On systems where hyphens are valid path characters, decoding cannot always be done by simply replacing every hyphen with a slash. A reliable reader checks the real filesystem when it can and keeps unresolved suffixes intact instead of inventing a project path.
+
+`models.json` is separate from the transcript. It can provide model context-window sizes that the JSONL session itself does not persist historically.
+
+## What does the session header tell you?
+
+The first meaningful record should be a session header:
+
+```json
+{
+  "type": "session",
+  "version": 3,
+  "id": "pi-demo-session",
+  "timestamp": "2026-06-05T10:00:00.000Z",
+  "cwd": "~/workspace/demo-app"
+}
+```
+
+The header gives the stable session id, format version, start time, and working directory. It is also the boundary between a replayable session and an arbitrary JSONL file that happens to live nearby.
+
+If the first record is missing or malformed, the safest behavior is to mark the source as unreadable or metadata-only. Turning an arbitrary file into an empty replay hides the real data-quality problem.
+
+## Why `parentId` changes everything
+
+Most Pi entries have an `id` and a `parentId`. That is enough to reconstruct the current path through the session tree.
+
+Suppose a session contains this shape:
+
+```text
+a (user prompt)
+└── b (assistant response)
+    ├── c (user follow-up)
+    │   └── d (assistant response)
+    └── e (alternate user follow-up)
+        └── f (assistant response)
+```
+
+The file contains both `c → d` and `e → f`, but only one branch is active. A replay that renders every id in file order will show abandoned work as if it were the final conversation.
+
+The branch-selection algorithm is simple in principle:
+
+1. choose the current leaf;
+2. follow `parentId` links back to the header;
+3. reverse the collected entries into conversation order;
+4. keep id-less metadata entries when they are not attached to an abandoned branch;
+5. report how many off-branch entries were omitted.
+
+That last count is useful. A branch is not data loss; it is part of the session history. The viewer can preserve the active replay while telling you that alternate entries existed.
+
+## What kinds of records does Pi write?
+
+Pi’s JSONL is an event log, not only a message log. Common records include:
+
+```text
+session_info   → human-readable session name
+model_change   → provider and model selection
+message        → user, assistant, toolResult, or bashExecution
+compaction     → summary and pre-compaction context estimate
+branch_summary → context carried across a branch operation
+custom_message → extension or injected context
+```
+
+Assistant content can contain text, thinking blocks, images, and tool-call blocks. A `toolResult` message arrives separately and is joined to the assistant tool call by `toolCallId`.
+
+That join matters for both correctness and privacy. The tool-call record tells you what was attempted; the result record tells you whether it completed, failed, produced images, or returned an exit code. A replay should not show “success” merely because a tool call was present.
+
+## Compaction is persisted, but its trigger may not be
+
+Pi persists a completed `compaction` entry with a summary and sometimes `tokensBefore`. It does not necessarily persist the full lifecycle around that operation.
+
+In particular, older Pi JSONL formats may not contain:
+
+- `compaction_start` and `compaction_end` events;
+- a durable `session_compact_failed` event;
+- every automatic retry or summarization retry.
+
+That means a completed compaction can be exact while its trigger is unknown. A reader should not label every compaction “automatic” just because it happened near the context limit.
+
+There are a few durable clues:
+
+- explicit details can record a manual, threshold, overflow, or automatic reason;
+- a preceding assistant message with `stopReason: "length"` supports an inferred automatic-context classification;
+- a persisted failure message can be classified as a failed compaction diagnostic;
+- an ordinary assistant API error should remain an assistant error, not be relabeled as compaction failure.
+
+This distinction is more useful than a single compaction count. It tells a reader what Pi actually recorded and where the replay is making an inference.
+
+## Where do tokens and context limits come from?
+
+Assistant message entries can carry usage fields such as:
+
+```json
+{
+  "usage": {
+    "input": 4200,
+    "output": 1100,
+    "cacheRead": 6800,
+    "cacheWrite": 700
+  }
+}
+```
+
+Pi also records usage on summarization entries. Those calls are separate model calls and must be included in session totals even though they do not create an ordinary assistant scene.
+
+`models.json` can supply a configured context window for the active model. That is useful for charts, but it is not a historical guarantee that the same limit was used for every earlier turn. The honest labels are “recorded usage,” “configured limit,” and “inferred context drop,” not one blended number pretending to be exact.
+
+## How vibe-replay reads Pi sessions
+
+vibe-replay follows the tree first, then parses the active branch:
+
+1. discover JSONL files under the configured sessions directory;
+2. validate the session header and collect lightweight metadata;
+3. select the active parent chain and count abandoned entries;
+4. join assistant tool calls with `toolResult` records;
+5. render user prompts, thinking, text, tools, images, branch summaries, and compactions;
+6. aggregate message usage and summarization usage separately;
+7. keep diagnostics about incomplete lifecycle events without copying raw error text into index metadata.
+
+The output is a normal self-contained replay. You do not need to understand every branch pointer to browse the session, but the underlying tree still informs what the replay labels as active, abandoned, recorded, or inferred.
+
+## Inspecting a Pi session safely
+
+Start by listing files and headers, not by dumping the entire directory:
+
+```bash
+SESSIONS="${PI_CODING_AGENT_SESSION_DIR:-$HOME/.pi/agent/sessions}"
+find "$SESSIONS" -name '*.jsonl' -maxdepth 3 -print
+head -n 1 "$SESSIONS"/*/*.jsonl
+```
+
+A session can contain prompts, tool arguments, command output, images, file paths, and extension-provided context. Do not paste raw JSONL into a public issue. Replace paths and prompts with synthetic values, and share only a reviewed replay.
+
+Pi’s storage is a good reminder that JSONL does not automatically mean “linear.” The file is durable, inspectable, and easy to back up — but its parent links, branch state, separate tool results, and incomplete compaction lifecycle make the tree semantics part of the format. Once you respect that, replaying Pi becomes a matter of following the conversation the user actually left active, not merely printing every line in the file.
+
+For database-backed comparisons, see [OpenCode’s `opencode.db`](/blog/opencode-local-storage/) and [Hermes’s profile-aware `state.db`](/blog/hermes-local-storage/).

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -17,7 +17,7 @@ const blogIndexJsonLd = [
     "name": "vibe-replay blog",
     "url": new URL("/blog/", siteBase).href,
     "description":
-      "Updates, guides, and deep-dives on Claude Code, Cursor, AI coding workflows, and the vibe-replay project.",
+      "Reader-first deep-dives into Claude Code, Cursor, Codex, OpenCode, Hermes, Pi, local AI-agent storage, and replayable coding workflows.",
     "publisher": {
       "@type": "Organization",
       "name": "vibe-replay",
@@ -48,8 +48,8 @@ const blogIndexJsonLd = [
 ---
 
 <Layout
-  title="Blog — Claude Code, Cursor, and AI coding deep-dives | vibe-replay"
-  description="Updates, guides, and deep-dives on Claude Code, Cursor, and AI coding workflows. Learn what AI agents actually store on your machine, how to capture sessions, and more."
+  title="Blog — AI agent storage, replays, and coding workflows | vibe-replay"
+  description="Reader-first deep-dives into what Claude Code, Cursor, Codex, OpenCode, Hermes, and Pi store locally, how AI coding sessions work, and how to replay them."
   jsonLd={blogIndexJsonLd}
 >
   <Nav active="blog" />


### PR DESCRIPTION
## Summary
- add reader-first local-storage deep dives for Codex, OpenCode, Hermes, and Pi
- explain each provider’s actual storage model, version/WAL/branch caveats, and how vibe-replay reconstructs sessions
- use synthetic examples only; no local session, prompt, path, or personal usage data
- update blog SEO metadata, structured BlogPosting output, internal links, and `llms.txt` discovery

## Publication dates
Each article is dated the day after the corresponding provider-support merge:
- Codex: 2026-04-27
- Pi: 2026-06-06
- OpenCode: 2026-08-03
- Hermes: 2026-08-05

## Validation
- `pnpm --filter @vibe-replay/website check`
- `pnpm --filter @vibe-replay/website build`
- reviewed heading structure, excerpts, canonical URLs, JSON-LD, internal links, and privacy-safe examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guides covering local storage and session replay for Codex, Hermes, OpenCode, and Pi.
  * Documented storage formats, session structures, configuration options, replay behavior, and safe inspection practices.

* **Documentation**
  * Updated blog metadata and descriptions to highlight AI-agent storage and replayable coding workflows.
  * Expanded coverage beyond Claude Code and Cursor to include additional AI coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->