### PR TITLE
docs(blog): improve quality, privacy, and SEO across all posts

### DIFF
--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -2,7 +2,7 @@
 
 > vibe-replay turns your AI coding sessions — Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi — into local-first interactive, shareable web replays. Then use Insights, embedded AI Studio, and Ask Replay to understand what happened. One command for local use, no account required, free and open source.
 
-vibe-replay is a CLI (npm package: `vibe-replay`) that reads your local AI agent session data (Claude Code `~/.claude/`, Cursor `~/.cursor/` + SQLite stores, Codex, OpenCode `~/.local/share/opencode/opencode.db`, Hermes `~/.hermes/state.db`, Pi `~/.pi/agent/sessions/`), then renders it as a scrubbable timeline showing every prompt, AI response, tool call, file diff, and thinking block. The local dashboard adds searchable session discovery, usage facets, project analytics, and personal Insights. Output is a single HTML file with all assets inlined — no server, no external requests.
+vibe-replay is a CLI (npm package: `vibe-replay`) that reads your local AI agent session data (Claude Code `~/.claude/`, Cursor `~/.cursor/` + SQLite stores, Codex, OpenCode `~/.local/share/opencode/opencode.db`, Hermes `~/.hermes/state.db`, Pi `~/.pi/agent/sessions/`), then renders recorded prompts, AI responses, tool calls, file diffs, and available thinking blocks as a scrubbable timeline. The local dashboard adds searchable session discovery, usage facets, project analytics, and personal Insights. Output is a single HTML file with all assets inlined — no server, no external requests.
 
 Install: `npx vibe-replay`
 Source: https://github.com/tuo-lei/vibe-replay
@@ -18,7 +18,7 @@ License: MIT
 ## What it does
 
 - **All your sessions, one place**: a local dashboard (`npx vibe-replay -d`) lists every session across all supported agents with activity heatmaps, per-project analytics, and cost estimates. Search and filter by git repo, tool, MCP server/tool, or skill.
-- **Full replay**: step through every prompt, thinking block, tool call, and code diff with All/Compact/Custom view modes, outline navigation, search, and playback controls.
+- **Full replay**: step through recorded prompts, thinking blocks, tool calls, and code diffs with All/Compact/Custom view modes, outline navigation, search, and playback controls.
 - **Session insights**: per-session analytics — token burn and cost per turn, context window usage, cache hit rates, tool call distribution, model breakdown, and data-quality hints.
 - **Personal insights**: GitHub-style activity heatmap, streaks, weekly trends, top projects, model usage, provider breakdown, and cost tracking across all sessions.
 - **AI Studio**: embedded Pi runtime for replay analysis, translation, and tone adjustment with the provider/model selected by the user, including OpenAI-compatible endpoints.
@@ -40,21 +40,21 @@ License: MIT
 
 ## Blog posts
 
-- [Where Does Cursor's SDK Actually Store Your Agents? A Deep Dive into sdk-agent-store](https://vibe-replay.com/blog/cursor-sdk-deep-dive/): Inside the Cursor SDK's local storage layer — its own schema, event stream, and tool-result format.
-- [What Does OpenCode Store on Your Machine? A Deep Dive into opencode.db](https://vibe-replay.com/blog/opencode-local-storage/): How OpenCode's SQLite session, message, and part tables encode prompts, reasoning, tools, and compaction.
-- [What Does Hermes Store on Your Machine? A Deep Dive into state.db and Profiles](https://vibe-replay.com/blog/hermes-local-storage/): How Hermes stores profile-aware sessions, usage, tools, reasoning, costs, and compaction markers in SQLite.
-- [What Does Pi Coding Agent Store on Your Machine? A Deep Dive into Session JSONL](https://vibe-replay.com/blog/pi-local-storage/): How Pi's parent-linked JSONL tree represents branches, tool results, model changes, and compaction.
-- [What Does Codex Store on Your Machine? A Deep Dive into Rollout JSONL and state_5.sqlite](https://vibe-replay.com/blog/codex-local-storage/): How Codex combines rollout events, the thread catalog, and its append-only session-name index.
-- [Capturing Claude's Autonomous Agent Mode: A Deep Dive into Dispatch](https://vibe-replay.com/blog/dispatch-deep-dive/): How vibe-replay captures Claude Desktop Cowork / autonomous sessions, including the technical challenges and the parser changes required.
-- [878 Sessions, 52.9k Tool Calls — What a Year of Vibe Coding Looks Like](https://vibe-replay.com/blog/personal-insights/): Year-long usage breakdown: prompts, tool calls, model distribution, and what the data reveals about real AI coding habits.
-- [What Actually Happens When Claude Code /simplify Cleans Your Codebase](https://vibe-replay.com/blog/simplify-codebase-with-ai/): Behavioral analysis of Claude Code's `/simplify` slash command and the kinds of refactors it produces.
-- [Claude Code's Source Leaked. We Read It and Shipped 5 Features in a Day](https://vibe-replay.com/blog/claude-code-source-leak/): Findings from the Claude Code source leak, with concrete features built on that knowledge.
-- [What Does Cursor Store on Your Machine? A Deep Dive into ~/.cursor/](https://vibe-replay.com/blog/cursor-local-storage/): Walkthrough of Cursor's local storage layout — SQLite `store.db`, `state.vscdb`, JSONL fallback, and how vibe-replay merges them.
-- [What Does Claude Code Store on Your Machine? A Deep Dive into ~/.claude/](https://vibe-replay.com/blog/claude-code-local-storage/): JSONL transcripts, project mapping, hooks/plugins, and what each file in `~/.claude/` actually contains.
-- [From Prompt to MVP in 53 Minutes — with Full AI Session Replay](https://vibe-replay.com/blog/introducing-vibe-replay/): Project introduction and the 53-minute build session that produced the first working version.
+- [Where Does Cursor SDK Store Agents? sdk-agent-store Explained](https://vibe-replay.com/blog/cursor-sdk-deep-dive/): How Cursor SDK's SQLite run catalog and JSONL transcript join into one replay.
+- [What Does OpenCode Store Locally? opencode.db Explained](https://vibe-replay.com/blog/opencode-local-storage/): How OpenCode's SQLite session, message, and part tables encode prompts, reasoning, tools, and compaction.
+- [What Does Hermes Store Locally? state.db + Profiles](https://vibe-replay.com/blog/hermes-local-storage/): How Hermes stores profile-aware sessions, usage, tools, reasoning, costs, and compaction markers in SQLite.
+- [What Does Pi Coding Agent Store? Session JSONL Explained](https://vibe-replay.com/blog/pi-local-storage/): How Pi's parent-linked JSONL tree represents branches, tool results, model changes, and compaction.
+- [What Does Codex Store Locally? Rollout JSONL + state_5.sqlite](https://vibe-replay.com/blog/codex-local-storage/): How Codex combines rollout events, the thread catalog, and its append-only session-name index.
+- [How Claude Cowork Stores Autonomous Agent Sessions](https://vibe-replay.com/blog/dispatch-deep-dive/): How Claude Desktop Cowork stores autonomous audit logs separately from Claude Code transcripts.
+- [What AI Coding Insights Reveal Over Time](https://vibe-replay.com/blog/personal-insights/): How local metrics, heatmaps, model usage, and optional sharing help analyze AI coding activity without exporting conversation text.
+- [What Happens When Claude Code /simplify Runs?](https://vibe-replay.com/blog/simplify-codebase-with-ai/): How to inspect `/simplify` file discovery, delegated review, refactors, and verification in a replay.
+- [What Claude Code's Source Map Revealed About Sessions and MCP](https://vibe-replay.com/blog/claude-code-source-leak/): How source-level clues clarified JSONL metadata, compaction, skills, MCP tools, and pricing mappings.
+- [What Does Cursor Store Locally? ~/.cursor/ + state.vscdb](https://vibe-replay.com/blog/cursor-local-storage/): A version-aware map of Cursor's SQLite, JSONL, global state, checkpoints, and attribution layers.
+- [What Does Claude Code Store Locally? A ~/.claude/ Deep Dive](https://vibe-replay.com/blog/claude-code-local-storage/): Where Claude Code keeps JSONL transcripts, sub-agent records, file snapshots, usage fields, and other local metadata.
+- [From Prompt to MVP: Why AI Coding Sessions Need Replay](https://vibe-replay.com/blog/introducing-vibe-replay/): Why a replay preserves prompts, tool calls, decisions, and verification that a final diff cannot show.
 
 ## Optional
 
 - [GitHub repository](https://github.com/tuo-lei/vibe-replay): Source code, issues, releases.
-- [npm package](https://www.npmjs.com/package/vibe-replay): Install via `npm i -g vibe-replay` or one-shot `npx vibe-replay`.
+- [npm package](https://www.npmjs.com/package/vibe-replay): Install with one-shot `npx vibe-replay` or through your preferred package manager.
 - [RSS feed](https://vibe-replay.com/rss.xml): Blog updates.

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -11,6 +11,7 @@ const blogCollection = defineCollection({
     author: z.string().optional().default("Tuo Lei"),
     authorUrl: z.string().optional().default("https://tuo-lei.com"),
     date: z.date(),
+    updated: z.date().optional(),
     readTime: z.string(),
     draft: z.boolean().optional().default(false),
   }),

--- a/website/src/content/blog/claude-code-local-storage.md
+++ b/website/src/content/blog/claude-code-local-storage.md
@@ -1,8 +1,9 @@
 ---
-title: "What Does Claude Code Store on Your Machine? A Deep Dive into ~/.claude/"
-excerpt: "858 MB in three weeks. Every prompt, every tool call, every file edit — all stored as plain text in ~/.claude/. Here's what's inside."
+title: "What Does Claude Code Store Locally? A ~/.claude/ Deep Dive"
+excerpt: "Claude Code stores session history, tool calls, file snapshots, and usage data under ~/.claude/. Here's where the files live and how to inspect them safely."
 cover: "/blog/claude-storage/dashboard.png"
 date: 2026-03-24
+updated: 2026-09-03
 readTime: "8 min read"
 ---
 
@@ -12,15 +13,15 @@ Run this right now:
 du -sh ~/.claude/
 ```
 
-Mine says **858 MB**. Three weeks of usage. 129 sessions (plus hundreds of sub-agent files), 1,642 prompts, 17,487 tool calls — all stored as plain text on my local machine.
+The result is machine-specific. A busy installation can grow quickly because the directory may contain transcripts, tool results, file snapshots, images, and indexes. The examples in this post are synthetic; use the commands against your own data instead of treating any number here as a benchmark.
 
-Most [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) users never look inside this directory. I did, because I needed to parse it for [vibe-replay](/blog/introducing-vibe-replay/). What I found was more than I expected — a complete record of every AI coding session, with data that reveals things Claude Code's own UI never shows you.
+Most [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) users never look inside this directory. It is worth inspecting when you need to understand retention, recover a file version, or build analytics that the terminal UI does not provide. [vibe-replay](/blog/introducing-vibe-replay/) reads these local sources and turns them into a navigable replay.
 
 ---
 
 ## Where are Claude Code sessions stored?
 
-Every Claude Code session lives in `~/.claude/projects/` as a plain-text JSONL file. Each file contains the full conversation: every prompt you typed, every tool Claude called, every file it edited, even its internal thinking process.
+Every Claude Code session is typically represented under `~/.claude/projects/` as a plain-text JSONL file. Depending on the release and session type, a record can include prompts, tool calls, file edits, images, metadata, and reasoning or thinking blocks when those are persisted.
 
 Claude Code has a built-in `/resume` command that lets you browse past sessions and continue them. And `/stats` gives you a quick overview of your usage history. But both are scoped to the current terminal — you can't search across sessions, compare them, or see what happened inside.
 
@@ -36,17 +37,16 @@ From here you can click into any session to replay it turn by turn, or drill int
 
 Claude Code has `/cost` to show token usage for the current session, and `/usage` to show your plan limits. Both are useful in the moment.
 
-But every response also logs exact token counts to the JSONL — input, output, cache creation, and cache read. Aggregate them across all sessions and you get a picture neither command shows you:
+Assistant records often include token counts in the JSONL — input, output, cache creation, and cache read. Aggregate the records across sessions and you get a picture neither command shows you:
 
-| Metric | Value |
-|--------|-------|
-| Cache read tokens | **3.25 billion** |
-| Cache hit rate | **97.8%** |
-| API-equivalent cost (Opus pricing) | ~$7,900 |
-| API-equivalent cost without caching | ~$50,200 |
-| **Saved by prompt caching** | **~$42,300** |
+| Metric | Why it matters |
+|--------|----------------|
+| Cache read tokens | Shows how much input was served from the prompt cache |
+| Cache hit rate | Helps explain why repeated context can be cheaper than fresh input |
+| API-equivalent cost | A model- and pricing-dependent estimate, not a subscription bill |
+| Cost without caching | A useful counterfactual for understanding cache impact |
 
-To be clear: if you're on Claude Max ($100 or $200/month), you're not actually paying $7,900 — that's the API-equivalent cost based on per-token Opus pricing. But the caching ratio is real and remarkable: 97.8% of input tokens come from cache, which is what makes flat-rate subscriptions viable.
+Do not confuse an API-equivalent estimate with an invoice or a subscription charge. Pricing changes, model aliases differ, and some records are incomplete. Treat the cache ratio as an observation from the stored usage fields, and label any derived cost as an estimate.
 
 In vibe-replay, the Insights tab calculates this per session automatically — cost per turn, cumulative token burn, cache hit rate, and context window growth:
 
@@ -70,9 +70,9 @@ jq -s '[.[] | select(.type=="assistant") | .message.usage // empty] |
 
 Claude Code gives you `/context` to see a colored grid of how full your context window is right now, and `/compact` to manually trigger compaction when you feel the context getting stale.
 
-But neither tells you what happened historically. In vibe-replay's Insights panel, you can watch it visually — the context window chart shows steady growth, then a sharp drop at compaction. You can see exactly how many tokens were in the window before compression (in my data: up to **167,142 tokens**).
+But neither tells you what happened historically. In vibe-replay's Insights panel, you can watch it visually — the context window chart shows steady growth, then a sharp drop at compaction. When a provider records pre-compaction usage, the replay can show that boundary without pretending the number is the model's exact internal context size.
 
-Across my 129 sessions, I found **51 compaction events**. Now I can see exactly when and why Claude lost context.
+Across a collection of sessions, the same view makes compaction events easier to compare. A compaction boundary explains that context was summarized; it does not by itself prove that the model “forgot” a particular fact.
 
 **The CLI way:**
 
@@ -86,18 +86,17 @@ jq 'select(.type=="system" and .subtype=="compact_boundary")
 
 ## What tools does Claude Code use most?
 
-I assumed Claude Code mostly reads and edits files. The data tells a different story:
+It is easy to assume Claude Code mostly reads and edits files. The data tells a different story:
 
-| Tool | Calls | Share |
-|------|-------|-------|
-| **Bash** | **7,452** | **43%** |
-| Read | 3,806 | 22% |
-| Edit | 3,025 | 17% |
-| Grep | 1,043 | 6% |
-| Write | 506 | 3% |
-| Agent (sub-agent) | 287 | 2% |
+| Tool family | What it often represents |
+|-------------|---------------------------|
+| **Bash** | Shell inspection, tests, builds, and version-control commands |
+| Read | File and directory inspection |
+| Edit / Write | Applying source changes |
+| Grep | Searching the codebase |
+| Agent | Delegated work in a separate context |
 
-**Bash dominates.** Nearly half of everything Claude Code does is running shell commands — `git status`, `pnpm build`, `ls`, `cat`. The read-edit-write loop accounts for another 42%.
+In many agent-heavy sessions, Bash is one of the largest categories because the model uses shell commands for discovery, tests, builds, and version-control checks. The exact distribution depends on the task, permissions, and enabled tools, so compare sessions rather than treating one histogram as a universal benchmark.
 
 In the vibe-replay replay view, you can watch this play out in real time — what command Claude ran, what the output was, what it decided to do next:
 
@@ -117,33 +116,33 @@ jq -r 'select(.type=="assistant") | .message.content[]?
 
 When Claude Code spawns a sub-agent (via the `Agent` tool), you see a spinner and then a result. But behind that spinner, the sub-agent might run 50+ tools — reading files, searching code, running commands — all in its own context window.
 
-Those 287 `Agent` calls in my data spawned **567 sub-agent files**, each with its own JSONL conversation and a metadata file:
+A sub-agent can create its own JSONL conversation and a small metadata record:
 
 ```json
 {
   "agentType": "general-purpose",
-  "description": "Research blog SEO best practices"
+  "description": "Review a module for duplicated logic"
 }
 ```
 
-In vibe-replay, sub-agent work is expandable inline — you can open one up and see its entire internal conversation: what it was tasked with, what tools it ran, what it found. It's a whole hidden layer of work that's normally invisible.
+In vibe-replay, sub-agent work is expandable inline — you can open one up and see what it was tasked with, which tools it ran, and what it returned. It is a hidden layer of work that a final diff normally leaves out.
 
 ---
 
 ## Does Claude Code record every prompt you type?
 
-Yes. `~/.claude/history.jsonl` is a **global index of every prompt across all projects**:
+Often, but do not treat it as a guaranteed audit log. `~/.claude/history.jsonl` is a **global prompt index across projects**:
 
 ```json
 {
-  "display": "Fix the authentication bug in login.ts",
+  "display": "Review the authentication flow",
   "timestamp": 1772598497513,
-  "project": "/Users/you/Code/myapp",
-  "sessionId": "f79f8cf8-..."
+  "project": "/home/example/project",
+  "sessionId": "session-demo-..."
 }
 ```
 
-My file has **1,642 entries** across 12 projects. It's a complete chronological diary of your AI-assisted work — what you asked, when, and in which project. If you pasted something, that's recorded too (large pastes get saved separately in `~/.claude/paste-cache/`).
+This index can become a chronological record of AI-assisted work — what you asked, when, and in which project. It may be incomplete or shaped by provider version and cleanup behavior. If you pasted something, that may be recorded too; large pastes can be stored separately in `~/.claude/paste-cache/`. Treat both locations as sensitive.
 
 ```bash
 # Try it — how many prompts have you typed?
@@ -168,23 +167,23 @@ file-history/<session-uuid>/
 ├── 12e0d72e037caf5f@v3    # before third edit
 ```
 
-The filename is SHA-256 of the file's absolute path, truncated to 16 hex chars. You can locate snapshots for any file directly:
+In the observed layout, the filename is a truncated SHA-256 of the file's absolute path. You can locate snapshots for any file directly, but treat the naming rule as an implementation detail:
 
 ```bash
-HASH=$(echo -n "/Users/you/Code/myapp/src/auth.ts" | shasum -a 256 | cut -c1-16)
+HASH=$(echo -n "/home/example/project/src/auth.ts" | shasum -a 256 | cut -c1-16)
 ls ~/.claude/file-history/*/${HASH}@*
 ```
 
-Across my sessions, that's **36 MB of invisible undo history**. Even if `/rewind` doesn't go far enough, or you've already started a new session — these snapshots are still on disk.
+These snapshots can preserve earlier file contents even after a conversation moves on. Retention and cleanup behavior can vary, so do not treat them as a guaranteed backup.
 
 ---
 
 ## What else is in ~/.claude/?
 
-- **Shell snapshots** (`shell-snapshots/`) — your complete shell environment captured periodically (~148 KB each): every function, alias, env var, and PATH entry. This is how Claude Code runs commands in your exact environment.
-- **Extended thinking** — Claude's full internal reasoning is stored verbatim in every session JSONL, with cryptographic signatures verifying the content. I have 2,130 thinking blocks across my sessions — you can read every step of Claude's decision-making process.
-- **343 embedded screenshots** — base64 PNG stored inside the JSONL. Every image you paste or Claude captures is preserved.
-- **118 PR links** — Claude records every PR it creates. Find them all: `jq 'select(.type=="pr-link")' ~/.claude/projects/*/*.jsonl`
+- **Shell snapshots** (`shell-snapshots/`) — periodic snapshots of shell state used to reproduce the command environment. They can contain sensitive environment values.
+- **Reasoning and thinking blocks** — some sessions persist model reasoning or thinking metadata. The presence, completeness, and format depend on the provider and version; never assume a transcript contains the full internal process.
+- **Embedded images** — images may be stored as data inside session records, which can make a transcript much larger than its text suggests.
+- **Pull-request metadata** — sessions can include links or records for repository actions. Review these before sharing an export.
 
 ---
 
@@ -198,8 +197,8 @@ For the full picture — token burn over time, context window growth, tool distr
 npx vibe-replay
 ```
 
-One command. It discovers your Claude Code (and Cursor) sessions, you pick one, and it generates a self-contained HTML replay. No server, no account, no external requests. Open it in any browser, share it with your team, or [publish it to the cloud](/explore/).
+One command. It discovers supported local providers, you pick a session, and it generates a self-contained HTML replay. No server, no account, no external requests. Open it in any browser, share it with your team, or [publish it to the cloud](/explore/).
 
 Your `~/.claude/` directory is a goldmine. Stop grepping through JSONL.
 
-**[Try it on your own sessions](https://github.com/tuo-lei/vibe-replay)** · **[Watch a live demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore public replays](/explore/)**
+**[Try it on your own sessions](https://github.com/tuo-lei/vibe-replay)** · **[Explore public replays](/explore/)**

--- a/website/src/content/blog/claude-code-source-leak.md
+++ b/website/src/content/blog/claude-code-source-leak.md
@@ -1,7 +1,8 @@
 ---
-title: "Claude Code's Source Leaked. We Read It and Shipped 5 Features in a Day."
-excerpt: "513,000 lines of TypeScript, extracted from a source map left in the npm package. We found undocumented JSONL fields, hidden metadata, and MCP tool naming conventions — then turned them into product improvements."
+title: "What Claude Code's Source Map Revealed About Sessions and MCP"
+excerpt: "A source-map discovery clarified Claude Code's JSONL fields, compaction markers, MCP names, and pricing metadata. Here's what changed in replay tooling."
 date: 2026-04-02
+updated: 2026-09-03
 readTime: "7 min read"
 ---
 
@@ -31,7 +32,7 @@ When Claude Code runs out of context, it compacts the conversation into a summar
 
 We'd been detecting this with a string prefix match. Fragile — if Anthropic ever changed the wording, our detection would silently break.
 
-The source revealed that every compaction summary message carries `isCompactSummary: true` as a top-level field. A reliable, future-proof flag that was sitting in the data all along.
+The source revealed that compaction summary messages carry `isCompactSummary: true` as a top-level field. That is a more reliable signal than depending on wording that may change between releases.
 
 We now use the flag as the primary detection, with the string prefix as a fallback for older sessions.
 
@@ -45,14 +46,14 @@ Claude Code injects system messages into the conversation that are invisible in 
 
 Our parser was treating them as regular user turns. In replays, they'd show up as mysterious user prompts with XML tags or skill configuration text that the user never actually typed.
 
-After reading the source, we understood the taxonomy (counts from one developer machine, 129 sessions):
+After reading the source, we could separate the categories more clearly:
 
-| `isMeta` pattern | Frequency | Value |
-|---|---|---|
-| `<local-command-caveat>` | 108 | Low — just a wrapper telling the model to ignore |
-| Skill injection (`Base directory for this skill:`) | 14 | High — shows which skills were activated |
-| `/insights` output | 1 | High — slash command data |
-| Image injection metadata | 6 | Medium |
+| `isMeta` pattern | Why it matters |
+|---|---|
+| `<local-command-caveat>` | Usually low-value wrapper text |
+| Skill injection (`Base directory for this skill:`) | Indicates which skills were activated |
+| Slash-command output | Preserves useful command context |
+| Image injection metadata | Explains why an image entered the conversation |
 
 We now classify each `isMeta` message and handle them differently:
 - **Skill injections** become `context-injection` scenes with a specific label like "Skill: playwright-cli" — visible in the replay with blue styling, distinct from user prompts
@@ -79,7 +80,7 @@ We now track this per-message and surface it:
 - The viewer shows a small "Response truncated (max_tokens reached)" indicator
 - Session metadata includes `truncatedResponses` count
 
-Across all sessions on one test machine, we found 211 truncated responses — far more than we expected.
+The count is useful as a session-level data-quality signal, but it should be measured per corpus rather than presented as a universal rate.
 
 ---
 
@@ -100,7 +101,7 @@ Before the leak, these names rendered verbatim in replays — long, ugly, and ha
 3. **Format display names** as `server · tool` (e.g., "claude-in-chrome · navigate")
 4. **Use a plug icon** instead of the generic gear for MCP tools
 
-On one test machine, 21 sessions used MCP tools across over 1,000 total calls — primarily `claude-in-chrome` (454 calls) and `playwright` (16 calls).
+The server and tool names can then be aggregated per session without exposing the full tool arguments. That is useful for answering “which MCP integrations did this workflow use?” while keeping the replay readable.
 
 ---
 
@@ -108,7 +109,7 @@ On one test machine, 21 sessions used MCP tools across over 1,000 total calls �
 
 The `usage` object on assistant messages includes a `service_tier` field (e.g., `"standard"`) that we'd been ignoring. We now extract it as session metadata.
 
-More importantly, the source at `src/utils/modelCost.ts` contains the exact pricing tiers:
+More importantly, the source at `src/utils/modelCost.ts` contains the pricing tiers used by that Claude Code release. The table below is a historical snapshot of that package, not a current quote; check the [official Anthropic pricing](https://www.anthropic.com/pricing) before using it for a bill:
 
 | Model | Input | Output | Cache write | Cache read |
 |---|---|---|---|---|
@@ -118,7 +119,7 @@ More importantly, the source at `src/utils/modelCost.ts` contains the exact pric
 | Haiku 4.5 | $1/Mtok | $5/Mtok | $1.25/Mtok | $0.10/Mtok |
 | Opus 4.6 fast mode | $30/Mtok | $150/Mtok | $37.50/Mtok | $3.00/Mtok |
 
-We validated our cost estimation against these exact numbers. The Sonnet 4 (non-4.5/4.6) model had been falling through to a generic rate — we added an explicit entry matching Claude Code's `COST_TIER_3_15`.
+We used those tiers to validate cost estimation and added an explicit mapping for a model alias that had previously fallen through to a generic rate. Pricing is versioned data: a parser should keep provider-reported usage separate from its local price table and make the table easy to update.
 
 ---
 
@@ -146,10 +147,12 @@ We've been parsing Claude Code's JSONL output for months, treating it as an opaq
 
 The `isMeta` bug is a good example: we'd never noticed the skill injection messages leaking into replays because they were rare and looked vaguely plausible. Without the source telling us that `isMeta: true` marks system-injected content, we might never have caught it.
 
-The full implementation is across two PRs: [#116](https://github.com/tuo-lei/vibe-replay/pull/116) (parser improvements, context-injection scenes, skill detection) and [#119](https://github.com/tuo-lei/vibe-replay/pull/119) (MCP server detection, tool name display). Both are merged.
+The implementation was split across parser, context-injection, skill, and MCP changes. The important lesson is less about a particular patch number and more about the contract: preserve provider metadata, classify it explicitly, and avoid presenting injected context as if it were a user prompt.
 
 If you want to see these improvements in action, install vibe-replay and run `vibe-replay -d` to open the dashboard — sessions with skills and MCP tools will now show the new badges and labels.
 
 ```bash
 npx vibe-replay -d
 ```
+
+For the storage layout that those parser changes consume, see [What Does Claude Code Store Locally?](/blog/claude-code-local-storage/).

--- a/website/src/content/blog/codex-local-storage.md
+++ b/website/src/content/blog/codex-local-storage.md
@@ -1,8 +1,9 @@
 ---
-title: "What Does Codex Store on Your Machine? A Deep Dive into Rollout JSONL and state_5.sqlite"
+title: "What Does Codex Store Locally? Rollout JSONL + state_5.sqlite"
 excerpt: "Codex keeps the replay in rollout JSONL, the /resume metadata in SQLite, and renamed threads in an append-only index. Here's how the pieces fit together."
 cover: "/blog/codex-storage/storage-map.png"
 date: 2026-04-27
+updated: 2026-09-03
 readTime: "7 min read"
 ---
 
@@ -138,7 +139,7 @@ vibe-replay merges the three local surfaces instead of choosing one and pretendi
 
 The result is a self-contained replay that can show both the conversation and the context around it: model changes, task boundaries, compactions, tool calls, and data-quality notes.
 
-You can compare this with the simpler one-file mental model in [What Does Claude Code Store on Your Machine?](/blog/claude-code-local-storage/), or with Cursor's multi-store design in [What Does Cursor Store on Your Machine?](/blog/cursor-local-storage/).
+You can compare this with the simpler one-file mental model in [What Does Claude Code Store Locally?](/blog/claude-code-local-storage/), or with Cursor's multi-store design in [What Does Cursor Store Locally?](/blog/cursor-local-storage/).
 
 ## A privacy note before you inspect the files
 

--- a/website/src/content/blog/cursor-local-storage.md
+++ b/website/src/content/blog/cursor-local-storage.md
@@ -1,7 +1,8 @@
 ---
-title: "What Does Cursor Store on Your Machine? A Deep Dive into ~/.cursor/ and state.vscdb"
-excerpt: "2.1 GB in ~/.cursor/, another 4.9 GB in Application Support, and a 1.2 GB state.vscdb. Cursor's local data is everywhere: transcripts, SQLite chat stores, global state blobs, checkpoints, and editor history."
+title: "What Does Cursor Store Locally? ~/.cursor/ + state.vscdb"
+excerpt: "Cursor stores sessions across SQLite, JSONL transcripts, global state, checkpoints, and editor history. Here's how the layers connect—and what each tells you."
 date: 2026-03-27
+updated: 2026-09-03
 readTime: "9 min read"
 ---
 
@@ -11,22 +12,25 @@ Run this right now:
 du -sh ~/.cursor ~/Library/Application\ Support/Cursor 2>/dev/null
 ```
 
-On my Mac, that prints:
+The output is specific to the machine and retention history. An illustrative audit might look like this:
 
 | Path | Size |
 |------|------|
-| `~/.cursor` | **2.1 GB** |
-| `~/Library/Application Support/Cursor` | **4.9 GB** |
+| `~/.cursor` | **machine-specific** |
+| `~/Library/Application Support/Cursor` | **machine-specific** |
 
-One important caveat up front: this is a local audit of one heavily used macOS machine, not an official Cursor storage spec.
+One important caveat up front: this is a reader-oriented map of observed local storage, not an official Cursor storage specification. Folder names, schemas, and retention behavior can change between releases.
 
-The exact sizes and counts on your machine will differ. The useful part is the shape of the system.
+The exact sizes and counts on your machine will differ. The useful part is the shape of the system, not a number from someone else's disk.
+The IDs, names, and numeric values in code samples below are synthetic examples.
 
-I expected Cursor to have one obvious "session log" folder, the way Claude Code has `~/.claude/projects/*.jsonl`.
+The examples use macOS paths. Linux and Windows use different home and application-data roots, but the same distinction between chat stores, project transcripts, global state, and recovery sidecars still applies.
+
+It is tempting to look for one obvious "session log" folder, the way Claude Code has `~/.claude/projects/*.jsonl`.
 
 It doesn't.
 
-What I found instead was a layered system:
+A local audit usually reveals a layered system:
 
 - SQLite chat databases in `~/.cursor/chats/`
 - transcript JSONL files in `~/.cursor/projects/.../agent-transcripts/`
@@ -39,19 +43,19 @@ If you're building tooling on top of Cursor session data, this matters. If you'r
 
 ## Where are Cursor sessions actually stored?
 
-On this machine, Cursor session data is spread across **three primary sources**.
+Cursor session data is spread across **three primary sources**.
 
 ### 1. `~/.cursor/chats/*/*/store.db`
 
 This is the cleanest "real chat database" layer.
 
-I found **171** local `store.db` files under `~/.cursor/chats/`, totaling about **280 MB** of actual SQLite payload.
+There may be many local `store.db` files under `~/.cursor/chats/`; their count and size depend on how long the installation has been used.
 
-A recent one on my machine has:
+A representative database has:
 
 - tables: `meta`, `blobs`
-- 1 `meta` row
-- **835** blob rows
+- a small `meta` table
+- a variable number of blob rows
 - metadata fields like:
   - `agentId`
   - `latestRootBlobId`
@@ -64,10 +68,10 @@ One sample session metadata looked like this:
 
 ```json
 {
-  "agentId": "d5c2d589-344b-4f62-a091-af4701f742ce",
-  "name": "Cursor Session TTL",
+  "agentId": "agent-demo-001",
+  "name": "Review a workspace",
   "mode": "auto-run",
-  "lastUsedModel": "gpt-5.4-high"
+  "lastUsedModel": "example-model"
 }
 ```
 
@@ -77,10 +81,7 @@ This is not "some cache." It's a real local conversation store.
 
 This is the most Claude-like layer.
 
-I found:
-
-- **138** transcript JSONL files
-- **17** `agent-tools/*.txt` sidecar files
+An audit may also find transcript JSONL files and `agent-tools/*.txt` sidecars.
 
 These transcripts can be flat:
 
@@ -102,19 +103,19 @@ But it is not the whole story. On its own, it is incomplete.
 
 This is where things get wild.
 
-On my machine, `state.vscdb` alone is **1.24 GB**.
+`state.vscdb` can become large because it stores key-value blobs as well as editor preferences.
 
-And it doesn't just hold preferences. It holds large volumes of chat/composer state in a key-value table called `cursorDiskKV`.
+It does not just hold preferences. It can hold large volumes of chat/composer state in a key-value table called `cursorDiskKV`.
 
-Here are the biggest key families I found:
+The key families that matter most for replay and recovery include:
 
-| Prefix | Count | Approx size |
-|--------|-------|-------------|
-| `agentKv` | 88,826 | **506.5 MB** |
-| `bubbleId` | 55,889 | **463.9 MB** |
-| `composerData` | 1,188 | **45.4 MB** |
-| `checkpointId` | 5,842 | **42.5 MB** |
-| `messageRequestContext` | 1,786 | **23.8 MB** |
+| Prefix | Typical role |
+|--------|--------------|
+| `agentKv` | Request-level messages and provider metadata |
+| `bubbleId` | Conversation bubbles and tool state |
+| `composerData` | Session summaries and conversation headers |
+| `checkpointId` | Restore and inline-diff state |
+| `messageRequestContext` | Prompt-building context snapshots |
 
 So if you were imagining "Cursor stores some chats locally," undersell that by a lot. Cursor stores a **huge amount of local state**, and much of it is not in tidy text logs.
 
@@ -125,17 +126,15 @@ One important nuance: not every big key family here is equally useful for replay
 - `checkpointId` looks like restore / inline-diff state
 - `agentKv` appears to be a separate message/blob store that is often tagged with request IDs
 
-One subtle thing I learned after a deeper pass: `messageRequestContext:<uuid>:<uuid>` does appear to share its **first** UUID with `composerData` / checkpoint session IDs, so this layer is probably best understood as a per-session context sidecar rather than random junk.
+One useful observation is that `messageRequestContext:<uuid>:<uuid>` can share its **first** UUID with `composerData` / checkpoint session IDs, so this layer is better understood as a per-session context sidecar than as random junk.
 
 An even more important nuance is that Cursor does **not** appear to use one universal session UUID across all of these stores.
 
-On this machine, the `store.db` session IDs and the `composerData` session IDs were disjoint. The transcript layer sat across both:
+The `store.db` session IDs and the `composerData` session IDs are not guaranteed to be the same. The transcript layer can sit across both:
 
-- **106** transcript IDs matched `store.db` sessions
-- **24** transcript IDs matched `composerData` sessions
-- **0** matched both
+Some transcript IDs match `store.db` sessions, some match `composerData` sessions, and some may not match either source cleanly.
 
-That pushed me to a more precise mental model: Cursor has at least **two replay stacks**, and transcript JSONL can attach to either one.
+The practical mental model is that Cursor has at least **two replay stacks**, and transcript JSONL can attach to either one.
 
 ---
 
@@ -163,9 +162,9 @@ That complexity is exactly why tools like [vibe-replay](https://github.com/tuo-l
 
 ## How the pieces actually connect
 
-The most useful thing I learned on the second pass was not "there are more tables." It was "these UUIDs do not all mean the same thing."
+The most useful observation is not "there are more tables." It is "these UUIDs do not all mean the same thing."
 
-The cleanest public-safe mental model I have now is:
+A public-safe mental model is:
 
 - one replay stack built around `store.db`
 - another replay stack built around `composerData` + `bubbleId`
@@ -196,11 +195,11 @@ Not every `composerData:*` row is replayable. Some are more like summaries or st
 
 When that array is populated, you effectively get the bubble list for a session.
 
-One replayable sample on my machine looked like this:
+A synthetic replayable sample looks like this:
 
 ```json
 {
-  "name": "Checking Retool Version on Helm",
+  "name": "Reviewing a service configuration",
   "isAgentic": true,
   "fullConversationHeadersOnly": [
     { "bubbleId": "5d29a280-...", "type": 1 },
@@ -221,12 +220,12 @@ Then each `bubbleId:*` row can carry far more than plain text:
 - sometimes `thinkingDurationMs`
 - sometimes `errorDetails`
 
-Here's a real tool bubble I found:
+A synthetic tool bubble looks like this:
 
 ```json
 {
   "name": "run_terminal_cmd",
-  "params": "{\"command\":\"helm list -n retool | cat\",\"requireUserApproval\":true}",
+  "params": "{\"command\":\"git status\",\"requireUserApproval\":true}",
   "userDecision": "rejected",
   "result": "{\"rejected\":true}"
 }
@@ -238,11 +237,11 @@ So Cursor isn't just storing "messages." It's storing structured traces of what 
 
 ## How much of Cursor's behavior is visible locally?
 
-More than I expected, but in a fragmented way.
+More than a simple chat export, but in a fragmented way.
 
 ### Token counts
 
-I found bubble payloads with token snapshots like:
+Some bubble payloads include token snapshots like:
 
 ```json
 {
@@ -251,17 +250,17 @@ I found bubble payloads with token snapshots like:
 }
 ```
 
-That's enough to do best-effort token and cost estimation for some Cursor sessions.
+That is enough for best-effort token and cost estimation for some Cursor sessions.
 
-The important caveat, after building and testing [vibe-replay](https://github.com/tuo-lei/vibe-replay) against a much larger Cursor corpus, is coverage: many sessions still have **no** usable token snapshots. In practice, that means aggregate Cursor cost totals are often a **lower bound**, not a full bill.
+The important caveat is coverage: many sessions still have **no** usable token snapshots. In practice, aggregate Cursor cost totals can be a **lower bound**, not a full bill.
 
 ### Timing
 
-I also found fields like:
+Fields may include:
 
 ```json
 {
-  "thinkingDurationMs": 21322
+  "thinkingDurationMs": 1200
 }
 ```
 
@@ -278,9 +277,9 @@ That means Cursor's local state sometimes preserves its own context-building bre
 
 ### Request-level message blobs
 
-The biggest family in `state.vscdb` is actually `agentKv`, not `composerData`.
+One of the largest families in `state.vscdb` can be `agentKv`, not `composerData`.
 
-On this machine, I decoded over **32,000** readable `agentKv:blob:*` payloads. They look like structured message objects with:
+Readable `agentKv:blob:*` payloads can look like structured message objects with:
 
 - `role`
 - `content`
@@ -288,9 +287,9 @@ On this machine, I decoded over **32,000** readable `agentKv:blob:*` payloads. T
 
 The important takeaway is not the exact row count. It is that Cursor appears to keep a request-level message/blob archive with assistant text, tool traffic, reasoning blocks, and injected context wrappers like `<user_query>` and `<open_and_recently_viewed_files>`.
 
-I would not treat `agentKv` as the main replay source yet. But it is strong evidence that Cursor stores more than just transcript text and chat summaries.
+Do not treat `agentKv` as the main replay source yet. It is, however, strong evidence that Cursor stores more than just transcript text and chat summaries.
 
-After a deeper join-key pass, I am more confident about *what kind* of thing `agentKv` is: it sits on a **request/provenance axis**, not the main session axis. On this machine, checkpoint `metadata.json.agentRequestId` values overlapped both `agentKv.providerOptions.cursor.requestId` and `ai_code_hashes.requestId`, while `messageRequestContext`'s second UUID did not.
+The safest interpretation is that `agentKv` sits on a **request/provenance axis**, not the main session axis. Checkpoint `metadata.json.agentRequestId` values can overlap request IDs in `agentKv` and `ai_code_hashes`, while the UUIDs in `messageRequestContext` have a different role.
 
 ---
 
@@ -298,17 +297,11 @@ After a deeper join-key pass, I am more confident about *what kind* of thing `ag
 
 Yes, but not in the same way Claude Code does.
 
-I found:
-
 ```bash
 ~/.cursor/prompt_history.json
 ```
 
-On this machine:
-
-- size: **223 KB**
-- entries: **500**
-- payload shape: plain strings
+This file is typically a rolling list of prompt strings. Its size, entry limit, and retention behavior can change between releases.
 
 That is important because it suggests **Cursor keeps a rolling prompt history locally**, but it does **not** look like Claude Code's rich `history.jsonl` global index with timestamps, project paths, and session IDs on every row.
 
@@ -320,7 +313,7 @@ The unsafe statement is:
 
 - Cursor stores a complete structured cross-project prompt log equivalent to Claude Code.
 
-I don't think the evidence supports that stronger claim yet.
+The evidence does not support that stronger claim yet.
 
 ---
 
@@ -328,19 +321,13 @@ I don't think the evidence supports that stronger claim yet.
 
 Partially, yes.
 
-Cursor's docs say [Agent checkpoints are stored locally and are separate from Git](https://cursor.com/docs/agent/chat/checkpoints). My machine backs that up.
+Cursor's docs say [Agent checkpoints are stored locally and are separate from Git](https://cursor.com/docs/agent/chat/checkpoints). Local checkpoint artifacts support that distinction, but their exact layout is version-dependent.
 
-I found local checkpoint artifacts here:
+Local checkpoint artifacts commonly appear here:
 
 ```text
 ~/Library/Application Support/Cursor/User/globalStorage/anysphere.cursor-commits/checkpoints/
 ```
-
-On my machine:
-
-- **9** checkpoint directories
-- **87** files
-- total size: **1.04 MB**
 
 Each checkpoint contains:
 
@@ -366,7 +353,7 @@ And one diff payload looked like a real file-level patch snapshot with:
 
 So Cursor checkpoints are not just a UI concept. They have real local file artifacts behind them.
 
-The relationship part matters too: the checkpoint folder's `metadata.json` is request-scoped. Its `agentRequestId` lined up with request IDs I found in both `agentKv` and `ai_code_hashes`, which makes checkpoints feel less like "chat history" and more like a provenance/recovery sidecar for specific agent requests.
+The relationship part matters too: the checkpoint folder's `metadata.json` is request-scoped. Its `agentRequestId` can line up with request IDs in both `agentKv` and `ai_code_hashes`, which makes checkpoints feel less like "chat history" and more like a provenance/recovery sidecar for specific agent requests.
 
 There is also a **separate** recovery system:
 
@@ -375,11 +362,6 @@ There is also a **separate** recovery system:
 ```
 
 That's VS Code-style local file history, not AI chat history.
-
-On this machine:
-
-- **640** `entries.json`
-- **5,162** total files
 
 So if you're asking "can I recover what the AI touched?", the answer is:
 
@@ -393,13 +375,13 @@ But unlike Claude Code, those answers are split across multiple systems.
 
 ## Cursor also keeps a separate AI tracking database
 
-This was the most surprising "extra" database I found:
+There is also a separate AI-tracking database:
 
 ```text
 ~/.cursor/ai-tracking/ai-code-tracking.db
 ```
 
-On my machine it's about **14.7 MB**, and it has tables like:
+It can contain tables like:
 
 - `ai_code_hashes`
 - `scored_commits`
@@ -411,8 +393,8 @@ This does **not** look like the main chat/session database. It looks more like C
 
 The two most revealing tables were:
 
-- `ai_code_hashes`, with **about 42k** rows linking hashes to sources like `cli` and `composer`
-- `scored_commits`, with **1,071** rows and fields like:
+- `ai_code_hashes`, linking hashes to sources like `cli` and `composer`
+- `scored_commits`, with fields like:
 
 - `commitHash`
 - `branchName`
@@ -424,7 +406,7 @@ The two most revealing tables were:
 
 In other words: Cursor appears to keep a local database specifically for tracking AI-touched code and commit-level attribution.
 
-I also found that `ai_code_hashes.conversationId` overlaps real `composerData` session IDs in many cases on this machine, which suggests this attribution layer is not fully separate from Cursor's session model.
+In some versions, `ai_code_hashes.conversationId` can overlap `composerData` session IDs, which suggests this attribution layer is not fully separate from Cursor's session model.
 
 That is a very different kind of local artifact from a replay log, so I would treat it as a secondary storage layer, not "where the chats are."
 
@@ -432,29 +414,23 @@ That is a very different kind of local artifact from a replay log, so I would tr
 
 ## Does Cursor auto-delete old sessions?
 
-I could not find evidence of a fixed local TTL like Claude Code's default 30-day cleanup behavior.
+There is no simple fixed local TTL visible across all of these stores.
 
-On this machine:
+The presence of older local artifacts does **not** prove that Cursor never cleans anything up. Retention is distributed across several stores and can depend on updates, user actions, workspace state, and provider policy. Do not assume a fixed TTL from one local audit.
 
-- `store.db` files older than 30 days: **61**
-- local history entries go back to **2025-02-06**
-- workspace state DBs also persist far beyond 30 days
-
-That does **not** prove Cursor never cleans anything up. But it does strongly suggest there is no simple "all sessions expire after 30 days" rule visible in local storage.
-
-The public docs I found are much stronger on privacy, checkpoints, usage, and cloud sharing than on local retention policy.
+The public docs are much stronger on privacy, checkpoints, usage, and cloud sharing than on local retention policy.
 
 ---
 
 ## What about workspace state?
 
-There are also **97** workspace DBs here:
+There may also be workspace DBs here:
 
 ```text
 ~/Library/Application Support/Cursor/User/workspaceStorage/*/state.vscdb
 ```
 
-The newest one on my machine contains keys like:
+These databases can contain keys like:
 
 - `composer.composerData`
 - `cursor/pinnedComposers`
@@ -500,11 +476,11 @@ all at once.
 
 Not one folder.
 
-If I had to answer in one sentence:
+The concise answer is:
 
 **Cursor's equivalent is a storage system, not a transcript directory.**
 
-If I had to answer in two sentences:
+In two sentences:
 
 **Cursor appears to have at least two replay stacks locally, plus a separate request/provenance layer.**  
 **That is the real reason local reverse-engineering and replay tooling for Cursor are harder than for Claude Code.**
@@ -527,7 +503,7 @@ plus the supporting layers:
 ~/.cursor/ai-tracking/ai-code-tracking.db
 ```
 
-That is the map I wish I had before I started reverse-engineering Cursor session replay.
+That is the map to keep in mind before inspecting Cursor session replay.
 
 ---
 
@@ -549,6 +525,8 @@ If you want the interactive version instead of grepping databases:
 npx vibe-replay
 ```
 
+Cursor's local stores can contain prompts, file contents, command arguments, workspace paths, and recovery data. Read them locally, avoid uploading raw databases, and review any replay before sharing it.
+
 It already knows how to merge Cursor's JSONL, SQLite, and global-state layers into a replayable session view, and newer builds can also surface some Cursor-specific sidecars such as request-context breadcrumbs and checkpoint-side metadata when those local artifacts exist.
 
 Cursor stores a lot more locally than its UI reveals.
@@ -559,3 +537,4 @@ The deeper point is that Cursor's local footprint is not one transcript director
 
 Once you look at it that way, the scattered files start to make sense.
 
+If your sessions came from Cursor's programmatic SDK rather than the IDE, see [Where Does Cursor SDK Store Agents?](/blog/cursor-sdk-deep-dive/) for the separate `sdk-agent-store` layout.

--- a/website/src/content/blog/cursor-sdk-deep-dive.md
+++ b/website/src/content/blog/cursor-sdk-deep-dive.md
@@ -1,7 +1,8 @@
 ---
-title: "Where Does Cursor's SDK Actually Store Your Agents? A Deep Dive into sdk-agent-store"
-excerpt: "The Cursor SDK lets you run coding agents programmatically from TypeScript. The result is a brand-new local storage layer — separate from the IDE chat database, with its own schema, its own event stream, and its own tool-result format. Here's what's inside."
+title: "Where Does Cursor SDK Store Agents? sdk-agent-store Explained"
+excerpt: "Cursor SDK agents use a separate sdk-agent-store: SQLite for runs and results, JSONL for prompts. Here's how to join the two safely."
 date: 2026-05-22
+updated: 2026-09-03
 readTime: "8 min read"
 ---
 
@@ -13,7 +14,7 @@ find ~/.cursor/projects -name index.db -path '*/sdk-agent-store/*' 2>/dev/null
 
 Anything that prints is a Cursor session you didn't create from the IDE. It came from `@cursor/sdk` — Cursor's TypeScript SDK for running coding agents programmatically — and it lives in a completely different storage layer than your regular Cursor chats. Different folder, different schema, different event stream. The IDE's session picker doesn't list these. None of the usual [`~/.cursor/chats/` and `state.vscdb` advice](/blog/cursor-local-storage/) applies.
 
-I learned this the hard way while adding SDK support to [vibe-replay](https://github.com/tuo-lei/vibe-replay) in v0.2.1. Below is the map I wish I had on day one.
+That separation matters when a replay tool discovers sessions automatically. Below is the storage map to keep in mind before you inspect an SDK workspace.
 
 ---
 
@@ -48,7 +49,7 @@ On macOS, every SDK agent lands at:
 A few things worth flagging right away:
 
 - **`<workspace-slug>`** is the same folder the existing Cursor provider already walks for IDE transcripts. The SDK is reusing the per-project root, just in a new `sdk-agent-store/` subdirectory.
-- **`<projectHash>`** is an opaque hex-looking identifier — I haven't reverse-engineered exactly what's being hashed, but treat it as "one stable directory per project + how you opened it."
+- **`<projectHash>`** is an opaque hex-looking identifier — the exact hash input is not documented, so treat it as "one stable directory per project + how you opened it."
 - **`index.db`** is the per-project catalog. It is *not* the per-agent blob store (more on that below).
 
 Each project hash gets its own `index.db`, plus a sibling per-agent store:
@@ -63,7 +64,7 @@ Each project hash gets its own `index.db`, plus a sibling per-agent store:
 
 The interesting bit is that the agent ID directory is **hashed**. If you `ls agents/` you'll see a bunch of 64-character hex names with no obvious correspondence to the agent IDs in `index.db`. To find the store for a given agent, you have to hash the agent ID yourself.
 
-For replay purposes I never had to crack open `store.db` — the catalog already contains everything that ends up rendered in the UI. But it's good to know the blob store is there if you ever need to recover raw payloads.
+For replay purposes, the catalog may contain everything needed for the rendered session, so a reader can avoid opening `store.db`. The blob store still matters if raw payload recovery is required.
 
 ---
 
@@ -83,14 +84,14 @@ What you find on inspection:
 
 | Column | Meaning |
 |---|---|
-| `agent_id` | UUID-ish identifier, prefixed `agent-` in our experience |
+| `agent_id` | UUID-ish identifier, commonly prefixed `agent-` |
 | `workspace_ref` | Path or ref back to the workspace |
 | `status` | e.g. `IDLE`, `RUNNING`, `COMPLETED` |
 | `name` | Optional human label for the agent |
 | `created_at` / `updated_at` | ISO timestamps |
 | `latest_checkpoint_ref_json` | Pointer into the blob store |
 
-We don't read `latest_checkpoint_ref_json` in vibe-replay — it's a pointer into the per-agent `store.db` we never need to open. Mentioning it for completeness; if you ever want raw blob recovery, this is the column to start from.
+vibe-replay does not need to read `latest_checkpoint_ref_json` — it points into the per-agent `store.db`. If raw blob recovery is required, this is the column to investigate first.
 
 The `agent-` prefix on `agent_id` is load-bearing for tooling — it's the only reliable way to tell an SDK agent apart from a plain IDE chat session (which is a bare UUID).
 
@@ -108,7 +109,7 @@ One row per turn. This is where the per-turn metadata sits:
 | `started_at` / `finished_at` | ISO timestamps |
 | `result` | Final assistant text for the run (if recorded) |
 
-A subtle but useful fact: **`model` is per run, not per agent.** If you switch models mid-conversation, the SDK records each turn's actual model — which is great for cost attribution, and matches what we already do for Claude Code's per-turn model field.
+A subtle but useful fact: **`model` is per run, not per agent.** If you switch models mid-conversation, the SDK records each turn's actual model — useful for cost attribution and consistent with per-turn model data from other providers.
 
 ### `run_events`
 
@@ -118,10 +119,10 @@ This is the firehose. Every streamed SDK message becomes a row:
 |---|---|
 | `run_id` | FK back to `runs.run_id` |
 | `seq` | Monotonic sequence within a run |
-| `event_type` | Always `run_stream_event` in our reads |
+| `event_type` | Commonly `run_stream_event` in observed stores |
 | `payload_json` | The actual `sdk_message` envelope |
 
-In practice we only `SELECT run_id, seq, payload_json` — `event_type` is on the schema but we never branch on it, because every row in this table has been `run_stream_event` so far. If Cursor introduces other event types later, that's the column to start filtering on.
+In practice a reader can start with `SELECT run_id, seq, payload_json` — `event_type` is on the schema, even though current rows may all be `run_stream_event`. If Cursor introduces other event types, that is the column to filter on.
 
 `payload_json` is the JSON payload from the SDK's `agent.events()` stream. Each row's `message.type` tells you what kind of event it is — assistant text deltas, tool calls, tool results, thinking blocks, and so on.
 
@@ -170,7 +171,7 @@ A few things to notice:
 2. **`result` is a `{ status, value }` envelope.** Not raw text. For Bash-shaped tools `value` carries `stdout`, `stderr`, `exitCode`. For file reads `value.content`. For edits `value.diffString`.
 3. **`args` may grow across updates.** Sometimes the early "running" event has a thin args object and the args fill in by the next update. The right strategy is to overwrite `args` on *every* update where the new payload is non-empty — not just the terminal event. By the time you reach `completed`, you have the fullest known args object.
 
-That last one bit me. My first pass just used the args from the first `running` event and missed late-arriving fields on long-running tools. Switching to "non-empty update wins" fixed it.
+An initial parser that only uses the first `running` event can miss late-arriving fields on long-running tools. The safer rule is "non-empty update wins."
 
 ---
 
@@ -180,7 +181,7 @@ Here's the gotcha that surprised me most.
 
 **User prompts don't appear in `run_events`.**
 
-I expected the SDK to log everything in one place, but the event stream is purely about agent output: thinking, tool calls, tool results, assistant text. The user-facing prompts that *triggered* those runs aren't in there.
+It is tempting to expect the SDK to log everything in one place, but the event stream is primarily agent output: thinking, tool calls, tool results, and assistant text. The user-facing prompts that *triggered* those runs are not necessarily in the event rows.
 
 So where do they live?
 
@@ -216,7 +217,7 @@ sessionId starts with "agent-"  →  SDK session
 sessionId is a bare UUID         →  IDE chat session
 ```
 
-That's literally the check we use in `vibe-replay`. It avoids paying SQLite cost on every IDE session probe (and avoids the messy job of joining UUIDs across the IDE's three storage layers).
+That is the cheap check used by `vibe-replay`. It avoids paying the SQLite cost on every IDE session probe and avoids joining UUIDs across the IDE's multiple storage layers.
 
 A more robust check, if you don't trust the prefix on future versions:
 
@@ -229,7 +230,7 @@ For now the prefix is good enough.
 
 ## Tool name and arg quirks
 
-The SDK uses different tool names than the IDE chat. Some examples we hit:
+The SDK uses different tool names than the IDE chat. Examples include:
 
 - `shell.execute` instead of `Bash`
 - `file.read` instead of `Read`
@@ -237,7 +238,7 @@ The SDK uses different tool names than the IDE chat. Some examples we hit:
 
 For replay we map them back to canonical tool names so the UI looks consistent across providers. The mapping is shared with the IDE Cursor reader (`mapCursorToolName`) so adding a new tool only takes one edit.
 
-The `args` shapes are usually close to the canonical Cursor names, but the **result** shapes are where the SDK diverges most. The biggest one: for `file.edit`, the SDK gives you `value.diffString` (a unified diff), not the `oldString` / `newString` pair the IDE stores. Downstream code that wants to render before/after has to parse the diff back out — or, like we do, wrap the SDK result in the `diff.chunks[].diffString` envelope the existing IDE inference helpers already understand.
+The `args` shapes are usually close to the canonical Cursor names, but the **result** shapes are where the SDK diverges most. For `file.edit`, the SDK gives you `value.diffString` (a unified diff), not the `oldString` / `newString` pair the IDE stores. Downstream code that wants to render before/after has to parse the diff back out — or wrap the SDK result in the `diff.chunks[].diffString` envelope used by the existing IDE inference helpers.
 
 ---
 
@@ -245,7 +246,7 @@ The `args` shapes are usually close to the canonical Cursor names, but the **res
 
 For completeness: each agent has its own `store.db` under `agents/<sha256(agentId)>/`. This is the *per-agent* blob store, distinct from the *project-level* `index.db`.
 
-We haven't found anything in there that isn't already reachable from `index.db` + the JSONL transcript. So `sdk-reader.ts` never opens it.
+The catalog and JSONL transcript may already expose everything needed for replay, so `sdk-reader.ts` does not open the per-agent store today.
 
 If Cursor changes that — e.g. starts writing thinking blocks or images there instead of the JSONL — we'd add a second pass. For now, one less thing to merge.
 
@@ -295,7 +296,7 @@ If Cursor's SDK keeps growing, this is probably going to become the *cleaner* of
 
 ## What `vibe-replay` does with all this
 
-As of v0.2.1, [vibe-replay](https://github.com/tuo-lei/vibe-replay) automatically detects SDK sessions (the `agent-` prefix trick), opens `index.db` read-only, and merges its run/event data onto the JSONL transcript so:
+Current [vibe-replay](https://github.com/tuo-lei/vibe-replay) builds automatically detect SDK sessions (the `agent-` prefix trick), open `index.db` read-only, and merge run/event data onto the JSONL transcript so:
 
 - tool calls show real outputs (stdout, file content, diffs) instead of "result pending"
 - each assistant turn carries the actual model used
@@ -304,6 +305,8 @@ As of v0.2.1, [vibe-replay](https://github.com/tuo-lei/vibe-replay) automaticall
 If the `find` command at the top of this post printed anything, those agents are already replayable — the next `npx vibe-replay` run will pick them up alongside your regular Cursor and Claude Code sessions, same picker, same dashboard, same HTML output.
 
 If it printed nothing, you haven't run an SDK agent on this machine yet. Spin one up, then come back and check.
+
+The JSONL transcript and SDK database can contain prompts, workspace references, command arguments, tool results, and file content. Keep the read path read-only and review a replay before sharing it.
 
 ---
 

--- a/website/src/content/blog/dispatch-deep-dive.md
+++ b/website/src/content/blog/dispatch-deep-dive.md
@@ -1,16 +1,17 @@
 ---
-title: "Capturing Claude's Autonomous Agent Mode: A Deep Dive into Dispatch"
-excerpt: "I ran a long autonomous task in Cowork mode, then tried to replay it — and vibe-replay couldn't see the session at all. Here's what it took to fix that."
+title: "How Claude Cowork Stores Autonomous Agent Sessions"
+excerpt: "Claude Desktop's Cowork mode writes its audit trail separately from Claude Code. Here's how Dispatch sessions are stored and replayed."
 cover: "/blog/dispatch-deep-dive/dashboard.png"
 date: 2026-04-25
+updated: 2026-09-03
 readTime: "8 min read"
 ---
 
-I ran a long research and planning task in autonomous mode. Six hours, 125 prompts, and 364 tool calls were chained together while I went about my day. When I came back, I wanted to replay it.
+Long-running autonomous work exposes a storage problem quickly: a session can run for hours, issue many prompts and tool calls, and still be invisible to a tool that only scans terminal transcripts.
 
-vibe-replay couldn't see the session.
+That was the original failure mode for Cowork sessions in vibe-replay.
 
-[![Sanitized Cowork session landing page showing an example replay](/blog/dispatch-deep-dive/cowork-landing.png)](/blog/dispatch-deep-dive/cowork-landing.png)
+[![Synthetic Cowork session landing page showing an example replay](/blog/dispatch-deep-dive/cowork-landing.png)](/blog/dispatch-deep-dive/cowork-landing.png)
 
 It now can. This is what it took.
 
@@ -20,7 +21,7 @@ It now can. This is what it took.
 
 Claude Desktop is actually two AI experiences sharing a window. The **Code tab** is Claude Code in a managed wrapper — the same CLI, the same JSONL transcripts, the same tool calls you'd see in your terminal. The **Cowork tab** is something else entirely: an autonomous agent mode where Claude runs in an isolated sandbox VM, orchestrates multi-step plans on its own, and writes its transcript to a completely different place on disk.
 
-Anthropic internally calls the orchestrator behind Cowork **Dispatch** — and the name fits. Each Cowork session spins up a sandboxed VM with a codename like `hopeful-awesome-feynman` or `zealous-wonderful-meitner`, mounts your real folders into a fake filesystem rooted at `/sessions/{processName}/`, and writes its full audit trail into:
+Anthropic internally calls the orchestrator behind Cowork **Dispatch**. Each Cowork session spins up a sandboxed VM, mounts folders into a session-scoped filesystem rooted at `/sessions/{processName}/`, and writes its audit trail into:
 
 ```
 ~/Library/Application Support/Claude/local-agent-mode-sessions/.../audit.jsonl
@@ -28,7 +29,7 @@ Anthropic internally calls the orchestrator behind Cowork **Dispatch** — and t
 
 That's nowhere near `~/.claude/projects/`, which is what vibe-replay had been scanning since day one.
 
-That answered the surface question — *why didn't vibe-replay see the session?* But once I actually opened those audit files, two deeper things mattered.
+That answers the surface question — *why did vibe-replay miss the session?* Opening the audit files also reveals two deeper details.
 
 ---
 
@@ -66,7 +67,7 @@ The `cliSessionId` in a Cowork session is the UUID of the **inner Claude Code su
 
 The right key is the metadata's `sessionId` field (with the `local_` prefix stripped). That's the stable, outer-loop identity of the Cowork session itself.
 
-I learned this the long way. Future me, reading this post, gets to skip that.
+That distinction is easy to miss because the field name sounds like the outer session identity.
 
 ---
 
@@ -92,15 +93,15 @@ claude-cowork → claude-desktop → claude-code → cursor
 
 A Cowork session in the player:
 
-[![Sanitized replay player showing a long-running autonomous task — prompt outline on left, conversation in center, tool use tags visible](/blog/dispatch-deep-dive/cowork-player.png)](/blog/dispatch-deep-dive/cowork-player.png)
+[![Synthetic replay player showing a long-running autonomous task — prompt outline on left, conversation in center, tool use tags visible](/blog/dispatch-deep-dive/cowork-player.png)](/blog/dispatch-deep-dive/cowork-player.png)
 
 Left panel: outline of every user prompt — useful when there are 125 of them. Center: the conversation, with tool-use tags inline (the parser normalizes Cowork's `mcp__workspace__*` names into recognizable tags like `gmail_read_message` and `Claude_in_Chrome`).
 
 Code-tab sessions running through Desktop pick up metadata the raw JSONL never sees — the human-readable title Desktop inferred, the permission mode, the git worktree branch:
 
-[![Claude Desktop session landing showing 'A Claude Desktop session replay' with worktree branch and dangerous mode badge](/blog/dispatch-deep-dive/desktop-session-landing.png)](/blog/dispatch-deep-dive/desktop-session-landing.png)
+[![Synthetic Claude Desktop session landing showing a replay title, worktree metadata, and permission badge](/blog/dispatch-deep-dive/desktop-session-landing.png)](/blog/dispatch-deep-dive/desktop-session-landing.png)
 
-(That session is literally the implementation of the Cowork provider itself. The first prompt: *"Add support for Cowork (Dispatch) sessions to vibe-replay…"* The `dangerous mode` badge and `claude/crazy-ishizaka-06a286` branch name come from Desktop's metadata.)
+(The screenshot uses synthetic session metadata. In a real export, the title, permission mode, worktree branch, and prompts may all contain private project information; review them before sharing.)
 
 [![Synthetic vibe-replay dashboard showing provider-aware recent sessions, replays, and activity heatmaps](/blog/dispatch-deep-dive/dashboard.png)](/blog/dispatch-deep-dive/dashboard.png)
 
@@ -110,7 +111,7 @@ Code-tab sessions running through Desktop pick up metadata the raw JSONL never s
 
 ## Try it
 
-If you've used Cowork at all, you have audit files sitting on disk right now:
+If you've used Cowork, there may be audit files on disk:
 
 ```bash
 npx vibe-replay
@@ -124,8 +125,12 @@ Or surface them all at once:
 npx vibe-replay --dashboard
 ```
 
-The foundation is in place. Every audit.jsonl Claude produces — Code, Desktop, Cowork — is now fair game.
+Cowork audit files can contain prompts, tool arguments, sandbox paths, and imported content. Treat them as private application data and review the generated replay before sharing it.
+
+The foundation is in place. Supported `audit.jsonl` sources from Code, Desktop, and Cowork can now be discovered without treating them as one identical provider.
 
 ---
 
 *vibe-replay is open source. The providers discussed here landed in [PR #187](https://github.com/tuo-lei/vibe-replay/pull/187).*
+
+The same local-first principle applies to the other providers: start with the [Claude Code storage guide](/blog/claude-code-local-storage/) before opening raw session files.

--- a/website/src/content/blog/hermes-local-storage.md
+++ b/website/src/content/blog/hermes-local-storage.md
@@ -1,8 +1,9 @@
 ---
-title: "What Does Hermes Store on Your Machine? A Deep Dive into state.db and Profiles"
+title: "What Does Hermes Store Locally? state.db + Profiles"
 excerpt: "Hermes keeps session metadata, token accounting, reasoning, and tool calls in SQLite — with named profiles and two different compaction signals."
 cover: "/blog/hermes-storage/storage-map.png"
 date: 2026-08-05
+updated: 2026-09-03
 readTime: "7 min read"
 ---
 

--- a/website/src/content/blog/introducing-vibe-replay.md
+++ b/website/src/content/blog/introducing-vibe-replay.md
@@ -1,20 +1,19 @@
 ---
-title: "From Prompt to MVP in 53 Minutes — with Full AI Session Replay"
-excerpt: "I gave Claude Code 8 prompts to create vibe-replay, an open source tool that turns AI coding sessions into interactive replays. 53 minutes, 447 tool calls. Watch the entire process unfold."
+title: "From Prompt to MVP: Why AI Coding Sessions Need Replay"
+excerpt: "An interactive replay makes AI coding sessions searchable: prompts, tool calls, abandoned paths, and the final result in one self-contained view."
 cover: "/blog/replay-landing.png"
 date: 2026-03-05
+updated: 2026-09-03
 readTime: "5 min read"
 ---
 
-[![Synthetic vibe-replay replay landing page showing a prompt, assistant response, session stats, and Watch Replay action](/blog/replay-landing.png)](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)
+[![Synthetic vibe-replay replay landing page showing a prompt, assistant response, session stats, and Watch Replay action](/blog/replay-landing.png)](/explore/)
 
-**[Watch the full interactive replay](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)**
+**[Explore public replays](/explore/)**
 
-That link isn't a screen recording. It's an interactive replay — you can drag the timeline, jump to any point, and see every prompt and every action the AI took.
+An interactive replay is not a screen recording. You can drag the timeline, jump to any point, and inspect prompts, assistant turns, tool calls, and file changes in context. The screenshots in this post use synthetic demo data.
 
-What it shows is the birth of [vibe-replay](https://github.com/tuo-lei/vibe-replay) itself. Yes — this tool replays the process of its own creation.
-
-8 prompts. 447 AI tool calls. 53 minutes.
+The product is designed around the same question: what happened between the first prompt and the final diff? [vibe-replay](https://github.com/tuo-lei/vibe-replay) turns that process into a searchable, navigable artifact instead of asking readers to reconstruct it from terminal logs.
 
 ---
 
@@ -26,70 +25,56 @@ You spend two hours with Claude Code building a feature. The resulting PR diff s
 
 Screen recordings are too heavy (nobody watches 90 minutes of terminal footage). Raw JSONL logs are unreadable. Screenshots lose context.
 
-I wanted something that compresses a full AI coding session into a few minutes of interactive animation. Like watching at 10x speed, but you can drag, search, and jump to any moment.
-
-So I opened Claude Code and started building.
+The useful alternative is a replay that compresses a full AI coding session into a few minutes of interactive animation. Like watching at 10x speed, but with the ability to drag, search, and jump to any moment.
 
 ---
 
-## Three turning points from the Claude Code session
+## Three turning points in a useful replay
 
-The full session has 663 scenes, but the story is concentrated in three turning points.
+The clearest replays usually surface three turning points.
 
-### 1. The first prompt was a product vision, not a coding instruction
+### 1. Start with a product vision, not a coding instruction
 
-> *"I have a need — I do a massive amount of vibe coding, and sharing or demoing it is extremely difficult... I'm wondering if there's a tool out there that can generate an animated replay of the vibe coding process at 10x speed or faster..."*
+> *"Build a small replay viewer for an AI coding session. Before writing code, compare the existing options and propose the smallest useful architecture."*
 
-This is a full product vision, not "write me a function." Claude's response wasn't to start writing code either — it first researched competitors, searched for tools like asciinema and claudebin, analyzed their strengths and weaknesses, and only then proposed an architecture.
+This is a product vision, not just "write me a function." A useful agent workflow starts by clarifying the audience, checking existing options, and proposing an architecture before it edits files.
 
 ![Synthetic vibe-replay player showing the first prompt, assistant response, tool badges, and outline navigation](/blog/replay-first-prompt.png)
 
-### 2. Knowing when to stop AI from building (Scene 218)
+### 2. Know when to pause the implementation
 
-> *"You haven't provided any research or competitor analysis. I need to know if there are already good solutions out there — if so, we don't need to reinvent the wheel..."*
+> *"Pause implementation and show the competing tools, their trade-offs, and what would make this approach distinct."*
 
-By this point, the core functionality was mostly working. But I noticed Claude Code had skipped the competitive analysis and jumped straight to building. This prompt pulled it back — first confirm the project is worth building, then keep investing.
+When an agent jumps straight to implementation, a checkpoint prompt can pull it back: validate the problem, then keep investing. A replay makes that steering moment visible instead of flattening it into a final diff.
 
 This is a crucial pattern in vibe coding: **AI's execution speed is a double-edged sword. The human's most important role isn't writing code — it's steering direction.**
 
 ![Synthetic vibe-replay compact replay view showing the conversation outline and condensed assistant cards](/blog/replay-brakes.png)
 
-### 3. Ten UX improvements in a single prompt (Scene 334)
+### 3. Batch UX decisions, then let the agent execute
 
-> *1. The playback bar should be sticky at the bottom*
-> *2. Too many speed options — just 1x/10x/50x*
-> *3. Spacebar should toggle pause*
-> *4. Long text blocks should collapse*
-> *5. User/Assistant/Tool sections need clear visual separation*
-> *... (10 items total)*
+> *1. Keep playback controls visible.*
+> *2. Make speed and keyboard behavior predictable.*
+> *3. Collapse long blocks without hiding their meaning.*
+> *4. Separate user, assistant, and tool activity clearly.*
 
-One prompt drove changes across dozens of files. This is vibe coding at peak efficiency: **humans make UX decisions, AI handles implementation.** One prompt, 56 tool calls.
+One well-scoped UX brief can drive changes across many files. This is the useful division of labor: **humans make product decisions, AI handles implementation, and the replay makes the trade-offs auditable.**
 
 ![Synthetic vibe-replay Insights view showing session overview, activity timeline, token composition, and context composition](/blog/replay-ten-improvements.png)
 
 ---
 
-## The session by the numbers
+## What a replay lets you measure
 
 | | |
 |---|---|
-| User prompts | 8 |
-| AI autonomous actions | 447 tool calls |
-| Avg. tool calls per prompt | 56 |
-| AI output | 151,353 tokens |
-| Session duration | 53.6 minutes |
-| Actual human input time | ~10 minutes |
-| API-equivalent cost | **$24.01** |
+| User prompts | How the task was directed |
+| Tool calls | What the agent actually executed |
+| Turn timing | Where work sped up, stalled, or retried |
+| Token and cache usage | How provider accounting changed over time |
+| File edits and tests | What changed and how it was verified |
 
-The API-equivalent cost is what this session would cost using the Claude API directly. I used a Claude Code subscription ($200/mo with Max plan), so the actual out-of-pocket cost was just part of my monthly subscription.
-
-For comparison: a senior developer building a React replay viewer + CLI + JSONL parser + keyboard controls + timeline navigation from scratch would take 2–3 days.
-
----
-
-## What happened after the first session
-
-That 53-minute session was on March 5th, 2026. Over the following 10 days, I ran 20 more vibe coding sessions — adding a dashboard, GIF export, AI coaching feedback, GitHub OAuth, cloud sharing. API-equivalent total: $483 (all covered by my Claude Max subscription). Every session has its own replay.
+Cost is intentionally not presented as a universal productivity score. Provider pricing, cache coverage, subscription terms, and missing usage records can all change the interpretation. Use the metrics to understand a workflow, not to imply that one session predicts an engineer's output.
 
 ---
 
@@ -99,8 +84,8 @@ That 53-minute session was on March 5th, 2026. Over the following 10 days, I ran
 npx vibe-replay
 ```
 
-One command. It discovers your Claude Code and Cursor sessions, picks the one you want, and generates an interactive replay.
+One command. It discovers sessions from supported local providers, lets you pick one, and generates an interactive replay.
 
 The output is a single self-contained HTML file. No server, no account, no external requests. Open it in any browser, share it anywhere. Or sign in and [share it to the cloud](/explore/).
 
-**[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Live Demo](https://vibe-replay.com/view/?gist=586f3f56d9e6c82e3b60b42ea13b341e)** · **[Explore Public Replays](/explore/)**
+**[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Explore Public Replays](/explore/)**

--- a/website/src/content/blog/opencode-local-storage.md
+++ b/website/src/content/blog/opencode-local-storage.md
@@ -1,8 +1,9 @@
 ---
-title: "What Does OpenCode Store on Your Machine? A Deep Dive into opencode.db"
-excerpt: "OpenCode stores sessions, messages, and tool parts in SQLite instead of a folder of JSONL files. Here's the schema, the compaction trap, and how to read it safely."
+title: "What Does OpenCode Store Locally? opencode.db Explained"
+excerpt: "OpenCode stores sessions, messages, and tool parts in SQLite—not JSONL. Here's the schema, the compaction trap, and how to read it safely."
 cover: "/blog/opencode-storage/storage-map.png"
 date: 2026-08-03
+updated: 2026-09-03
 readTime: "7 min read"
 ---
 
@@ -192,3 +193,5 @@ sqlite3 "$DB" \
 Do not paste the result into a public issue without checking it. Titles, directories, prompts, tool arguments, and file contents can all be sensitive. Generate a reviewed replay instead of sharing the database.
 
 If Claude Code’s one-file JSONL model is the simple case, OpenCode is the database case: structured, queryable, and more version-sensitive. Once you follow the session → message → part chain, the storage stops looking mysterious — and the replay can preserve the details that a flat session list leaves out.
+
+For the same storage question in other providers, compare the profile-aware [Hermes `state.db`](/blog/hermes-local-storage/) and the branch-aware [Pi session JSONL](/blog/pi-local-storage/) layouts.

--- a/website/src/content/blog/personal-insights.md
+++ b/website/src/content/blog/personal-insights.md
@@ -3,16 +3,17 @@ title: "What AI Coding Insights Reveal Over Time"
 excerpt: "vibe-replay tracks AI coding activity across machines and tools. Explore GitHub-style heatmaps, streaks, model usage, and privacy-aware shareable profiles."
 cover: "/blog/personal-insights/insights-hero.png"
 date: 2026-04-09
+updated: 2026-09-03
 readTime: "5 min read"
 ---
 
-[![Example personal insights dashboard showing sessions, prompts, tool calls, and activity trends](/blog/personal-insights/insights-hero.png)](/insights/)
+[![Synthetic personal insights dashboard showing sessions, prompts, tool calls, and activity trends](/blog/personal-insights/insights-hero.png)](/insights/)
 
 **[Explore Insights](https://vibe-replay.com/insights/)**
 
-After enough AI-assisted coding sessions, patterns emerge — which models you use, which days are most productive, and whether your workflow is speeding up or slowing down.
+After enough AI-assisted coding sessions, patterns emerge — which models you use, which days are busiest, and whether a workflow is speeding up or slowing down.
 
-Now I do. vibe-replay's new **Personal Insights** feature turns your local AI session history into a full analytics dashboard — synced across machines, with optional public sharing.
+vibe-replay's **Personal Insights** feature turns local AI session history into an analytics dashboard. Optional sync can combine metrics across machines, and optional public sharing lets you choose what to reveal.
 
 ---
 
@@ -26,42 +27,42 @@ The dashboard keeps the numbers concrete: sessions, prompts, tool calls, file ed
 
 ## The contribution heatmap
 
-![GitHub-style contribution heatmap showing 52 weeks of vibe coding activity, with streak stats and weekly trends](/blog/personal-insights/insights-activity.png)
+![Synthetic GitHub-style contribution heatmap showing 52 weeks of AI coding activity, with streak stats and weekly trends](/blog/personal-insights/insights-activity.png)
 
 If you've used GitHub, this looks familiar. Each cell is a day, colored by how many sessions you ran. The full year view reveals patterns that individual sessions hide:
 
-- The sparse July–December 2025 stretch is misleading — I was actively vibe coding with Claude Code during that period, but **Claude Code only retains JSONL files for 30 days**. By the time I started capturing data with vibe-replay in March 2026, months of sessions had already been cleaned up. The Cursor sessions from that era survived because Cursor stores them in SQLite databases that persist indefinitely.
-- Activity appears to ramp up around October 2025 — partly real (that's when I started building vibe-replay), partly an artifact of data loss
-- The densest weeks are in February–March 2026, with multiple high-intensity days — this is the period where I had full coverage from both providers
-- Saturday is consistently the quietest day (54 sessions vs. Thursday's 173)
+- A sparse period may reflect missing source files, not low activity. Provider retention and cleanup behavior vary, so the heatmap is only as complete as the data that was captured.
+- A sudden ramp can be real, or it can reflect a new provider, a new machine, or the first time a local store was scanned.
+- The densest weeks are useful for comparing workflow phases, but they should not be treated as a productivity score.
+- Day-of-week patterns are descriptive, not prescriptive: a quiet Saturday can mean fewer sessions, a different schedule, or missing data.
 
-This is exactly why the persistent local store matters. Once vibe-replay captures your session metrics, they're safe — even after Claude Code's 30-day cleanup or Cursor's transcript deletion.
+This is why the persistent local store matters. Once vibe-replay captures aggregate session metrics, those metrics can remain available after a provider removes or rotates its source files. The local store does not recover data that was never scanned.
 
-The streak cards below the heatmap add context: **9-day current streak**, best of 19 days, averaging 6.1 sessions on active days. The peak day — March 6, 2026 — had **36 sessions** in a single day.
+The streak cards add context: current streak, best streak, and average sessions on active days. They describe activity patterns; they do not measure code quality.
 
 ---
 
 ## Weekly trends and day-of-week patterns
 
-![Weekly trend bar chart showing acceleration through March, and day-of-week distribution showing Thursday as the most active day](/blog/personal-insights/insights-trends.png)
+![Synthetic weekly trend bar chart showing acceleration and day-of-week distribution](/blog/personal-insights/insights-trends.png)
 
 The weekly trend chart tells a story the heatmap compresses. You can see activity building through February and peaking in mid-March. The "Slowing down" label is auto-generated — it compares the last two weeks against your 90-day average.
 
-The day-of-week breakdown confirms what I suspected: weekdays are roughly equal (138–173 sessions), but **Saturday drops to a third of Thursday's volume**. Sunday is even lower. Vibe coding is, for me at least, a weekday activity.
+The day-of-week breakdown can reveal whether a workflow clusters around workdays, weekends, or a release cadence. Treat it as a description of the selected data range, not a recommendation about when to code.
 
 ---
 
 ## Which models do you actually use?
 
-![Model usage breakdown showing 20+ models across Claude and GPT families, and provider split of 79% Cursor vs 21% Claude Code](/blog/personal-insights/insights-models-providers.png)
+![Synthetic model usage breakdown showing Claude and GPT families, plus a provider split](/blog/personal-insights/insights-models-providers.png)
 
-This was the most surprising section. I expected to be a Claude-heavy user. The data says otherwise:
+This section answers a practical question: which models and providers actually appear in the selected history?
 
-- **c-opus-4-6** leads with 179 sessions — my primary Claude Code model
-- **gpt-5.3-codex-high** is a close second at 168 — Cursor's default workhorse
-- The long tail is remarkable: 20+ distinct models across Claude, GPT, and Gemini families
+- Model names are grouped from the provider records that were discovered locally.
+- The long tail can show experiments, fallbacks, and provider defaults that are easy to forget.
+- A provider split is meaningful only when the same date range and comparable source coverage are selected.
 
-The provider split makes it clear: **79% Cursor, 21% Claude Code**. I use Cursor for quick edits and exploratory work, Claude Code for heavy-lifting sessions that need agentic depth. The insights page makes this split visible for the first time.
+The Insights page makes that split visible without requiring conversation text. It also keeps incomplete usage and source coverage distinct from zero activity.
 
 ---
 
@@ -69,7 +70,7 @@ The provider split makes it clear: **79% Cursor, 21% Claude Code**. I use Cursor
 
 Personal Insights operates in three layers:
 
-**Local store** — Every time you run `npx vibe-replay`, session metrics are persisted to `~/.vibe-replay/insights/store.json`. Claude Code deletes JSONL files after 30 days. Cursor can lose transcripts across updates. I learned this the hard way — months of Claude Code sessions from mid-2025 are gone forever because I didn't have a persistent store yet. The local insights store solves this: once captured, your data survives regardless of what the AI tools do with their own files.
+**Local store** — Every time you run `npx vibe-replay`, session metrics are persisted to `~/.vibe-replay/insights/store.json`. Provider retention and cleanup behavior can vary, so the local store preserves the aggregate metrics that were captured before source files changed. It cannot reconstruct sessions that were never scanned.
 
 **Cloud sync** — If you sign in, daily aggregates sync to a lightweight time-series store (one row per machine per day). Delta sync means only new or modified days are uploaded. Multi-machine usage merges automatically.
 
@@ -79,7 +80,7 @@ Personal Insights operates in three layers:
 
 ## Share your vibe coding profile
 
-Every user gets a shareable URL: `vibe-replay.com/shared-insights/?s=your-slug` (or the short form `vibe-replay.com/i/your-slug`).
+You can create a shareable URL such as `vibe-replay.com/shared-insights/?s=your-slug` (or the short form `vibe-replay.com/i/your-slug`).
 
 The privacy defaults are conservative — dollar amounts are hidden (model names and session counts are still visible), projects are visible but can be blurred, and you can toggle every section independently. Think of it as a GitHub contribution graph, but for AI-assisted coding.
 
@@ -91,6 +92,8 @@ The privacy defaults are conservative — dollar amounts are hidden (model names
 npx vibe-replay
 ```
 
-Sign in from the dashboard, and your insights page builds automatically from your local session history. No manual tracking, no configuration. If you've been vibe coding with Claude Code or Cursor, the data is already on your machine — insights just surfaces it.
+Sign in from the dashboard, and your insights page builds automatically from your local session history. No manual tracking, no configuration. If you've been using a supported provider, the source data may already be on your machine — Insights surfaces the aggregate without requiring conversation export.
 
 **[Explore Insights](https://vibe-replay.com/insights/)** · **[GitHub](https://github.com/tuo-lei/vibe-replay)** · **[Explore public replays](/explore/)**
+
+For the underlying local sources, see the storage guides for [Claude Code](/blog/claude-code-local-storage/) and [Cursor](/blog/cursor-local-storage/).

--- a/website/src/content/blog/pi-local-storage.md
+++ b/website/src/content/blog/pi-local-storage.md
@@ -1,8 +1,9 @@
 ---
-title: "What Does Pi Coding Agent Store on Your Machine? A Deep Dive into Session JSONL"
+title: "What Does Pi Coding Agent Store? Session JSONL Explained"
 excerpt: "Pi stores a session as a JSONL tree, not a flat transcript: entries point to parents, branches can be abandoned, and compaction is its own event."
 cover: "/blog/pi-storage/session-tree.png"
 date: 2026-06-06
+updated: 2026-09-03
 readTime: "7 min read"
 ---
 

--- a/website/src/content/blog/simplify-codebase-with-ai.md
+++ b/website/src/content/blog/simplify-codebase-with-ai.md
@@ -1,7 +1,9 @@
 ---
-title: "What Actually Happens When Claude Code /simplify Cleans Your Codebase"
-excerpt: "We ran the built-in /simplify command on our own repo and captured every file read, agent spawn, and fix as an interactive replay. Here's what we learned by watching the black box."
+title: "What Happens When Claude Code /simplify Runs?"
+excerpt: "We captured Claude Code's /simplify workflow as an interactive replay to see file discovery, parallel agents, fixes, and verification—not just the final diff."
+cover: "/blog/replay-landing.png"
 date: 2026-04-03
+updated: 2026-09-03
 readTime: "5 min read"
 ---
 
@@ -11,59 +13,57 @@ readTime: "5 min read"
 
 You type `/simplify`, walk away, come back to a cleaner codebase. But what actually happened? Which files did it read? How did it decide what to change and what to skip? Did it break anything along the way?
 
-We ran `/simplify` on [vibe-replay](https://github.com/tuo-lei/vibe-replay) itself — a 150-file TypeScript monorepo — and captured the entire session as an interactive replay so you can see exactly what the AI did:
-
-**[Watch the full session replay (67 min, 108 tool calls)](https://vibe-replay.com/view/?gist=e5b2731d90cfa20fee4f3f7ab980cbb1)**
+The useful way to study `/simplify` is to capture the workflow as an interactive replay. That lets you inspect file discovery, agent delegation, fixes, and verification instead of seeing only the final diff. The examples below are synthetic and intentionally omit repository-specific paths and prompts.
 
 ---
 
-## What we learned by watching the replay
+## What the replay reveals
 
-Without the replay, we'd just see a diff. With vibe-replay, we could watch the entire decision-making process unfold — every `git diff`, every file exploration, every sub-agent spawned, every test run. Here's what `/simplify` actually did:
+Without a replay, you usually see only a diff. With vibe-replay, you can inspect the decision-making process — `git diff`, file exploration, sub-agents, and test runs. A typical `/simplify` workflow looks like this:
 
 ### Phase 1: Scoping the work
 
-The replay shows `/simplify` starting with `git diff` to find recently changed files, then exploring the surrounding codebase for context. You can see it reading files it never changes — understanding the codebase before making decisions.
+`/simplify` can start with `git diff` to find recently changed files, then explore the surrounding codebase for context. It may read files it never changes because understanding the surrounding code is part of deciding what is safe to simplify.
 
-### Phase 2: Three parallel review agents
+### Phase 2: Parallel review agents
 
-This is where the replay gets interesting. You can watch `/simplify` spawn **three independent sub-agents simultaneously**, each analyzing the same code from a different angle:
+This is where the replay gets interesting. `/simplify` can spawn independent sub-agents simultaneously, each analyzing the same code from a different angle:
 
 - **Code Reuse agent** — searches for existing utilities that could replace newly written code
 - **Code Quality agent** — reviews for redundant state, copy-paste patterns, parameter sprawl
 - **Efficiency agent** — hunts for unnecessary work, missed concurrency, hot-path bloat
 
-In the replay, you can see each agent exploring different parts of the codebase in parallel, then reporting back independently. The main agent aggregates findings and filters false positives before making any changes.
+Each agent can explore a different part of the codebase and report back independently. The main agent then aggregates findings and filters false positives before making changes.
 
 ### Phase 3: Fix and verify
 
-The replay shows the agent working through validated findings one by one. After each batch of changes, you can watch it run the full verification cycle — lint, build, test suite — and when a test fails, you can see exactly how it diagnoses and fixes the issue before moving on.
+After findings are validated, the agent works through them one by one. A good replay shows the verification cycle — lint, build, and tests — plus how a failure is diagnosed before the next change.
 
 ---
 
-## What it found in our codebase
+## What it may find in a codebase
 
-By watching the replay, we could see not just what changed, but *why* each change was made:
+By watching the replay, you can see not just what changed, but *why* each change was made:
 
 ### Duplicated utility functions
 
-`shortenPath()` — a 4-line function that replaces `$HOME` with `~` — was copy-pasted into **four separate files** across two provider directories and the scanner. The replay shows the reuse agent discovering each copy, then extracting it to a shared `utils.ts`.
+Repeated path-formatting helpers are a common `/simplify` finding. The reuse agent can discover each copy, compare behavior, and extract a shared utility only when the semantics match.
 
-`normalizeTitle()` — identical whitespace-collapsing logic in both `index.ts` and `server.ts`, with the constant `TITLE_MAX_CHARS = 120` duplicated too.
+The same applies to duplicated title normalization and validation constants: the interesting part is not the identifier, but whether the copies have the same contract.
 
 ### Copy-pasted React patterns
 
-The outside-click handler pattern — `useEffect` + `addEventListener("mousedown")` + `contains()` check — appeared **four times** across `App.tsx` and `Dashboard.tsx`. Extracted to a `useOutsideClick` hook.
+Repeated outside-click handlers are a useful candidate for a hook when the lifecycle and event behavior are identical.
 
-Identical filter state + URL sync logic (3 `useState` calls, a `popstate` listener, 3 handler functions) was duplicated between `SessionsPanel` and `ReplaysPanel`. Extracted to a `usePanelFilters` hook.
+Repeated filter state and URL synchronization can become a shared hook when the panels have the same URL contract.
 
 ### Hardcoded validation patterns
 
-The Cloudflare worker had the regex `/^[a-zA-Z0-9_-]{10,16}$/` copy-pasted **six times** for cloud replay ID validation. All extracted to module-level constants.
+Repeated replay-ID validation is another safe-looking cleanup, but the rule should be defined once and tested at its boundaries before it is shared.
 
 ### What it skipped (and why)
 
-This was the most valuable part of watching the replay. The agents flagged validation constants in `feedback.ts` as duplicated — the same enum values appeared in a JSON schema string and in runtime `Set` checks. But watching the replay, you can see the agent reason through this: the schema string is an LLM prompt template, not code logic. Different purpose, not real duplication. It recognized this and moved on.
+This is the most valuable part of watching the replay. An agent may flag the same enum values in a JSON schema and in runtime checks, but those copies can serve different purposes. The schema is an interface for a model; the `Set` is executable validation. The correct outcome may be to leave them separate.
 
 Without the replay, you'd never know this judgment call happened.
 
@@ -73,28 +73,23 @@ Without the replay, you'd never know this judgment call happened.
 
 | | |
 |---|---|
-| User prompts | 3 |
-| AI tool calls | 108 |
-| Sub-agents spawned | 7 (parallel) |
-| Files changed | 16 |
-| Lines added | 289 |
-| Lines removed | 369 |
-| **Net** | **-80 lines** |
-| Unit tests | 694 passed |
-| E2E tests | 23 passed |
-| Tests broken | 0 |
-| API-equivalent cost | $4.36 |
+| What to inspect | Why it matters |
+| Files read versus changed | Shows whether the agent scoped the task before editing |
+| Delegated work | Makes parallel review and aggregation visible |
+| Verification commands | Shows whether cleanup was tested rather than assumed |
+| Rejected findings | Reveals where the agent avoided an unsafe abstraction |
+| Final diff | Confirms the net effect on the codebase |
 
 ---
 
 ## Try it yourself
 
-1. Run `/simplify` in any [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session — it's built in, no setup required.
+1. Run `/simplify` in any [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session — availability can depend on your Claude Code version and configuration.
 2. After the session, run `npx vibe-replay` to generate an interactive replay of what happened.
 3. Watch the replay to understand every decision the AI made.
 
 The more complex the AI session, the more valuable the replay. `/simplify` is a great example — it spawns parallel agents, makes nuanced judgment calls, and runs verification loops. All of that is invisible without a replay.
 
-**[Watch the interactive replay](https://vibe-replay.com/view/?gist=e5b2731d90cfa20fee4f3f7ab980cbb1)**
+**[Read why AI coding sessions need replay](/blog/introducing-vibe-replay/)**
 
 **[GitHub](https://github.com/tuo-lei/vibe-replay)** | **[Explore Public Replays](/explore/)**

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -6,9 +6,11 @@ interface Props {
   description?: string;
   canonicalPath?: string;
   ogImage?: string;
+  ogImageAlt?: string;
   ogType?: "website" | "article";
   article?: {
     publishedTime: string;
+    modifiedTime?: string;
     author: string;
   };
   jsonLd?: Record<string, unknown> | Record<string, unknown>[];
@@ -20,6 +22,7 @@ const {
   description = "vibe-replay turns Claude Code, Claude Desktop, Claude Cowork, Cursor, Codex, OpenCode, Hermes, and Pi sessions into local-first interactive replays, insights, AI Studio analyses, and shareable self-contained HTML files.",
   canonicalPath,
   ogImage: ogImageProp,
+  ogImageAlt = "vibe-replay — AI coding session replays",
   ogType = "website",
   article,
   jsonLd: jsonLdProp,
@@ -61,16 +64,17 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:alt" content="vibe-replay — AI coding session replays" />
+    <meta property="og:image:alt" content={ogImageAlt} />
     <meta property="og:site_name" content="vibe-replay" />
     <meta property="og:locale" content="en_US" />
     {article && <meta property="article:published_time" content={article.publishedTime} />}
+    {article?.modifiedTime && <meta property="article:modified_time" content={article.modifiedTime} />}
     {article && <meta property="article:author" content={article.author} />}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
-    <meta name="twitter:image:alt" content="vibe-replay — AI coding session replays" />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
 
     <!-- Structured Data -->
     {(() => {

--- a/website/src/pages/blog/[slug].astro
+++ b/website/src/pages/blog/[slug].astro
@@ -31,7 +31,7 @@ const blogPostJsonLd = [
     headline: post.data.title,
     description: post.data.excerpt,
     datePublished: post.data.date.toISOString(),
-    dateModified: post.data.date.toISOString(),
+    dateModified: (post.data.updated ?? post.data.date).toISOString(),
     author: {
       "@type": "Person",
       name: post.data.author,
@@ -64,8 +64,13 @@ const blogPostJsonLd = [
   title={`${post.data.title} — vibe-replay`}
   description={post.data.excerpt}
   ogImage={post.data.cover}
+  ogImageAlt={post.data.title}
   ogType="article"
-  article={{ publishedTime: post.data.date.toISOString(), author: post.data.author }}
+  article={{
+    publishedTime: post.data.date.toISOString(),
+    modifiedTime: (post.data.updated ?? post.data.date).toISOString(),
+    author: post.data.author,
+  }}
   jsonLd={blogPostJsonLd}
 >
   <Nav active="blog" />
@@ -82,6 +87,12 @@ const blogPostJsonLd = [
           <time datetime={post.data.date.toISOString().split("T")[0]}>
             {formatDate(post.data.date, "long")}
           </time>
+          {post.data.updated && post.data.updated.getTime() !== post.data.date.getTime() && (
+            <>
+              <span>&middot;</span>
+              <span>Updated {formatDate(post.data.updated, "long")}</span>
+            </>
+          )}
           <span>&middot;</span>
           <span>{post.data.readTime}</span>
         </div>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -32,6 +32,8 @@ const blogIndexJsonLd = [
       "headline": p.data.title,
       "description": p.data.excerpt,
       "datePublished": p.data.date.toISOString(),
+      "dateModified": (p.data.updated ?? p.data.date).toISOString(),
+      ...(p.data.cover ? { "image": new URL(p.data.cover, siteBase).href } : {}),
       "url": new URL(`/blog/${p.id}/`, siteBase).href,
       "author": { "@type": "Person", "name": p.data.author, "url": p.data.authorUrl },
     })),
@@ -62,7 +64,7 @@ const blogIndexJsonLd = [
           <span class="bg-gradient-to-r from-accent via-emerald-400 to-cyan-400 bg-clip-text text-transparent">vibe-replay</span>
           <span class="text-text-primary"> blog</span>
         </h1>
-        <p class="text-text-secondary text-lg">Stories, insights, and updates from building with AI.</p>
+        <p class="text-text-secondary text-lg">Reader-first guides to AI agent storage, session replay, and coding workflows.</p>
       </header>
 
       <!-- Post list -->


### PR DESCRIPTION
## Summary
- review and refresh all 12 public blog posts with tighter titles/excerpts, current provider coverage, clearer caveats, and reader-first explanations
- remove personal session counts, prompts, paths, branches, costs, and live replay URLs from public copy; keep examples synthetic and privacy-safe
- add internal links across the provider storage cluster and refresh `website/public/llms.txt`
- add optional `updated` metadata, visible update dates, `dateModified` JSON-LD, modified-time Open Graph metadata, and article-specific image alt text

## Validation
- `pnpm verify`
- `pnpm --filter @vibe-replay/website check`
- `pnpm build:website`
- internal blog-link and public-content privacy scans


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated blog articles with clearer, provider-specific guidance on local storage, session replay, SDK behavior, and AI-assisted workflows.
  - Reworked examples to use synthetic or generalized data, adding privacy guidance and more cautious version-dependent explanations.
  - Refreshed blog titles, excerpts, cross-links, and navigation to improve content discovery.
  - Updated installation guidance to use `npx vibe-replay` or a preferred package manager.

- **Enhancements**
  - Blog posts now display update dates when applicable.
  - Added richer metadata for search and social sharing, including modified dates and configurable image descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->