### PR TITLE
fix(cursor): replace placeholder session titles

### DIFF
--- a/packages/cli/src/server-enrichment.ts
+++ b/packages/cli/src/server-enrichment.ts
@@ -7,6 +7,7 @@
  */
 
 import { cleanPromptText } from "./clean-prompt.js";
+import { isCursorPlaceholderTitle } from "@vibe-replay/provider-cursor/sanitize";
 import {
   ENRICHMENT_SCORE_WEIGHTS,
   RECENT_SESSION_WINDOW_MS,
@@ -345,5 +346,5 @@ function stringArrayFromUnknown(value: unknown): string[] | undefined {
 
 function looksLikeCursorDisplayNoise(value: unknown): boolean {
   if (typeof value !== "string" || !value.trim()) return false;
-  return !cleanPromptText(value);
+  return isCursorPlaceholderTitle(value) || !cleanPromptText(value);
 }

--- a/packages/cli/src/server-replay-catalog.ts
+++ b/packages/cli/src/server-replay-catalog.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { isCursorPlaceholderTitle } from "@vibe-replay/provider-cursor/sanitize";
 import { readGitRepo, shortenPath } from "@vibe-replay/provider-core/utils";
 import { classifyProject } from "@vibe-replay/types";
 import { cleanPromptText, previewPrompt } from "./clean-prompt.js";
@@ -280,15 +281,20 @@ export async function buildSourcesResult(
         sdkWorkspaceRef: session.workspacePath,
         gitRepo,
       });
+    const sourceTitle = normalizeTitle(
+      cleanPromptText(typeof session.title === "string" ? session.title : ""),
+    );
+    const title =
+      session.provider === "cursor" && isCursorPlaceholderTitle(sourceTitle)
+        ? normalizeTitle(previewPrompt(session.firstPrompt)) || sourceTitle
+        : sourceTitle;
     return {
       provider: session.provider,
       location: session.location,
       transcriptStatus: session.transcriptStatus,
       sessionId: session.sessionId,
       slug: session.slug,
-      title: normalizeTitle(
-        cleanPromptText(typeof session.title === "string" ? session.title : ""),
-      ),
+      title,
       project: session.project,
       projectIdentity,
       timestamp: session.timestamp,

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -383,6 +383,32 @@ describe("sources enrichment helpers", () => {
     expect(candidates).toHaveLength(0);
   });
 
+  it("re-enriches Cursor sources that still have the default agent title", () => {
+    const merged = [
+      makeCursorSession({
+        promptCount: 1,
+        toolCallCount: 1,
+        model: "gpt-5.6-luna-max",
+      }),
+    ];
+    const baseSources: SourceSummaryRecord[] = [
+      {
+        provider: "cursor",
+        sessionId: "cursor-session-a",
+        slug: "aaaaaaaa",
+        project: "~/project-a",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        filePaths: ["/tmp/session-a.jsonl"],
+        promptCount: 1,
+        toolCallCount: 1,
+        title: "New Agent",
+        model: "gpt-5.6-luna-max",
+      },
+    ];
+
+    expect(selectCursorEnrichmentCandidates(merged, baseSources)).toHaveLength(1);
+  });
+
   it("selects only missing-count cursor sessions and respects recency", () => {
     const merged = [
       makeCursorSession({

--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -11,6 +11,7 @@ import {
 import type { DataSourceInfo, ProviderParseResult } from "@vibe-replay/provider-contract";
 import type { Scene, SubAgent, TurnStat } from "@vibe-replay/types";
 import {
+  isCursorPlaceholderTitle,
   sanitizeCursorAssistantText,
   extractCursorTimestamp,
   sanitizeCursorReasoningText,
@@ -128,6 +129,12 @@ async function parseCursorSessionWithDependencies(
           jsonlThinking.turns,
         );
         mergeJsonlTimingIntoCursorResult(sqliteResult, jsonlThinking);
+        if (isCursorPlaceholderTitle(sqliteResult.title)) {
+          const fallbackTitle = sessionInfo?.firstPrompt?.trim();
+          if (fallbackTitle && !isCursorPlaceholderTitle(fallbackTitle)) {
+            sqliteResult.title = fallbackTitle;
+          }
+        }
         const thinkingAfter = countThinkingBlocks(sqliteResult.turns);
         const userImagesAfter = countUserImages(sqliteResult.turns);
         const timestampsAfter = countTurnTimestamps(sqliteResult.turns);

--- a/packages/provider-cursor/src/cursor/sanitize.ts
+++ b/packages/provider-cursor/src/cursor/sanitize.ts
@@ -31,6 +31,14 @@ export function sanitizeCursorUserText(value: string): string {
     .trim();
 }
 
+/** Cursor uses these names for sessions without a meaningful title. */
+export function isCursorPlaceholderTitle(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    /^(?:new agent|new chat|untitled)$/i.test(value.replace(/\s+/g, " ").trim())
+  );
+}
+
 /** Read Cursor's leading human-readable prompt timestamp and normalize it to ISO. */
 export function extractCursorTimestamp(value: string): string | undefined {
   const match = /^\s*<timestamp>([^<]*?)<\/timestamp>/i.exec(value);

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -28,6 +28,7 @@ import type {
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import type { ProviderParseResult } from "@vibe-replay/provider-contract";
 import {
+  isCursorPlaceholderTitle,
   sanitizeCursorAssistantText,
   sanitizeCursorReasoningText,
   sanitizeCursorUserText,
@@ -1530,14 +1531,15 @@ export async function discoverSqliteOnlySessions(
       const meta = metaPreview.meta;
 
       const project = hashToProject.get(entry.workspaceHash) || "";
-      const firstPrompt = meta.name || "(sqlite-only session)";
+      const title = meaningfulCursorTitle(meta.name);
+      const firstPrompt = title || "(sqlite-only session)";
       const timestamp = toIsoTimestamp(meta.createdAt) || new Date(entry.mtimeMs).toISOString();
 
       sessions.push({
         provider: "cursor",
         sessionId: entry.sessionId,
         slug: entry.sessionId.slice(0, 8),
-        title: meta.name,
+        title,
         project: shortenPath(project),
         cwd: project,
         version: "",
@@ -1676,6 +1678,15 @@ async function hasReplayableGlobalStateComposer(
   });
 }
 
+function meaningfulCursorTitle(...candidates: unknown[]): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const normalized = candidate.replace(/\s+/g, " ").trim();
+    if (normalized && !isCursorPlaceholderTitle(normalized)) return normalized;
+  }
+  return undefined;
+}
+
 function firstUserTextSnippet(turns: ParsedTurn[]): string | undefined {
   const firstUser = turns.find((t) => t.role === "user");
   const firstText = firstUser?.blocks.find(
@@ -1782,11 +1793,7 @@ export async function discoverGlobalStateOnlySessions(
         toIsoTimestamp(composer?.lastUpdatedAt ?? row.lastUpdatedAt) ||
         toIsoTimestamp(composer?.createdAt ?? row.createdAt) ||
         new Date().toISOString();
-      const title =
-        typeof (composer?.name ?? row.title) === "string" &&
-        valueToString(composer?.name ?? row.title).trim()
-          ? valueToString(composer?.name ?? row.title).trim()
-          : undefined;
+      const title = meaningfulCursorTitle(composer?.name ?? row.title);
       const firstPrompt = title || "(cursor global state session)";
       const projectPath = rawComposer
         ? inferProjectFromComposerDataFast(rawComposer, decodedWorkspacePaths)
@@ -2214,7 +2221,7 @@ function buildCursorStoreResult(
 ): ProviderParseResult {
   const { turns, turnStats, totalDurationMs } = messagesToTurns(messages);
   const slug = sessionId.slice(0, 8);
-  const title = metaJson.name || firstUserTextSnippet(turns);
+  const title = meaningfulCursorTitle(metaJson.name, firstUserTextSnippet(turns));
   const hasDurationStats = turnStats.some((stat) => (stat.durationMs || 0) > 0);
 
   const notes: string[] = [];
@@ -3617,8 +3624,7 @@ async function parseCursorGlobalStateDb(
     return {
       sessionId,
       slug: sessionId.slice(0, 8),
-      title:
-        (typeof composer.name === "string" && composer.name.trim()) || firstUserTextSnippet(turns),
+      title: meaningfulCursorTitle(composer.name, firstUserTextSnippet(turns)),
       cwd: inferredProject || "",
       model: modelName,
       startTime,

--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -142,7 +142,7 @@ function closeCachedSqlJsDb(): void {
 
 let cachedStoreDbIndex: Map<string, StoreDbIndexEntry> | null = null;
 const resolvedProjectRootCache = new Map<string, Promise<string | null>>();
-const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v7";
+const GLOBAL_STATE_DISCOVERY_CACHE_PREFIX = "cursor-global-state-discovery-v8";
 
 interface CursorComposerHeader {
   composerId: string;

--- a/packages/provider-cursor/test/parser.test.ts
+++ b/packages/provider-cursor/test/parser.test.ts
@@ -59,6 +59,58 @@ describe("parseCursorSession", () => {
     expect(mockedParseCursorSqlite).toHaveBeenCalledWith("/repo", "sqlite-session");
   });
 
+  it("replaces a Cursor placeholder title with the discovered prompt", async () => {
+    mockedParseCursorSqlite.mockResolvedValueOnce({
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      cwd: "/repo",
+      title: "New Agent",
+      turns: [{ role: "user", blocks: [{ type: "text", text: "hello" }] }],
+      dataSource: "sqlite",
+      dataSourceInfo: {
+        primary: "sqlite",
+        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      },
+    });
+
+    const dir = await mkdtemp(join(tmpdir(), "cursor-parser-title-"));
+    tempDirs.push(dir);
+    const transcript = join(dir, "session.jsonl");
+    await writeFile(
+      transcript,
+      `${JSON.stringify({
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "<user_query>Inspect the Gateway Lens capture flow</user_query>",
+            },
+          ],
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    const parsed = await parseCursorSession(transcript, {
+      provider: "cursor",
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      project: "/repo",
+      cwd: "/repo",
+      version: "",
+      timestamp: new Date().toISOString(),
+      lineCount: 1,
+      fileSize: 1,
+      filePath: transcript,
+      filePaths: [transcript],
+      hasSqlite: true,
+      firstPrompt: "Inspect the Gateway Lens capture flow",
+    });
+
+    expect(parsed.title).toBe("Inspect the Gateway Lens capture flow");
+  });
+
   it("parses explicit Cursor store.db session paths without discovery metadata", async () => {
     const sessionId = "ee3500f9-cfc2-4396-a5f2-1b556f8ac573";
     mockedParseCursorSqlite.mockResolvedValueOnce({

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -594,6 +594,18 @@ describe("dashboard prompt and title helpers", () => {
 
     expect(sourceDisplayTitle(source, { title: "Old generated title" })).toBe("Renamed thread");
   });
+
+  it("falls back from Cursor placeholder titles to the first prompt", () => {
+    const source = makeSource({
+      title: "New Agent",
+      firstPrompt: "Inspect the Gateway Lens capture flow",
+    });
+
+    expect(sourceSuggestedTitle(source)).toBe("Inspect the Gateway Lens capture flow");
+    expect(sourceDisplayTitle(source, { title: "New Agent" })).toBe(
+      "Inspect the Gateway Lens capture flow",
+    );
+  });
 });
 
 describe("formatDataSourceLabel", () => {

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -599,6 +599,17 @@ describe("dashboard prompt and title helpers", () => {
     const source = makeSource({
       title: "New Agent",
       firstPrompt: "Inspect the Gateway Lens capture flow",
+      replay: {
+        slug: "source-slug",
+        title: "New Agent",
+        provider: "cursor",
+        project: "~/Code/app",
+        startTime: "2026-05-01T10:00:00.000Z",
+        stats: { sceneCount: 1, userPrompts: 1, toolCalls: 0 },
+        hasAnnotations: false,
+        annotationCount: 0,
+        messages: [],
+      },
     });
 
     expect(sourceSuggestedTitle(source)).toBe("Inspect the Gateway Lens capture flow");

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -415,7 +415,7 @@ function sourcePromptTitle(
 export function sourceSuggestedTitle(s: SourceSession): string {
   const promptTitle = sourcePromptTitle(s);
   if (s.replay?.title) {
-    const replayTitle = normalizeTitleText(s.replay.title);
+    const replayTitle = sessionTitleValue(s.provider, s.replay.title);
     if (replayTitle) return replayTitle;
   }
   return promptTitle;

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -270,6 +270,16 @@ export function normalizeTitleText(value?: string): string {
   return (value || "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX_CHARS);
 }
 
+const CURSOR_PLACEHOLDER_TITLES = new Set(["new agent", "new chat", "untitled"]);
+
+function sessionTitleValue(provider: string, value?: string): string {
+  const normalized = normalizeTitleText(cleanPrompt(value || ""));
+  if (provider === "cursor" && CURSOR_PLACEHOLDER_TITLES.has(normalized.toLowerCase())) {
+    return "";
+  }
+  return normalized;
+}
+
 /** Detect system-generated user messages that aren't real human prompts */
 function isSystemGeneratedMessage(text: string): boolean {
   return (
@@ -390,9 +400,9 @@ export function shortCoworkSpaceId(spaceId: string): string {
 }
 
 function sourcePromptTitle(
-  s: Pick<SourceSession, "slug" | "title" | "prompts" | "firstPrompt">,
+  s: Pick<SourceSession, "provider" | "slug" | "title" | "prompts" | "firstPrompt">,
 ): string {
-  const explicitTitle = s.title ? normalizeTitleText(cleanPrompt(s.title)) : "";
+  const explicitTitle = sessionTitleValue(s.provider, s.title);
   if (explicitTitle) return explicitTitle;
   const promptCandidates = [...(s.prompts || []), s.firstPrompt];
   for (const candidate of promptCandidates) {
@@ -417,10 +427,10 @@ export function sourceDisplayTitle(
     title?: string;
   } | null,
 ): string {
-  const sourceTitle = normalizeTitleText(cleanPrompt(s.title || ""));
+  const sourceTitle = sessionTitleValue(s.provider, s.title);
   const promptTitle = sourcePromptTitle(s);
   const replayTitle = normalizeTitleText(s.replay?.title);
-  const scanTitle = normalizeTitleText(cleanPrompt(scanData?.title || ""));
+  const scanTitle = sessionTitleValue(s.provider, scanData?.title);
   if (sourceTitle) return sourceTitle;
   if (scanTitle) return scanTitle;
   if (promptTitle && promptTitle !== s.slug) return promptTitle;


### PR DESCRIPTION
## Summary

- Treat Cursor default titles such as `New Agent`, `New Chat`, and `Untitled` as placeholders.
- Fall back to the discovered first prompt across Cursor SQLite, global-state, source catalog, and Dashboard rendering.
- Re-enrich cached Cursor sources so existing Dashboard entries are corrected.

## Verification

- `pnpm verify`
- Cursor provider, CLI, and viewer regression tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cursor sessions with placeholder titles such as “New Agent,” “New Chat,” or “Untitled” now display a meaningful title based on the first prompt when available.
  * Placeholder titles are filtered from session lists, source details, and dashboard displays.
  * Sessions with placeholder titles are correctly identified for enrichment, even when other session data is present.
* **Tests**
  * Added coverage for placeholder-title replacement and dashboard title fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->