### PR TITLE
fix(cursor): prefer transcript-derived titles

### DIFF
--- a/packages/provider-cursor/src/cursor/parser.ts
+++ b/packages/provider-cursor/src/cursor/parser.ts
@@ -130,8 +130,10 @@ async function parseCursorSessionWithDependencies(
         );
         mergeJsonlTimingIntoCursorResult(sqliteResult, jsonlThinking);
         if (isCursorPlaceholderTitle(sqliteResult.title)) {
-          const fallbackTitle = sessionInfo?.firstPrompt?.trim();
-          if (fallbackTitle && !isCursorPlaceholderTitle(fallbackTitle)) {
+          const fallbackTitle = [jsonlThinking.title, sessionInfo?.firstPrompt]
+            .map((value) => value?.trim())
+            .find((value) => value && !isCursorPlaceholderTitle(value));
+          if (fallbackTitle) {
             sqliteResult.title = fallbackTitle;
           }
         }

--- a/packages/provider-cursor/test/parser.test.ts
+++ b/packages/provider-cursor/test/parser.test.ts
@@ -111,6 +111,53 @@ describe("parseCursorSession", () => {
     expect(parsed.title).toBe("Inspect the Gateway Lens capture flow");
   });
 
+  it("uses the transcript title when the discovered prompt is unavailable", async () => {
+    mockedParseCursorSqlite.mockResolvedValueOnce({
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      cwd: "/repo",
+      title: "New Agent",
+      turns: [{ role: "user", blocks: [{ type: "text", text: "hello" }] }],
+      dataSource: "sqlite",
+      dataSourceInfo: {
+        primary: "sqlite",
+        sources: ["cursor/chats/<workspace-hash>/<session-id>/store.db"],
+      },
+    });
+
+    const dir = await mkdtemp(join(tmpdir(), "cursor-parser-transcript-title-"));
+    tempDirs.push(dir);
+    const transcript = join(dir, "session.jsonl");
+    await writeFile(
+      transcript,
+      `${JSON.stringify({
+        role: "user",
+        message: {
+          content: [{ type: "text", text: "<user_query>Transcript title fallback</user_query>" }],
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    const parsed = await parseCursorSession(transcript, {
+      provider: "cursor",
+      sessionId: "sqlite-session",
+      slug: "sqlite-s",
+      project: "/repo",
+      cwd: "/repo",
+      version: "",
+      timestamp: new Date().toISOString(),
+      lineCount: 1,
+      fileSize: 1,
+      filePath: transcript,
+      filePaths: [transcript],
+      hasSqlite: true,
+      firstPrompt: "",
+    });
+
+    expect(parsed.title).toBe("Transcript title fallback");
+  });
+
   it("parses explicit Cursor store.db session paths without discovery metadata", async () => {
     const sessionId = "ee3500f9-cfc2-4396-a5f2-1b556f8ac573";
     mockedParseCursorSqlite.mockResolvedValueOnce({

--- a/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
+++ b/packages/viewer/src/components/__tests__/dashboard-utils.test.ts
@@ -617,6 +617,16 @@ describe("dashboard prompt and title helpers", () => {
       "Inspect the Gateway Lens capture flow",
     );
   });
+
+  it("skips Cursor placeholder prompt previews when choosing a title", () => {
+    const source = makeSource({
+      title: "New Agent",
+      prompts: ["New Agent", "Inspect the Gateway Lens capture flow"],
+      firstPrompt: "Fallback prompt",
+    });
+
+    expect(sourceDisplayTitle(source)).toBe("Inspect the Gateway Lens capture flow");
+  });
 });
 
 describe("formatDataSourceLabel", () => {

--- a/packages/viewer/src/components/dashboard-utils.ts
+++ b/packages/viewer/src/components/dashboard-utils.ts
@@ -406,7 +406,7 @@ function sourcePromptTitle(
   if (explicitTitle) return explicitTitle;
   const promptCandidates = [...(s.prompts || []), s.firstPrompt];
   for (const candidate of promptCandidates) {
-    const cleaned = normalizeTitleText(cleanPrompt(candidate || ""));
+    const cleaned = sessionTitleValue(s.provider, candidate);
     if (cleaned) return cleaned;
   }
   return s.slug;


### PR DESCRIPTION
## Summary

- Prefer a transcript-derived title when Cursor SQLite metadata only contains a placeholder title and discovery has no prompt fallback.
- Skip Cursor placeholder prompt values while deriving Dashboard titles.
- Add regression coverage for both fallback paths.

## Verification

- `pnpm verify`
- Cursor provider, CLI, and viewer tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session title selection when Cursor provides a generic placeholder title.
  * Transcript titles are now used when the initial prompt is unavailable or not meaningful.
  * Dashboard titles now prioritize meaningful prompts over placeholder previews, such as “New Agent.”
* **Tests**
  * Added coverage for Cursor transcript title fallback and dashboard title selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->