### PR TITLE
refactor(cli): narrow model input array type

### DIFF
--- a/packages/cli/src/ai-runtime.ts
+++ b/packages/cli/src/ai-runtime.ts
@@ -877,9 +877,9 @@ function positiveNumber(value: unknown, fallback: number): number {
 }
 
 function modelInput(raw: Record<string, unknown>): ("text" | "image")[] {
-  const modalities = [raw.modalities, raw.input_modalities, raw.input].find((value) =>
-    Array.isArray(value),
-  ) as unknown[] | undefined;
+  const modalities = [raw.modalities, raw.input_modalities, raw.input].find(
+    (value): value is unknown[] => Array.isArray(value),
+  );
   if (modalities?.some((value) => typeof value === "string" && /image|vision/i.test(value))) {
     return ["text", "image"];
   }


### PR DESCRIPTION
## Summary

- Replace the `as unknown[]` assertion in custom model input discovery with an `Array.isArray` type predicate.
- Net diff: 0 lines (3 insertions, 3 deletions), 1 file.

## Motivation

The type predicate preserves the exact runtime check while keeping the array narrowing in TypeScript instead of relying on a cast.

## Test plan

- [x] `pnpm test`全绿
- [x] `pnpm lint:check`零 warning/zero error
- [x] `pnpm --filter vibe-replay exec tsc --noEmit`零错
- [x] `pnpm build`成功
- [ ] E2E：未运行；这是纯类型级、语义等价改动

> 🤖 Daily auto-quality routine. Self-merged after AI review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->