### PR TITLE
feat(cloudflare): tag Sentry events by Worker release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,6 +286,9 @@ cd cloudflare
 pnpm exec wrangler secret put SENTRY_DSN
 ```
 
+Cloudflare version metadata is used as the Sentry release ID, so each Worker
+deployment is automatically associated with its own release.
+
 The Worker disables Sentry user information and HTTP request bodies so prompts,
 replay contents, and credentials are not sent as event data. It samples 10% of
 traces and streams sampled spans from the Worker. Local and test environments

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -70,6 +70,8 @@ type Env = AuthEnv & {
   TEST_AUTH_USER_NAME?: string;
   /** Sentry project DSN; absent in local/test environments disables reporting. */
   SENTRY_DSN?: string;
+  /** Cloudflare deployment version metadata used as the Sentry release ID. */
+  CF_VERSION_METADATA?: { id: string };
 };
 
 type HonoEnv = { Bindings: Env };
@@ -2300,6 +2302,7 @@ export function scrubSentryRequest(event: Sentry.ErrorEvent): Sentry.ErrorEvent 
 export function createSentryOptions(env: Env): Sentry.CloudflareOptions {
   return {
     dsn: env.SENTRY_DSN,
+    release: env.CF_VERSION_METADATA?.id,
     sendDefaultPii: false,
     // Keep tracing useful without sending every static asset request.
     tracesSampleRate: 0.1,

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -167,7 +167,9 @@ describe("Cloud API integration", () => {
   it("disables sensitive request data in Sentry events", () => {
     const options = createSentryOptions({
       SENTRY_DSN: "https://example.invalid/1",
+      CF_VERSION_METADATA: { id: "version-test" },
     } as Parameters<typeof createSentryOptions>[0]);
+    expect(options.release).toBe("version-test");
     expect(options.sendDefaultPii).toBe(false);
     expect(options.tracesSampleRate).toBe(0.1);
     expect(options.traceLifecycle).toBe("stream");

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -5,6 +5,9 @@ compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 routes = [{ pattern = "vibe-replay.com", custom_domain = true }]
 
+[version_metadata]
+binding = "CF_VERSION_METADATA"
+
 [assets]
 directory = "../website/dist"
 binding = "ASSETS"


### PR DESCRIPTION
## Summary

- Add the Cloudflare version metadata binding to the Worker.
- Use the deployed Worker version ID as the Sentry release name.
- Document automatic release association.

## Verification

- `pnpm install --frozen-lockfile`
- Cloudflare tests: 14 passed
- Cloudflare TypeScript check
- `pnpm lint:check`
- Wrangler deploy dry-run confirms `CF_VERSION_METADATA` binding

## Deployment

After merge, deploy the Worker so new Sentry events are tagged with the Cloudflare version ID.