### PR TITLE
feat(cloudflare): enable basic Sentry logs and metrics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,11 @@ replay contents, and credentials are not sent as event data. It samples 10% of
 traces and streams sampled spans from the Worker. Local and test environments
 remain reporting-disabled when `SENTRY_DSN` is absent.
 
+Sentry Logs and Application Metrics are enabled explicitly. The Worker emits a
+fixed, content-free log and counter for API requests, plus a fixed error log
+for unhandled requests; request bodies, URLs, IDs, and replay contents are not
+included.
+
 ## Key conventions
 
 - **pnpm** only — no npm/yarn

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -98,6 +98,8 @@ const app = new Hono<HonoEnv>();
 app.onError((error, c) => {
   if (!c.env.SENTRY_DSN) {
     console.error(error);
+  } else {
+    Sentry.logger.error("Unhandled Worker request error");
   }
   Sentry.captureException(error);
   return c.text("Internal Server Error", 500);
@@ -125,6 +127,13 @@ app.use("/api/*", async (c, next) => {
     credentials: true,
   });
   return mw(c, next);
+});
+
+app.use("/api/*", async (c, next) => {
+  await next();
+  if (!c.env.SENTRY_DSN) return;
+  Sentry.logger.info("Worker API request");
+  Sentry.metrics.count("worker.api_requests", 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -2304,6 +2313,8 @@ export function createSentryOptions(env: Env): Sentry.CloudflareOptions {
     dsn: env.SENTRY_DSN,
     release: env.CF_VERSION_METADATA?.id,
     sendDefaultPii: false,
+    enableLogs: true,
+    enableMetrics: true,
     // Keep tracing useful without sending every static asset request.
     tracesSampleRate: 0.1,
     traceLifecycle: "stream",

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -171,6 +171,8 @@ describe("Cloud API integration", () => {
     } as Parameters<typeof createSentryOptions>[0]);
     expect(options.release).toBe("version-test");
     expect(options.sendDefaultPii).toBe(false);
+    expect(options.enableLogs).toBe(true);
+    expect(options.enableMetrics).toBe(true);
     expect(options.tracesSampleRate).toBe(0.1);
     expect(options.traceLifecycle).toBe("stream");
     expect(options.dataCollection).toEqual({


### PR DESCRIPTION
## Summary

- Explicitly enable Sentry Logs and Application Metrics for the Cloudflare Worker.
- Emit one content-free API request log and counter per `/api/*` request.
- Emit a fixed log for unhandled Worker request errors.
- Do not send URLs, IDs, request bodies, prompts, or replay contents.

## Scope

This only changes the Cloudflare Worker. The local CLI/server does not import Sentry and is unaffected.

## Verification

- `pnpm install --frozen-lockfile`
- Cloudflare tests: 14 passed
- Cloudflare TypeScript check
- `pnpm lint:check`

## Deployment

Deploy after merge and verify the Logs and Metrics pages.