### PR TITLE
fix: harden API validation, CSRF protection, and usage aggregation

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -27,6 +27,13 @@ import {
 const CLOUD_REPLAY_ID_RE = /^[a-zA-Z0-9_-]{10,16}$/;
 const GIST_ID_RE = /^[a-f0-9]{20,40}$/;
 const VALID_VISIBILITY = new Set(["public", "unlisted", "private"]);
+// JSON string escaping can nearly double a 10 MB replay/gist payload when it
+// is nested inside the request envelope, so leave headroom above the stored
+// content limit while still bounding chunked requests without Content-Length.
+const MAX_JSON_BODY_BYTES = 24 * 1024 * 1024;
+const MAX_INSIGHTS_SYNC_BODY_BYTES = 32 * 1024 * 1024;
+const MAX_FILE_UPLOAD_BODY_BYTES = 16 * 1024 * 1024;
+const MAX_LEGACY_REPLAY_BODY_BYTES = 64 * 1024;
 // D1 starts failing once the user+machine+dates lookup goes past ~100 bound params.
 // Reuse the same conservative chunk size for both query and write paths so older clients
 // that still send large sync payloads stay under the database ceiling server-side too.
@@ -78,9 +85,44 @@ type HonoEnv = { Bindings: Env };
 
 type JsonBodyResult = { ok: true; body: any } | { ok: false; response: Response };
 
-async function readJsonBody(c: Context<HonoEnv>): Promise<JsonBodyResult> {
+async function readJsonBody(
+  c: Context<HonoEnv>,
+  maxBytes = MAX_JSON_BODY_BYTES,
+): Promise<JsonBodyResult> {
+  const contentLength = Number(c.req.header("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    return { ok: false, response: c.json({ error: "Request body too large" }, 413) };
+  }
+
+  const body = c.req.raw.body;
+  if (!body) return { ok: false, response: c.json({ error: "Invalid JSON body" }, 400) };
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
   try {
-    return { ok: true, body: await c.req.json() };
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > maxBytes) {
+        await reader.cancel().catch(() => {});
+        return { ok: false, response: c.json({ error: "Request body too large" }, 413) };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  try {
+    const bytes = new Uint8Array(byteLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { ok: true, body: JSON.parse(new TextDecoder().decode(bytes)) };
   } catch {
     return { ok: false, response: c.json({ error: "Invalid JSON body" }, 400) };
   }
@@ -506,6 +548,9 @@ app.post("/api/cloud-replays", async (c) => {
   const parsedBody = await readJsonBody(c);
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   if (!body.replay || typeof body.replay !== "object") {
     return c.json({ error: "replay object required" }, 400);
   }
@@ -689,6 +734,9 @@ app.patch("/api/cloud-replays/:id", async (c) => {
   const parsedBody = await readJsonBody(c);
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   const { visibility } = body;
   if (!visibility || !VALID_VISIBILITY.has(visibility)) {
     return c.json({ error: "Invalid visibility (must be public, unlisted, or private)" }, 400);
@@ -751,7 +799,12 @@ app.post("/api/gists", async (c) => {
   if (authResult instanceof Response) return authResult;
   const { userId } = authResult;
 
-  const body = await c.req.json();
+  const parsedBody = await readJsonBody(c);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   if (!body.filename || typeof body.filename !== "string" || body.filename.length > 255) {
     return c.json({ error: "filename required (max 255 chars)" }, 400);
   }
@@ -875,7 +928,12 @@ app.patch("/api/gists/:gistId", async (c) => {
     return c.json({ error: "Invalid gist ID" }, 400);
   }
 
-  const body = await c.req.json();
+  const parsedBody = await readJsonBody(c);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   if (!body.filename || typeof body.filename !== "string" || body.filename.length > 255) {
     return c.json({ error: "filename required (max 255 chars)" }, 400);
   }
@@ -1166,23 +1224,48 @@ app.post("/api/insights/sync", async (c) => {
   if (authResult instanceof Response) return authResult;
   const { userId } = authResult;
 
-  const parsedBody = await readJsonBody(c);
+  const parsedBody = await readJsonBody(c, MAX_INSIGHTS_SYNC_BODY_BYTES);
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   if (!Array.isArray(body.days) || body.days.length === 0) {
     return c.json({ error: "days array required" }, 400);
   }
   if (body.days.length > MAX_DAILY_BATCH) {
     return c.json({ error: `Max ${MAX_DAILY_BATCH} days per batch` }, 400);
   }
+  if (
+    body.days.some(
+      (day: unknown) =>
+        !day ||
+        typeof day !== "object" ||
+        Array.isArray(day) ||
+        !isValidCalendarDate((day as { date?: unknown }).date),
+    )
+  ) {
+    return c.json({ error: "Each day must have a valid YYYY-MM-DD date" }, 400);
+  }
 
   const now = new Date().toISOString().replace("T", " ").slice(0, 19);
 
   // Pre-fetch existing rows for this user+machine combo
-  const machineId = body.machineId?.slice(0, 64);
-  if (!machineId) return c.json({ error: "machineId required" }, 400);
+  if (typeof body.machineId !== "string" || !body.machineId.trim()) {
+    return c.json({ error: "machineId required" }, 400);
+  }
+  const machineId = body.machineId.trim().slice(0, 64);
+  const machineName = boundedString(body.machineName, 200);
 
-  const dates = body.days.map((d: any) => String(d.date)).filter(Boolean);
+  // A retry may contain the same date more than once. Keep the last sample so
+  // one request cannot enqueue duplicate inserts for the unique date key.
+  const daysByDate = new Map<string, Record<string, unknown>>();
+  for (const day of body.days as Record<string, unknown>[]) {
+    daysByDate.set(day.date as string, day);
+  }
+  const days = [...daysByDate.values()];
+
+  const dates = [...daysByDate.keys()];
   const existingMap = new Map<string, string>();
   for (const dateChunk of chunkItems(dates, SAFE_DAILY_SYNC_DB_CHUNK)) {
     if (dateChunk.length === 0) continue;
@@ -1200,10 +1283,9 @@ app.post("/api/insights/sync", async (c) => {
   const statements: D1PreparedStatement[] = [];
   let synced = 0;
 
-  for (const day of body.days) {
-    if (!day.date || !/^\d{4}-\d{2}-\d{2}$/.test(day.date)) continue;
-
-    const existingId = existingMap.get(day.date);
+  for (const day of days) {
+    const date = day.date as string;
+    const existingId = existingMap.get(date);
     if (existingId) {
       statements.push(
         c.env.DB.prepare(
@@ -1216,11 +1298,11 @@ app.post("/api/insights/sync", async (c) => {
           clamp(day.toolCalls, 0, 1_000_000),
           clamp(day.edits, 0, 1_000_000),
           clamp(day.durationMs, 0, 86_400_000),
-          Math.max(0, Math.min(Number(day.cost) || 0, 100_000)),
-          day.projects ? String(day.projects).slice(0, 50_000) : null,
-          day.models ? String(day.models).slice(0, 10_000) : null,
-          day.providers ? String(day.providers).slice(0, 10_000) : null,
-          body.machineName?.slice(0, 200) || null,
+          clamp(day.cost, 0, 100_000),
+          boundedString(day.projects, 50_000),
+          boundedString(day.models, 10_000),
+          boundedString(day.providers, 10_000),
+          machineName,
           now,
           existingId,
         ),
@@ -1237,20 +1319,20 @@ app.post("/api/insights/sync", async (c) => {
           id,
           userId,
           machineId,
-          body.machineName?.slice(0, 200) || null,
-          day.date,
+          machineName,
+          date,
           clamp(day.sessions, 0, 10_000),
           clamp(day.prompts, 0, 100_000),
           clamp(day.toolCalls, 0, 1_000_000),
           clamp(day.edits, 0, 1_000_000),
           clamp(day.durationMs, 0, 86_400_000),
-          Math.max(0, Math.min(Number(day.cost) || 0, 100_000)),
-          day.projects ? String(day.projects).slice(0, 50_000) : null,
-          day.models ? String(day.models).slice(0, 10_000) : null,
-          day.providers ? String(day.providers).slice(0, 10_000) : null,
+          clamp(day.cost, 0, 100_000),
+          boundedString(day.projects, 50_000),
+          boundedString(day.models, 10_000),
+          boundedString(day.providers, 10_000),
         ),
       );
-      existingMap.set(day.date, id);
+      existingMap.set(date, id);
     }
     synced++;
   }
@@ -1517,6 +1599,9 @@ app.post("/api/insights/profile", async (c) => {
   const parsedBody = await readJsonBody(c);
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
 
   const slug = body.slug ? String(body.slug).toLowerCase().trim() : null;
   if (slug && !SLUG_RE.test(slug)) {
@@ -1868,9 +1953,12 @@ app.post("/api/files", async (c) => {
   if (authResult instanceof Response) return authResult;
   const { userId } = authResult;
 
-  const parsedBody = await readJsonBody(c);
+  const parsedBody = await readJsonBody(c, MAX_FILE_UPLOAD_BODY_BYTES);
   if (!parsedBody.ok) return parsedBody.response;
   const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Request body must be an object" }, 400);
+  }
   const { content, contentType, filename, parentReplayId, visibility: vis } = body;
 
   if (!content || typeof content !== "string") {
@@ -2150,10 +2238,17 @@ function validateReplaySchema(replay: any): string | null {
   if (!Array.isArray(replay.scenes)) {
     return "Missing scenes array";
   }
-  // Validate scenes have a type field (don't enforce specific types — future-proof)
-  for (let i = 0; i < Math.min(replay.scenes.length, 5); i++) {
+  // Validate every scene has a type field (don't enforce specific types —
+  // future-proof). Checking only a prefix lets malformed later scenes crash
+  // the viewer and can leave an R2 object orphaned during metadata extraction.
+  for (let i = 0; i < replay.scenes.length; i++) {
     const scene = replay.scenes[i];
-    if (!scene || typeof scene.type !== "string") {
+    if (
+      !scene ||
+      typeof scene !== "object" ||
+      Array.isArray(scene) ||
+      typeof scene.type !== "string"
+    ) {
       return `Invalid scene at index ${i}: missing type`;
     }
   }
@@ -2163,7 +2258,13 @@ function validateReplaySchema(replay: any): string | null {
 function extractFirstUserPrompt(replay: any): string | null {
   const scenes = replay?.scenes;
   if (!Array.isArray(scenes)) return null;
-  const first = scenes.find((s: any) => s.type === "user-prompt");
+  const first = scenes.find(
+    (scene: unknown) =>
+      scene &&
+      typeof scene === "object" &&
+      !Array.isArray(scene) &&
+      (scene as { type?: unknown }).type === "user-prompt",
+  ) as { content?: unknown } | undefined;
   return first?.content ? String(first.content).slice(0, 300) : null;
 }
 
@@ -2350,9 +2451,14 @@ export default Sentry.withSentry(createSentryOptions, worker);
 // POST /api/replays — register or refresh a replay
 // ---------------------------------------------------------------------------
 
-async function handlePostReplay(c: { env: Env; req: { json: () => Promise<any> } }) {
+async function handlePostReplay(c: Context<HonoEnv>) {
   try {
-    const body = await c.req.json();
+    const parsedBody = await readJsonBody(c, MAX_LEGACY_REPLAY_BODY_BYTES);
+    if (!parsedBody.ok) return parsedBody.response;
+    const body = parsedBody.body;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return Response.json({ error: "Request body must be an object" }, { status: 400 });
+    }
 
     if (!body.gist_id || typeof body.gist_id !== "string") {
       return Response.json({ error: "gist_id required" }, { status: 400 });
@@ -2726,7 +2832,22 @@ function extractFirstMessage(json: string): string | null {
   return null;
 }
 
-function clamp(val: number | undefined, min: number, max: number): number {
-  const n = Number(val) || 0;
+function isValidCalendarDate(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (year < 1 || month < 1 || month > 12 || day < 1) return false;
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+  );
+}
+
+function boundedString(value: unknown, maxLength: number): string | null {
+  return typeof value === "string" && value.length > 0 ? value.slice(0, maxLength) : null;
+}
+
+function clamp(val: unknown, min: number, max: number): number {
+  const parsed = typeof val === "number" ? val : Number(val);
+  const n = Number.isFinite(parsed) ? parsed : min;
   return Math.max(min, Math.min(max, n));
 }

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -2836,7 +2836,10 @@ function isValidCalendarDate(value: unknown): value is string {
   if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
   const [year, month, day] = value.split("-").map(Number);
   if (year < 1 || month < 1 || month > 12 || day < 1) return false;
-  const date = new Date(Date.UTC(year, month - 1, day));
+  // Date.UTC remaps years 0000–0099 to 1900–1999. Set the full year after
+  // constructing the date so historical calendar dates round-trip correctly.
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
   return (
     date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
   );

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -576,6 +576,17 @@ describe("Cloud API integration", () => {
     });
   });
 
+  it("accepts calendar years below 100 without Date.UTC remapping", async () => {
+    const response = await dispatch("/api/insights/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ machineId: "machine-early", days: [{ date: "0001-01-01" }] }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ synced: 1 });
+  });
+
   it("preserves insight profile privacy config when updating metadata only", async () => {
     const create = await dispatch("/api/insights/profile", {
       method: "POST",

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -382,6 +382,61 @@ describe("Cloud API integration", () => {
     await expect(fileUpload.json()).resolves.toEqual({ error: "Invalid JSON body" });
   });
 
+  it("rejects JSON primitives where an object body is required", async () => {
+    const cloudReplay = await dispatch("/api/cloud-replays", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "null",
+    });
+    const fileUpload = await dispatch("/api/files", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "null",
+    });
+
+    expect(cloudReplay.status).toBe(400);
+    await expect(cloudReplay.json()).resolves.toEqual({
+      error: "Request body must be an object",
+    });
+    expect(fileUpload.status).toBe(400);
+    await expect(fileUpload.json()).resolves.toEqual({
+      error: "Request body must be an object",
+    });
+  });
+
+  it("rejects oversized JSON bodies before parsing them", async () => {
+    const response = await dispatch("/api/cloud-replays", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: " ".repeat(24 * 1024 * 1024 + 1),
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toEqual({ error: "Request body too large" });
+  });
+
+  it("rejects malformed scenes anywhere in an uploaded replay", async () => {
+    const replay = sampleReplay();
+    replay.scenes = [
+      ...replay.scenes,
+      { type: "text-response", content: "still valid" },
+      null as never,
+    ];
+    const response = await dispatch("/api/cloud-replays", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ replay }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Invalid scene at index 3: missing type",
+    });
+    expect((await env.REPLAY_BUCKET.list()).objects).toHaveLength(0);
+  });
+
   it("rejects unsafe browser login callbacks before starting OAuth", async () => {
     for (const callback of [
       "javascript:alert(1)",
@@ -498,6 +553,26 @@ describe("Cloud API integration", () => {
       models: { "claude-sonnet-4-5": 2 },
       sessionsPerDay: { "2026-05-01": 2 },
       topProjects: [{ project: "/repo", sessions: 2 }],
+    });
+  });
+
+  it("rejects malformed insight sync input instead of throwing", async () => {
+    const invalidMachine = await dispatch("/api/insights/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ machineId: 42, days: [{ date: "2026-05-01" }] }),
+    });
+    expect(invalidMachine.status).toBe(400);
+    await expect(invalidMachine.json()).resolves.toEqual({ error: "machineId required" });
+
+    const invalidDate = await dispatch("/api/insights/sync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ machineId: "machine-a", days: [{ date: "2026-02-30" }] }),
+    });
+    expect(invalidDate.status).toBe(400);
+    await expect(invalidDate.json()).resolves.toEqual({
+      error: "Each day must have a valid YYYY-MM-DD date",
     });
   });
 

--- a/packages/cli/src/server-origin.ts
+++ b/packages/cli/src/server-origin.ts
@@ -22,6 +22,16 @@ export function isSameOriginSettingsRequest(c: Context): boolean {
     !fetchSite || fetchSite === "same-origin" || fetchSite === "same-site" || fetchSite === "none";
   if (!fetchSiteAllowed) return false;
 
+  let apiOrigin: URL;
+  try {
+    apiOrigin = new URL(c.req.url);
+  } catch {
+    return false;
+  }
+  // A DNS-rebinding host can match its own Origin while still reaching the
+  // loopback listener. Only loopback request URLs are valid local API origins.
+  if (!isLoopbackHostname(apiOrigin.hostname)) return false;
+
   const trustedDevProxy =
     process.env.VIBE_REPLAY_DEV_MENU === "1" &&
     c.req.header("x-vibe-replay-dev-proxy") === "1" &&
@@ -29,7 +39,6 @@ export function isSameOriginSettingsRequest(c: Context): boolean {
   if (origin) {
     try {
       const requestOrigin = new URL(origin);
-      const apiOrigin = new URL(c.req.url);
       if (!equivalentLocalOrigin(requestOrigin, apiOrigin) && !trustedDevProxy) return false;
     } catch {
       return false;

--- a/packages/cli/src/server-origin.ts
+++ b/packages/cli/src/server-origin.ts
@@ -1,4 +1,4 @@
-import type { Context } from "hono";
+import type { Context, Hono } from "hono";
 
 function isLoopbackHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
@@ -36,4 +36,24 @@ export function isSameOriginSettingsRequest(c: Context): boolean {
     }
   }
   return true;
+}
+
+/**
+ * Protect every mutating local API route from cross-site requests.
+ *
+ * The dashboard server is intentionally unauthenticated and listens on
+ * loopback, so a malicious web page could otherwise issue CSRF requests to a
+ * known dashboard port and mutate or delete local replay data. Read-only GETs
+ * remain available to support the dashboard's normal loading flow.
+ */
+export function registerSameOriginMutationGuard(app: Hono): void {
+  app.use("/api/*", async (c, next) => {
+    const method = c.req.method;
+    const mutating =
+      method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
+    if (mutating && !isSameOriginSettingsRequest(c)) {
+      return c.json({ error: "API requests must be same-origin" }, 403);
+    }
+    return next();
+  });
 }

--- a/packages/cli/src/server-runtime.ts
+++ b/packages/cli/src/server-runtime.ts
@@ -92,7 +92,7 @@ import {
 import type { SessionInfo } from "./types.js";
 import { localDayKey, normalizeTitle } from "./utils.js";
 
-import { isSameOriginSettingsRequest } from "./server-origin.js";
+import { isSameOriginSettingsRequest, registerSameOriginMutationGuard } from "./server-origin.js";
 
 interface SourcesEnrichmentStatus {
   running: boolean;
@@ -977,6 +977,8 @@ export async function startServer(
   }
 
   const app = new Hono();
+
+  registerSameOriginMutationGuard(app);
 
   // Dashboard APIs are mutable scan snapshots. Prevent browser/proxy caching
   // from serving an earlier aggregate after a background scan completes.

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,4 +1,4 @@
-import { isSameOriginSettingsRequest } from "./server-origin.js";
+import { isSameOriginSettingsRequest, registerSameOriginMutationGuard } from "./server-origin.js";
 import { resolveDefaultAiSelection } from "./server-ai-selection.js";
 import { buildInsightsSyncBatches } from "./server-core.js";
 import {
@@ -40,6 +40,7 @@ export const __testables = {
   getStaleSourceProviders,
   findReplayForSource,
   isSameOriginSettingsRequest,
+  registerSameOriginMutationGuard,
   isFilesystemProjectKey,
   mergeSourceCatalogSessionUpdates,
   normalizeSessionProjectsForHome,

--- a/packages/cli/test/server-origin.test.ts
+++ b/packages/cli/test/server-origin.test.ts
@@ -5,10 +5,10 @@ import { __testables } from "../src/server.js";
 
 const API_URL = "http://127.0.0.1:13456/api/assistant/chat";
 
-function context(headers: Record<string, string>): Context {
+function context(headers: Record<string, string>, url = API_URL): Context {
   return {
     req: {
-      url: API_URL,
+      url,
       header(name: string) {
         return headers[name.toLowerCase()];
       },
@@ -76,6 +76,22 @@ describe("same-origin API protection", () => {
           origin: "https://attacker.example",
           "sec-fetch-site": "cross-site",
         }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a matching origin on a non-loopback rebinding host", () => {
+    delete process.env.VIBE_REPLAY_DEV_MENU;
+
+    expect(
+      __testables.isSameOriginSettingsRequest(
+        context(
+          {
+            origin: "http://rebound.example:13456",
+            "sec-fetch-site": "same-origin",
+          },
+          "http://rebound.example:13456/api/assistant/chat",
+        ),
       ),
     ).toBe(false);
   });

--- a/packages/cli/test/server-origin.test.ts
+++ b/packages/cli/test/server-origin.test.ts
@@ -1,3 +1,4 @@
+import { Hono } from "hono";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { __testables } from "../src/server.js";
@@ -101,5 +102,28 @@ describe("same-origin API protection", () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  it("blocks cross-origin mutations while allowing read-only requests", async () => {
+    const app = new Hono();
+    __testables.registerSameOriginMutationGuard(app);
+    app.get("/api/replay", (c) => c.json({ ok: true }));
+    app.post("/api/replay", (c) => c.json({ ok: true }));
+
+    const crossOrigin = {
+      Origin: "https://attacker.example",
+      "Sec-Fetch-Site": "cross-site",
+    };
+    const read = await app.request("http://127.0.0.1:13456/api/replay", {
+      headers: crossOrigin,
+    });
+    const write = await app.request("http://127.0.0.1:13456/api/replay", {
+      method: "POST",
+      headers: crossOrigin,
+    });
+
+    expect(read.status).toBe(200);
+    expect(write.status).toBe(403);
+    await expect(write.json()).resolves.toEqual({ error: "API requests must be same-origin" });
   });
 });

--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -510,13 +510,22 @@ function usageByModelFromDb(
 
   const byModel: Record<string, TokenUsage> = {};
   for (const row of rows) {
+    const model = row.model || "unknown";
     const usage: TokenUsage = {
       inputTokens: Number(row.input_tokens ?? 0),
       outputTokens: Number(row.output_tokens ?? 0),
       cacheCreationTokens: Number(row.cache_write_tokens ?? 0),
       cacheReadTokens: Number(row.cache_read_tokens ?? 0),
     };
-    byModel[row.model || "unknown"] = usage;
+    const existing = byModel[model];
+    if (!existing) {
+      byModel[model] = usage;
+      continue;
+    }
+    existing.inputTokens += usage.inputTokens;
+    existing.outputTokens += usage.outputTokens;
+    existing.cacheCreationTokens += usage.cacheCreationTokens;
+    existing.cacheReadTokens += usage.cacheReadTokens;
   }
   return byModel;
 }

--- a/packages/provider-hermes/test/parser.test.ts
+++ b/packages/provider-hermes/test/parser.test.ts
@@ -141,6 +141,45 @@ describe("hermes parser", () => {
     }
   });
 
+  it("sums duplicate per-model rows from separate billing dimensions", async () => {
+    const db = await buildHermesDb({
+      sessions: [baseSession],
+      messages: [
+        {
+          id: 1,
+          sessionId: baseSession.id,
+          role: "user",
+          content: "hello",
+          timestamp: 1_800_000_001,
+        },
+      ],
+      modelUsage: [
+        {
+          sessionId: baseSession.id,
+          model: baseSession.model,
+          inputTokens: 100,
+          outputTokens: 20,
+        },
+      ],
+    });
+    db.run(
+      `INSERT INTO session_model_usage (
+        session_id, model, billing_provider, input_tokens, output_tokens
+      ) VALUES (?, ?, ?, ?, ?)`,
+      [baseSession.id, baseSession.model, "fallback-provider", 40, 8],
+    );
+
+    try {
+      const result = parseSessionFromDb(db, baseSession.id);
+      expect(result.tokenUsageByModel?.[baseSession.model]).toMatchObject({
+        inputTokens: 140,
+        outputTokens: 28,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("prefers actual_cost_usd over estimated_cost_usd for reportedCostUsd", async () => {
     const db = await buildHermesDb({
       sessions: [baseSession],


### PR DESCRIPTION
## Summary

This quality pass closes five correctness, security, and resilience gaps found during a repository audit:

- Protect all mutating local dashboard API routes against cross-origin CSRF and DNS-rebinding requests while keeping read-only routes available.
- Bound Cloudflare JSON request bodies, including chunked requests without `Content-Length`, and reject non-object payloads safely.
- Validate every uploaded replay scene so malformed later scenes cannot break the viewer or leave orphaned R2 objects.
- Harden daily insight sync validation for machine IDs, calendar dates (including years before 100), duplicate dates, optional strings, and non-finite metrics.
- Aggregate Hermes per-model usage across billing/task dimensions instead of silently overwriting duplicate model rows.

## Validation

- `pnpm verify`
- `pnpm audit --prod --json`
- Targeted regression tests for local-origin protection, Cloudflare input handling, and Hermes aggregation

All repository tests, type checks, lint/format checks, Cloudflare tests, and builds pass.
