### PR TITLE
fix: exclude dev launcher from telemetry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,6 +284,7 @@ binding is present. Configure the production secret without committing the DSN:
 ```bash
 cd cloudflare
 pnpm exec wrangler secret put SENTRY_DSN
+pnpm exec wrangler secret put TELEMETRY_HASH_SECRET
 ```
 
 Cloudflare version metadata is used as the Sentry release ID, so each Worker
@@ -299,6 +300,24 @@ fixed, content-free log and counter for API requests, plus a fixed error log
 for unhandled requests. Product counters include `replay.views`,
 `replay.created`, `insights.sync`, and `auth.sign_in.success`; request bodies,
 URLs, IDs, and replay contents are not included.
+
+### CLI usage telemetry
+
+The CLI sends opt-out, anonymous usage events to the Cloudflare telemetry
+collector after a one-time notice. It reports only allowlisted feature names,
+CLI version, coarse platform, and bucketed counts/sizes/durations. It never
+sends prompts, replay/session contents, paths, project names, or user IDs.
+
+```bash
+vibe-replay telemetry status
+vibe-replay telemetry disable
+vibe-replay telemetry enable
+```
+
+Set `VIBE_REPLAY_TELEMETRY=0` or `DO_NOT_TRACK=1` to disable it for a process
+or environment. CI runs disable telemetry automatically. The collector keeps
+daily aggregates and month-rotated pseudonymous installation hashes, not raw
+installation IDs.
 
 ## Key conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ URLs, IDs, and replay contents are not included.
 
 ### CLI usage telemetry
 
-The CLI sends opt-out, anonymous usage events to the Cloudflare telemetry
+The CLI sends opt-out, pseudonymous usage events to the Cloudflare telemetry
 collector after a one-time notice. It reports only allowlisted feature names,
 CLI version, coarse platform, and bucketed counts/sizes/durations. It never
 sends prompts, replay/session contents, paths, project names, or user IDs.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/
 - **Generate HTML replays** — self-contained interactive replay files
 - **PR workflow integration** — agent automatically embeds replay context when you create PRs
 
-### Anonymous CLI telemetry
+### Pseudonymous CLI telemetry
 
-The CLI sends opt-out, anonymous feature counts and coarse scan-size buckets
+The CLI sends opt-out, pseudonymous feature counts and coarse scan-size buckets
 to improve the product. It never sends prompts, replay/session contents, paths,
 project names, or user IDs. Disable it with `vibe-replay telemetry disable`,
 `VIBE_REPLAY_TELEMETRY=0`, or `DO_NOT_TRACK=1`; CI runs disable it automatically.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ vibe-replay is also available as a [Claude Code plugin](https://code.claude.com/
 - **Generate HTML replays** — self-contained interactive replay files
 - **PR workflow integration** — agent automatically embeds replay context when you create PRs
 
+### Anonymous CLI telemetry
+
+The CLI sends opt-out, anonymous feature counts and coarse scan-size buckets
+to improve the product. It never sends prompts, replay/session contents, paths,
+project names, or user IDs. Disable it with `vibe-replay telemetry disable`,
+`VIBE_REPLAY_TELEMETRY=0`, or `DO_NOT_TRACK=1`; CI runs disable it automatically.
+
 ### Install (recommended)
 
 Open Claude Code, run `/plugin`, then search **vibe-replay** in the **Discover** tab and install.

--- a/cloudflare/drizzle/0010_ambitious_iron_monger.sql
+++ b/cloudflare/drizzle/0010_ambitious_iron_monger.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `telemetry_daily` (
+	`day` text NOT NULL,
+	`event` text NOT NULL,
+	`version` text NOT NULL,
+	`platform` text NOT NULL,
+	`dimensions` text DEFAULT '' NOT NULL,
+	`count` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_telemetry_daily_day` ON `telemetry_daily` (`day`);--> statement-breakpoint
+CREATE INDEX `idx_telemetry_daily_event` ON `telemetry_daily` (`event`,`day`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_telemetry_daily` ON `telemetry_daily` (`day`,`event`,`version`,`platform`,`dimensions`);--> statement-breakpoint
+CREATE TABLE `telemetry_monthly_users` (
+	`month` text NOT NULL,
+	`event` text NOT NULL,
+	`installation_hash` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_telemetry_monthly_event` ON `telemetry_monthly_users` (`event`,`month`);--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_telemetry_monthly_user` ON `telemetry_monthly_users` (`month`,`event`,`installation_hash`);

--- a/cloudflare/drizzle/meta/0010_snapshot.json
+++ b/cloudflare/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1277 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b559d3a5-9f18-47a4-b9dd-fd54a540a9a8",
+  "prevId": "c3febe8d-17be-4eec-acb7-259020e36c4e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local:oauth:github'"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            "issuer",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cloud_replays": {
+      "name": "cloud_replays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'r2'"
+        },
+        "gist_id": {
+          "name": "gist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_url": {
+          "name": "gist_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_owner": {
+          "name": "gist_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-code'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scene_count": {
+          "name": "scene_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_prompts": {
+          "name": "user_prompts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_estimate": {
+          "name": "cost_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unlisted'"
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cloud_replays_gist_id_unique": {
+          "name": "cloud_replays_gist_id_unique",
+          "columns": [
+            "gist_id"
+          ],
+          "isUnique": true
+        },
+        "idx_cloud_replays_user": {
+          "name": "idx_cloud_replays_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cloud_replays_expires": {
+          "name": "idx_cloud_replays_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_cloud_replays_gist": {
+          "name": "idx_cloud_replays_gist",
+          "columns": [
+            "gist_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cloud_replays_public": {
+          "name": "idx_cloud_replays_public",
+          "columns": [
+            "visibility",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cloud_replays_user_id_user_id_fk": {
+          "name": "cloud_replays_user_id_user_id_fk",
+          "tableFrom": "cloud_replays",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_insights": {
+      "name": "daily_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "machine_id": {
+          "name": "machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "machine_name": {
+          "name": "machine_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessions": {
+          "name": "sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "edits": {
+          "name": "edits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "projects": {
+          "name": "projects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "providers": {
+          "name": "providers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_daily_user": {
+          "name": "idx_daily_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_daily_date": {
+          "name": "idx_daily_date",
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_daily_machine": {
+          "name": "idx_daily_machine",
+          "columns": [
+            "user_id",
+            "machine_id"
+          ],
+          "isUnique": false
+        },
+        "uq_daily": {
+          "name": "uq_daily",
+          "columns": [
+            "user_id",
+            "machine_id",
+            "date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "daily_insights_user_id_user_id_fk": {
+          "name": "daily_insights_user_id_user_id_fk",
+          "tableFrom": "daily_insights",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "insight_profiles": {
+      "name": "insight_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "insight_profiles_user_id_unique": {
+          "name": "insight_profiles_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "insight_profiles_slug_unique": {
+          "name": "insight_profiles_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_insight_profiles_slug": {
+          "name": "idx_insight_profiles_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_insight_profiles_user": {
+          "name": "idx_insight_profiles_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "insight_profiles_user_id_user_id_fk": {
+          "name": "insight_profiles_user_id_user_id_fk",
+          "tableFrom": "insight_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replays": {
+      "name": "replays",
+      "columns": {
+        "gist_id": {
+          "name": "gist_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'claude-code'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scene_count": {
+          "name": "scene_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_prompts": {
+          "name": "user_prompts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_estimate": {
+          "name": "cost_estimate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_message": {
+          "name": "first_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gist_owner": {
+          "name": "gist_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_replays_created": {
+          "name": "idx_replays_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_replays_views": {
+          "name": "idx_replays_views",
+          "columns": [
+            "view_count"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_daily": {
+      "name": "telemetry_daily",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_telemetry_daily_day": {
+          "name": "idx_telemetry_daily_day",
+          "columns": [
+            "day"
+          ],
+          "isUnique": false
+        },
+        "idx_telemetry_daily_event": {
+          "name": "idx_telemetry_daily_event",
+          "columns": [
+            "event",
+            "day"
+          ],
+          "isUnique": false
+        },
+        "uq_telemetry_daily": {
+          "name": "uq_telemetry_daily",
+          "columns": [
+            "day",
+            "event",
+            "version",
+            "platform",
+            "dimensions"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "telemetry_monthly_users": {
+      "name": "telemetry_monthly_users",
+      "columns": {
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_hash": {
+          "name": "installation_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_telemetry_monthly_event": {
+          "name": "idx_telemetry_monthly_event",
+          "columns": [
+            "event",
+            "month"
+          ],
+          "isUnique": false
+        },
+        "uq_telemetry_monthly_user": {
+          "name": "uq_telemetry_monthly_user",
+          "columns": [
+            "month",
+            "event",
+            "installation_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_files": {
+      "name": "user_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unlisted'"
+        },
+        "parent_replay_id": {
+          "name": "parent_replay_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_files_user": {
+          "name": "idx_user_files_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_user_files_expires": {
+          "name": "idx_user_files_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_files_user_id_user_id_fk": {
+          "name": "user_files_user_id_user_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/cloudflare/drizzle/meta/_journal.json
+++ b/cloudflare/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788416961315,
       "tag": "0009_add_account_issuer",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1788541251491,
+      "tag": "0010_ambitious_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/cloudflare/src/db/schema.ts
+++ b/cloudflare/src/db/schema.ts
@@ -271,3 +271,40 @@ export const dailyInsights = sqliteTable(
     index("idx_daily_machine").on(table.userId, table.machineId),
   ],
 );
+
+// Anonymous CLI telemetry aggregates. Raw installation IDs are never stored.
+export const telemetryDaily = sqliteTable(
+  "telemetry_daily",
+  {
+    day: text("day").notNull(),
+    event: text("event").notNull(),
+    version: text("version").notNull(),
+    platform: text("platform").notNull(),
+    dimensions: text("dimensions").notNull().default(""),
+    count: integer("count").notNull().default(0),
+  },
+  (table) => [
+    unique("uq_telemetry_daily").on(
+      table.day,
+      table.event,
+      table.version,
+      table.platform,
+      table.dimensions,
+    ),
+    index("idx_telemetry_daily_day").on(table.day),
+    index("idx_telemetry_daily_event").on(table.event, table.day),
+  ],
+);
+
+export const telemetryMonthlyUsers = sqliteTable(
+  "telemetry_monthly_users",
+  {
+    month: text("month").notNull(),
+    event: text("event").notNull(),
+    installationHash: text("installation_hash").notNull(),
+  },
+  (table) => [
+    unique("uq_telemetry_monthly_user").on(table.month, table.event, table.installationHash),
+    index("idx_telemetry_monthly_event").on(table.event, table.month),
+  ],
+);

--- a/cloudflare/src/db/schema.ts
+++ b/cloudflare/src/db/schema.ts
@@ -272,7 +272,7 @@ export const dailyInsights = sqliteTable(
   ],
 );
 
-// Anonymous CLI telemetry aggregates. Raw installation IDs are never stored.
+// Pseudonymous CLI telemetry aggregates. Raw installation IDs are never stored.
 export const telemetryDaily = sqliteTable(
   "telemetry_daily",
   {

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -62,6 +62,31 @@ const TELEMETRY_PROPERTY_KEYS = new Set([
   "size",
   "storage",
 ]);
+const TELEMETRY_ALLOWED_VALUES: Record<string, Set<string>> = {
+  duration: new Set(["<1s", "1-9s", "10-59s", "1-4m", "5m+"]),
+  matches: new Set(["0", "1-9", "10-99", "100-999", "1k-9k", "10k+"]),
+  mode: new Set(["basic", "richer"]),
+  provider: new Set([
+    "claude-code",
+    "claude-cowork",
+    "claude-desktop",
+    "codex",
+    "cursor",
+    "grok-bot",
+    "hermes",
+    "opencode",
+    "pi",
+    "unknown",
+  ]),
+  scan: new Set(["basic", "richer"]),
+  scenes: new Set(["0", "1-9", "10-99", "100-999", "1k-9k", "10k+"]),
+  sessions: new Set(["0", "1-9", "10-99", "100-999", "1k-9k", "10k+"]),
+  size: new Set(["0", "<1mb", "1-9mb", "10-99mb", "100mb+"]),
+  storage: new Set(["r2", "gist", "legacy-gist"]),
+};
+const MAX_TELEMETRY_EVENTS_PER_DAY = 100_000;
+const MAX_TELEMETRY_EVENTS_PER_INSTALLATION = 1_000;
+const telemetryRateLimits = new Map<string, { day: string; count: number }>();
 
 // GitHub API constants — shared across user gist routes and worker-side fetches.
 const GITHUB_API_ACCEPT = "application/vnd.github+json";
@@ -122,7 +147,7 @@ function telemetryDimensions(value: unknown): string | null {
       ([key, item]) =>
         TELEMETRY_PROPERTY_KEYS.has(key) &&
         typeof item === "string" &&
-        /^[a-z0-9_.+-]{1,32}$/i.test(item),
+        TELEMETRY_ALLOWED_VALUES[key]?.has(item) === true,
     )
     .sort(([a], [b]) => a.localeCompare(b));
   if (entries.length > 8) return null;
@@ -149,6 +174,19 @@ async function hashTelemetryInstallation(
   return Array.from(new Uint8Array(signature))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
+}
+
+function allowTelemetryInstallation(day: string, installationHash: string): boolean {
+  const key = `${day}:${installationHash}`;
+  const previous = telemetryRateLimits.get(key);
+  if (!previous || previous.day !== day) {
+    if (telemetryRateLimits.size > 10_000) telemetryRateLimits.clear();
+    telemetryRateLimits.set(key, { day, count: 1 });
+    return true;
+  }
+  if (previous.count >= MAX_TELEMETRY_EVENTS_PER_INSTALLATION) return false;
+  previous.count += 1;
+  return true;
 }
 
 type JsonBodyResult = { ok: true; body: any } | { ok: false; response: Response };
@@ -266,7 +304,7 @@ app.post("/api/telemetry", async (c) => {
     typeof event !== "string" ||
     !TELEMETRY_EVENTS.has(event) ||
     typeof version !== "string" ||
-    !/^[a-z0-9+._-]{1,64}$/i.test(version) ||
+    !/^\d+\.\d+\.\d+(?:[-+][a-z0-9.-]+)?$/i.test(version) ||
     typeof platform !== "string" ||
     !TELEMETRY_PLATFORMS.has(platform)
   ) {
@@ -284,6 +322,13 @@ app.post("/api/telemetry", async (c) => {
     month,
     installationId,
   );
+  const dailyTotal = await c.env.DB.prepare(
+    "SELECT COALESCE(SUM(count), 0) AS count FROM telemetry_daily WHERE day = ?",
+  )
+    .bind(day)
+    .first<{ count: number }>();
+  if ((dailyTotal?.count || 0) >= MAX_TELEMETRY_EVENTS_PER_DAY) return c.body(null, 204);
+  if (!allowTelemetryInstallation(day, installationHash)) return c.body(null, 204);
 
   await c.env.DB.batch([
     c.env.DB.prepare(

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -34,10 +34,34 @@ const MAX_JSON_BODY_BYTES = 24 * 1024 * 1024;
 const MAX_INSIGHTS_SYNC_BODY_BYTES = 32 * 1024 * 1024;
 const MAX_FILE_UPLOAD_BODY_BYTES = 16 * 1024 * 1024;
 const MAX_LEGACY_REPLAY_BODY_BYTES = 64 * 1024;
+const MAX_TELEMETRY_BODY_BYTES = 8 * 1024;
 // D1 starts failing once the user+machine+dates lookup goes past ~100 bound params.
 // Reuse the same conservative chunk size for both query and write paths so older clients
 // that still send large sync payloads stay under the database ceiling server-side too.
 const SAFE_DAILY_SYNC_DB_CHUNK = 90;
+const TELEMETRY_EVENTS = new Set([
+  "cli.started",
+  "scan.completed",
+  "session.query",
+  "replay.generated",
+  "dashboard.opened",
+  "cloud.publish",
+  "insights.sync",
+  "auth.login",
+]);
+const TELEMETRY_PLATFORMS = new Set(["darwin", "win32", "linux", "other"]);
+const TELEMETRY_PROPERTY_KEYS = new Set([
+  "duration",
+  "matches",
+  "mode",
+  "platform",
+  "provider",
+  "scan",
+  "scenes",
+  "sessions",
+  "size",
+  "storage",
+]);
 
 // GitHub API constants — shared across user gist routes and worker-side fetches.
 const GITHUB_API_ACCEPT = "application/vnd.github+json";
@@ -77,6 +101,8 @@ type Env = AuthEnv & {
   TEST_AUTH_USER_NAME?: string;
   /** Sentry project DSN; absent in local/test environments disables reporting. */
   SENTRY_DSN?: string;
+  /** Secret used to pseudonymize local telemetry installation IDs. */
+  TELEMETRY_HASH_SECRET?: string;
   /** Cloudflare deployment version metadata used as the Sentry release ID. */
   CF_VERSION_METADATA?: { id: string };
 };
@@ -86,6 +112,43 @@ type HonoEnv = { Bindings: Env };
 function recordProductMetric(env: Env, name: string, attributes?: Record<string, string>): void {
   if (!env.SENTRY_DSN) return;
   Sentry.metrics.count(name, 1, attributes ? { attributes } : undefined);
+}
+
+function telemetryDimensions(value: unknown): string | null {
+  if (value === undefined) return "";
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value)
+    .filter(
+      ([key, item]) =>
+        TELEMETRY_PROPERTY_KEYS.has(key) &&
+        typeof item === "string" &&
+        /^[a-z0-9_.+-]{1,32}$/i.test(item),
+    )
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length > 8) return null;
+  return entries.map(([key, item]) => `${key}=${item}`).join(";");
+}
+
+async function hashTelemetryInstallation(
+  secret: string,
+  month: string,
+  installationId: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${month}:${installationId}`),
+  );
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 type JsonBodyResult = { ok: true; body: any } | { ok: false; response: Response };
@@ -181,6 +244,62 @@ app.use("/api/*", async (c, next) => {
   if (!c.env.SENTRY_DSN) return;
   Sentry.logger.info("Worker API request");
   Sentry.metrics.count("worker.api_requests", 1);
+});
+
+app.post("/api/telemetry", async (c) => {
+  if (!c.env.TELEMETRY_HASH_SECRET) return c.body(null, 204);
+
+  const parsedBody = await readJsonBody(c, MAX_TELEMETRY_BODY_BYTES);
+  if (!parsedBody.ok) return parsedBody.response;
+  const body = parsedBody.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return c.json({ error: "Invalid telemetry payload" }, 400);
+  }
+
+  const installationId = body.installationId;
+  const event = body.event;
+  const version = body.version;
+  const platform = body.platform;
+  if (
+    typeof installationId !== "string" ||
+    !/^[0-9a-f-]{16,64}$/i.test(installationId) ||
+    typeof event !== "string" ||
+    !TELEMETRY_EVENTS.has(event) ||
+    typeof version !== "string" ||
+    !/^[a-z0-9+._-]{1,64}$/i.test(version) ||
+    typeof platform !== "string" ||
+    !TELEMETRY_PLATFORMS.has(platform)
+  ) {
+    return c.json({ error: "Invalid telemetry payload" }, 400);
+  }
+
+  const dimensions = telemetryDimensions(body.properties);
+  if (dimensions === null) return c.json({ error: "Invalid telemetry properties" }, 400);
+
+  const now = new Date();
+  const day = now.toISOString().slice(0, 10);
+  const month = day.slice(0, 7);
+  const installationHash = await hashTelemetryInstallation(
+    c.env.TELEMETRY_HASH_SECRET,
+    month,
+    installationId,
+  );
+
+  await c.env.DB.batch([
+    c.env.DB.prepare(
+      `INSERT INTO telemetry_daily (day, event, version, platform, dimensions, count)
+       VALUES (?, ?, ?, ?, ?, 1)
+       ON CONFLICT(day, event, version, platform, dimensions)
+       DO UPDATE SET count = telemetry_daily.count + 1`,
+    ).bind(day, event, version, platform, dimensions),
+    c.env.DB.prepare(
+      `INSERT OR IGNORE INTO telemetry_monthly_users
+       (month, event, installation_hash)
+       VALUES (?, ?, ?)`,
+    ).bind(month, event, installationHash),
+  ]);
+
+  return c.body(null, 204);
 });
 
 // ---------------------------------------------------------------------------
@@ -2344,6 +2463,16 @@ const worker = {
   fetch: app.fetch,
 
   async scheduled(_controller: ScheduledController, env: Env) {
+    const telemetryRetentionDate = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    const telemetryDayCutoff = telemetryRetentionDate.toISOString().slice(0, 10);
+    const telemetryMonthCutoff = telemetryDayCutoff.slice(0, 7);
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM telemetry_daily WHERE day < ?").bind(telemetryDayCutoff),
+      env.DB.prepare("DELETE FROM telemetry_monthly_users WHERE month < ?").bind(
+        telemetryMonthCutoff,
+      ),
+    ]).catch(() => {});
+
     const db = drizzle(env.DB);
     const BATCH = 50;
     // R2 grace period: keep data 7 days after expiry for potential recovery.

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -211,7 +211,7 @@ describe("Cloud API integration", () => {
     expect(JSON.stringify(event)).not.toContain("sentinel");
   });
 
-  it("aggregates anonymous telemetry without storing installation IDs", async () => {
+  it("aggregates pseudonymous telemetry without storing installation IDs", async () => {
     const payload = {
       installationId: "123e4567-e89b-12d3-a456-426614174000",
       event: "scan.completed",

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -18,6 +18,7 @@ interface TestEnv {
   TEST_AUTH_USER_ID: string;
   TEST_AUTH_USER_EMAIL: string;
   TEST_AUTH_USER_NAME: string;
+  TELEMETRY_HASH_SECRET: string;
 }
 
 interface TestExecutionContext extends ExecutionContext {
@@ -67,6 +68,8 @@ async function resetDb() {
     "account",
     "session",
     "verification",
+    "telemetry_daily",
+    "telemetry_monthly_users",
     "replays",
     "user",
   ]) {
@@ -144,6 +147,7 @@ describe("Cloud API integration", () => {
         TEST_AUTH_USER_ID: TEST_USER_ID,
         TEST_AUTH_USER_EMAIL: "test@example.com",
         TEST_AUTH_USER_NAME: "Test User",
+        TELEMETRY_HASH_SECRET: "test-telemetry-secret",
       },
     });
     env = {
@@ -205,6 +209,57 @@ describe("Cloud API integration", () => {
     expect(event.request?.query_string).toBeUndefined();
     expect(event.request?.data).toBeUndefined();
     expect(JSON.stringify(event)).not.toContain("sentinel");
+  });
+
+  it("aggregates anonymous telemetry without storing installation IDs", async () => {
+    const payload = {
+      installationId: "123e4567-e89b-12d3-a456-426614174000",
+      event: "scan.completed",
+      version: "0.2.9",
+      platform: "darwin",
+      properties: { sessions: "10-99", duration: "1-9s" },
+    };
+
+    for (let i = 0; i < 2; i++) {
+      const response = await worker.fetch(
+        new Request("http://localhost/api/telemetry", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }),
+        env,
+        createCtx(),
+      );
+      expect(response.status).toBe(204);
+    }
+
+    const daily = await env.DB.prepare(
+      "SELECT event, version, platform, dimensions, count FROM telemetry_daily",
+    ).first<{
+      event: string;
+      version: string;
+      platform: string;
+      dimensions: string;
+      count: number;
+    }>();
+    expect(daily).toEqual({
+      event: "scan.completed",
+      version: "0.2.9",
+      platform: "darwin",
+      dimensions: "duration=1-9s;sessions=10-99",
+      count: 2,
+    });
+
+    const uniqueUsers = await env.DB.prepare(
+      "SELECT count(*) AS count FROM telemetry_monthly_users",
+    ).first<{ count: number }>();
+    expect(uniqueUsers?.count).toBe(1);
+    const rawId = await env.DB.prepare(
+      "SELECT * FROM telemetry_monthly_users WHERE installation_hash = ?",
+    )
+      .bind(payload.installationId)
+      .first();
+    expect(rawId).toBeNull();
   });
 
   it("keeps Better Auth account writes compatible with the issuer migration", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,6 +39,16 @@ import { getRemoteHome, hydrateCachedRemoteHomes } from "./remote.js";
 import { hasReplayableContent, replayOutputSlug } from "./server-core.js";
 import { startDashboard, startServer } from "./server.js";
 import { formatSessionQueryText, queryLocalSessions } from "./session-query.js";
+import {
+  bucketBytes,
+  bucketCount,
+  bucketDurationMs,
+  flushTelemetry,
+  getTelemetryNotice,
+  getTelemetryStatus,
+  recordTelemetry,
+  setTelemetryEnabled,
+} from "./telemetry.js";
 import { transformToReplay } from "./transform.js";
 import type { ParseWarning, ReplaySession, SessionInfo } from "./types.js";
 import { expandUserPath, normalizeTitle, shortenPath } from "./utils.js";
@@ -251,6 +261,13 @@ program
     "--github",
     "Generate GitHub export (markdown + animated GIF + SVG) and exit (non-interactive)",
   )
+  .hook("preAction", async (thisCommand, actionCommand) => {
+    const commandName = actionCommand?.name() || thisCommand.name();
+    if (commandName === "telemetry" || process.argv[2] === "telemetry") return;
+    const notice = await getTelemetryNotice();
+    if (notice) process.stderr.write(`\n  ${notice}\n\n`);
+    recordTelemetry("cli.started");
+  })
   .action(async (opts) => {
     console.log(chalk.bold.cyan("\n  vibe-replay") + chalk.dim(` v${CLI_VERSION}\n`));
 
@@ -389,8 +406,13 @@ program
       } else {
         const spinner = ora("Scanning sessions...").start();
         try {
+          const scanStartedAt = Date.now();
           displayedSessions = await discoverAllSessions();
           await writeFileCache(SESSION_DISCOVERY_CACHE_KEY, displayedSessions);
+          recordTelemetry("scan.completed", {
+            sessions: bucketCount(displayedSessions.length),
+            duration: bucketDurationMs(Date.now() - scanStartedAt),
+          });
         } finally {
           spinner.stop();
         }
@@ -589,8 +611,14 @@ program
     const genSpinner = ora("Generating replay...").start();
     const outputPath = await generateOutput(replay, outputDir);
     const { stat: fsStat } = await import("node:fs/promises");
-    const size = await fsStat(outputPath).then((s) => (s.size / 1024 / 1024).toFixed(1));
+    const outputSizeBytes = await fsStat(outputPath).then((s) => s.size);
+    const size = (outputSizeBytes / 1024 / 1024).toFixed(1);
     genSpinner.succeed(`${outputPath} (${size} MB)`);
+    recordTelemetry("replay.generated", {
+      provider: providerName,
+      scenes: bucketCount(replay.scenes.length),
+      size: bucketBytes(outputSizeBytes),
+    });
 
     // Second-layer leak detection: scan the serialized replay for secrets
     const scanSpinner = ora("Scanning for secrets...").start();
@@ -717,6 +745,7 @@ program
           try {
             const result = await publishCloudWithOverlays(outputDir);
             cloudSpinner.succeed("Uploaded!");
+            recordTelemetry("cloud.publish", { storage: "r2" });
             console.log(chalk.dim("  Share URL: ") + chalk.cyan(result.url));
             console.log(
               chalk.dim("  Expires:   ") +
@@ -768,6 +797,7 @@ program
                 overwrite: overwriteGist,
               });
               gistSpinner.succeed(result.mode === "updated" ? "Gist updated!" : "Published!");
+              recordTelemetry("cloud.publish", { storage: "gist" });
               console.log(chalk.dim("  Gist:   ") + chalk.white(result.gistUrl));
               console.log(chalk.dim("  Viewer: ") + chalk.cyan(result.viewerUrl));
             } catch (err: unknown) {
@@ -848,6 +878,10 @@ program
         opts.scan && !opts.json ? ora("Scanning matching sessions...").start() : undefined;
       const matches = await queryLocalSessions(sessions, queryOptions);
       scanSpinner?.succeed(`Prepared ${matches.length} session result(s)`);
+      recordTelemetry("session.query", {
+        matches: bucketCount(matches.length),
+        scan: opts.scan ? "richer" : "basic",
+      });
 
       if (opts.json) {
         console.log(JSON.stringify({ sessions: matches }, null, 2));
@@ -1255,7 +1289,33 @@ program
       ?.parseAsync(["login", ...process.argv.slice(3)], { from: "user" });
   });
 
-program.parse();
+const telemetryCmd = program.command("telemetry").description("Manage anonymous usage telemetry");
+
+const showTelemetryStatus = async () => {
+  const status = await getTelemetryStatus();
+  console.log(`Telemetry: ${status.enabled ? "enabled" : "disabled"} (${status.source})`);
+  console.log("  No replay contents, prompts, paths, or user IDs are sent.");
+};
+
+telemetryCmd.action(showTelemetryStatus);
+telemetryCmd.command("status").description("Show telemetry status").action(showTelemetryStatus);
+telemetryCmd
+  .command("enable")
+  .description("Enable anonymous usage telemetry")
+  .action(async () => {
+    await setTelemetryEnabled(true);
+    console.log("Anonymous telemetry enabled.");
+  });
+telemetryCmd
+  .command("disable")
+  .description("Disable anonymous usage telemetry")
+  .action(async () => {
+    await setTelemetryEnabled(false);
+    console.log("Anonymous telemetry disabled.");
+  });
+
+await program.parseAsync();
+await flushTelemetry();
 
 function normalizeSessionsCommandOptions(
   opts: SessionsCommandOptions,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1289,7 +1289,9 @@ program
       ?.parseAsync(["login", ...process.argv.slice(3)], { from: "user" });
   });
 
-const telemetryCmd = program.command("telemetry").description("Manage anonymous usage telemetry");
+const telemetryCmd = program
+  .command("telemetry")
+  .description("Manage pseudonymous usage telemetry");
 
 const showTelemetryStatus = async () => {
   const status = await getTelemetryStatus();
@@ -1301,17 +1303,17 @@ telemetryCmd.action(showTelemetryStatus);
 telemetryCmd.command("status").description("Show telemetry status").action(showTelemetryStatus);
 telemetryCmd
   .command("enable")
-  .description("Enable anonymous usage telemetry")
+  .description("Enable pseudonymous usage telemetry")
   .action(async () => {
     await setTelemetryEnabled(true);
-    console.log("Anonymous telemetry enabled.");
+    console.log("Pseudonymous telemetry enabled.");
   });
 telemetryCmd
   .command("disable")
-  .description("Disable anonymous usage telemetry")
+  .description("Disable pseudonymous usage telemetry")
   .action(async () => {
     await setTelemetryEnabled(false);
-    console.log("Anonymous telemetry disabled.");
+    console.log("Pseudonymous telemetry disabled.");
   });
 
 await program.parseAsync();

--- a/packages/cli/src/server-routes/auth.ts
+++ b/packages/cli/src/server-routes/auth.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono";
 import { saveAuthToken } from "../publishers/cloud.js";
 import type { AuthSession } from "../server-auth.js";
+import { recordTelemetry } from "../telemetry.js";
 
 interface AuthRouteDeps {
   cloudApiBaseUrl: string;
@@ -109,6 +110,7 @@ export function registerAuthRoutes(app: Hono, deps: AuthRouteDeps): void {
 
               // Save auth keyed by current API environment
               await saveAuthToken({ token: data.token, user: data.user }, cloudApiBaseUrl);
+              recordTelemetry("auth.login");
 
               // Auto-sync insights to cloud after login (fire-and-forget)
               autoSyncInsights().catch(() => {});

--- a/packages/cli/src/server-routes/insights.ts
+++ b/packages/cli/src/server-routes/insights.ts
@@ -15,6 +15,7 @@ import { buildUsageCoverageReport } from "../usage-coverage.js";
 import { enrichmentHintsFromBody } from "../server-enrichment.js";
 import { safeTargetId } from "../server-core.js";
 import type { ReplaySummary } from "../server-types.js";
+import { recordTelemetry } from "../telemetry.js";
 
 interface InsightsCache {
   userInsights: ReturnType<typeof aggregateUserInsights> | null;
@@ -229,8 +230,10 @@ export function registerInsightsRoutes(app: Hono, deps: InsightsRouteDeps): void
       });
     }
     if (result.total === 0) {
+      recordTelemetry("insights.sync");
       return c.json({ synced: 0, message: "All insights already synced" });
     }
+    recordTelemetry("insights.sync");
     return c.json({
       synced: result.synced,
       total: result.total,

--- a/packages/cli/src/server-runtime.ts
+++ b/packages/cli/src/server-runtime.ts
@@ -18,6 +18,7 @@ import { discoverProvidersSafely, type SafeProviderDiscoveryResult } from "./pro
 import { getApiUrl } from "./publishers/cloud.js";
 import { mergeSameSessions } from "./session-merge.js";
 import { getRemoteHome } from "./remote.js";
+import { recordTelemetry } from "./telemetry.js";
 import {
   type EnrichmentHints,
   mergeEnrichmentHints,
@@ -121,6 +122,7 @@ export async function startServer(
   },
 ): Promise<void> {
   await mkdir(baseDir, { recursive: true });
+  recordTelemetry("dashboard.opened");
 
   const isDevMode = !!opts?.externalViewerUrl;
   // In dev mode, Vite serves the viewer with HMR — no need to load/cache viewer HTML

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { CLI_VERSION } from "./version.js";
+
+export const TELEMETRY_EVENTS = [
+  "cli.started",
+  "scan.completed",
+  "session.query",
+  "replay.generated",
+  "dashboard.opened",
+  "cloud.publish",
+  "insights.sync",
+  "auth.login",
+] as const;
+
+export type TelemetryEventName = (typeof TELEMETRY_EVENTS)[number];
+
+export interface TelemetryStatus {
+  enabled: boolean;
+  configured: boolean;
+  source: "default" | "config" | "environment" | "ci";
+}
+
+interface TelemetryState {
+  version: 1;
+  installationId: string;
+  enabled: boolean;
+  notified: boolean;
+  createdAt: string;
+}
+
+const TELEMETRY_ENDPOINT_PATH = "/api/telemetry";
+const TELEMETRY_TIMEOUT_MS = 500;
+const pendingRequests = new Set<Promise<void>>();
+let telemetryStatePromise: Promise<TelemetryState> | undefined;
+let telemetryStatePath: string | undefined;
+
+function telemetryFilePath(): string {
+  return (
+    process.env.VIBE_REPLAY_TELEMETRY_FILE || join(homedir(), ".vibe-replay", "telemetry.json")
+  );
+}
+
+function telemetryDisabledByEnvironment(): boolean {
+  return (
+    process.env.VIBE_REPLAY_TELEMETRY === "0" ||
+    process.env.DO_NOT_TRACK === "1" ||
+    process.env.CI === "true" ||
+    process.env.CI === "1"
+  );
+}
+
+function telemetryForcedOnByEnvironment(): boolean {
+  return process.env.VIBE_REPLAY_TELEMETRY === "1";
+}
+
+function getApiOrigin(): string {
+  return (process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com").replace(/\/$/, "");
+}
+
+async function readTelemetryState(): Promise<TelemetryState | null> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(telemetryFilePath(), "utf8"),
+    ) as Partial<TelemetryState>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.installationId !== "string" ||
+      !/^[0-9a-f-]{36}$/i.test(parsed.installationId)
+    ) {
+      return null;
+    }
+    return {
+      version: 1,
+      installationId: parsed.installationId,
+      enabled: parsed.enabled !== false,
+      notified: parsed.notified === true,
+      createdAt: typeof parsed.createdAt === "string" ? parsed.createdAt : new Date().toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function writeTelemetryState(state: TelemetryState): Promise<void> {
+  const path = telemetryFilePath();
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const tempPath = `${path}.${process.pid}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(tempPath, 0o600);
+  await rename(tempPath, path);
+}
+
+async function ensureTelemetryState(): Promise<TelemetryState> {
+  const path = telemetryFilePath();
+  if (telemetryStatePath !== path) {
+    telemetryStatePath = path;
+    telemetryStatePromise = undefined;
+  }
+  telemetryStatePromise ??= (async () => {
+    const existing = await readTelemetryState();
+    if (existing) return existing;
+    const state: TelemetryState = {
+      version: 1,
+      installationId: randomUUID(),
+      enabled: true,
+      notified: false,
+      createdAt: new Date().toISOString(),
+    };
+    await writeTelemetryState(state);
+    return state;
+  })();
+  return telemetryStatePromise;
+}
+
+function effectiveTelemetryStatus(state: TelemetryState | null): TelemetryStatus {
+  if (telemetryDisabledByEnvironment()) {
+    return {
+      enabled: false,
+      configured: state !== null,
+      source: process.env.CI ? "ci" : "environment",
+    };
+  }
+  if (telemetryForcedOnByEnvironment()) {
+    return { enabled: true, configured: state !== null, source: "environment" };
+  }
+  if (state) return { enabled: state.enabled, configured: true, source: "config" };
+  return { enabled: true, configured: false, source: "default" };
+}
+
+export async function getTelemetryStatus(): Promise<TelemetryStatus> {
+  return effectiveTelemetryStatus(await readTelemetryState());
+}
+
+export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
+  const state = await ensureTelemetryState();
+  const nextState = { ...state, enabled, notified: true };
+  await writeTelemetryState(nextState);
+  telemetryStatePromise = Promise.resolve(nextState);
+}
+
+/** Returns the one-time notice for default-on telemetry, if it has not been shown. */
+export async function getTelemetryNotice(): Promise<string | null> {
+  if (telemetryDisabledByEnvironment() || telemetryForcedOnByEnvironment()) return null;
+  const state = await ensureTelemetryState();
+  if (state.notified) return null;
+  const nextState = { ...state, notified: true };
+  await writeTelemetryState(nextState);
+  telemetryStatePromise = Promise.resolve(nextState);
+  return (
+    "vibe-replay collects anonymous feature counts and coarse scan-size buckets " +
+    "to improve the CLI. It never sends replay content, prompts, paths, or IDs. " +
+    "Disable with `vibe-replay telemetry disable`."
+  );
+}
+
+function sanitizeProperties(
+  properties?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!properties) return undefined;
+  const entries = Object.entries(properties)
+    .filter(
+      ([key, value]) =>
+        /^[a-z][a-z0-9_]{0,31}$/.test(key) &&
+        typeof value === "string" &&
+        /^[a-z0-9_.-]{1,32}$/i.test(value),
+    )
+    .slice(0, 8);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function telemetryPlatform(): "darwin" | "win32" | "linux" | "other" {
+  if (process.platform === "darwin") return "darwin";
+  if (process.platform === "win32") return "win32";
+  if (process.platform === "linux") return "linux";
+  return "other";
+}
+
+async function sendTelemetry(
+  event: TelemetryEventName,
+  properties?: Record<string, string>,
+): Promise<void> {
+  if (telemetryDisabledByEnvironment()) return;
+  const state = await ensureTelemetryState();
+  if (!effectiveTelemetryStatus(state).enabled) return;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+  try {
+    await fetch(`${getApiOrigin()}${TELEMETRY_ENDPOINT_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        installationId: state.installationId,
+        event,
+        version: CLI_VERSION,
+        platform: telemetryPlatform(),
+        properties: sanitizeProperties(properties),
+      }),
+      signal: controller.signal,
+    });
+  } catch {
+    // Telemetry is strictly best-effort and must never affect the CLI.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function recordTelemetry(
+  event: TelemetryEventName,
+  properties?: Record<string, string>,
+): void {
+  const request = sendTelemetry(event, properties);
+  pendingRequests.add(request);
+  void request.finally(() => pendingRequests.delete(request));
+}
+
+export async function flushTelemetry(timeoutMs = TELEMETRY_TIMEOUT_MS): Promise<void> {
+  if (pendingRequests.size === 0) return;
+  await Promise.race([
+    Promise.allSettled(pendingRequests),
+    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
+}
+
+export function bucketCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value < 10) return "1-9";
+  if (value < 100) return "10-99";
+  if (value < 1_000) return "100-999";
+  if (value < 10_000) return "1k-9k";
+  return "10k+";
+}
+
+export function bucketBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value < 1024 * 1024) return "<1mb";
+  if (value < 10 * 1024 * 1024) return "1-9mb";
+  if (value < 100 * 1024 * 1024) return "10-99mb";
+  return "100mb+";
+}
+
+export function bucketDurationMs(value: number): string {
+  if (!Number.isFinite(value) || value < 1_000) return "<1s";
+  if (value < 10_000) return "1-9s";
+  if (value < 60_000) return "10-59s";
+  if (value < 300_000) return "1-4m";
+  return "5m+";
+}

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -20,7 +20,7 @@ export type TelemetryEventName = (typeof TELEMETRY_EVENTS)[number];
 export interface TelemetryStatus {
   enabled: boolean;
   configured: boolean;
-  source: "default" | "config" | "environment" | "ci";
+  source: "default" | "config" | "environment" | "ci" | "development";
 }
 
 interface TelemetryState {
@@ -47,6 +47,8 @@ function telemetryDisabledByEnvironment(): boolean {
   return (
     process.env.VIBE_REPLAY_TELEMETRY === "0" ||
     process.env.DO_NOT_TRACK === "1" ||
+    process.env.VIBE_REPLAY_DEV === "1" ||
+    process.env.VIBE_REPLAY_DEV_MENU === "1" ||
     process.env.CI === "true" ||
     process.env.CI === "1"
   );
@@ -128,7 +130,11 @@ function effectiveTelemetryStatus(state: TelemetryState | null): TelemetryStatus
     return {
       enabled: false,
       configured: state !== null,
-      source: process.env.CI ? "ci" : "environment",
+      source: process.env.CI
+        ? "ci"
+        : process.env.VIBE_REPLAY_DEV || process.env.VIBE_REPLAY_DEV_MENU
+          ? "development"
+          : "environment",
     };
   }
   if (telemetryForcedOnByEnvironment()) {

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -57,7 +57,12 @@ function telemetryForcedOnByEnvironment(): boolean {
 }
 
 function getApiOrigin(): string {
-  return (process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com").replace(/\/$/, "");
+  try {
+    const url = new URL(process.env.VIBE_REPLAY_API_URL || "https://vibe-replay.com");
+    return url.protocol === "https:" ? url.origin : "";
+  } catch {
+    return "";
+  }
 }
 
 async function readTelemetryState(): Promise<TelemetryState | null> {
@@ -147,13 +152,17 @@ export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
 /** Returns the one-time notice for default-on telemetry, if it has not been shown. */
 export async function getTelemetryNotice(): Promise<string | null> {
   if (telemetryDisabledByEnvironment() || telemetryForcedOnByEnvironment()) return null;
-  const state = await ensureTelemetryState();
-  if (state.notified) return null;
-  const nextState = { ...state, notified: true };
-  await writeTelemetryState(nextState);
-  telemetryStatePromise = Promise.resolve(nextState);
+  try {
+    const state = await ensureTelemetryState();
+    if (state.notified) return null;
+    const nextState = { ...state, notified: true };
+    await writeTelemetryState(nextState);
+    telemetryStatePromise = Promise.resolve(nextState);
+  } catch {
+    return null;
+  }
   return (
-    "vibe-replay collects anonymous feature counts and coarse scan-size buckets " +
+    "vibe-replay collects pseudonymous feature counts and coarse scan-size buckets " +
     "to improve the CLI. It never sends replay content, prompts, paths, or IDs. " +
     "Disable with `vibe-replay telemetry disable`."
   );
@@ -181,33 +190,42 @@ function telemetryPlatform(): "darwin" | "win32" | "linux" | "other" {
   return "other";
 }
 
+function monthlyInstallationToken(installationId: string): string {
+  const month = new Date().toISOString().slice(0, 7);
+  return createHash("sha256").update(`${month}:${installationId}`).digest("hex");
+}
+
 async function sendTelemetry(
   event: TelemetryEventName,
   properties?: Record<string, string>,
 ): Promise<void> {
   if (telemetryDisabledByEnvironment()) return;
-  const state = await ensureTelemetryState();
-  if (!effectiveTelemetryStatus(state).enabled) return;
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
   try {
-    await fetch(`${getApiOrigin()}${TELEMETRY_ENDPOINT_PATH}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        installationId: state.installationId,
-        event,
-        version: CLI_VERSION,
-        platform: telemetryPlatform(),
-        properties: sanitizeProperties(properties),
-      }),
-      signal: controller.signal,
-    });
+    const origin = getApiOrigin();
+    if (!origin) return;
+    const state = await ensureTelemetryState();
+    if (!effectiveTelemetryStatus(state).enabled) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+    try {
+      await fetch(`${origin}${TELEMETRY_ENDPOINT_PATH}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          installationId: monthlyInstallationToken(state.installationId),
+          event,
+          version: CLI_VERSION,
+          platform: telemetryPlatform(),
+          properties: sanitizeProperties(properties),
+        }),
+        signal: controller.signal,
+        redirect: "error",
+      });
+    } finally {
+      clearTimeout(timer);
+    }
   } catch {
     // Telemetry is strictly best-effort and must never affect the CLI.
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -217,15 +235,22 @@ export function recordTelemetry(
 ): void {
   const request = sendTelemetry(event, properties);
   pendingRequests.add(request);
-  void request.finally(() => pendingRequests.delete(request));
+  void request.finally(() => pendingRequests.delete(request)).catch(() => {});
 }
 
 export async function flushTelemetry(timeoutMs = TELEMETRY_TIMEOUT_MS): Promise<void> {
   if (pendingRequests.size === 0) return;
-  await Promise.race([
-    Promise.allSettled(pendingRequests),
-    new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.allSettled(pendingRequests),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function bucketCount(value: number): string {

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -77,6 +77,13 @@ describe("local telemetry", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("does not send from the pnpm dev launcher", async () => {
+    process.env.VIBE_REPLAY_DEV_MENU = "1";
+    recordTelemetry("cli.started");
+    await flushTelemetry();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("does not send telemetry to a non-HTTPS collector", async () => {
     process.env.VIBE_REPLAY_API_URL = "http://collector.example";
     recordTelemetry("cli.started");

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -37,7 +37,7 @@ describe("local telemetry", () => {
 
   it("defaults on, shows one notice, and supports disable/enable", async () => {
     expect((await getTelemetryStatus()).enabled).toBe(true);
-    expect(await getTelemetryNotice()).toContain("anonymous feature counts");
+    expect(await getTelemetryNotice()).toContain("pseudonymous feature counts");
     expect(await getTelemetryNotice()).toBeNull();
 
     await setTelemetryEnabled(false);
@@ -60,17 +60,25 @@ describe("local telemetry", () => {
     expect(payload.event).toBe("scan.completed");
     expect(payload.version).toBeTruthy();
     expect(payload.platform).toBeTruthy();
-    expect(payload.installationId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(payload.installationId).toMatch(/^[0-9a-f]{64}$/i);
     expect(payload.properties).toEqual({ sessions: "10-99", duration: "1-9s" });
     expect(JSON.stringify(payload)).not.toContain("prompt");
     expect(JSON.stringify(payload)).not.toContain("replay");
 
     const state = JSON.parse(await readFile(process.env.VIBE_REPLAY_TELEMETRY_FILE!, "utf8"));
-    expect(state.installationId).toBe(payload.installationId);
+    expect(state.installationId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(payload.installationId).not.toBe(state.installationId);
   });
 
   it("does not send when explicitly disabled", async () => {
     await setTelemetryEnabled(false);
+    recordTelemetry("cli.started");
+    await flushTelemetry();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not send telemetry to a non-HTTPS collector", async () => {
+    process.env.VIBE_REPLAY_API_URL = "http://collector.example";
     recordTelemetry("cli.started");
     await flushTelemetry();
     expect(fetch).not.toHaveBeenCalled();

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  flushTelemetry,
+  getTelemetryNotice,
+  getTelemetryStatus,
+  recordTelemetry,
+  setTelemetryEnabled,
+} from "../src/telemetry.js";
+
+describe("local telemetry", () => {
+  let stateDir: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(join(tmpdir(), "vibe-replay-telemetry-"));
+    process.env.VIBE_REPLAY_TELEMETRY_FILE = join(stateDir, "telemetry.json");
+    delete process.env.VIBE_REPLAY_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+    delete process.env.CI;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("defaults on, shows one notice, and supports disable/enable", async () => {
+    expect((await getTelemetryStatus()).enabled).toBe(true);
+    expect(await getTelemetryNotice()).toContain("anonymous feature counts");
+    expect(await getTelemetryNotice()).toBeNull();
+
+    await setTelemetryEnabled(false);
+    expect((await getTelemetryStatus()).enabled).toBe(false);
+    await setTelemetryEnabled(true);
+    expect((await getTelemetryStatus()).enabled).toBe(true);
+  });
+
+  it("sends only the allowlisted event envelope", async () => {
+    recordTelemetry("scan.completed", {
+      sessions: "10-99",
+      duration: "1-9s",
+    });
+    await flushTelemetry();
+
+    const fetchMock = vi.mocked(fetch);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const payload = JSON.parse(String(request.body)) as Record<string, unknown>;
+    expect(payload.event).toBe("scan.completed");
+    expect(payload.version).toBeTruthy();
+    expect(payload.platform).toBeTruthy();
+    expect(payload.installationId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(payload.properties).toEqual({ sessions: "10-99", duration: "1-9s" });
+    expect(JSON.stringify(payload)).not.toContain("prompt");
+    expect(JSON.stringify(payload)).not.toContain("replay");
+
+    const state = JSON.parse(await readFile(process.env.VIBE_REPLAY_TELEMETRY_FILE!, "utf8"));
+    expect(state.installationId).toBe(payload.installationId);
+  });
+
+  it("does not send when explicitly disabled", async () => {
+    await setTelemetryEnabled(false);
+    recordTelemetry("cli.started");
+    await flushTelemetry();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Exclude `pnpm dev` and `pnpm dev:dashboard` via `VIBE_REPLAY_DEV_MENU=1`.
- Also honor `VIBE_REPLAY_DEV=1`.
- Add regression coverage so development runs cannot send telemetry.

The production collector and local CLI telemetry implementation were merged in PR #556; this is the follow-up safety fix requested for dev-data pollution.

## Verification

- CLI telemetry tests: 5 passed
- Full CLI tests: 553 passed, 4 skipped
- Cloudflare tests: 20 passed
- TypeScript and lint checks

## Deployment

No Worker deployment is needed; this changes only the local CLI package.