### PR TITLE
fix: exclude dev launcher from telemetry

### DIFF
--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -20,7 +20,7 @@ export type TelemetryEventName = (typeof TELEMETRY_EVENTS)[number];
 export interface TelemetryStatus {
   enabled: boolean;
   configured: boolean;
-  source: "default" | "config" | "environment" | "ci";
+  source: "default" | "config" | "environment" | "ci" | "development";
 }
 
 interface TelemetryState {
@@ -47,6 +47,8 @@ function telemetryDisabledByEnvironment(): boolean {
   return (
     process.env.VIBE_REPLAY_TELEMETRY === "0" ||
     process.env.DO_NOT_TRACK === "1" ||
+    process.env.VIBE_REPLAY_DEV === "1" ||
+    process.env.VIBE_REPLAY_DEV_MENU === "1" ||
     process.env.CI === "true" ||
     process.env.CI === "1"
   );
@@ -128,7 +130,11 @@ function effectiveTelemetryStatus(state: TelemetryState | null): TelemetryStatus
     return {
       enabled: false,
       configured: state !== null,
-      source: process.env.CI ? "ci" : "environment",
+      source: process.env.CI
+        ? "ci"
+        : process.env.VIBE_REPLAY_DEV || process.env.VIBE_REPLAY_DEV_MENU
+          ? "development"
+          : "environment",
     };
   }
   if (telemetryForcedOnByEnvironment()) {

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -132,7 +132,7 @@ function effectiveTelemetryStatus(state: TelemetryState | null): TelemetryStatus
       configured: state !== null,
       source: process.env.CI
         ? "ci"
-        : process.env.VIBE_REPLAY_DEV || process.env.VIBE_REPLAY_DEV_MENU
+        : process.env.VIBE_REPLAY_DEV === "1" || process.env.VIBE_REPLAY_DEV_MENU === "1"
           ? "development"
           : "environment",
     };

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -77,6 +77,13 @@ describe("local telemetry", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("does not send from the pnpm dev launcher", async () => {
+    process.env.VIBE_REPLAY_DEV_MENU = "1";
+    recordTelemetry("cli.started");
+    await flushTelemetry();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("does not send telemetry to a non-HTTPS collector", async () => {
     process.env.VIBE_REPLAY_API_URL = "http://collector.example";
     recordTelemetry("cli.started");


### PR DESCRIPTION
## Summary

- Exclude `pnpm dev` and `pnpm dev:dashboard` via `VIBE_REPLAY_DEV_MENU=1`.
- Also honor `VIBE_REPLAY_DEV=1`.
- Add regression coverage so development runs cannot send telemetry.

This is the clean follow-up to the merged local telemetry implementation.

## Verification

- Telemetry tests: 5 passed
- `pnpm lint:check`

## Deployment

No Worker deployment is needed; this changes only the local CLI package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Privacy**
  - Telemetry is disabled when development mode or the development menu is enabled.
  - Telemetry status now identifies development-mode disabling separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->