### PR TITLE
fix: harden replay loading and compatibility

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -113,6 +113,16 @@ function isSafeCallbackPath(value: string): boolean {
   return value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\");
 }
 
+/** Escape JSON values before embedding them in an inline script expression. */
+function jsonForInlineScript(value: unknown): string {
+  return (JSON.stringify(value) ?? "null")
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 type Env = AuthEnv & {
   ASSETS: Fetcher;
   REPLAY_BUCKET: R2Bucket;
@@ -462,9 +472,9 @@ app.get("/auth/success", async (c) => {
   if (session) {
     recordProductMetric(c.env, "auth.sign_in.success");
   }
-  const userJson = session?.user
-    ? JSON.stringify({ name: session.user.name, image: session.user.image })
-    : "null";
+  const userJson = jsonForInlineScript(
+    session?.user ? { name: session.user.name, image: session.user.image } : null,
+  );
   // Get session token from cookie to pass back to opener
   const cookies = c.req.raw.headers.get("cookie") || "";
   const tokenMatch = cookies.match(/(?:__Secure-)?better-auth\.session_token=([^;]+)/);
@@ -474,8 +484,9 @@ app.get("/auth/success", async (c) => {
   const dev = isDev(c.env);
   const trustedOpenerOrigins = [...PROD_ORIGINS];
   if (dev) trustedOpenerOrigins.push(...DEV_ORIGINS);
-  const originsJson = JSON.stringify(trustedOpenerOrigins);
+  const originsJson = jsonForInlineScript(trustedOpenerOrigins);
 
+  c.header("Cache-Control", "no-store");
   return c.html(`<!DOCTYPE html>
 <html><head><title>vibe-replay - Logged in</title>
 <style>
@@ -497,7 +508,7 @@ body{background:#0a0a0f;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFo
 </div>
 <script>
 // Post auth result to opener — try each trusted origin (mismatches are silently ignored)
-if(window.opener){var msg={type:'vibe-replay-auth',user:${userJson},token:${JSON.stringify(token)}};${originsJson}.forEach(function(o){try{window.opener.postMessage(msg,o);}catch(e){}});}
+if(window.opener){var msg={type:'vibe-replay-auth',user:${userJson},token:${jsonForInlineScript(token)}};${originsJson}.forEach(function(o){try{window.opener.postMessage(msg,o);}catch(e){}});}
 var s=3;
 var cd=document.getElementById('cd');
 cd.textContent='Auto-closing in '+s+'s...';

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -311,7 +311,7 @@ describe("Cloud API integration", () => {
           JSON.stringify({
             id: 424242,
             login: "demo-user",
-            name: "Demo User",
+            name: '</script><script>alert("profile-name")</script>',
             email: "github-test-user",
             avatar_url: "https://avatars.example/demo",
           }),
@@ -346,6 +346,19 @@ describe("Cloud API integration", () => {
         .map((cookie) => cookie.split(";", 1)[0])
         .find((cookie) => cookie.startsWith("better-auth.session_token="));
       expect(sessionCookie).toMatch(/^better-auth\.session_token=/);
+
+      const success = await worker.fetch(
+        new Request("http://localhost/auth/success", {
+          headers: { Cookie: sessionCookie! },
+        }),
+        env,
+        createCtx(),
+      );
+      expect(success.status).toBe(200);
+      expect(success.headers.get("cache-control")).toBe("no-store");
+      const successHtml = await success.text();
+      expect(successHtml).toContain("\\u003c/script\\u003e\\u003cscript");
+      expect(successHtml).not.toContain('</script><script>alert("profile-name")');
 
       const authenticatedApi = await worker.fetch(
         new Request("http://localhost/api/cloud-replays", {

--- a/packages/provider-hermes/src/hermes/parser.ts
+++ b/packages/provider-hermes/src/hermes/parser.ts
@@ -89,6 +89,14 @@ function firstValue(db: Database, sql: string, params: Record<string, any> = {})
   return rows[0] ?? null;
 }
 
+function hasColumn(db: Database, table: string, column: string): boolean {
+  try {
+    return rowValues(db, `PRAGMA table_info(${table})`).some((row) => row.name === column);
+  } catch {
+    return false;
+  }
+}
+
 export async function parseHermesSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
@@ -203,11 +211,12 @@ export function parseSessionFromDb(
     sid: sessionId,
   }) as HermesSessionRow | null;
 
+  const compactedColumn = hasColumn(db, "messages", "compacted") ? "compacted" : "0 AS compacted";
   const messages = rowValues(
     db,
     `
       SELECT id, role, content, tool_call_id, tool_calls, tool_name, timestamp,
-             finish_reason, reasoning_content, compacted
+             finish_reason, reasoning_content, ${compactedColumn}
       FROM messages
       WHERE session_id = ?
       ORDER BY timestamp ASC, id ASC
@@ -496,16 +505,23 @@ function usageByModelFromDb(
   db: Database,
   sessionId: string,
 ): Record<string, TokenUsage> | undefined {
-  const rows = rowValues(
-    db,
-    `
-      SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
-             reasoning_tokens
-      FROM session_model_usage
-      WHERE session_id = ?
-    `,
-    { sid: sessionId },
-  ) as HermesModelUsageRow[];
+  let rows: HermesModelUsageRow[];
+  try {
+    rows = rowValues(
+      db,
+      `
+        SELECT model, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+               reasoning_tokens
+        FROM session_model_usage
+        WHERE session_id = ?
+      `,
+      { sid: sessionId },
+    ) as HermesModelUsageRow[];
+  } catch {
+    // Per-model billing was added after the original Hermes schema. The
+    // session-level counters remain authoritative when this table is absent.
+    return undefined;
+  }
   if (rows.length === 0) return undefined;
 
   const byModel: Record<string, TokenUsage> = {};

--- a/packages/provider-hermes/test/parser.test.ts
+++ b/packages/provider-hermes/test/parser.test.ts
@@ -92,6 +92,36 @@ describe("hermes parser", () => {
     }
   });
 
+  it("parses older databases without optional compaction and model-usage schema", async () => {
+    const db = await buildHermesDb({
+      sessions: [baseSession],
+      messages: [
+        {
+          id: 1,
+          sessionId: baseSession.id,
+          role: "user",
+          content: "Parse this legacy database",
+          timestamp: 1_800_000_001,
+        },
+      ],
+    });
+    db.run("ALTER TABLE messages DROP COLUMN compacted");
+    db.run("DROP TABLE session_model_usage");
+
+    try {
+      const result = parseSessionFromDb(db, baseSession.id);
+      expect(result.turns).toHaveLength(1);
+      expect(result.turns[0]?.blocks[0]).toMatchObject({
+        type: "text",
+        text: "Parse this legacy database",
+      });
+      expect(result.compactions).toBeUndefined();
+      expect(result.tokenUsageByModel).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
   it("aggregates token usage from session and per-model rows", async () => {
     const db = await buildHermesDb({
       sessions: [

--- a/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useSessionLoader.test.tsx
@@ -149,6 +149,31 @@ describe("useSessionLoader", () => {
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/session?slug=my-slug"));
   });
 
+  it("does not let a stale session response overwrite a newer navigation", async () => {
+    win.__VIBE_REPLAY_EDITOR__ = true;
+    setSearch("?session=slow-session");
+    let resolveSlow!: (session: ReplaySession) => void;
+    const slowJson = new Promise<ReplaySession>((resolve) => {
+      resolveSlow = resolve;
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => slowJson,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useSessionLoader());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    setSearch("?view=dashboard");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await waitFor(() => expect(result.current.status).toBe("dashboard"));
+
+    resolveSlow(fakeSession);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.current.status).toBe("dashboard");
+  });
+
   it("ignores ?live when an explicit ?session is present in editor mode (stale URL guard)", async () => {
     win.__VIBE_REPLAY_EDITOR__ = true;
     // ?live=1&provider=claude-code&sessionId=abc would normally start SSE,

--- a/packages/viewer/src/hooks/useSessionLoader.ts
+++ b/packages/viewer/src/hooks/useSessionLoader.ts
@@ -86,6 +86,7 @@ interface LoadResult {
 export function useSessionLoader(): LoadState {
   const [state, setState] = useState<LoadState>({ status: "loading" });
   const liveSourceRef = useRef<EventSource | null>(null);
+  const loadGenerationRef = useRef(0);
 
   const closeLive = useCallback(() => {
     if (liveSourceRef.current) {
@@ -95,6 +96,7 @@ export function useSessionLoader(): LoadState {
   }, []);
 
   const load = useCallback(() => {
+    const generation = ++loadGenerationRef.current;
     closeLive();
     setState({ status: "loading" });
 
@@ -107,6 +109,7 @@ export function useSessionLoader(): LoadState {
 
     loadSession().then(
       (result) => {
+        if (loadGenerationRef.current !== generation) return;
         if (result === "dashboard") {
           setState({ status: "dashboard" });
         } else {
@@ -118,7 +121,10 @@ export function useSessionLoader(): LoadState {
           });
         }
       },
-      (err) => setState({ status: "error", message: String(err.message || err) }),
+      (err) => {
+        if (loadGenerationRef.current !== generation) return;
+        setState({ status: "error", message: String(err.message || err) });
+      },
     );
   }, [closeLive]);
 


### PR DESCRIPTION
## Summary
- Ignore stale viewer session loads after a newer navigation.
- Keep Hermes parsing compatible with older databases without optional compaction/model-usage schema.
- Escape OAuth profile data before inline-script embedding and prevent caching the token-bearing success page.

## Validation
- `pnpm verify`
- Includes 20 Cloudflare tests, 426 viewer tests, and 38 Hermes tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Privacy**
  - Auth success pages now safely escape user-provided content and prevent browser caching of session details.

- **Bug Fixes**
  - Older Hermes databases without optional schema elements can now be read successfully.
  - Slow session requests no longer overwrite newer dashboard navigation state.

- **Tests**
  - Added coverage for secure auth-page rendering, legacy database compatibility, and stale session-load responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->