### PR TITLE
fix: harden live replay and local privacy paths

### DIFF
--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -2906,6 +2906,7 @@ async function fetchGistMeta(
   if (!gistResp.ok) return null;
 
   const gistData = (await gistResp.json()) as {
+    public?: boolean;
     owner?: { login?: string };
     files?: Record<
       string,
@@ -2918,6 +2919,7 @@ async function fetchGistMeta(
       }
     >;
   };
+  if (gistData.public !== true) return null;
 
   const jsonFile = Object.values(gistData.files || {}).find((f) => f.filename?.endsWith(".json"));
   if (!jsonFile) return null;

--- a/cloudflare/test/cloud-api.test.ts
+++ b/cloudflare/test/cloud-api.test.ts
@@ -422,6 +422,42 @@ describe("Cloud API integration", () => {
     expect(await env.REPLAY_BUCKET.get(`replays/${uploaded.id}.json`)).toBeNull();
   });
 
+  it("does not register secret gists in the public legacy replay index", async () => {
+    const gistId = "a".repeat(20);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          public: false,
+          owner: { login: "demo-user" },
+          files: {
+            "replay.json": {
+              filename: "replay.json",
+              content: JSON.stringify(sampleReplay()),
+            },
+          },
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    try {
+      const response = await dispatch("/api/replays", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gist_id: gistId }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "not a valid vibe-replay gist" });
+      const row = await env.DB.prepare("SELECT gist_id FROM replays WHERE gist_id = ?")
+        .bind(gistId)
+        .first();
+      expect(row).toBeNull();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("rejects malformed JSON bodies with 400 responses", async () => {
     const uploaded = await uploadReplay();
     const invalidJson = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { getAllProviders, getProvider } from "./providers/index.js";
 import {
   DEFAULT_API_URL,
   getAuthFilePath,
+  isAllowedApiUrl,
   loadAuthToken,
   publishCloudWithOverlays,
   removeAuthTokenSync,
@@ -916,13 +917,9 @@ authCmd
     const crypto = await import("node:crypto");
     const apiUrl = opts.apiUrl.replace(/\/$/, "");
 
-    // Only allow official domain or localhost to prevent phishing via crafted --api-url
-    const parsed = new URL(apiUrl);
-    if (
-      parsed.hostname !== "vibe-replay.com" &&
-      parsed.hostname !== "localhost" &&
-      parsed.hostname !== "127.0.0.1"
-    ) {
+    // Only allow official HTTPS or loopback URLs to prevent phishing and
+    // plaintext token transport via crafted --api-url values.
+    if (!isAllowedApiUrl(apiUrl)) {
       console.error(chalk.red(`\n  ✗ Untrusted API URL: ${apiUrl}`));
       console.error(chalk.dim("  Only https://vibe-replay.com and localhost are allowed.\n"));
       process.exit(1);

--- a/packages/cli/src/publishers/cloud.ts
+++ b/packages/cli/src/publishers/cloud.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import {
@@ -13,6 +13,18 @@ const CLOUD_META_FILE = ".vibe-replay-cloud.json";
 export const DEFAULT_API_URL = "https://vibe-replay.com";
 const AUTH_DIR = join(homedir(), ".config", "vibe-replay");
 const AUTH_FILE = join(AUTH_DIR, "auth.json");
+
+/** Allow production HTTPS and local development HTTP API origins only. */
+export function isAllowedApiUrl(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl);
+    const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+    const loopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+    return loopback || (hostname === "vibe-replay.com" && url.protocol === "https:");
+  } catch {
+    return false;
+  }
+}
 
 export interface CloudResult {
   id: string;
@@ -67,11 +79,15 @@ function readAuthStore(): AuthStore {
 function writeAuthStoreSync(store: AuthStore): void {
   mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
   writeFileSync(AUTH_FILE, JSON.stringify(store, null, 2), { mode: 0o600 });
+  chmodSync(AUTH_DIR, 0o700);
+  chmodSync(AUTH_FILE, 0o600);
 }
 
 async function writeAuthStoreAsync(store: AuthStore): Promise<void> {
   await mkdir(AUTH_DIR, { recursive: true, mode: 0o700 });
   await writeFile(AUTH_FILE, JSON.stringify(store, null, 2), { mode: 0o600 });
+  await chmod(AUTH_DIR, 0o700);
+  await chmod(AUTH_FILE, 0o600);
 }
 
 /** Load auth token for the given API URL (defaults to current VIBE_REPLAY_API_URL) */

--- a/packages/cli/src/server-origin.ts
+++ b/packages/cli/src/server-origin.ts
@@ -47,8 +47,18 @@ export function isSameOriginSettingsRequest(c: Context): boolean {
   return true;
 }
 
+/** Reject requests whose Host header has been replaced by DNS rebinding. */
+export function isLoopbackApiRequest(c: Context): boolean {
+  try {
+    return isLoopbackHostname(new URL(c.req.url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Protect every mutating local API route from cross-site requests.
+ * Protect every local API route from DNS rebinding and mutating routes from
+ * cross-site requests.
  *
  * The dashboard server is intentionally unauthenticated and listens on
  * loopback, so a malicious web page could otherwise issue CSRF requests to a
@@ -57,6 +67,9 @@ export function isSameOriginSettingsRequest(c: Context): boolean {
  */
 export function registerSameOriginMutationGuard(app: Hono): void {
   app.use("/api/*", async (c, next) => {
+    if (!isLoopbackApiRequest(c)) {
+      return c.json({ error: "API requests must target loopback" }, 403);
+    }
     const method = c.req.method;
     const mutating =
       method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";

--- a/packages/cli/src/server-routes/live.ts
+++ b/packages/cli/src/server-routes/live.ts
@@ -7,6 +7,7 @@ import { streamSSE } from "hono/streaming";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import { parseClaudeCodeLines } from "../providers/claude-code/parser.js";
 import { parseCodexLines } from "../providers/codex/parser.js";
+import { parseGrokBotLines } from "../providers/grok-bot/parser.js";
 import { parsePiLines } from "../providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
@@ -20,6 +21,24 @@ import type { SessionInfo } from "../types.js";
 import { CLI_VERSION } from "../version.js";
 
 type LiveSessionState = "busy" | "idle" | "stopped" | "unknown";
+
+export async function parseJsonlLiveSession(
+  providerName: string,
+  lines: string[],
+  sessionInfo: SessionInfo,
+  paths: string[],
+) {
+  if (providerName === "claude-code") {
+    return parseClaudeCodeLines(lines, { subagentsSourcePath: paths[0] });
+  }
+  if (providerName === "codex") {
+    return parseCodexLines(lines, sessionInfo, paths);
+  }
+  if (providerName === "grok-bot") {
+    return parseGrokBotLines(lines, { sourcePath: paths[0], sessionInfo });
+  }
+  return parsePiLines(lines, { sourcePath: paths[0], sessionInfo });
+}
 
 async function readClaudeSessionState(sessionId: string): Promise<LiveSessionState> {
   const sessionsDir = join(homedir(), ".claude", "sessions");
@@ -250,11 +269,7 @@ export function registerLiveRoutes(app: Hono): void {
               const lines = await tailReadJsonl(fp);
               allLines.push(...lines);
             }
-            parsed = isClaudeProvider
-              ? await parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] })
-              : isCodexProvider
-                ? parseCodexLines(allLines, info, paths)
-                : parsePiLines(allLines, { sourcePath: paths[0], sessionInfo: info });
+            parsed = await parseJsonlLiveSession(providerName, allLines, info, paths);
           } else {
             parsed = await provider.parse(paths, info);
           }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,4 +1,8 @@
-import { isSameOriginSettingsRequest, registerSameOriginMutationGuard } from "./server-origin.js";
+import {
+  isLoopbackApiRequest,
+  isSameOriginSettingsRequest,
+  registerSameOriginMutationGuard,
+} from "./server-origin.js";
 import { resolveDefaultAiSelection } from "./server-ai-selection.js";
 import { buildInsightsSyncBatches } from "./server-core.js";
 import {
@@ -39,6 +43,7 @@ export const __testables = {
   countSessionStats,
   getStaleSourceProviders,
   findReplayForSource,
+  isLoopbackApiRequest,
   isSameOriginSettingsRequest,
   registerSameOriginMutationGuard,
   isFilesystemProjectKey,

--- a/packages/cli/test/cloud-publisher.test.ts
+++ b/packages/cli/test/cloud-publisher.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,8 +10,13 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => mockAuthDir };
 });
 
-const { loadAuthToken, loadSavedCloudInfo, publishCloudWithOverlays } =
-  await import("../src/publishers/cloud.js");
+const {
+  isAllowedApiUrl,
+  loadAuthToken,
+  loadSavedCloudInfo,
+  publishCloudWithOverlays,
+  saveAuthTokenSync,
+} = await import("../src/publishers/cloud.js");
 
 describe("cloud publisher", () => {
   beforeEach(() => {
@@ -129,6 +134,32 @@ describe("cloud publisher", () => {
       expect(auth).toBeNull();
     });
   });
+
+  it("requires HTTPS for production auth while allowing loopback development", () => {
+    expect(isAllowedApiUrl("https://vibe-replay.com")).toBe(true);
+    expect(isAllowedApiUrl("http://vibe-replay.com")).toBe(false);
+    expect(isAllowedApiUrl("http://localhost:8787")).toBe(true);
+    expect(isAllowedApiUrl("http://127.0.0.1:8787")).toBe(true);
+    expect(isAllowedApiUrl("https://vibe-replay.com.evil.example")).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "tightens permissions on an existing auth file and directory",
+    () => {
+      const authDir = join(mockAuthDir, ".config", "vibe-replay");
+      const authPath = join(authDir, "auth.json");
+      chmodSync(authDir, 0o755);
+      writeFileSync(authPath, "{}", { mode: 0o644 });
+
+      saveAuthTokenSync({
+        token: "session-token",
+        user: { id: "u1", name: "Test User" },
+      });
+
+      expect(statSync(authDir).mode & 0o777).toBe(0o700);
+      expect(statSync(authPath).mode & 0o777).toBe(0o600);
+    },
+  );
 
   describe("loadSavedCloudInfo", () => {
     it("returns undefined when no cloud meta file exists", async () => {

--- a/packages/cli/test/live.test.ts
+++ b/packages/cli/test/live.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonlLiveSession } from "../src/server-routes/live.js";
+import type { SessionInfo } from "../src/types.js";
+
+const sessionInfo: SessionInfo = {
+  provider: "grok-bot",
+  sessionId: "grok-live-session",
+  slug: "grok-live-session",
+  project: "~/grok-bot",
+  cwd: "~/grok-bot",
+  version: "1",
+  timestamp: "2026-01-01T00:00:00.000Z",
+  lineCount: 0,
+  fileSize: 0,
+  filePath: "session.jsonl",
+  filePaths: ["session.jsonl"],
+  firstPrompt: "hello",
+};
+
+describe("live JSONL parsing", () => {
+  it("uses the Grok Bot parser for Grok live sessions", async () => {
+    const parsed = await parseJsonlLiveSession(
+      "grok-bot",
+      [
+        JSON.stringify({
+          role: "user",
+          message: { content: [{ type: "text", text: "[t0u] hello" }] },
+        }),
+        JSON.stringify({
+          role: "assistant",
+          message: {
+            content: [{ type: "tool_use", name: "send_message", input: { text: "hi there" } }],
+          },
+        }),
+      ],
+      sessionInfo,
+      ["session.jsonl"],
+    );
+
+    expect(parsed.turns).toHaveLength(2);
+    expect(parsed.turns[0]?.blocks[0]).toEqual({ type: "text", text: "hello" });
+    expect(parsed.turns[1]?.blocks[0]).toEqual({ type: "text", text: "hi there" });
+  });
+});

--- a/packages/cli/test/server-origin.test.ts
+++ b/packages/cli/test/server-origin.test.ts
@@ -142,4 +142,17 @@ describe("same-origin API protection", () => {
     expect(write.status).toBe(403);
     await expect(write.json()).resolves.toEqual({ error: "API requests must be same-origin" });
   });
+
+  it("rejects API reads addressed through a DNS-rebinding host", async () => {
+    const app = new Hono();
+    __testables.registerSameOriginMutationGuard(app);
+    app.get("/api/replay", (c) => c.json({ ok: true }));
+
+    const response = await app.request("http://rebound.example:13456/api/replay");
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "API requests must target loopback",
+    });
+  });
 });

--- a/packages/replay-core/src/transform.ts
+++ b/packages/replay-core/src/transform.ts
@@ -38,6 +38,10 @@ function redactFilePath(s: string): string {
   return process.platform === "win32" ? redacted.replaceAll("\\", "/") : redacted;
 }
 
+function redactSubAgentDescription(description: string): string {
+  return redactSecrets(redactPath(description));
+}
+
 function replaceRemoteHomeInText(value: string, remoteHome: string): string {
   const home = remoteHome.replace(/\/+$/, "");
   if (!home) return value;
@@ -265,7 +269,7 @@ export function transformToReplay(
             parentComposerId: sa.parentComposerId,
             toolCallId: sa.toolCallId,
             agentType: sa.agentType,
-            description: sa.description,
+            ...(sa.description ? { description: redactSubAgentDescription(sa.description) } : {}),
             prompt: redactSecrets(redactPath(sa.prompt || "")),
             toolCalls: sa.toolCalls,
             thinkingBlocks: sa.thinkingBlocks,
@@ -281,7 +285,9 @@ export function transformToReplay(
             syntheticSubAgentSummary.push({
               agentId: minimal.agentId,
               agentType: minimal.agentType,
-              description: minimal.description,
+              ...(minimal.description
+                ? { description: redactSubAgentDescription(minimal.description) }
+                : {}),
               toolCalls: minimal.toolCalls,
               model: minimal.model,
             });
@@ -359,7 +365,14 @@ export function transformToReplay(
       ...(parsed.prLinks && parsed.prLinks.length > 0 ? { prLinks: parsed.prLinks } : {}),
       compactions: parsed.compactions,
       ...(parsed.subAgentSummary && parsed.subAgentSummary.length > 0
-        ? { subAgentSummary: parsed.subAgentSummary }
+        ? {
+            subAgentSummary: parsed.subAgentSummary.map((summary) => ({
+              ...summary,
+              ...(summary.description
+                ? { description: redactSubAgentDescription(summary.description) }
+                : {}),
+            })),
+          }
         : syntheticSubAgentSummary.length > 0
           ? { subAgentSummary: syntheticSubAgentSummary }
           : {}),
@@ -400,7 +413,15 @@ export function transformToReplay(
       ...(parsed.mcpServersUsed ? { mcpServersUsed: parsed.mcpServersUsed } : {}),
       ...(parsed.truncatedResponses ? { truncatedResponses: parsed.truncatedResponses } : {}),
       ...(parsed.agentName ? { agentName: parsed.agentName } : {}),
-      ...(parsed.worktree ? { worktree: parsed.worktree } : {}),
+      ...(parsed.worktree
+        ? {
+            worktree: {
+              ...(parsed.worktree.name ? { name: parsed.worktree.name } : {}),
+              ...(parsed.worktree.path ? { path: redactFilePath(parsed.worktree.path) } : {}),
+              ...(parsed.worktree.branch ? { branch: parsed.worktree.branch } : {}),
+            },
+          }
+        : {}),
       ...(parsed.queueOperationStats ? { queueOperationStats: parsed.queueOperationStats } : {}),
     },
     scenes,

--- a/packages/replay-core/test/transform-security.test.ts
+++ b/packages/replay-core/test/transform-security.test.ts
@@ -274,6 +274,53 @@ describe("path redaction", () => {
     expect(replay.meta.cwd).toBe("~/my-workspace");
   });
 
+  it("redacts local worktree paths and subagent descriptions", () => {
+    const parsed = makeParsed(
+      [
+        {
+          role: "assistant",
+          blocks: [
+            {
+              type: "tool_use",
+              id: "agent-1",
+              name: "Agent",
+              input: {},
+              _subAgent: {
+                agentId: "agent-1",
+                agentType: "Explore",
+                description: `Inspect ${HOME}/child-worktree`,
+                prompt: "Inspect the project",
+                toolCalls: 0,
+                thinkingBlocks: 0,
+                textResponses: 0,
+                scenes: [],
+              },
+            },
+          ],
+        },
+      ],
+      {
+        worktree: { path: `${HOME}/worktrees/feature`, branch: "feature" },
+        subAgentSummary: [
+          {
+            agentId: "agent-1",
+            agentType: "Explore",
+            description: `Inspect ${HOME}/child-worktree`,
+            toolCalls: 0,
+          },
+        ],
+      },
+    );
+
+    const replay = transform(parsed);
+    const agentScene = replay.scenes.find((scene) => scene.type === "tool-call") as ToolCallScene;
+
+    expect(replay.meta.worktree?.path).toBe("~/worktrees/feature");
+    expect(agentScene.subAgent?.description).not.toContain(HOME);
+    expect(agentScene.subAgent?.description).toContain("~/child-worktree");
+    expect(replay.meta.subAgentSummary?.[0]?.description).toContain("~/child-worktree");
+  });
+
   it("redacts remote paths only in known path fields", () => {
     const remoteHome = "/remote/home";
     const parsed = makeParsed(

--- a/packages/viewer/src/utils/__tests__/replay-schema.test.ts
+++ b/packages/viewer/src/utils/__tests__/replay-schema.test.ts
@@ -32,4 +32,18 @@ describe("parseReplaySession", () => {
       "unsupported scene at index 0",
     );
   });
+
+  it("rejects scenes missing renderer-required fields", () => {
+    expect(() => parseReplaySession(replay({ scenes: [{ type: "user-prompt" }] }))).toThrow(
+      "missing string content",
+    );
+    expect(() =>
+      parseReplaySession(replay({ scenes: [{ type: "tool-call", toolName: "Read" }] })),
+    ).toThrow("missing tool input");
+    expect(() =>
+      parseReplaySession(
+        replay({ scenes: [{ type: "tool-call", toolName: "Read", input: {}, result: 42 }] }),
+      ),
+    ).toThrow("missing tool result");
+  });
 });

--- a/packages/viewer/src/utils/replaySchema.ts
+++ b/packages/viewer/src/utils/replaySchema.ts
@@ -9,6 +9,49 @@ const SCENE_TYPES = new Set([
   "tool-call",
 ]);
 
+const CONTENT_SCENE_TYPES = new Set([
+  "user-prompt",
+  "compaction-summary",
+  "context-injection",
+  "thinking",
+  "text-response",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function validateScene(scene: unknown, index: number): void {
+  if (!isRecord(scene) || typeof scene.type !== "string" || !SCENE_TYPES.has(scene.type)) {
+    throw new Error(`Invalid replay: unsupported scene at index ${index}`);
+  }
+
+  if (CONTENT_SCENE_TYPES.has(scene.type) && typeof scene.content !== "string") {
+    throw new Error(`Invalid replay: scene ${index} is missing string content`);
+  }
+  if (scene.type === "user-prompt" && scene.images !== undefined) {
+    if (!Array.isArray(scene.images) || scene.images.some((image) => typeof image !== "string")) {
+      throw new Error(`Invalid replay: scene ${index} has invalid images`);
+    }
+  }
+  if (scene.type === "context-injection" && scene.injectionType !== undefined) {
+    if (typeof scene.injectionType !== "string") {
+      throw new Error(`Invalid replay: scene ${index} has invalid injectionType`);
+    }
+  }
+  if (scene.type === "tool-call") {
+    if (typeof scene.toolName !== "string") {
+      throw new Error(`Invalid replay: scene ${index} is missing toolName`);
+    }
+    if (!isRecord(scene.input)) {
+      throw new Error(`Invalid replay: scene ${index} is missing tool input`);
+    }
+    if (typeof scene.result !== "string") {
+      throw new Error(`Invalid replay: scene ${index} is missing tool result`);
+    }
+  }
+}
+
 /** Validate replay identity, scene envelopes, and forward schema compatibility. */
 export function parseReplaySession(value: unknown): ReplaySession {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -42,16 +85,7 @@ export function parseReplaySession(value: unknown): ReplaySession {
     throw new Error("Invalid replay: missing scenes array");
   }
   for (let index = 0; index < replay.scenes.length; index++) {
-    const scene = replay.scenes[index];
-    if (
-      !scene ||
-      typeof scene !== "object" ||
-      Array.isArray(scene) ||
-      typeof (scene as { type?: unknown }).type !== "string" ||
-      !SCENE_TYPES.has((scene as { type: string }).type)
-    ) {
-      throw new Error(`Invalid replay: unsupported scene at index ${index}`);
-    }
+    validateScene(replay.scenes[index], index);
   }
   return value as ReplaySession;
 }


### PR DESCRIPTION
## Summary
- Use the Grok Bot parser for Grok live sessions.
- Redact local worktree paths and subagent descriptions in replay metadata.
- Reject malformed scenes before viewer rendering and block DNS-rebinding API reads.
- Keep secret gists out of the legacy public index.
- Require HTTPS for production auth URLs and repair auth-store permissions on write.

## Validation
- `pnpm verify`
- Full unit, Cloudflare, build, and lint checks passed.
