### PR TITLE
fix(codex): keep world_state metadata-only and JSONL order

### DIFF
--- a/packages/provider-codex/src/codex/discover.ts
+++ b/packages/provider-codex/src/codex/discover.ts
@@ -227,7 +227,8 @@ export async function extractCodexSessionInfo(
         obj.type === "turn_context" ||
         obj.type === "event_msg" ||
         obj.type === "response_item" ||
-        obj.type === "compacted"
+        obj.type === "compacted" ||
+        obj.type === "world_state"
       ) {
         sawKnownRecord = true;
       }
@@ -262,6 +263,15 @@ export async function extractCodexSessionInfo(
       if (obj.type === "turn_context") {
         const p = obj.payload || {};
         model = model || p.model;
+        continue;
+      }
+
+      if (obj.type === "world_state") {
+        const state = obj.payload?.state;
+        if (state && typeof state === "object" && !Array.isArray(state) && !model) {
+          const worldModel = state.model;
+          if (typeof worldModel === "string" && worldModel.trim()) model = worldModel;
+        }
         continue;
       }
 

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -48,6 +48,13 @@ function asOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function worldStatePayload(payload: unknown): Record<string, unknown> | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  const state = (payload as { state?: unknown }).state;
+  if (!state || typeof state !== "object" || Array.isArray(state)) return undefined;
+  return state as Record<string, unknown>;
+}
+
 export async function parseCodexSession(
   filePaths: string | string[],
   sessionInfo?: SessionInfo,
@@ -94,6 +101,11 @@ export function parseCodexLines(
   const seenUserMessages = new Map<string, number[]>();
   const seenAssistantMessages = new Map<string, number[]>();
   const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
+
+  // Codex JSONL now carries a sequential `ordinal` envelope field. Sampled
+  // rollouts match file order, so we keep JSONL order rather than sorting:
+  // concatenated `/resume` files each restart ordinal at 0, and a global sort
+  // would scramble them.
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
@@ -351,6 +363,14 @@ export function parseCodexLines(
           blocks: [{ type: "text", text }],
         });
       }
+      continue;
+    }
+
+    if (obj.type === "world_state") {
+      // Environment snapshot (skills, agents.md, plugins, permissions). Keep
+      // it metadata-only — never turn those blobs into replay scenes.
+      const state = worldStatePayload(obj.payload);
+      model = model || asOptionalString(state?.model);
       continue;
     }
 

--- a/packages/provider-codex/test/discover.test.ts
+++ b/packages/provider-codex/test/discover.test.ts
@@ -231,6 +231,43 @@ describe("extractCodexSessionInfo transcript status", () => {
     expect(result?.prompts).toBeUndefined();
   });
 
+  it("treats world_state envelope records as known Codex metadata", async () => {
+    const secret = "WORLD_STATE_INSTRUCTION_BLOB";
+    const filePath = await writeRollout(
+      [
+        JSON.stringify({
+          type: "session_meta",
+          ordinal: 0,
+          timestamp: "2026-09-04T15:32:40.000Z",
+          payload: { id: "codex-session", cwd: "/tmp/project" },
+        }),
+        JSON.stringify({
+          type: "world_state",
+          ordinal: 1,
+          timestamp: "2026-09-04T15:32:40.100Z",
+          payload: {
+            full: true,
+            state: {
+              model: "gpt-5.6-sol",
+              skills: { body: secret },
+            },
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const result = await extractCodexSessionInfo(filePath, 2);
+
+    expect(result).toMatchObject({
+      sessionId: "codex-session",
+      model: "gpt-5.6-sol",
+      firstPrompt: "",
+      promptCount: 0,
+      transcriptStatus: "no-prompts",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
   it("keeps short human prompts replayable", async () => {
     const filePath = await writeRollout(
       [

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -1454,6 +1454,78 @@ describe("Codex parser", () => {
       _result: "permission denied",
     });
   });
+
+  it("keeps world_state snapshots out of replay turns", () => {
+    const secret = "WORLD_STATE_INSTRUCTION_BLOB";
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-09-04T15:32:40.000Z",
+          type: "session_meta",
+          ordinal: 0,
+          payload: { id: "codex-session-world", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-09-04T15:32:40.100Z",
+          type: "world_state",
+          ordinal: 1,
+          payload: {
+            full: true,
+            state: {
+              model: "gpt-5.6-sol",
+              skills: { body: secret },
+              agents_md: { "AGENTS.md": secret },
+              plugins_instructions: secret,
+            },
+          },
+        },
+        {
+          timestamp: "2026-09-04T15:32:41.000Z",
+          type: "event_msg",
+          ordinal: 2,
+          payload: { type: "user_message", message: "Ship the parser change." },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    const texts = result.turns.flatMap((turn) =>
+      turn.blocks.flatMap((block) => (block.type === "text" ? [block.text] : [])),
+    );
+    expect(texts).toEqual(["Ship the parser change."]);
+    expect(texts.join("\n")).not.toContain(secret);
+    expect(result.model).toBe("gpt-5.6-sol");
+  });
+
+  it("keeps JSONL file order when envelope ordinals are not sequential", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-09-04T15:33:00.000Z",
+          type: "session_meta",
+          ordinal: 0,
+          payload: { id: "codex-session-ordinal", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-09-04T15:33:01.000Z",
+          type: "event_msg",
+          ordinal: 9,
+          payload: { type: "user_message", message: "First in file." },
+        },
+        {
+          timestamp: "2026-09-04T15:33:02.000Z",
+          type: "event_msg",
+          ordinal: 1,
+          payload: { type: "user_message", message: "Second in file." },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(
+      result.turns
+        .filter((turn) => turn.role === "user")
+        .map((turn) => turn.blocks.find((block) => block.type === "text")?.text),
+    ).toEqual(["First in file.", "Second in file."]);
+  });
 });
 
 describe("Codex response item compatibility", () => {


### PR DESCRIPTION
## Summary

- Recognize Codex `world_state` envelope records from schema-watch #563 as known metadata. They carry skills, `AGENTS.md`, plugins, and permissions — keep them out of replay turns and discovery prompts.
- Fall back to `state.model` only when the session has no model yet (same first-wins rule as `turn_context`).
- Do **not** sort by the new `ordinal` field. All 45 local rollouts match file order; a global sort would scramble concatenated `/resume` files that restart ordinal at 0.
- Tests cover instruction-blob non-leakage, model fallback, discovery `no-prompts` status, and shuffled-ordinal file order.

Fixes #563

## Test plan

- [x] `pnpm --filter @vibe-replay/provider-codex test` (52 tests)
- [x] oxlint + oxfmt on touched files
- [ ] CI on this PR
