### PR TITLE
docs: point Grok Bot blog at this room's real Eng+GTM replay

### DIFF
--- a/website/src/content/blog/grok-bot-local-storage.md
+++ b/website/src/content/blog/grok-bot-local-storage.md
@@ -108,7 +108,7 @@ When any group payload is seen, the session title becomes `Group: <room title>`.
 
 [PR #565](https://github.com/tuo-lei/vibe-replay/pull/565) then merges sibling transcripts that share a room into one playable HTML timeline. Eng and GTM stay separate JSONLs on disk; the replay joins them by room so you see each bot's own `send_message`, tools, and scratch instead of a single-agent view. Default visible replies are still `send_message`. Private assistant `text` is draft/thinking — the model sees it, the chat bubble does not.
 
-[Watch a merged Eng+GTM multi-speaker timeline](https://vibe-replay.com/view/?gist=f1e134205551e3d65aeb6b849f0bff79) after [#565](https://github.com/tuo-lei/vibe-replay/pull/565) — one room, both agents, English speaker turns ([gist](https://gist.github.com/tuo-lei/f1e134205551e3d65aeb6b849f0bff79)).
+[Watch this room's real Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=acad9ab8e8ab9a4510fb765684f2d60c) after [#565](https://github.com/tuo-lei/vibe-replay/pull/565) — the actual group room (Tuo Lei / Vibe Replay GTM / Vibe Replay Eng) merged into one timeline, not a synthetic or translated stand-in ([gist](https://gist.github.com/tuo-lei/acad9ab8e8ab9a4510fb765684f2d60c)).
 
 ## Try it
 
@@ -131,6 +131,6 @@ For comparison, see the JSONL tree used by [Pi coding agent](/blog/pi-local-stor
 - [PR #544 — native `provider-grok-bot`](https://github.com/tuo-lei/vibe-replay/pull/544)
 - [PR #546 — group wake speaker split](https://github.com/tuo-lei/vibe-replay/pull/546)
 - [PR #565 — multi-party group-session merge](https://github.com/tuo-lei/vibe-replay/pull/565)
-- [Example replay — merged Eng+GTM multi-speaker timeline](https://vibe-replay.com/view/?gist=f1e134205551e3d65aeb6b849f0bff79)
+- [This room's real Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=acad9ab8e8ab9a4510fb765684f2d60c)
 - [vibe-replay.com](https://vibe-replay.com/)
 - Earlier in this series: [Claude Code](/blog/claude-code-local-storage/), [Cursor](/blog/cursor-local-storage/), [Codex](/blog/codex-local-storage/), [Cowork](/blog/dispatch-deep-dive/), [Pi](/blog/pi-local-storage/), [OpenCode](/blog/opencode-local-storage/), [Hermes](/blog/hermes-local-storage/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace the Grok Bot blog CTA and Related link with this room's **real** Eng+GTM merged multi-speaker replay (`acad9ab8e8ab9a4510fb765684f2d60c`) instead of the English demo gist (`f1e134205551e3d65aeb6b849f0bff79`).
- Copy now names the actual group room (Tuo Lei / Vibe Replay GTM / Vibe Replay Eng) after [#565](https://github.com/tuo-lei/vibe-replay/pull/565) and no longer describes it as a demo or translated stand-in.
- `updated` frontmatter stays `2026-09-05`. Repo-wide search found no leftover old gist ids.

Watch: https://vibe-replay.com/view/?gist=acad9ab8e8ab9a4510fb765684f2d60c
Gist: https://gist.github.com/tuo-lei/acad9ab8e8ab9a4510fb765684f2d60c

## Validation

- [x] Repo-wide search: old gist id `f1e134205551e3d65aeb6b849f0bff79` has no remaining hits
- [x] New gist confirmed as “Real Eng+GTM group merge replay (post-#565): Group: Tuo Lei, Vibe Replay GTM, Vibe Replay Eng”
- [ ] `pnpm verify` — docs-only markdown change; no code/runtime paths touched
- [ ] `pnpm test:e2e` — not applicable
- [x] Manual review of CTA + Related copy and both URLs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-516d2281-3618-4596-aa6c-5e44d29e73ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-516d2281-3618-4596-aa6c-5e44d29e73ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the blog post’s group-chat replay links to point to the merged Eng+GTM multi-speaker replay.
  * Replaced the previous example timeline with the corresponding real group-room replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->