### PR TITLE
docs: point Grok Bot blog CTA at English redacted Eng+GTM replay

### DIFF
--- a/website/src/content/blog/grok-bot-local-storage.md
+++ b/website/src/content/blog/grok-bot-local-storage.md
@@ -108,7 +108,7 @@ When any group payload is seen, the session title becomes `Group: <room title>`.
 
 [PR #565](https://github.com/tuo-lei/vibe-replay/pull/565) then merges sibling transcripts that share a room into one playable HTML timeline. Eng and GTM stay separate JSONLs on disk; the replay joins them by room so you see each bot's own `send_message`, tools, and scratch instead of a single-agent view. Default visible replies are still `send_message`. Private assistant `text` is draft/thinking — the model sees it, the chat bubble does not.
 
-[Watch this room's real Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=acad9ab8e8ab9a4510fb765684f2d60c) after [#565](https://github.com/tuo-lei/vibe-replay/pull/565) — the actual group room (Tuo Lei / Vibe Replay GTM / Vibe Replay Eng) merged into one timeline, not a synthetic or translated stand-in ([gist](https://gist.github.com/tuo-lei/acad9ab8e8ab9a4510fb765684f2d60c)).
+[Watch this room's English Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=de4b16545915ce7ae9a50ca53f58df92) after [#565](https://github.com/tuo-lei/vibe-replay/pull/565) — *Group: Tuo Lei, Vibe Replay GTM, Vibe Replay Eng (EN)* · 834 scenes, an English translation of the real room with GCP/GA4 identifiers redacted ([gist](https://gist.github.com/tuo-lei/de4b16545915ce7ae9a50ca53f58df92)).
 
 ## Try it
 
@@ -131,6 +131,6 @@ For comparison, see the JSONL tree used by [Pi coding agent](/blog/pi-local-stor
 - [PR #544 — native `provider-grok-bot`](https://github.com/tuo-lei/vibe-replay/pull/544)
 - [PR #546 — group wake speaker split](https://github.com/tuo-lei/vibe-replay/pull/546)
 - [PR #565 — multi-party group-session merge](https://github.com/tuo-lei/vibe-replay/pull/565)
-- [This room's real Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=acad9ab8e8ab9a4510fb765684f2d60c)
+- [This room's English Eng+GTM multi-speaker replay](https://vibe-replay.com/view/?gist=de4b16545915ce7ae9a50ca53f58df92)
 - [vibe-replay.com](https://vibe-replay.com/)
 - Earlier in this series: [Claude Code](/blog/claude-code-local-storage/), [Cursor](/blog/cursor-local-storage/), [Codex](/blog/codex-local-storage/), [Cowork](/blog/dispatch-deep-dive/), [Pi](/blog/pi-local-storage/), [OpenCode](/blog/opencode-local-storage/), [Hermes](/blog/hermes-local-storage/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace the Grok Bot blog CTA and Related link with the public **English + redacted** Eng+GTM merged multi-speaker replay (`de4b16545915ce7ae9a50ca53f58df92`) instead of the Chinese original (`acad9ab8e8ab9a4510fb765684f2d60c`).
- Copy now names the Explore title — *Group: Tuo Lei, Vibe Replay GTM, Vibe Replay Eng (EN)* · 834 scenes — and describes it as an English translation of the real room with GCP/GA4 identifiers redacted. It no longer claims the public demo is untranslated.
- The Chinese gist itself is left alone; only site/blog references changed. `updated` frontmatter stays `2026-09-05`. Repo-wide search found no leftover old gist ids.

Watch: https://vibe-replay.com/view/?gist=de4b16545915ce7ae9a50ca53f58df92
Gist: https://gist.github.com/tuo-lei/de4b16545915ce7ae9a50ca53f58df92

## Validation

- [x] Repo-wide search: old gist id `acad9ab8e8ab9a4510fb765684f2d60c` has no remaining hits
- [x] Older demo gist `f1e134205551e3d65aeb6b849f0bff79` also has no remaining hits
- [x] New view URL loads (`de4b16545915ce7ae9a50ca53f58df92`)
- [ ] `pnpm verify` — docs-only markdown change; no code/runtime paths touched
- [ ] `pnpm test:e2e` — not applicable
- [x] Manual review of CTA + Related copy and both URLs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb54a16b-b519-4f8d-81d6-750667462b99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb54a16b-b519-4f8d-81d6-750667462b99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

