### PR TITLE
docs(website): retitle Cursor storage post for Search CTR

### DIFF
--- a/website/src/content/blog/cursor-local-storage.md
+++ b/website/src/content/blog/cursor-local-storage.md
@@ -1,8 +1,8 @@
 ---
-title: "What Does Cursor Store Locally? ~/.cursor/ + state.vscdb"
-excerpt: "Cursor stores sessions across SQLite, JSONL transcripts, global state, checkpoints, and editor history. Here's how the layers connect—and what each tells you."
+title: "Find Cursor Chat History: state.vscdb, agent-transcripts"
+excerpt: "Where Cursor keeps chat history: state.vscdb, ~/.cursor/chats, agent-transcripts, and globalStorage — a practical map of the layers, and how to recover sessions."
 date: 2026-03-27
-updated: 2026-09-03
+updated: 2026-09-06
 readTime: "9 min read"
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GTM experiment: raise Google Search CTR on `/blog/cursor-local-storage/` by changing only the frontmatter title and excerpt (which also feed `<title>`, meta description, Open Graph, Twitter, JSON-LD, RSS, and the blog listing). The article body is unchanged.

Search Console (~Aug 8–Sep 3) showed ~20.7k impressions and ~23 clicks (CTR ~0.11%, avg position ~6.2). Converting / high-impression queries cluster around `cursor state.vscdb`, `cursor globalstorage`, and long-tail recovery of chat history via `state.vscdb` / `agent-transcripts` / workspaceStorage. The previous title/excerpt described a storage map and did not promise finding or recovering chats.

**New title** (56 chars): `Find Cursor Chat History: state.vscdb, agent-transcripts`

**New excerpt** (~161 chars): `Where Cursor keeps chat history: state.vscdb, ~/.cursor/chats, agent-transcripts, and globalStorage — a practical map of the layers, and how to recover sessions.`

`updated` bumped to 2026-09-06.

## Validation

- [x] `pnpm lint:check`
- [ ] `pnpm test:e2e` when generated HTML, editor server, CLI flows, or auth changed
- [x] Relevant manual testing completed, including small and large sessions for viewer changes

Local Astro preview confirmed the new title/excerpt on the post page, blog index card, and in `<title>` / meta description / OG / Twitter / JSON-LD / RSS. Body still starts with `Run this right now:`.

[Post page header with new title, excerpt, and Updated September 6, 2026](https://cursor.com/agents/bc-2b4828c3-3513-4177-9d4b-b1bdcbf05fef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_blog_post_header.webp)
[Blog index card showing the new Cursor chat-history title and excerpt](https://cursor.com/agents/bc-2b4828c3-3513-4177-9d4b-b1bdcbf05fef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_blog_index_card.webp)
[cursor_blog_ctr_title_excerpt.mp4](https://cursor.com/agents/bc-2b4828c3-3513-4177-9d4b-b1bdcbf05fef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_blog_ctr_title_excerpt.mp4)

**Success metric:** Search Console CTR on this URL over the next 2–4 weeks.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b4828c3-3513-4177-9d4b-b1bdcbf05fef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b4828c3-3513-4177-9d4b-b1bdcbf05fef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

