### PR TITLE
refactor(cli): dedupe generated replay error

### DIFF
--- a/packages/cli/src/local-assistant.ts
+++ b/packages/cli/src/local-assistant.ts
@@ -36,6 +36,10 @@ const MAX_ANNOTATIONS = 40;
 const MAX_OVERLAYS = 40;
 const MAX_SESSION_LIST = 20;
 
+function generatedReplayNotFoundError(slug: string): Error {
+  return new Error(`Generated replay not found: ${slug}`);
+}
+
 type LocalAssistantTool = AgentTool<any, LocalAssistantToolDetails>;
 
 export interface LocalAssistantContext {
@@ -1566,7 +1570,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as SessionArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const session = await data.getSession(args.slug, args.targetId);
       const overlays = await data.getOverlays?.(args.slug, args.targetId);
@@ -1595,7 +1599,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as ContentArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const session = await data.getSession(args.slug, args.targetId);
       const overlays = await data.getOverlays?.(args.slug, args.targetId);
@@ -1685,7 +1689,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as SceneArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const session = await data.getSession(args.slug, args.targetId);
       const overlays = await data.getOverlays?.(args.slug, args.targetId);
@@ -1757,7 +1761,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as AnnotationArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const session = await data.getSession(args.slug, args.targetId);
       const annotations = (session.annotations || [])
@@ -1825,7 +1829,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as OverlayArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const overlays = await data.getOverlays?.(args.slug, args.targetId);
       if (!overlays) throw new Error("Replay overlay data is unavailable for this server");
@@ -2531,7 +2535,7 @@ export function createLocalAssistantTools(
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as OpenReplayArgs;
       const record = findRecord(await buildSessionRecords(data), args);
-      if (!record?.replay) throw new Error(`Generated replay not found: ${args.slug}`);
+      if (!record?.replay) throw generatedReplayNotFoundError(args.slug);
       assertRecordAccess(record, context);
       const sceneIndex =
         args.sceneIndex === undefined ? undefined : Math.max(0, Math.floor(args.sceneIndex));


### PR DESCRIPTION
## Summary

- Extract the repeated generated-replay-not-found error construction into one local helper.
- Net diff: +10/-6 in one CLI file.

## Motivation

The six call sites keep the exact same error text and behavior while sharing one construction path; this is a mechanical refactor with no runtime semantic change.

## Test plan

- [x] \
> vibe-replay-monorepo@0.0.3 test /Users/tuo/.codex/worktrees/463b/vibe-replay2
> pnpm --filter @vibe-replay/provider-contract test && pnpm --filter @vibe-replay/provider-core test && pnpm --filter @vibe-replay/provider-claude-code test && pnpm --filter @vibe-replay/provider-codex test && pnpm --filter @vibe-replay/provider-cursor test && pnpm --filter @vibe-replay/provider-grok-bot test && pnpm --filter @vibe-replay/provider-hermes test && pnpm --filter @vibe-replay/provider-opencode test && pnpm --filter @vibe-replay/provider-pi test && pnpm --filter @vibe-replay/providers-default test && pnpm --filter @vibe-replay/replay-core test && pnpm --filter vibe-replay test && pnpm --filter @vibe-replay/viewer test


> @vibe-replay/provider-contract@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-contract
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-contract


 Test Files  2 passed (2)
      Tests  20 passed (20)
   Start at  07:07:19
   Duration  96ms (transform 32ms, setup 0ms, import 47ms, tests 5ms, environment 0ms)


> @vibe-replay/provider-core@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-core
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-core


 Test Files  2 passed (2)
      Tests  44 passed (44)
   Start at  07:07:20
   Duration  98ms (transform 38ms, setup 0ms, import 55ms, tests 9ms, environment 0ms)


> @vibe-replay/provider-claude-code@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-claude-code
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-claude-code


 Test Files  15 passed (15)
      Tests  215 passed (215)
   Start at  07:07:20
   Duration  330ms (transform 869ms, setup 0ms, import 1.18s, tests 448ms, environment 1ms)


> @vibe-replay/provider-codex@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-codex
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-codex


 Test Files  2 passed (2)
      Tests  52 passed (52)
   Start at  07:07:21
   Duration  428ms (transform 112ms, setup 0ms, import 149ms, tests 331ms, environment 0ms)


> @vibe-replay/provider-cursor@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-cursor
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-cursor


 Test Files  10 passed (10)
      Tests  228 passed | 1 skipped (229)
   Start at  07:07:22
   Duration  346ms (transform 1.00s, setup 0ms, import 1.45s, tests 474ms, environment 0ms)


> @vibe-replay/provider-grok-bot@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-grok-bot
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-grok-bot


 Test Files  3 passed (3)
      Tests  40 passed (40)
   Start at  07:07:22
   Duration  208ms (transform 182ms, setup 0ms, import 246ms, tests 107ms, environment 0ms)


> @vibe-replay/provider-hermes@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-hermes
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-hermes


 Test Files  3 passed (3)
      Tests  38 passed (38)
   Start at  07:07:23
   Duration  180ms (transform 123ms, setup 0ms, import 161ms, tests 104ms, environment 0ms)


> @vibe-replay/provider-opencode@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-opencode
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-opencode


 Test Files  4 passed (4)
      Tests  34 passed (34)
   Start at  07:07:23
   Duration  186ms (transform 168ms, setup 0ms, import 223ms, tests 123ms, environment 0ms)


> @vibe-replay/provider-pi@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-pi
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/provider-pi


 Test Files  2 passed (2)
      Tests  27 passed (27)
   Start at  07:07:24
   Duration  171ms (transform 106ms, setup 0ms, import 139ms, tests 45ms, environment 0ms)


> @vibe-replay/providers-default@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/providers-default
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/providers-default


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  07:07:24
   Duration  276ms (transform 171ms, setup 0ms, import 214ms, tests 2ms, environment 0ms)


> @vibe-replay/replay-core@0.0.1 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/replay-core
> vitest run --passWithNoTests


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/replay-core


 Test Files  4 passed (4)
      Tests  131 passed | 2 skipped (133)
   Start at  07:07:25
   Duration  302ms (transform 208ms, setup 0ms, import 262ms, tests 267ms, environment 0ms)


> vibe-replay@0.2.9 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/cli
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/cli


 Test Files  46 passed (46)
      Tests  559 passed | 3 skipped (562)
   Start at  07:07:25
   Duration  1.92s (transform 2.54s, setup 0ms, import 6.76s, tests 5.15s, environment 2ms)


> @vibe-replay/viewer@0.1.0 test /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/viewer
> vitest run


 RUN  v4.1.11 /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/viewer


 Test Files  43 passed (43)
      Tests  429 passed (429)
   Start at  07:07:28
   Duration  3.12s (transform 3.27s, setup 0ms, import 7.59s, tests 4.65s, environment 16.50s) (all unit tests green)
- [x] \
> vibe-replay-monorepo@0.0.3 lint:check /Users/tuo/.codex/worktrees/463b/vibe-replay2
> oxlint packages/ scripts/ website/astro.config.mjs website/src cloudflare/src && oxfmt --check packages/ scripts/ website/astro.config.mjs website/src cloudflare/src

Checking formatting...

All matched files use the correct format.
Finished in 83ms on 417 files using 12 threads. (zero warnings/errors; formatting clean)
- [x] \
- [x] \
> vibe-replay-monorepo@0.0.3 build /Users/tuo/.codex/worktrees/463b/vibe-replay2
> pnpm --filter @vibe-replay/viewer build && node scripts/copy-file.mjs packages/viewer/dist/index.html packages/cli/assets/viewer.html && pnpm --filter vibe-replay build


> @vibe-replay/viewer@0.1.0 build /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/viewer
> vite build

vite v8.2.2 building client environment for production...
transforming...
✓ 116 modules transformed.
rendering chunks...
[plugin vite:singlefile] 

[plugin vite:singlefile] Inlining: index-4Ufz586r.js
[plugin vite:singlefile] Inlining: style-CU25bKOT.css
computing gzip size...
dist/index.html  1,124.81 kB │ gzip: 284.49 kB

✓ built in 183ms

> vibe-replay@0.2.9 build /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/cli
> tsup

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/tuo/.codex/worktrees/463b/vibe-replay2/packages/cli/tsup.config.ts
CLI Target: node22
CLI Cleaning output folder
ESM Build start
ESM dist/index.js 1.11 MB
ESM ⚡️ Build success in 39ms
- [x] Pre-commit format/lint hook
- [ ] E2E: not run; this is a CLI-only structural refactor

> 🤖 Daily auto-quality routine. Self-merged after AI review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized handling for missing generated replay errors across replay-related tools.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->