### PR TITLE
refactor(opencode): remove unused session id helper

### DIFF
--- a/packages/provider-opencode/src/opencode/sqlite.ts
+++ b/packages/provider-opencode/src/opencode/sqlite.ts
@@ -62,8 +62,3 @@ export async function openOpencodeDb(
     return null;
   }
 }
-
-/** True when the session id looks like an opencode session id (`ses_...`). */
-export function isOpencodeSessionId(value: string): boolean {
-  return value.startsWith("ses_");
-}


### PR DESCRIPTION
## Summary

- Remove the unreferenced `isOpencodeSessionId` helper from the private OpenCode provider SQLite module.
- Net diff: -5 lines.

## Motivation

The helper has no references anywhere in the repository and is not part of the provider root API; deleting it removes dead code without changing runtime behavior.

## Test plan

- [x] `pnpm test` via `pnpm verify` (all workspace and Cloudflare tests green)
- [x] `pnpm lint:check` zero warnings/errors
- [x] `pnpm --filter vibe-replay exec tsc --noEmit`
- [x] `pnpm build` via `pnpm verify`
- [x] Pre-commit oxfmt/oxlint hook

> 🤖 Daily auto-quality routine. Self-merged after AI review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an internal session ID validation helper from the OpenCode integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->