### PR TITLE
fix(grok-bot): live session media, MCP, wakes, and status tools

### DIFF
--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -326,6 +326,72 @@ describe("scanSession", () => {
     expect(result.usageSummary?.tools).toMatchObject({ Read: 1 });
   });
 
+  it("indexes Grok Bot dynamic MCP short names and skips get_mcp_tools", async () => {
+    const grokPath = join(tmpDir, "grok-bot-mcp.jsonl");
+    await writeFile(
+      grokPath,
+      [
+        {
+          role: "user",
+          message: { content: [{ type: "text", text: "[t0u]\ncheck the PR" }] },
+        },
+        {
+          role: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "get_mcp_tools", toolCallId: "g-1", input: {} },
+              {
+                type: "tool_use",
+                name: "pull_request_read",
+                toolCallId: "p-1",
+                input: {
+                  serverIdentifier: "github",
+                  toolName: "pull_request_read",
+                  args: { pullNumber: 544 },
+                },
+              },
+            ],
+          },
+        },
+        {
+          role: "tool",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                name: "get_mcp_tools",
+                toolCallId: "g-1",
+                result: { success: { content: "github" } },
+              },
+              {
+                type: "tool_result",
+                name: "pull_request_read",
+                toolCallId: "p-1",
+                result: { success: { content: "PR 544" } },
+              },
+            ],
+          },
+        },
+      ]
+        .map((line) => `${JSON.stringify(line)}\n`)
+        .join(""),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "grok-bot-mcp",
+      provider: "grok-bot",
+      project: "/home/box",
+      slug: "grok-bot-mcp",
+      filePaths: [grokPath],
+    });
+
+    expect(result.toolCallCount).toBe(1);
+    expect(result.usageSummary?.tools).toEqual({});
+    expect(result.usageSummary?.mcpServers).toMatchObject({ github: 1 });
+    expect(result.usageSummary?.mcpTools).toMatchObject({ "github/pull_request_read": 1 });
+  });
+
   it("persists structured Pi compaction diagnostics in scan results", async () => {
     const piPath = join(tmpDir, "pi-diagnostics.jsonl");
     await writeFile(

--- a/packages/provider-grok-bot/AGENTS.md
+++ b/packages/provider-grok-bot/AGENTS.md
@@ -14,9 +14,10 @@ Defaults (when no env override is set):
 Env (Pi-style, replaces defaults): `GROK_BOT_TRANSCRIPTS_DIR` or
 `VIBE_REPLAY_GROK_BOT_DIR`.
 
-Layout: `<root>/<agentId>/<agentId>.jsonl`. `sand-subagent-<uuid>/` files are
-**separate sessions** — do not attach them to a parent. Duplicate roots
-(symlink overlap) are collapsed via `realpath`.
+Layout: `<root>/<agentId>/<agentId>.jsonl`. `sand-subagent-<uuid>/` files stay
+in discovery as their own sessions. A parent `task` call attaches a child-run
+card when the result/input names that sibling id (no nested grandchildren).
+Duplicate roots (symlink overlap) are collapsed via `realpath`.
 
 Project/title: sibling `agents/<id>/profile.json` `name` (and `cwd` / `workspace`
 when present). Missing profiles are fine. DM sessions prefer that profile name;
@@ -29,25 +30,33 @@ follow-up, not this package. Skip `store.db` / conversation-blobs / encryption.
 
 One object per line: `{ role: "user"|"assistant"|"tool", message: { content: [...] } }`.
 
-- Skip user text containing `[SAND_HIDDEN_PROMPT]`
+- Skip user text containing `[SAND_HIDDEN_PROMPT]` or a lone `[first run]`
 - Strip leading `[t0u]` / `[t3u]` prefixes from user text
 - Meta wakes (after `[tNu]` strip):
   - `[routine]` / `[agent]` → `subtype: "context-injection"` (empty bodies dropped)
   - `[inbound]` → remaining body is a normal user prompt
   - `[Answering your question tbs1: "…"]` → context-injection; trailing text after
     the wrapper is a follow-up prompt when present
+  - `[A background task just completed]` → context-injection (not a user prompt /
+    Explore firstPrompt)
+  - `<<SAND_AGENT_PROFILE_UPDATE…>>` → skipped (or stripped if other text remains)
   - A meta tag wrapping `[Group chat:` is peeled so the group splitter still runs
 - Assistant `text` is private scratch → `thinking` blocks (not the visible reply)
-- `send_message` and successful `communicate_update` are user-visible replies /
-  status pings (`input.text.content`, widgets, occasional `to: "dm"` /
-  attachments). Promote visible text to an assistant `text` block; do **not**
-  emit those as tool-call scenes. Ignore `to` / `attachments` when extracting
-  text. A `failure` / `rejected` / `error` `communicate_update` stays a
-  `CommunicateUpdate` tool scene with `_isError` so a failed ping is visible
+- `send_message` is the user-visible reply (`input.text.content` dict or string,
+  widgets). Promote visible text to an assistant `text` block; do **not** emit
+  it as a tool-call scene. Ignore `to` / `attachments` when extracting text.
+  `file://` / data-URL markdown images in that text become a path mention —
+  they are not inlined into shareable HTML
+- `communicate_update` is a high-volume status/memory side-effect. Keep it as a
+  `CommunicateUpdate` tool scene (including success). Do **not** promote it to
+  an assistant reply. `_isError` still marks `failure` / `rejected` / `error`
 - `role: "tool"` lines carry `tool_result` (not Claude's user-nested pattern).
   Pair to the preceding `tool_use` by `toolCallId` when present, else by order
   (prefer matching tool name; leave unenriched rather than attaching another
   tool's result)
+- `generate_image` / `computer_use` results keep `filePath` / `screenshotPath`
+  and replace embedded `imageData` / screenshot base64 with an `[omitted …]`
+  stub so a 16MB artist JSONL stays parseable
 - Few/no top-level timestamps; synthesize ISO times from `result.success.timestamp`
   when it is epoch ms. Tool durations use the assistant record timestamp (when
   present) as the initial baseline, then advance to each result so later tools
@@ -58,10 +67,12 @@ One object per line: `{ role: "user"|"assistant"|"tool", message: { content: [..
 
 Sand builtins map onto the viewer vocabulary in `tool-mapping.ts`: `read`→`Read`,
 `shell`→`Bash`, `update_todos`→`TodoWrite`, `task`→`Agent`, `await`→`Await`,
-`computer_use`→`ComputerUse`, `get_mcp_tools`→`GetMcpTools`, plus the usual
-web/edit aliases. `mcp` keeps its raw name and normalizes `server` / `tool` /
-`tool_name` so scan usage matches Pi's single-`mcp` bridge. Bare GitHub MCP
-names (`pull_request_read`, `get_file_contents`) pass through unchanged.
+`computer_use`→`ComputerUse`, `generate_image`→`GenerateImage`, plus the usual
+web/edit aliases. `get_mcp_tools` is discovery noise and is omitted from scenes.
+`mcp` keeps its raw name and normalizes `server` / `tool` / `tool_name`. Dynamic
+MCP calls use short names (`pull_request_read`, `search_analytics_query`) plus
+`serverIdentifier` / `providerIdentifier` / `toolName` / `args` and become
+`mcp__<server>__<tool>` cards with `_mcpServer` / `_mcpTool`.
 
 ## Group chat
 
@@ -73,21 +84,24 @@ Do **not** treat the blob as one human prompt.
 - Humans (`User`, or any name not in the bot participant list) stay `role:
   "user"` with `speaker` set — the viewer shows `You` for generic `User`/`You`/
   `Human`, otherwise the name
-- Other bots are `role: "assistant"` with `speaker` set (Eng, GTM, …). Do **not**
-  stuff them into User. The contract stays `user | assistant`; `speaker` is the
-  label
+- Other bots are `role: "assistant"` with `speaker` set (Eng, GTM, 艺术家, …).
+  Display names (including emoji/CJK) are labels; merge/dedupe keys strip
+  punctuation/emoji so `🧭旅游助手` matches `旅游助手`
 - Drop procedural cues: `It's your turn…`, `The room is wrapping up…`,
   `The conversation is wrapping up…`, `Waiting for participants…`,
   `No new messages in the room…` (empty wakes are not prompts)
 - Repeat wakes for the same room do **not** re-emit the header
 - Title becomes `Group: <room title>` when any group payload is seen
 - `@Vibe Replay Eng` stays in speaker text and is listed on the room header
+- Room slug `normalizeGroupKey` keeps Unicode letters/numbers so CJK titles
+  do not all collapse to `group`
 
 ### Cross-agent merge
 
 Sibling JSONLs that share the same room title (wake `[Group chat:"…"]`, else
 `group.json` / profile `groupTitle`) merge into one discovered session
 (`sessionId` / `slug` = `group-<normalized-title>`, `filePaths` = all members).
+Member identity is the agent UUID (directory name); display names are labels.
 
 Parse each agent independently (owner name from profile, else `It's your turn,
 <name>`), then:
@@ -103,7 +117,7 @@ Parse each agent independently (owner name from profile, else `It's your turn,
 
 Single-agent / DM sessions are unchanged. A lone group transcript still shows
 peer bots as assistant-side speakers using injected wake text (no sibling to
-prefer). `sand-subagent-*` never merges.
+prefer). `sand-subagent-*` never merges into a group room.
 
 Fixtures: `test/fixtures/sample.jsonl` (DM), `dm-session.jsonl`,
 `group-eng.jsonl`, `group-gtm.jsonl`, `subagent.jsonl`, `meta-wake.jsonl`.

--- a/packages/provider-grok-bot/src/grok-bot/group-chat.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-chat.ts
@@ -29,7 +29,7 @@ const GROUP_PREFIX_RE = /^\s*\[Group chat:/i;
 const HEADER_RE =
   /^\[Group chat:\s*(?:"([^"]+)"|“([^”]+)”|([^\]-]+?))(?:\s*-\s*with\s+([^\]]+))?\]\s*/i;
 const PARTICIPANT_PAIR_RE = /([^,()]+?)\s*\(([^)]*)\)/g;
-const MENTION_TOKEN_RE = /@([A-Za-z][\w.-]*)/g;
+const MENTION_TOKEN_RE = /@([\p{L}][\p{L}\p{N}_.-]*)/gu;
 const TURN_RECIPIENT_RE = /^It's your turn,\s*(.+?)(?:\.|$)/i;
 const NEW_MESSAGES_RE = /^New messages in the room\b/i;
 const NO_NEW_MESSAGES_RE = /^No new messages in the room\b/i;
@@ -204,7 +204,22 @@ export function groupHeaderSignature(wake: GrokBotGroupWake): string {
   return [wake.groupTitle.trim().toLowerCase(), ...participants].join("\0");
 }
 
+/**
+ * Compare speaker labels after stripping punctuation/emoji. Display names
+ * (`🧭旅游助手`) stay on the turn; merge/dedupe uses this letter+number key
+ * so a profile rename that only adds an emoji still matches.
+ */
+export function speakerIdentityKey(name: string): string {
+  return name
+    .normalize("NFC")
+    .replace(/[^\p{L}\p{N}]+/gu, "")
+    .toLowerCase();
+}
+
 export function sameSpeakerName(left: string, right: string): boolean {
+  const leftKey = speakerIdentityKey(left);
+  const rightKey = speakerIdentityKey(right);
+  if (leftKey && rightKey) return leftKey === rightKey;
   return left.trim().toLowerCase() === right.trim().toLowerCase();
 }
 
@@ -219,16 +234,17 @@ export function isHumanGroupSpeaker(name: string, botNames: string[] = []): bool
 export function normalizeGroupKey(title: string): string {
   return (
     title
+      .normalize("NFC")
       .trim()
       .toLowerCase()
       .replace(/['"]/g, "")
-      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/[^\p{L}\p{N}]+/gu, "-")
       .replace(/^-+|-+$/g, "") || "group"
   );
 }
 
 export function humanMessageKey(speaker: string, text: string): string {
-  return `${speaker.trim().toLowerCase()}\0${text.replace(/\s+/g, " ").trim().toLowerCase()}`;
+  return `${speakerIdentityKey(speaker) || speaker.trim().toLowerCase()}\0${text.replace(/\s+/g, " ").trim().toLowerCase()}`;
 }
 
 export function groupWakeBotNames(wake: GrokBotGroupWake): string[] {
@@ -340,7 +356,9 @@ function findSpeaker(
     }
   }
 
-  const fallback = /^([A-Z][\w .'-]{0,60}?)\s*:\s+(.*)$/.exec(line);
+  const fallback = /^([\p{L}\p{N}\p{M}\p{S}][\p{L}\p{N}\p{M}\p{S} .'_-]{0,60}?)\s*:\s+(.*)$/u.exec(
+    line,
+  );
   if (!fallback) return null;
   const name = fallback[1].trim();
   if (!looksLikeSpeakerName(name)) return null;
@@ -351,7 +369,9 @@ function looksLikeSpeakerName(name: string): boolean {
   if (name.length < 1 || name.length > 60) return false;
   if (RESERVED_SPEAKERS.has(name.toLowerCase())) return false;
   if (/[.?!]$/.test(name)) return false;
-  return /^[A-Z][A-Za-z0-9]*(?:[ _-][A-Z][A-Za-z0-9]*)*$/.test(name);
+  const letters = speakerIdentityKey(name);
+  if (!letters) return false;
+  return /^[\p{L}\p{N}\p{M}\p{S}][\p{L}\p{N}\p{M}\p{S} .'_-]*$/u.test(name);
 }
 
 function startsWithInsensitive(line: string, prefix: string): boolean {

--- a/packages/provider-grok-bot/src/grok-bot/group-merge.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-merge.ts
@@ -271,7 +271,7 @@ export function mergeGrokBotGroupParses(
   const notes = [
     `Merged ${usable.length} sibling Grok Bot transcripts for group "${groupTitle || "room"}" (${ownerLabel}).`,
     "Peer messages use each agent's own send_message / tools / scratch; injected wake copies are dropped when that peer's JSONL is present.",
-    "Assistant text blocks are private scratch (thinking); send_message and successful communicate_update stay visible replies.",
+    "Assistant text blocks are private scratch (thinking); send_message stays the visible reply. communicate_update is a status tool scene.",
   ];
 
   const parseWarnings = usable.flatMap((member) => member.parsed.parseWarnings || []);

--- a/packages/provider-grok-bot/src/grok-bot/media.ts
+++ b/packages/provider-grok-bot/src/grok-bot/media.ts
@@ -1,0 +1,115 @@
+/**
+ * Grok Bot tool results (generate_image, computer_use screenshots) embed
+ * multi-MB base64 payloads next to a filePath/screenshotPath. Replay HTML
+ * must stay usable, so strip/truncate binary fields and keep the path.
+ *
+ * Markdown `![alt](<file:///home/box/...>)` images are rewritten to a path
+ * mention. Shareable HTML cannot load `file://` and this repo has no bundle
+ * step for those attachments; inlining would reintroduce the size problem.
+ */
+
+const MEDIA_KEYS = new Set([
+  "imagedata",
+  "image_data",
+  "screenshot",
+  "screenshotdata",
+  "screenshot_data",
+  "thumbnail",
+  "thumbnaildata",
+  "thumbnail_data",
+]);
+
+const PATH_KEYS = new Set([
+  "filepath",
+  "file_path",
+  "path",
+  "screenshotpath",
+  "screenshot_path",
+  "imagepath",
+  "image_path",
+]);
+
+const MARKDOWN_FILE_IMAGE_RE = /!\[([^\]]*)\]\(\s*<?(file:\/\/[^)\s>]+)>?\s*\)/gi;
+const MARKDOWN_DATA_IMAGE_RE = /!\[([^\]]*)\]\(\s*data:image\/[^)]+\)/gi;
+const DATA_URL_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+
+export function omittedMediaPlaceholder(label: string, length: number): string {
+  return `[omitted ${label}, ${length} chars]`;
+}
+
+export function looksLikeBase64Payload(value: string): boolean {
+  if (DATA_URL_RE.test(value) && value.length > 80) return true;
+  const compact = value.replace(/\s+/g, "");
+  return compact.length >= 200 && /^[A-Za-z0-9+/]+=*$/.test(compact);
+}
+
+export function scrubGrokBotMediaPayload(value: unknown, depth = 0): unknown {
+  if (depth > 8 || value == null) return value;
+  if (typeof value === "string") {
+    return looksLikeBase64Payload(value)
+      ? omittedMediaPlaceholder("binary payload", value.length)
+      : value;
+  }
+  if (Array.isArray(value)) return value.map((item) => scrubGrokBotMediaPayload(item, depth + 1));
+  if (typeof value !== "object") return value;
+
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(obj)) {
+    const lower = key.toLowerCase();
+    if (typeof item === "string" && MEDIA_KEYS.has(lower) && item.length > 80) {
+      out[key] = omittedMediaPlaceholder(key, item.length);
+      continue;
+    }
+    if (typeof item === "string" && looksLikeBase64Payload(item) && !PATH_KEYS.has(lower)) {
+      out[key] = omittedMediaPlaceholder(key, item.length);
+      continue;
+    }
+    out[key] = scrubGrokBotMediaPayload(item, depth + 1);
+  }
+  return out;
+}
+
+export function mediaPathFromPayload(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const obj = value as Record<string, unknown>;
+  for (const key of [
+    "filePath",
+    "file_path",
+    "screenshotPath",
+    "screenshot_path",
+    "imagePath",
+    "image_path",
+    "path",
+  ]) {
+    const item = obj[key];
+    if (typeof item === "string" && item.trim()) return item.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort rewrite so markdown images do not become broken `<img src>` tags
+ * in shareable HTML. Local files are not inlined.
+ */
+export function rewriteGrokBotShareableText(text: string): string {
+  return text
+    .replace(MARKDOWN_FILE_IMAGE_RE, (_match, alt: string, url: string) => {
+      const label = (alt || "image").trim() || "image";
+      const path = stripFileUrl(url);
+      return `[image: ${label} — ${path}]`;
+    })
+    .replace(MARKDOWN_DATA_IMAGE_RE, (_match, alt: string) => {
+      const label = (alt || "embedded").trim() || "embedded";
+      return `[image: ${label}]`;
+    });
+}
+
+function stripFileUrl(url: string): string {
+  const trimmed = url.trim();
+  try {
+    return decodeURIComponent(trimmed.replace(/^file:\/\//i, ""));
+  } catch {
+    return trimmed.replace(/^file:\/\//i, "");
+  }
+}

--- a/packages/provider-grok-bot/src/grok-bot/meta-wake.ts
+++ b/packages/provider-grok-bot/src/grok-bot/meta-wake.ts
@@ -9,9 +9,19 @@
  *   [inbound]  channel wrap; remaining body is the inbound message (prompt)
  *   [Answering your question tbs1: "…"] → context-injection; trailing text
  *              after the wrapper is a follow-up prompt when present
+ *   [A background task just completed] → context-injection (not a user chat)
+ *   [first run] → skip (bootstrap; often also wrapped in SAND_HIDDEN_PROMPT)
+ *   <<SAND_AGENT_PROFILE_UPDATE…>> → skip / strip; not a prompt
  */
 
-export type GrokBotMetaLabel = "routine" | "agent" | "inbound" | "answering-question";
+export type GrokBotMetaLabel =
+  | "routine"
+  | "agent"
+  | "inbound"
+  | "answering-question"
+  | "background-task"
+  | "first-run"
+  | "profile-update";
 
 export interface GrokBotMetaWake {
   label: GrokBotMetaLabel;
@@ -31,10 +41,35 @@ export type ClassifiedGrokBotUserWake =
 const META_TAG_RE = /^\s*\[(routine|agent|inbound)\]\s*/i;
 const ANSWERING_RE =
   /^\s*\[Answering your question\s+([^\]:]+):\s*(?:"([^"]*)"|“([^”]*)”|'([^']*)')\]\s*/i;
+const BACKGROUND_TASK_RE = /^\s*\[A background task just completed\]\s*/i;
+const FIRST_RUN_RE = /^\s*\[first run\]\s*/i;
+export function stripGrokBotProfileUpdate(text: string): string {
+  return text.replace(/<<SAND_AGENT_PROFILE_UPDATE[\s\S]*?>>/gi, "").trim();
+}
+
+function hasProfileUpdate(text: string): boolean {
+  return /<<SAND_AGENT_PROFILE_UPDATE/i.test(text);
+}
 
 export function parseGrokBotMetaWake(text: string): GrokBotMetaWake | null {
   const trimmed = text.replace(/^\uFEFF/, "").trim();
   if (!trimmed) return null;
+
+  const firstRun = FIRST_RUN_RE.exec(trimmed);
+  if (firstRun) {
+    return {
+      label: "first-run",
+      body: trimmed.slice(firstRun[0].length).trim(),
+    };
+  }
+
+  const background = BACKGROUND_TASK_RE.exec(trimmed);
+  if (background) {
+    return {
+      label: "background-task",
+      body: trimmed.slice(background[0].length).trim(),
+    };
+  }
 
   const answering = ANSWERING_RE.exec(trimmed);
   if (answering) {
@@ -57,8 +92,28 @@ export function parseGrokBotMetaWake(text: string): GrokBotMetaWake | null {
 }
 
 export function classifyGrokBotUserWake(text: string): ClassifiedGrokBotUserWake | null {
-  const wake = parseGrokBotMetaWake(text);
-  if (!wake) return null;
+  const trimmed = text.replace(/^\uFEFF/, "").trim();
+  const stripped = stripGrokBotProfileUpdate(trimmed);
+  if (hasProfileUpdate(trimmed) && !stripped) return { kind: "skip" };
+  const source = stripped || trimmed;
+
+  const wake = parseGrokBotMetaWake(source);
+  if (!wake) {
+    if (stripped && stripped !== trimmed) return { kind: "prompt", text: stripped };
+    return null;
+  }
+
+  if (wake.label === "first-run") return { kind: "skip" };
+
+  if (wake.label === "background-task") {
+    const header = "Background task completed";
+    if (!wake.body) return { kind: "context-injection", text: header, label: "background-task" };
+    return {
+      kind: "context-injection",
+      text: `${header}:\n${wake.body}`,
+      label: "background-task",
+    };
+  }
 
   if (wake.label === "inbound") {
     if (!wake.body) return { kind: "skip" };
@@ -93,7 +148,8 @@ export function formatAnsweringHeader(wake: GrokBotMetaWake): string {
 
 /** Remainder after peeling one meta tag — used so `[routine]\\n[Group chat:` still splits. */
 export function peelGrokBotMetaTag(text: string): { rest: string; wake: GrokBotMetaWake } | null {
-  const wake = parseGrokBotMetaWake(text);
+  const stripped = stripGrokBotProfileUpdate(text);
+  const wake = parseGrokBotMetaWake(stripped || text);
   if (!wake) return null;
   return { rest: wake.body, wake };
 }

--- a/packages/provider-grok-bot/src/grok-bot/parser.ts
+++ b/packages/provider-grok-bot/src/grok-bot/parser.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { estimateActiveDuration } from "@vibe-replay/provider-core/duration";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
+import { normalizeSubAgentType } from "@vibe-replay/provider-contract";
 import type { ContentBlock, ParsedTurn, SessionInfo } from "@vibe-replay/provider-contract";
 import type { ProviderParseResult } from "@vibe-replay/provider-contract";
 import { addParseWarning } from "@vibe-replay/provider-contract/warnings";
@@ -20,11 +21,18 @@ import {
 } from "./group-merge.js";
 import { classifyGrokBotUserWake, formatAnsweringHeader, peelGrokBotMetaTag } from "./meta-wake.js";
 import {
+  mediaPathFromPayload,
+  rewriteGrokBotShareableText,
+  scrubGrokBotMediaPayload,
+} from "./media.js";
+import {
   grokBotMcpAttribution,
+  grokBotReplayToolName,
   isGrokBotEditTool,
+  isGrokBotHiddenTool,
   mapGrokBotToolArgs,
-  mapGrokBotToolName,
 } from "./tool-mapping.js";
+import { findSandSubagentId } from "./subagent.js";
 
 export {
   extractGroupMentions,
@@ -38,6 +46,7 @@ export {
   normalizeGroupKey,
   parseGrokBotGroupWake,
   sameSpeakerName,
+  speakerIdentityKey,
 } from "./group-chat.js";
 export type {
   GrokBotGroupMessage,
@@ -52,12 +61,13 @@ export {
 } from "./group-merge.js";
 export { classifyGrokBotUserWake, parseGrokBotMetaWake, peelGrokBotMetaTag } from "./meta-wake.js";
 export type { ClassifiedGrokBotUserWake, GrokBotMetaWake } from "./meta-wake.js";
+export { rewriteGrokBotShareableText, scrubGrokBotMediaPayload } from "./media.js";
+export { findSandSubagentId } from "./subagent.js";
 
 export const SAND_HIDDEN_PROMPT = "[SAND_HIDDEN_PROMPT]";
 const USER_TURN_PREFIX_RE = /^\s*\[t\d+u\]\s*/i;
 const SEND_MESSAGE_TOOL = "send_message";
-const COMMUNICATE_UPDATE_TOOL = "communicate_update";
-const PROMOTED_TEXT_TOOLS = new Set([SEND_MESSAGE_TOOL, COMMUNICATE_UPDATE_TOOL]);
+const SAND_SUBAGENT_PREFIX = "sand-subagent-";
 
 interface GrokBotRecord {
   role?: unknown;
@@ -83,6 +93,7 @@ interface CollectedResult {
   text: string;
   isError: boolean;
   timestamp?: string;
+  subagentId?: string;
   used: boolean;
 }
 
@@ -103,21 +114,25 @@ export async function parseGrokBotSession(
     const sourcePath = paths[0] || (Array.isArray(filePaths) ? filePaths[0] : filePaths);
     const content = sourcePath ? await readFile(sourcePath, "utf-8") : "";
     const ownerName = sourcePath ? await resolveOwnerName(sourcePath, sessionInfo) : undefined;
-    return parseGrokBotLines(content.split("\n"), {
+    const parsed = parseGrokBotLines(content.split("\n"), {
       sourcePath,
       sessionInfo,
       ownerName,
     });
+    return attachGrokBotSubAgents(parsed, sourcePath);
   }
 
   const members = await Promise.all(
     paths.map(async (path) => {
       const content = await readFile(path, "utf-8");
       const ownerName = await resolveOwnerName(path, sessionInfo);
-      const parsed = parseGrokBotLines(content.split("\n"), {
-        sourcePath: path,
-        ownerName,
-      });
+      const parsed = await attachGrokBotSubAgents(
+        parseGrokBotLines(content.split("\n"), {
+          sourcePath: path,
+          ownerName,
+        }),
+        path,
+      );
       return {
         path,
         ownerName: ownerName || parsed.agentName,
@@ -288,30 +303,22 @@ export function parseGrokBotLines(
         if (!turnTimestamp) turnTimestamp = result.timestamp;
       }
 
-      if (PROMOTED_TEXT_TOOLS.has(rawName.toLowerCase())) {
-        const isStatusUpdate = rawName.toLowerCase() === COMMUNICATE_UPDATE_TOOL;
-        if (isStatusUpdate && result?.isError) {
-          const call: ToolCallSite = {
-            name: mapGrokBotToolName(rawName),
-            rawName,
-            id,
-            input: mapGrokBotToolArgs(rawName, block.input),
-            result,
-          };
-          blocks.push(buildToolUseBlock(call, durationStart));
-          continue;
-        }
-        const visible = isStatusUpdate
-          ? extractStatusUpdateText(block.input)
-          : extractSendMessageText(block.input);
+      if (rawName.toLowerCase() === SEND_MESSAGE_TOOL) {
+        const visible = extractSendMessageText(block.input);
         if (visible.trim()) blocks.push({ type: "text", text: visible });
         continue;
       }
 
+      if (isGrokBotHiddenTool(rawName)) continue;
+
       const mappedInput = mapGrokBotToolArgs(rawName, block.input);
+      const childId = result?.subagentId || findSandSubagentId(mappedInput);
+      if (childId && !stringField(mappedInput, "sessionId")) {
+        mappedInput.sessionId = childId;
+      }
       const mcp = grokBotMcpAttribution(rawName, mappedInput);
       const call: ToolCallSite = {
-        name: mapGrokBotToolName(rawName),
+        name: grokBotReplayToolName(rawName, mappedInput),
         rawName,
         id,
         input: mappedInput,
@@ -343,11 +350,12 @@ export function parseGrokBotLines(
   const roots = getGrokBotTranscriptRoots();
   const notes = [
     "Grok Bot JSONL does not record token usage or model IDs in v1.",
-    "send_message and successful communicate_update calls are promoted to assistant text; failed communicate_update stays a tool-call scene.",
+    "send_message is promoted to assistant text. communicate_update is a status/memory tool scene, not a user-visible reply.",
     "Assistant text blocks are private scratch and map to thinking scenes; they are not the visible reply.",
-    "sand-subagent transcripts are indexed as separate sessions.",
+    "sand-subagent transcripts stay discoverable as their own sessions; parent `task` calls attach a child-run card when the result names a sibling id.",
     "Group-chat wakes split into a room context-injection, human user turns, and assistant-side turns for other bots. Sibling transcripts that share the room title merge into one timeline.",
-    "[routine]/[agent] wakes are context-injection; [inbound] remaining text is a user prompt; answering-question wraps are context-injection.",
+    "[routine]/[agent] wakes are context-injection; [inbound] remaining text is a user prompt; answering-question wraps are context-injection; background-task wakes are context-injection.",
+    "generate_image / computer_use results keep filePath/screenshotPath and omit embedded imageData. file:// markdown images in send_message are rewritten to a path mention and are not bundled into shareable HTML.",
   ];
 
   return {
@@ -387,11 +395,16 @@ export function stripUserDecorators(text: string): string {
 }
 
 export function extractSendMessageText(input: unknown, depth = 0): string {
+  const raw = extractSendMessageTextRaw(input, depth);
+  return depth === 0 ? rewriteGrokBotShareableText(raw) : raw;
+}
+
+function extractSendMessageTextRaw(input: unknown, depth = 0): string {
   if (depth > 6 || input == null) return "";
   if (typeof input === "string") return input;
   if (Array.isArray(input)) {
     return input
-      .map((item) => extractSendMessageText(item, depth + 1))
+      .map((item) => extractSendMessageTextRaw(item, depth + 1))
       .filter(Boolean)
       .join("\n");
   }
@@ -400,7 +413,7 @@ export function extractSendMessageText(input: unknown, depth = 0): string {
   if (typeof obj.content === "string") return obj.content;
   if (typeof obj.text === "string") return obj.text;
   const nested = [obj.text, obj.content, obj.message, obj.widgets];
-  const parts = nested.map((item) => extractSendMessageText(item, depth + 1)).filter(Boolean);
+  const parts = nested.map((item) => extractSendMessageTextRaw(item, depth + 1)).filter(Boolean);
   if (parts.length > 0) return parts.join("\n");
   if (typeof obj.label === "string") return obj.label;
   if (typeof obj.title === "string") return obj.title;
@@ -426,12 +439,14 @@ function collectToolResults(records: { record: GrokBotRecord }[]): CollectedResu
       const name = typeof block.name === "string" ? block.name : "";
       const id = firstString(block.toolCallId, block.tool_call_id, block.tool_use_id);
       const formatted = formatToolResult(block.result ?? block.content);
+      const subagentId = findSandSubagentId(block.result ?? block.content);
       results.push({
         name,
         ...(id ? { id } : {}),
         text: formatted.text,
         isError: formatted.isError,
         ...(formatted.timestamp ? { timestamp: formatted.timestamp } : {}),
+        ...(subagentId ? { subagentId } : {}),
         used: false,
       });
     }
@@ -440,10 +455,11 @@ function collectToolResults(records: { record: GrokBotRecord }[]): CollectedResu
 }
 
 function formatToolResult(result: unknown): { text: string; isError: boolean; timestamp?: string } {
-  if (result == null) return { text: "", isError: false };
-  if (typeof result === "string") return { text: result, isError: false };
-  if (typeof result !== "object") return { text: String(result), isError: false };
-  const obj = result as Record<string, unknown>;
+  const scrubbed = scrubGrokBotMediaPayload(result);
+  if (scrubbed == null) return { text: "", isError: false };
+  if (typeof scrubbed === "string") return { text: scrubbed, isError: false };
+  if (typeof scrubbed !== "object") return { text: String(scrubbed), isError: false };
+  const obj = scrubbed as Record<string, unknown>;
   if ("success" in obj) {
     return {
       text: formatSuccessPayload(obj.success),
@@ -472,31 +488,56 @@ function formatToolResult(result: unknown): { text: string; isError: boolean; ti
 }
 
 function formatSuccessPayload(success: unknown): string {
-  if (typeof success === "string") return success;
-  if (!success || typeof success !== "object") return success == null ? "" : String(success);
-  const obj = success as Record<string, unknown>;
+  const scrubbed = scrubGrokBotMediaPayload(success);
+  if (typeof scrubbed === "string") return scrubbed;
+  if (!scrubbed || typeof scrubbed !== "object") return scrubbed == null ? "" : String(scrubbed);
+  const obj = scrubbed as Record<string, unknown>;
   if (typeof obj.content === "string") return obj.content;
   if (typeof obj.stdout === "string") return obj.stdout;
   if (typeof obj.output === "string") return obj.output;
   if (typeof obj.text === "string") return obj.text;
+  const mediaPath = mediaPathFromPayload(obj);
   const rest = omitKeys(obj, ["timestamp", "messageId", "message_id"]);
-  if (Object.keys(rest).length === 0) return "";
+  const remaining = mediaPath
+    ? omitKeys(rest, [
+        "filePath",
+        "file_path",
+        "screenshotPath",
+        "screenshot_path",
+        "imagePath",
+        "image_path",
+        "path",
+      ])
+    : rest;
+  const omittedNotes = Object.values(remaining).filter(
+    (item): item is string => typeof item === "string" && item.startsWith("[omitted "),
+  );
+  const onlyOmitted =
+    Object.keys(remaining).length === 0 ||
+    Object.values(remaining).every(
+      (item) => typeof item === "string" && item.startsWith("[omitted "),
+    );
+  if (mediaPath && onlyOmitted) {
+    return omittedNotes.length > 0 ? `${mediaPath}\n${omittedNotes[0]}` : mediaPath;
+  }
+  if (Object.keys(rest).length === 0) return mediaPath || "";
   return formatPayload(rest);
 }
 
 function formatPayload(value: unknown): string {
-  if (value == null) return "";
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
+  const scrubbed = scrubGrokBotMediaPayload(value);
+  if (scrubbed == null) return "";
+  if (typeof scrubbed === "string") return scrubbed;
+  if (typeof scrubbed === "number" || typeof scrubbed === "boolean") return String(scrubbed);
+  if (typeof scrubbed === "object") {
+    const obj = scrubbed as Record<string, unknown>;
     if (typeof obj.message === "string") return obj.message;
     if (typeof obj.reason === "string") return obj.reason;
     if (typeof obj.error === "string") return obj.error;
     if (typeof obj.content === "string") return obj.content;
   }
   try {
-    return JSON.stringify(value, null, 2);
+    return JSON.stringify(scrubbed, null, 2);
   } catch {
     return "";
   }
@@ -588,8 +629,126 @@ function firstString(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+function stringField(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
 function namesMatch(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();
+}
+
+const SUBAGENT_MAX_SCENES = 60;
+const SUBAGENT_PROMPT_CHARS = 500;
+const SUBAGENT_TEXT_CHARS = 1000;
+const SUBAGENT_THINKING_CHARS = 500;
+
+type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
+type AttachedSubAgent = NonNullable<ToolUseBlock["_subAgent"]>;
+
+async function attachGrokBotSubAgents(
+  parsed: ProviderParseResult,
+  sourcePath?: string,
+): Promise<ProviderParseResult> {
+  if (!sourcePath) return parsed;
+  const parentId = basename(sourcePath, ".jsonl");
+  if (!parentId || parentId.startsWith(SAND_SUBAGENT_PREFIX)) return parsed;
+  const transcriptsRoot = dirname(dirname(sourcePath));
+  const summaries: NonNullable<ProviderParseResult["subAgentSummary"]> = [
+    ...(parsed.subAgentSummary || []),
+  ];
+
+  for (const turn of parsed.turns) {
+    for (const block of turn.blocks) {
+      if (block.type !== "tool_use" || block.name !== "Agent" || block._subAgent) continue;
+      const childId = findSandSubagentId(block.input) || findSandSubagentId(block._result);
+      if (!childId || childId === parentId) continue;
+      const childPath = join(transcriptsRoot, childId, `${childId}.jsonl`);
+      const content = await readFile(childPath, "utf-8").catch(() => null);
+      if (content == null) continue;
+      const child = parseGrokBotLines(content.split("\n"), { sourcePath: childPath });
+      const subAgent = subAgentFromParsed(child, block, childId);
+      block._subAgent = subAgent;
+      summaries.push({
+        agentId: subAgent.agentId,
+        agentType: subAgent.agentType,
+        ...(subAgent.description ? { description: subAgent.description } : {}),
+        toolCalls: subAgent.toolCalls,
+        ...(subAgent.model ? { model: subAgent.model } : {}),
+      });
+    }
+  }
+
+  if (summaries.length === 0) return parsed;
+  return { ...parsed, subAgentSummary: summaries };
+}
+
+function subAgentFromParsed(
+  child: ProviderParseResult,
+  parentBlock: ToolUseBlock,
+  childId: string,
+): AttachedSubAgent {
+  const input = parentBlock.input || {};
+  const agentType = normalizeSubAgentType(
+    typeof input.subagent_type === "string" && input.subagent_type.trim()
+      ? input.subagent_type
+      : "unknown",
+  );
+  const description =
+    typeof input.description === "string" && input.description.trim()
+      ? input.description.trim()
+      : undefined;
+  const prompt =
+    typeof input.prompt === "string" ? input.prompt.slice(0, SUBAGENT_PROMPT_CHARS) : "";
+
+  let toolCalls = 0;
+  let thinkingBlocks = 0;
+  let textResponses = 0;
+  const scenes: AttachedSubAgent["scenes"] = [];
+
+  for (const turn of child.turns) {
+    if (turn.role !== "assistant") continue;
+    for (const block of turn.blocks) {
+      if (block.type === "thinking") {
+        thinkingBlocks++;
+        scenes.push({
+          type: "thinking",
+          content: block.thinking.slice(0, SUBAGENT_THINKING_CHARS),
+          ...(turn.timestamp ? { timestamp: turn.timestamp } : {}),
+        });
+      } else if (block.type === "text") {
+        textResponses++;
+        scenes.push({
+          type: "text-response",
+          content: block.text.slice(0, SUBAGENT_TEXT_CHARS),
+          ...(turn.timestamp ? { timestamp: turn.timestamp } : {}),
+        });
+      } else if (block.type === "tool_use") {
+        toolCalls++;
+        scenes.push({
+          type: "tool-call",
+          toolName: block.name,
+          input: block.input,
+          result: (block._result || "").slice(0, SUBAGENT_TEXT_CHARS),
+          ...(block._hasResult !== undefined ? { hasResult: block._hasResult } : {}),
+          isError: block._isError || false,
+          ...(turn.timestamp ? { timestamp: turn.timestamp } : {}),
+          ...(block._durationMs ? { durationMs: block._durationMs } : {}),
+        });
+      }
+    }
+  }
+
+  return {
+    agentId: childId,
+    agentType,
+    ...(description ? { description } : {}),
+    prompt,
+    toolCalls,
+    thinkingBlocks,
+    textResponses,
+    scenes: scenes.length > SUBAGENT_MAX_SCENES ? scenes.slice(0, SUBAGENT_MAX_SCENES) : scenes,
+  };
 }
 
 export function countGrokBotDiscoveryStats(content: string): {
@@ -666,7 +825,8 @@ export function countGrokBotDiscoveryStats(content: string): {
     for (const block of asBlocks(record.message?.content)) {
       if (block.type !== "tool_use") continue;
       const name = typeof block.name === "string" ? block.name : "";
-      if (PROMOTED_TEXT_TOOLS.has(name.toLowerCase())) continue;
+      if (name.toLowerCase() === SEND_MESSAGE_TOOL) continue;
+      if (isGrokBotHiddenTool(name)) continue;
       toolCallCount++;
       if (isGrokBotEditTool(name)) editCountEst++;
     }

--- a/packages/provider-grok-bot/src/grok-bot/subagent.ts
+++ b/packages/provider-grok-bot/src/grok-bot/subagent.ts
@@ -1,0 +1,40 @@
+const SAND_SUBAGENT_ID_RE =
+  /sand-subagent-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+const ID_KEYS = [
+  "sessionId",
+  "session_id",
+  "agentId",
+  "agent_id",
+  "subagentId",
+  "subagent_id",
+  "id",
+];
+
+/** Pull a `sand-subagent-<uuid>` id out of task input/result payloads. */
+export function findSandSubagentId(value: unknown, depth = 0): string | undefined {
+  if (depth > 6 || value == null) return undefined;
+  if (typeof value === "string") {
+    const match = SAND_SUBAGENT_ID_RE.exec(value);
+    return match?.[0];
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findSandSubagentId(item, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (typeof value !== "object") return undefined;
+  const obj = value as Record<string, unknown>;
+  for (const key of ID_KEYS) {
+    if (!(key in obj)) continue;
+    const found = findSandSubagentId(obj[key], depth + 1);
+    if (found) return found;
+  }
+  for (const item of Object.values(obj)) {
+    const found = findSandSubagentId(item, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
+}

--- a/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
+++ b/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
@@ -3,44 +3,56 @@
  * (`read`, `write`, `shell`). The viewer's transform layer keys off canonical
  * names like `Read`, `Write`, `Bash` to build diffs and shell scenes.
  *
- * `send_message` and successful `communicate_update` are promoted to assistant
- * text in the parser. Failed `communicate_update` reaches this map as
- * `CommunicateUpdate`. `mcp` keeps its raw name so the scanner's
- * Pi-style `parseMcpUsage` branch can attribute server/tool from args.
- * Unrecognized tools (GitHub MCP names, future builtins) pass through unchanged.
+ * `send_message` is promoted to assistant text in the parser.
+ * `communicate_update` is a status/memory side-effect and stays a
+ * `CommunicateUpdate` tool scene (success and failure). `get_mcp_tools` is
+ * discovery noise and is omitted from replay scenes. `mcp` keeps its raw
+ * name so the scanner's Pi-style `parseMcpUsage` branch can attribute
+ * server/tool from args. Dynamic MCP calls use short names plus
+ * `serverIdentifier` / `toolName` / `args` and are rewritten to
+ * `mcp__<server>__<tool>` cards. Unrecognized non-MCP tools pass through.
  */
+
+const GROK_BOT_TOOL_NAME_MAP: Record<string, string> = {
+  read: "Read",
+  write: "Write",
+  edit: "Edit",
+  strreplace: "Edit",
+  search_replace: "Edit",
+  multiedit: "MultiEdit",
+  delete: "Delete",
+  grep: "Grep",
+  glob: "Glob",
+  glob_file_search: "Glob",
+  ls: "LS",
+  find: "Find",
+  shell: "Bash",
+  bash: "Bash",
+  exec: "Bash",
+  web_search: "WebSearch",
+  websearch: "WebSearch",
+  web_fetch: "WebFetch",
+  webfetch: "WebFetch",
+  todo: "TodoWrite",
+  todowrite: "TodoWrite",
+  update_todos: "TodoWrite",
+  task: "Agent",
+  delegate_task: "Agent",
+  await: "Await",
+  computer_use: "ComputerUse",
+  generate_image: "GenerateImage",
+  get_mcp_tools: "GetMcpTools",
+  communicate_update: "CommunicateUpdate",
+};
+
+const GROK_BOT_BUILTIN_TOOLS = new Set([
+  ...Object.keys(GROK_BOT_TOOL_NAME_MAP),
+  "send_message",
+  "mcp",
+]);
+
 export function mapGrokBotToolName(name: string): string {
-  const mapping: Record<string, string> = {
-    read: "Read",
-    write: "Write",
-    edit: "Edit",
-    strreplace: "Edit",
-    search_replace: "Edit",
-    multiedit: "MultiEdit",
-    delete: "Delete",
-    grep: "Grep",
-    glob: "Glob",
-    glob_file_search: "Glob",
-    ls: "LS",
-    find: "Find",
-    shell: "Bash",
-    bash: "Bash",
-    exec: "Bash",
-    web_search: "WebSearch",
-    websearch: "WebSearch",
-    web_fetch: "WebFetch",
-    webfetch: "WebFetch",
-    todo: "TodoWrite",
-    todowrite: "TodoWrite",
-    update_todos: "TodoWrite",
-    task: "Agent",
-    delegate_task: "Agent",
-    await: "Await",
-    computer_use: "ComputerUse",
-    get_mcp_tools: "GetMcpTools",
-    communicate_update: "CommunicateUpdate",
-  };
-  return mapping[name.toLowerCase()] || name;
+  return GROK_BOT_TOOL_NAME_MAP[name.toLowerCase()] || name;
 }
 
 export function isGrokBotEditTool(name: string): boolean {
@@ -48,10 +60,20 @@ export function isGrokBotEditTool(name: string): boolean {
   return mapped === "Edit" || mapped === "Write" || mapped === "MultiEdit" || mapped === "Delete";
 }
 
+/** Discovery/list_tools noise — consume the result, do not emit a scene. */
+export function isGrokBotHiddenTool(name: string): boolean {
+  return name.toLowerCase() === "get_mcp_tools";
+}
+
+export function isGrokBotBuiltinTool(name: string): boolean {
+  return GROK_BOT_BUILTIN_TOOLS.has(name.toLowerCase());
+}
+
 /**
  * Normalize Grok Bot tool input into the field names the transform expects.
  * File tools use `path`; the transform wants `file_path`. Edit replacements
- * map onto `old_string` / `new_string`.
+ * map onto `old_string` / `new_string`. Dynamic MCP calls flatten `args` and
+ * copy `serverIdentifier` / `toolName` onto `server` / `tool`.
  */
 export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<string, unknown> {
   const obj =
@@ -59,6 +81,8 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
       ? { ...(input as Record<string, unknown>) }
       : {};
   const normalized = toolName.toLowerCase();
+
+  flattenToolArgs(obj);
 
   if (
     normalized === "read" ||
@@ -111,19 +135,29 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
     const description = firstString(obj.description, obj.goal, obj.title);
     const prompt = firstString(obj.prompt, obj.context, obj.task, obj.instruction);
     const subagentType = firstString(obj.subagent_type, obj.subagentType, obj.role, obj.type);
+    const sessionId = firstString(
+      obj.sessionId,
+      obj.session_id,
+      obj.agentId,
+      obj.agent_id,
+      obj.subagentId,
+    );
     if (description) obj.description = description;
     if (prompt) obj.prompt = prompt;
     if (subagentType) obj.subagent_type = subagentType;
+    if (sessionId) obj.sessionId = sessionId;
   }
 
-  if (normalized === "mcp") {
-    const server = firstString(obj.server, obj.serverName, obj.server_name);
-    const tool = firstString(obj.tool, obj.toolName, obj.tool_name, obj.name);
-    if (server) obj.server = server;
-    if (tool) {
-      obj.tool = tool;
-      if (!firstString(obj.tool_name)) obj.tool_name = tool;
-    }
+  if (normalized === "generate_image") {
+    const prompt = firstString(obj.prompt, obj.text, obj.description);
+    if (prompt) obj.prompt = prompt;
+  }
+
+  const mcp = grokBotMcpFields(obj);
+  if (mcp.server) obj.server = mcp.server;
+  if (mcp.tool) {
+    obj.tool = mcp.tool;
+    if (!firstString(obj.tool_name)) obj.tool_name = mcp.tool;
   }
 
   return obj;
@@ -133,14 +167,57 @@ export function grokBotMcpAttribution(
   toolName: string,
   input: Record<string, unknown>,
 ): { server?: string; tool?: string } | undefined {
-  if (toolName.toLowerCase() !== "mcp") return undefined;
-  const server = firstString(input.server, input.serverName, input.server_name);
-  const tool = firstString(input.tool, input.toolName, input.tool_name);
-  if (!server && !tool) return undefined;
+  const fields = grokBotMcpFields(input);
+  if (toolName.toLowerCase() === "mcp") {
+    if (!fields.server && !fields.tool) return undefined;
+    return fields;
+  }
+  if (isGrokBotBuiltinTool(toolName)) return undefined;
+  if (!hasDynamicMcpIdentifiers(input)) return undefined;
+  if (!fields.server && !fields.tool) return undefined;
+  return {
+    ...(fields.server ? { server: fields.server } : {}),
+    ...(fields.tool ? { tool: fields.tool } : { tool: toolName }),
+  };
+}
+
+/** Viewer MCP cards use `mcp__server__tool` so the 🔌 label parses. */
+export function grokBotReplayToolName(rawName: string, input: Record<string, unknown>): string {
+  if (rawName.toLowerCase() === "mcp") return "mcp";
+  const mcp = grokBotMcpAttribution(rawName, input);
+  if (mcp?.server && mcp.tool) return `mcp__${mcp.server}__${mcp.tool}`;
+  return mapGrokBotToolName(rawName);
+}
+
+function grokBotMcpFields(input: Record<string, unknown>): { server?: string; tool?: string } {
+  const server = firstString(
+    input.server,
+    input.serverIdentifier,
+    input.serverName,
+    input.server_name,
+    input.providerIdentifier,
+  );
+  const tool = firstString(input.tool, input.toolName, input.tool_name, input.name);
   return {
     ...(server ? { server } : {}),
     ...(tool ? { tool } : {}),
   };
+}
+
+function hasDynamicMcpIdentifiers(input: Record<string, unknown>): boolean {
+  return !!(
+    firstString(input.serverIdentifier, input.providerIdentifier, input.server) ||
+    firstString(input.toolName, input.tool_name) ||
+    (input.args && typeof input.args === "object")
+  );
+}
+
+function flattenToolArgs(obj: Record<string, unknown>): void {
+  const args = obj.args;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return;
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    if (obj[key] === undefined) obj[key] = value;
+  }
 }
 
 function firstString(...values: unknown[]): string | undefined {

--- a/packages/provider-grok-bot/test/discover.test.ts
+++ b/packages/provider-grok-bot/test/discover.test.ts
@@ -460,6 +460,73 @@ It's your turn, Vibe Replay GTM.`,
     expect(sessions[0].firstPrompt).not.toContain("[routine]");
   });
 
+  it("does not use a background-task wake as firstPrompt", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-grok-bot-bg-task-"));
+    tempDirs.push(root);
+    await writeSession(root, "77777777-7777-4777-8777-777777777777", [
+      {
+        role: "user",
+        message: {
+          content: [
+            {
+              type: "text",
+              text: "[A background task just completed]\nLong recap that must not be the Explore prompt.",
+            },
+          ],
+        },
+      },
+      {
+        role: "user",
+        message: { content: [{ type: "text", text: "[t0u]\nDraw a cat" }] },
+      },
+    ]);
+
+    const sessions = await discoverGrokBotSessions([root], false);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      promptCount: 1,
+      firstPrompt: "Draw a cat",
+    });
+    expect(sessions[0].firstPrompt).not.toContain("background task");
+    expect(sessions[0].firstPrompt).not.toContain("Long recap");
+  });
+
+  it("keeps CJK group titles as merge keys instead of collapsing to group", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-grok-bot-cjk-group-"));
+    tempDirs.push(root);
+    const travelId = "88888888-8888-4888-8888-888888888888";
+    const artistId = "99999999-9999-4999-8999-999999999999";
+    const wake = (recipient: string) =>
+      `[Group chat: "周末出行" - with 🧭旅游助手]
+Participants: 🧭旅游助手 (travel) 艺术家 (artist)
+New messages in the room (oldest first):
+User: 一起画画
+It's your turn, ${recipient}.`;
+    await writeSession(root, travelId, [
+      {
+        role: "user",
+        message: { content: [{ type: "text", text: wake("🧭旅游助手") }] },
+      },
+    ]);
+    await writeSession(root, artistId, [
+      {
+        role: "user",
+        message: { content: [{ type: "text", text: wake("艺术家") }] },
+      },
+    ]);
+
+    const sessions = await discoverGrokBotSessions([root], false);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: "group-周末出行",
+      slug: "group-周末出行",
+      title: "Group: 周末出行",
+      firstPrompt: "一起画画",
+    });
+    expect(sessions[0].sessionId).not.toBe("group-group");
+    expect(sessions[0].filePaths).toHaveLength(2);
+  });
+
   it("prefers profile.json name for a non-group DM and labels subagents without a profile", async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), "vibe-grok-bot-dm-title-"));
     tempDirs.push(dataRoot);

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -7,9 +7,12 @@ import {
   formatGroupSpeakerMessage,
   isGrokBotGroupChatPayload,
   isHumanGroupSpeaker,
+  normalizeGroupKey,
   parseGrokBotGroupWake,
   parseGrokBotLines,
   parseGrokBotSession,
+  sameSpeakerName,
+  speakerIdentityKey,
 } from "../src/grok-bot/parser.js";
 import { transformToReplay } from "./helpers/transform.js";
 
@@ -143,6 +146,24 @@ It's your turn, Vibe Replay Eng.`);
     expect(extractGroupMentions("@Vibe Replay Eng please look", ["Vibe Replay Eng"])).toEqual([
       "@Vibe Replay Eng",
     ]);
+  });
+
+  it("splits CJK and emoji display names as speakers and keeps Unicode room keys", () => {
+    const wake = parseGrokBotGroupWake(`[Group chat: "周末出行" - with 🧭旅游助手]
+Participants: 🧭旅游助手 (travel) 艺术家 (artist)
+New messages in the room (oldest first):
+User: 一起画画
+艺术家: 好的，我来起草图
+It's your turn, 🧭旅游助手.`);
+    expect(wake).toMatchObject({
+      groupTitle: "周末出行",
+      turnRecipient: "🧭旅游助手",
+    });
+    expect(wake?.messages.map((msg) => msg.speaker)).toEqual(["User", "艺术家"]);
+    expect(normalizeGroupKey("周末出行")).toBe("周末出行");
+    expect(normalizeGroupKey("🧭旅游助手")).toBe("旅游助手");
+    expect(sameSpeakerName("🧭旅游助手", "旅游助手")).toBe(true);
+    expect(speakerIdentityKey("🧭旅游助手")).toBe("旅游助手");
   });
 
   it("treats listed participants as bots and everyone else as human", () => {

--- a/packages/provider-grok-bot/test/parser.test.ts
+++ b/packages/provider-grok-bot/test/parser.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,11 +7,18 @@ import {
   classifyGrokBotUserWake,
   extractSendMessageText,
   extractStatusUpdateText,
+  findSandSubagentId,
   parseGrokBotLines,
   parseGrokBotSession,
+  rewriteGrokBotShareableText,
+  scrubGrokBotMediaPayload,
   stripUserDecorators,
 } from "../src/grok-bot/parser.js";
-import { mapGrokBotToolArgs, mapGrokBotToolName } from "../src/grok-bot/tool-mapping.js";
+import {
+  grokBotReplayToolName,
+  mapGrokBotToolArgs,
+  mapGrokBotToolName,
+} from "../src/grok-bot/tool-mapping.js";
 import { transformToReplay } from "./helpers/transform.js";
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
@@ -279,7 +286,7 @@ describe("Grok Bot parser", () => {
       .filter((block) => block.type === "text")
       .map((block) => (block.type === "text" ? block.text : ""));
     expect(assistantText).toContain("Hey — good to meet you.");
-    expect(assistantText).toContain("Checking the badge copy now.");
+    expect(assistantText).not.toContain("Checking the badge copy now.");
     expect(assistantText).toContain("Badge copy looks good.");
     expect(assistantText.some((text) => text.includes("example.invalid"))).toBe(false);
 
@@ -287,11 +294,12 @@ describe("Grok Bot parser", () => {
       .flatMap((turn) => turn.blocks)
       .filter((block) => block.type === "tool_use");
     expect(tools.map((block) => (block.type === "tool_use" ? block.name : ""))).toEqual([
+      "CommunicateUpdate",
       "Read",
       "TodoWrite",
       "Bash",
     ]);
-    expect(tools[1]).toMatchObject({
+    expect(tools[2]).toMatchObject({
       name: "TodoWrite",
       input: {
         todos: [
@@ -300,18 +308,21 @@ describe("Grok Bot parser", () => {
         ],
       },
     });
-    const read = tools[0];
+    const read = tools[1];
     expect(read.type === "tool_use" && read._durationMs).toBe(3000);
     expect(read.type === "tool_use" && read._durationSource).toBe("timestamp");
 
     const replay = transformToReplay(parsed, "grok-bot", "~/grok-bot");
     expect(
       replay.scenes.some(
-        (scene) =>
-          scene.type === "tool-call" &&
-          (scene.toolName === "send_message" || scene.toolName === "communicate_update"),
+        (scene) => scene.type === "tool-call" && scene.toolName === "send_message",
       ),
     ).toBe(false);
+    expect(
+      replay.scenes.some(
+        (scene) => scene.type === "tool-call" && scene.toolName === "CommunicateUpdate",
+      ),
+    ).toBe(true);
     expect(
       replay.scenes.some((scene) => scene.type === "tool-call" && scene.toolName === "Read"),
     ).toBe(true);
@@ -381,8 +392,12 @@ describe("Grok Bot parser", () => {
       .flatMap((turn) => turn.blocks)
       .filter((block) => block.type === "text")
       .map((block) => (block.type === "text" ? block.text : ""));
-    expect(assistantText).toContain("Scanning inbox…");
     expect(assistantText).toContain("I can help with that.");
+    expect(assistantText).not.toContain("Scanning inbox…");
+    const statusTools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use" && block.name === "CommunicateUpdate");
+    expect(statusTools).toHaveLength(1);
   });
 
   it("maps Sand-native tools including mcp, await, computer_use, and task", () => {
@@ -485,7 +500,6 @@ describe("Grok Bot parser", () => {
       "Await",
       "Agent",
       "mcp",
-      "GetMcpTools",
       "ComputerUse",
       "WebSearch",
     ]);
@@ -503,7 +517,7 @@ describe("Grok Bot parser", () => {
       _mcpServer: "github",
       _mcpTool: "pull_request_read",
     });
-    expect(tools[5]).toMatchObject({
+    expect(tools[4]).toMatchObject({
       name: "WebSearch",
       input: { search_term: "vibe-replay grok bot", query: "vibe-replay grok bot" },
     });
@@ -592,7 +606,7 @@ describe("Grok Bot parser", () => {
     expect(tools[0]).toMatchObject({ name: "Read", _durationMs: 4000 });
   });
 
-  it("keeps a failed communicate_update as an error tool and still promotes successes", () => {
+  it("keeps communicate_update as a status tool for both failure and success", () => {
     const parsed = parseGrokBotLines([
       JSON.stringify({
         role: "user",
@@ -654,18 +668,340 @@ describe("Grok Bot parser", () => {
     const tools = parsed.turns
       .flatMap((turn) => turn.blocks)
       .filter((block) => block.type === "tool_use");
-    expect(tools).toHaveLength(1);
+    expect(tools).toHaveLength(2);
     expect(tools[0]).toMatchObject({
       name: "CommunicateUpdate",
       _isError: true,
       _result: "delivery failed",
     });
+    expect(tools[1]).toMatchObject({
+      name: "CommunicateUpdate",
+    });
+    expect(tools[1].type === "tool_use" && tools[1]._isError).toBeUndefined();
     const texts = parsed.turns
       .flatMap((turn) => turn.blocks)
       .filter((block) => block.type === "text")
       .map((block) => (block.type === "text" ? block.text : ""));
-    expect(texts).toContain("Still working.");
+    expect(texts).not.toContain("Still working.");
     expect(texts).not.toContain("This ping never landed.");
+  });
+
+  it("classifies background-task, first-run, and profile-update wakes", () => {
+    expect(
+      classifyGrokBotUserWake("[A background task just completed]\nWrote the travel recap."),
+    ).toEqual({
+      kind: "context-injection",
+      text: "Background task completed:\nWrote the travel recap.",
+      label: "background-task",
+    });
+    expect(classifyGrokBotUserWake("[first run]\nbootstrap")).toEqual({ kind: "skip" });
+    expect(classifyGrokBotUserWake("<<SAND_AGENT_PROFILE_UPDATE\nname: 艺术家\n>>")).toEqual({
+      kind: "skip",
+    });
+    expect(
+      classifyGrokBotUserWake("<<SAND_AGENT_PROFILE_UPDATE name=x >>\nPlease draw a cat"),
+    ).toEqual({ kind: "prompt", text: "Please draw a cat" });
+  });
+
+  it("omits get_mcp_tools discovery noise and maps dynamic MCP short names", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "check the PR" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "get_mcp_tools", toolCallId: "g-1", input: {} },
+            {
+              type: "tool_use",
+              name: "pull_request_read",
+              toolCallId: "p-1",
+              input: {
+                serverIdentifier: "github",
+                providerIdentifier: "github",
+                toolName: "pull_request_read",
+                args: { pullNumber: 544, method: "get" },
+              },
+            },
+            {
+              type: "tool_use",
+              name: "search_analytics_query",
+              toolCallId: "s-1",
+              input: {
+                serverIdentifier: "google-analytics",
+                toolName: "search_analytics_query",
+                args: { property: "properties/1" },
+              },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "get_mcp_tools",
+              toolCallId: "g-1",
+              result: { success: { timestamp: 1788485472000, content: "github, slack" } },
+            },
+            {
+              type: "tool_result",
+              name: "pull_request_read",
+              toolCallId: "p-1",
+              result: { success: { timestamp: 1788485474000, content: "PR 544" } },
+            },
+            {
+              type: "tool_result",
+              name: "search_analytics_query",
+              toolCallId: "s-1",
+              result: { success: { timestamp: 1788485476000, content: "rows" } },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools.map((block) => (block.type === "tool_use" ? block.name : ""))).toEqual([
+      "mcp__github__pull_request_read",
+      "mcp__google-analytics__search_analytics_query",
+    ]);
+    expect(tools[0]).toMatchObject({
+      _mcpServer: "github",
+      _mcpTool: "pull_request_read",
+      input: { pullNumber: 544, method: "get", server: "github", tool: "pull_request_read" },
+      _result: "PR 544",
+    });
+    expect(JSON.stringify(parsed.turns)).not.toContain("GetMcpTools");
+  });
+
+  it("strips generate_image and computer_use base64 while keeping file paths", () => {
+    const imageData = `iVBOR${"A".repeat(120)}`;
+    const screenshot = `iVBOR${"B".repeat(120)}`;
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "draw then screenshot" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "generate_image",
+              toolCallId: "img-1",
+              input: { prompt: "a cat" },
+            },
+            {
+              type: "tool_use",
+              name: "computer_use",
+              toolCallId: "cu-1",
+              input: { action: "screenshot" },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "generate_image",
+              toolCallId: "img-1",
+              result: {
+                success: {
+                  timestamp: 1788485500000,
+                  filePath: "/home/box/agent-data/assets/cat.png",
+                  imageData,
+                },
+              },
+            },
+            {
+              type: "tool_result",
+              name: "computer_use",
+              toolCallId: "cu-1",
+              result: {
+                success: {
+                  timestamp: 1788485505000,
+                  screenshotPath: "/tmp/screenshot.png",
+                  screenshot,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools[0]).toMatchObject({
+      name: "GenerateImage",
+    });
+    expect(tools[0].type === "tool_use" && tools[0]._result).toContain(
+      "/home/box/agent-data/assets/cat.png",
+    );
+    expect(tools[1]).toMatchObject({
+      name: "ComputerUse",
+    });
+    expect(tools[1].type === "tool_use" && tools[1]._result).toContain("/tmp/screenshot.png");
+    const dumped = JSON.stringify(tools);
+    expect(dumped).not.toContain(imageData);
+    expect(dumped).not.toContain(screenshot);
+    expect(dumped).toContain("omitted");
+    expect(scrubGrokBotMediaPayload({ imageData, filePath: "/x.png" })).toMatchObject({
+      filePath: "/x.png",
+      imageData: expect.stringContaining("omitted"),
+    });
+  });
+
+  it("rewrites file:// markdown images in send_message instead of leaving a file URI", () => {
+    const input = {
+      text: {
+        content: "See ![sketch](<file:///home/box/agent-data/attachments/cat.png>) and the rest.",
+      },
+    };
+    expect(extractSendMessageText(input)).toBe(
+      "See [image: sketch — /home/box/agent-data/attachments/cat.png] and the rest.",
+    );
+    expect(rewriteGrokBotShareableText("![x](file:///home/box/agent-data/assets/a.png)")).toBe(
+      "[image: x — /home/box/agent-data/assets/a.png]",
+    );
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [{ type: "tool_use", name: "send_message", input }],
+        },
+      }),
+    ]);
+    expect(parsed.turns[0].blocks[0]).toEqual({
+      type: "text",
+      text: "See [image: sketch — /home/box/agent-data/attachments/cat.png] and the rest.",
+    });
+  });
+
+  it("attaches a sibling sand-subagent transcript onto a parent task card", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-grok-bot-task-"));
+    const parentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const subId = "sand-subagent-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    await mkdir(join(root, parentId), { recursive: true });
+    await mkdir(join(root, subId), { recursive: true });
+    await writeFile(
+      join(root, parentId, `${parentId}.jsonl`),
+      [
+        {
+          role: "user",
+          message: { content: [{ type: "text", text: "explore the UI" }] },
+        },
+        {
+          role: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                name: "task",
+                toolCallId: "t-1",
+                input: { goal: "explore UI", context: "list badges", role: "explore" },
+              },
+            ],
+          },
+        },
+        {
+          role: "tool",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                name: "task",
+                toolCallId: "t-1",
+                result: {
+                  success: {
+                    timestamp: 1788485510000,
+                    sessionId: subId,
+                    content: "started",
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      join(root, subId, `${subId}.jsonl`),
+      [
+        {
+          role: "user",
+          message: { content: [{ type: "text", text: "list badges" }] },
+        },
+        {
+          role: "assistant",
+          message: {
+            content: [
+              { type: "text", text: "opening spec" },
+              {
+                type: "tool_use",
+                name: "read",
+                toolCallId: "r-1",
+                input: { path: "/home/box/reference/app-ui.md" },
+              },
+            ],
+          },
+        },
+        {
+          role: "tool",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                name: "read",
+                toolCallId: "r-1",
+                result: { success: { content: "# UI" } },
+              },
+            ],
+          },
+        },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+      "utf-8",
+    );
+    try {
+      expect(findSandSubagentId({ sessionId: subId })).toBe(subId);
+      const parsed = await parseGrokBotSession(join(root, parentId, `${parentId}.jsonl`));
+      const agent = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use" && block.name === "Agent");
+      expect(agent?.type === "tool_use" && agent._subAgent).toMatchObject({
+        agentId: subId,
+        agentType: "Explore",
+        description: "explore UI",
+        prompt: "list badges",
+        toolCalls: 1,
+        thinkingBlocks: 1,
+      });
+      expect(parsed.subAgentSummary).toEqual([
+        { agentId: subId, agentType: "Explore", description: "explore UI", toolCalls: 1 },
+      ]);
+      const replay = transformToReplay(parsed, "grok-bot", "~/grok-bot");
+      const scene = replay.scenes.find(
+        (item) => item.type === "tool-call" && item.toolName === "Agent",
+      );
+      expect(scene?.type === "tool-call" && scene.subAgent?.agentId).toBe(subId);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });
 
@@ -676,6 +1012,7 @@ describe("Grok Bot tool mapping", () => {
     expect(mapGrokBotToolName("update_todos")).toBe("TodoWrite");
     expect(mapGrokBotToolName("await")).toBe("Await");
     expect(mapGrokBotToolName("computer_use")).toBe("ComputerUse");
+    expect(mapGrokBotToolName("generate_image")).toBe("GenerateImage");
     expect(mapGrokBotToolName("get_mcp_tools")).toBe("GetMcpTools");
     expect(mapGrokBotToolName("communicate_update")).toBe("CommunicateUpdate");
     expect(mapGrokBotToolName("mcp")).toBe("mcp");
@@ -713,14 +1050,21 @@ describe("Grok Bot tool mapping", () => {
       new_string: "b",
     });
     expect(
-      mapGrokBotToolArgs("edit", {
-        path: "/tmp/a.ts",
-        oldText: "  indented\n",
-        newText: "  indented\n  more\n",
+      grokBotReplayToolName("pull_request_read", {
+        serverIdentifier: "github",
+        toolName: "pull_request_read",
+      }),
+    ).toBe("mcp__github__pull_request_read");
+    expect(
+      mapGrokBotToolArgs("pull_request_read", {
+        serverIdentifier: "github",
+        toolName: "pull_request_read",
+        args: { pullNumber: 544 },
       }),
     ).toMatchObject({
-      old_string: "  indented\n",
-      new_string: "  indented\n  more\n",
+      server: "github",
+      tool: "pull_request_read",
+      pullNumber: 544,
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of `provider-grok-bot` against newer live-box JSONL (mtime ≥ ~2026-09-05). Several hypotheses were already handled; the rest are real gaps in this PR.

**Already correct (no change)**
- `send_message` `input.text` as `{ content: "…" }` — `extractSendMessageText` already unwraps nested dicts.
- Group “It's your turn…” / wrapping-up cues — already dropped.
- Answering-question widget wraps — already context-injection + optional follow-up prompt.
- `update_todos` / `await` / `task`→`Agent` — already mapped.
- `[SAND_HIDDEN_PROMPT][first run]` — already skipped via the hidden-prompt filter.

**Broken / incomplete — fixed**
1. **`communicate_update`** is always a `CommunicateUpdate` tool scene (success and failure). Not promoted to assistant text.
2. **`generate_image` / `computer_use`** keep `filePath`/`screenshotPath` and replace binary payloads with `[omitted …]` stubs.
3. **Dynamic MCP** short names plus identifiers become `mcp__<server>__<tool>` cards. Bare `mcp` stays `mcp`.
4. **`get_mcp_tools`** is discovery noise — consumed, no scene, no usage count.
5. **Wake taxonomy:** background-task completion is context-injection; `[first run]` and `<<SAND_AGENT_PROFILE_UPDATE…>>` are skipped/stripped.
6. **`task` / sand-subagent** attaches a child-run card when a sibling JSONL exists.
7. **Speaker identity:** emoji/CJK display names parse as labels; merge keys strip punctuation/emoji.
8. **Markdown `file://` images** rewrite to a path mention; shareable HTML still does not bundle those files.

**CodeRabbit follow-up (this commit)**
- Fallback speaker labels reject lowercase Latin phrases with whitespace (`one thing to note:`) and cap word count; CJK/emoji/uppercase labels stay valid.
- MCP `server`/`tool` copies are gated to `mcp` and non-builtin calls; `input.name` is no longer an MCP tool fallback, so builtin `name` args cannot become phantom MCP fields.
- Multi-file group parse passes `sessionInfo` through; a single usable sibling keeps discovery `sessionId`/`slug`/`cwd`/`title`.

## Validation

- [x] `pnpm --filter @vibe-replay/provider-grok-bot test` (50 tests)
- [x] `pnpm --filter vibe-replay exec vitest run test/scanner.test.ts` (68 tests)
- [x] `pnpm lint:check`
- [x] `tsc --noEmit -p packages/provider-grok-bot/tsconfig.json`
- [x] Docs: `packages/provider-grok-bot/AGENTS.md`
- [x] No website/blog CTAs or gist publishes

CI `windows-smoke` on the previous head failed on an unrelated `dev-utils.test.ts` port-exhaustion flake. Not grok-bot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b4da885-ac51-42c9-8fa1-57117696bcc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b4da885-ac51-42c9-8fa1-57117696bcc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Grok Bot transcript parsing for background tasks, first-run messages, profile updates, and sub-agent activity.
  * Added support for Unicode names and group titles in conversations.
  * Improved display of dynamic MCP tools, image-generation actions, and shareable media.
* **Bug Fixes**
  * Removed MCP discovery noise from activity displays.
  * Prevented large embedded media data from bloating replay views.
  * Corrected status updates so they are distinguished from visible replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->