### PR TITLE
fix(grok-bot): tighten speaker fallback, MCP fields, and group metadata

### DIFF
--- a/packages/provider-grok-bot/AGENTS.md
+++ b/packages/provider-grok-bot/AGENTS.md
@@ -75,8 +75,10 @@ Sand builtins map onto the viewer vocabulary in `tool-mapping.ts`: `read`→`Rea
 `computer_use`→`ComputerUse`, `generate_image`→`GenerateImage`, plus the usual
 web/edit aliases. `get_mcp_tools` is discovery noise and is omitted from scenes.
 `mcp` and dynamic MCP short names (`pull_request_read`, `search_analytics_query`)
-plus `serverIdentifier` / `providerIdentifier` / `toolName` / `args` become
-`mcp__<server>__<tool>` cards with `_mcpServer` / `_mcpTool`.
+plus top-level `serverIdentifier` / `providerIdentifier` / `server` /
+`toolName` / `tool` become `mcp__<server>__<tool>` cards with `_mcpServer` /
+`_mcpTool`. Nested `args` is the tool payload only — identifiers found only
+there (including after flatten) do not attribute a call as MCP.
 
 ## Group chat
 
@@ -93,8 +95,8 @@ Do **not** treat the blob as one human prompt.
   punctuation/emoji so `🧭旅游助手` matches `旅游助手`
 - Unknown `Name: text` fallback labels: CJK/emoji/uppercase stay valid; lowercase
   Latin display names of 2–3 alphabetic words (`john smith`) are speakers;
-  longer phrases or function-word prose (`one thing to note`) stay in the
-  previous turn
+  one-word lowercase Latin (`hello: text`), longer phrases, or function-word
+  prose (`one thing to note`) stay in the previous turn
 - Drop procedural cues: `It's your turn…`, `The room is wrapping up…`,
   `The conversation is wrapping up…`, `Waiting for participants…`,
   `No new messages in the room…` (empty wakes are not prompts)

--- a/packages/provider-grok-bot/AGENTS.md
+++ b/packages/provider-grok-bot/AGENTS.md
@@ -91,6 +91,10 @@ Do **not** treat the blob as one human prompt.
 - Other bots are `role: "assistant"` with `speaker` set (Eng, GTM, 艺术家, …).
   Display names (including emoji/CJK) are labels; merge/dedupe keys strip
   punctuation/emoji so `🧭旅游助手` matches `旅游助手`
+- Unknown `Name: text` fallback labels: CJK/emoji/uppercase stay valid; lowercase
+  Latin display names of 2–3 alphabetic words (`john smith`) are speakers;
+  longer phrases or function-word prose (`one thing to note`) stay in the
+  previous turn
 - Drop procedural cues: `It's your turn…`, `The room is wrapping up…`,
   `The conversation is wrapping up…`, `Waiting for participants…`,
   `No new messages in the room…` (empty wakes are not prompts)

--- a/packages/provider-grok-bot/src/grok-bot/group-chat.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-chat.ts
@@ -365,13 +365,21 @@ function findSpeaker(
   return { name, text: fallback[2], known: false };
 }
 
+const MAX_FALLBACK_SPEAKER_WORDS = 4;
+
 function looksLikeSpeakerName(name: string): boolean {
   if (name.length < 1 || name.length > 60) return false;
   if (RESERVED_SPEAKERS.has(name.toLowerCase())) return false;
   if (/[.?!]$/.test(name)) return false;
   const letters = speakerIdentityKey(name);
   if (!letters) return false;
-  return /^[\p{L}\p{N}\p{M}\p{S}][\p{L}\p{N}\p{M}\p{S} .'_-]*$/u.test(name);
+  if (!/^[\p{L}\p{N}\p{M}\p{S}][\p{L}\p{N}\p{M}\p{S} .'_-]*$/u.test(name)) return false;
+  const words = name.trim().split(/\s+/);
+  if (words.length > MAX_FALLBACK_SPEAKER_WORDS) return false;
+  // Lowercase Latin phrases ("one thing to note:") are prose, not speakers.
+  // CJK/Han, emoji, symbol, and uppercase labels stay valid.
+  if (words.length > 1 && /^[a-z0-9][a-z0-9 .'_-]*$/.test(name)) return false;
+  return true;
 }
 
 function startsWithInsensitive(line: string, prefix: string): boolean {

--- a/packages/provider-grok-bot/src/grok-bot/group-chat.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-chat.ts
@@ -469,8 +469,8 @@ function looksLikeSpeakerName(name: string): boolean {
 
 /** True for lowercase Latin phrases that are prose, not an unlisted human name. */
 function isLowercaseLatinProse(name: string, words: string[]): boolean {
-  if (words.length <= 1) return false;
   if (!/^[a-z][a-z0-9 .'_-]*$/.test(name)) return false;
+  if (words.length < 2) return true;
   if (words.length > MAX_LOWERCASE_LATIN_SPEAKER_WORDS) return true;
   return words.some((word) => SPEAKER_FUNCTION_WORDS.has(word) || !/^[a-z][a-z'-]*$/.test(word));
 }

--- a/packages/provider-grok-bot/src/grok-bot/group-chat.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-chat.ts
@@ -366,6 +366,93 @@ function findSpeaker(
 }
 
 const MAX_FALLBACK_SPEAKER_WORDS = 4;
+const MAX_LOWERCASE_LATIN_SPEAKER_WORDS = 3;
+
+/** English function words that mark prose ("one thing to note"), not a display name. */
+const SPEAKER_FUNCTION_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "but",
+  "if",
+  "then",
+  "so",
+  "as",
+  "at",
+  "by",
+  "for",
+  "from",
+  "in",
+  "into",
+  "of",
+  "on",
+  "onto",
+  "to",
+  "with",
+  "without",
+  "about",
+  "after",
+  "before",
+  "over",
+  "under",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "am",
+  "do",
+  "does",
+  "did",
+  "not",
+  "no",
+  "just",
+  "also",
+  "too",
+  "very",
+  "this",
+  "that",
+  "these",
+  "those",
+  "it",
+  "its",
+  "we",
+  "you",
+  "they",
+  "he",
+  "she",
+  "i",
+  "me",
+  "my",
+  "our",
+  "your",
+  "their",
+  "one",
+  "two",
+  "some",
+  "any",
+  "all",
+  "each",
+  "every",
+  "thing",
+  "things",
+  "note",
+  "please",
+  "should",
+  "would",
+  "could",
+  "will",
+  "can",
+  "must",
+  "may",
+  "might",
+  "let",
+  "lets",
+]);
 
 function looksLikeSpeakerName(name: string): boolean {
   if (name.length < 1 || name.length > 60) return false;
@@ -376,10 +463,16 @@ function looksLikeSpeakerName(name: string): boolean {
   if (!/^[\p{L}\p{N}\p{M}\p{S}][\p{L}\p{N}\p{M}\p{S} .'_-]*$/u.test(name)) return false;
   const words = name.trim().split(/\s+/);
   if (words.length > MAX_FALLBACK_SPEAKER_WORDS) return false;
-  // Lowercase Latin phrases ("one thing to note:") are prose, not speakers.
-  // CJK/Han, emoji, symbol, and uppercase labels stay valid.
-  if (words.length > 1 && /^[a-z0-9][a-z0-9 .'_-]*$/.test(name)) return false;
+  if (isLowercaseLatinProse(name, words)) return false;
   return true;
+}
+
+/** True for lowercase Latin phrases that are prose, not an unlisted human name. */
+function isLowercaseLatinProse(name: string, words: string[]): boolean {
+  if (words.length <= 1) return false;
+  if (!/^[a-z][a-z0-9 .'_-]*$/.test(name)) return false;
+  if (words.length > MAX_LOWERCASE_LATIN_SPEAKER_WORDS) return true;
+  return words.some((word) => SPEAKER_FUNCTION_WORDS.has(word) || !/^[a-z][a-z'-]*$/.test(word));
 }
 
 function startsWithInsensitive(line: string, prefix: string): boolean {

--- a/packages/provider-grok-bot/src/grok-bot/group-merge.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-merge.ts
@@ -395,7 +395,7 @@ function applySessionInfo(
     sessionId: sessionInfo.sessionId || parsed.sessionId,
     slug: sessionInfo.slug || parsed.slug,
     cwd: sessionInfo.cwd || sessionInfo.project || parsed.cwd,
-    title: parsed.title || sessionInfo.title,
+    title: sessionInfo.title || parsed.title,
   };
 }
 

--- a/packages/provider-grok-bot/src/grok-bot/group-merge.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-merge.ts
@@ -200,7 +200,9 @@ export function mergeGrokBotGroupParses(
   sessionInfo?: SessionInfo,
 ): ProviderParseResult {
   const usable = members.filter((member) => member.parsed.turns.length > 0 || members.length === 1);
-  if (usable.length === 1) return usable[0]?.parsed ?? emptyParse(sessionInfo);
+  if (usable.length === 1) {
+    return applySessionInfo(usable[0]?.parsed ?? emptyParse(sessionInfo), sessionInfo);
+  }
 
   const ownerNames = uniqueStrings(
     usable.map((member) => member.ownerName).filter((name): name is string => !!name),
@@ -381,6 +383,20 @@ function uniqueStrings(values: string[]): string[] {
     out.push(trimmed);
   }
   return out;
+}
+
+function applySessionInfo(
+  parsed: ProviderParseResult,
+  sessionInfo?: SessionInfo,
+): ProviderParseResult {
+  if (!sessionInfo) return parsed;
+  return {
+    ...parsed,
+    sessionId: sessionInfo.sessionId || parsed.sessionId,
+    slug: sessionInfo.slug || parsed.slug,
+    cwd: sessionInfo.cwd || sessionInfo.project || parsed.cwd,
+    title: parsed.title || sessionInfo.title,
+  };
 }
 
 function emptyParse(sessionInfo?: SessionInfo): ProviderParseResult {

--- a/packages/provider-grok-bot/src/grok-bot/parser.ts
+++ b/packages/provider-grok-bot/src/grok-bot/parser.ts
@@ -138,6 +138,7 @@ export async function parseGrokBotSession(
       const parsed = await attachGrokBotSubAgents(
         parseGrokBotLines(content.split("\n"), {
           sourcePath: path,
+          sessionInfo,
           ownerName,
         }),
         path,

--- a/packages/provider-grok-bot/src/grok-bot/parser.ts
+++ b/packages/provider-grok-bot/src/grok-bot/parser.ts
@@ -321,14 +321,18 @@ export function parseGrokBotLines(
 
       if (isGrokBotHiddenTool(rawName)) continue;
 
+      const rawInput =
+        block.input && typeof block.input === "object" && !Array.isArray(block.input)
+          ? (block.input as Record<string, unknown>)
+          : {};
       const mappedInput = mapGrokBotToolArgs(rawName, block.input);
       const childId = result?.subagentId || findSandSubagentId(mappedInput);
       if (childId && !stringField(mappedInput, "sessionId")) {
         mappedInput.sessionId = childId;
       }
-      const mcp = grokBotMcpAttribution(rawName, mappedInput);
+      const mcp = grokBotMcpAttribution(rawName, rawInput);
       const call: ToolCallSite = {
-        name: grokBotReplayToolName(rawName, mappedInput),
+        name: grokBotReplayToolName(rawName, rawInput),
         rawName,
         id,
         input: mappedInput,

--- a/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
+++ b/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
@@ -73,7 +73,7 @@ export function isGrokBotBuiltinTool(name: string): boolean {
  * Normalize Grok Bot tool input into the field names the transform expects.
  * File tools use `path`; the transform wants `file_path`. Edit replacements
  * map onto `old_string` / `new_string`. Dynamic MCP calls flatten `args` and
- * copy `serverIdentifier` / `toolName` onto `server` / `tool`.
+ * copy top-level `serverIdentifier` / `toolName` onto `server` / `tool`.
  */
 export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<string, unknown> {
   const obj =
@@ -81,6 +81,7 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
       ? { ...(input as Record<string, unknown>) }
       : {};
   const normalized = toolName.toLowerCase();
+  const mcpIdentifiers = topLevelMcpIdentifiers(obj);
 
   flattenToolArgs(obj);
 
@@ -163,7 +164,7 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
   }
 
   if (normalized === "mcp" || !isGrokBotBuiltinTool(toolName)) {
-    const mcp = grokBotMcpFields(obj);
+    const mcp = grokBotMcpFields(mcpIdentifiers);
     if (mcp.server) obj.server = mcp.server;
     if (mcp.tool) {
       obj.tool = mcp.tool;
@@ -178,13 +179,14 @@ export function grokBotMcpAttribution(
   toolName: string,
   input: Record<string, unknown>,
 ): { server?: string; tool?: string } | undefined {
-  const fields = grokBotMcpFields(input);
+  const identifiers = topLevelMcpIdentifiers(input);
+  const fields = grokBotMcpFields(identifiers);
   if (toolName.toLowerCase() === "mcp") {
     if (!fields.server && !fields.tool) return undefined;
     return fields;
   }
   if (isGrokBotBuiltinTool(toolName)) return undefined;
-  if (!hasDynamicMcpIdentifiers(input)) return undefined;
+  if (!hasDynamicMcpIdentifiers(identifiers)) return undefined;
   if (!fields.server && !fields.tool) return undefined;
   return {
     ...(fields.server ? { server: fields.server } : {}),
@@ -217,8 +219,26 @@ function grokBotMcpFields(input: Record<string, unknown>): { server?: string; to
 function hasDynamicMcpIdentifiers(input: Record<string, unknown>): boolean {
   return !!(
     firstString(input.serverIdentifier, input.providerIdentifier, input.server) ||
-    firstString(input.toolName, input.tool_name)
+    firstString(input.toolName, input.tool_name, input.tool)
   );
+}
+
+/**
+ * MCP attribution looks only at explicit top-level identifiers. Nested `args`
+ * fields (including copies `flattenToolArgs` lifts onto the parent) do not
+ * count — `{ args: { toolName: "foo" } }` is not an MCP call.
+ */
+function topLevelMcpIdentifiers(input: Record<string, unknown>): Record<string, unknown> {
+  const args = input.args;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return input;
+  const nested = args as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (key === "args") continue;
+    if (Object.prototype.hasOwnProperty.call(nested, key)) continue;
+    out[key] = value;
+  }
+  return out;
 }
 
 function flattenToolArgs(obj: Record<string, unknown>): void {

--- a/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
+++ b/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
@@ -162,11 +162,13 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
     if (update) obj.update = update;
   }
 
-  const mcp = grokBotMcpFields(obj);
-  if (mcp.server) obj.server = mcp.server;
-  if (mcp.tool) {
-    obj.tool = mcp.tool;
-    if (!firstString(obj.tool_name)) obj.tool_name = mcp.tool;
+  if (normalized === "mcp" || !isGrokBotBuiltinTool(toolName)) {
+    const mcp = grokBotMcpFields(obj);
+    if (mcp.server) obj.server = mcp.server;
+    if (mcp.tool) {
+      obj.tool = mcp.tool;
+      if (!firstString(obj.tool_name)) obj.tool_name = mcp.tool;
+    }
   }
 
   return obj;
@@ -205,7 +207,7 @@ function grokBotMcpFields(input: Record<string, unknown>): { server?: string; to
     input.server_name,
     input.providerIdentifier,
   );
-  const tool = firstString(input.tool, input.toolName, input.tool_name, input.name);
+  const tool = firstString(input.tool, input.toolName, input.tool_name);
   return {
     ...(server ? { server } : {}),
     ...(tool ? { tool } : {}),
@@ -215,8 +217,7 @@ function grokBotMcpFields(input: Record<string, unknown>): { server?: string; to
 function hasDynamicMcpIdentifiers(input: Record<string, unknown>): boolean {
   return !!(
     firstString(input.serverIdentifier, input.providerIdentifier, input.server) ||
-    firstString(input.toolName, input.tool_name) ||
-    (input.args && typeof input.args === "object")
+    firstString(input.toolName, input.tool_name)
   );
 }
 

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -176,17 +176,33 @@ It's your turn, 🧭旅游助手.`);
     expect(isHumanGroupSpeaker("vibe replay eng", bots)).toBe(false);
   });
 
-  it("does not treat lowercase prose before a colon as a speaker turn", () => {
+  it("treats short lowercase names as speakers and keeps function-word prose in the previous turn", () => {
+    // Rule: unlisted fallback labels — CJK/emoji/uppercase stay valid; lowercase
+    // Latin of 2–3 alphabetic words with no function words (`john smith`) is a
+    // speaker; longer phrases or stop-word prose (`one thing to note`) is not.
     const wake = parseGrokBotGroupWake(`[Group chat: "Vibe Replay launch" - with Vibe Replay GTM]
 Participants: Vibe Replay Eng (engineer) Vibe Replay GTM (go-to-market)
 New messages in the room (oldest first):
 User: Let's ship the Grok Bot replay provider this week.
 one thing to note: we should ship
+john smith: hello
+mary jane watson: three-word names are fine
+please note: this is still prose
 It's your turn, Vibe Replay Eng.`);
     expect(wake?.messages).toEqual([
       {
         speaker: "User",
         text: "Let's ship the Grok Bot replay provider this week.\none thing to note: we should ship",
+        mentions: [],
+      },
+      {
+        speaker: "john smith",
+        text: "hello",
+        mentions: [],
+      },
+      {
+        speaker: "mary jane watson",
+        text: "three-word names are fine\nplease note: this is still prose",
         mentions: [],
       },
     ]);

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -172,6 +174,22 @@ It's your turn, 🧭旅游助手.`);
     expect(isHumanGroupSpeaker("Tuo", bots)).toBe(true);
     expect(isHumanGroupSpeaker("Vibe Replay GTM", bots)).toBe(false);
     expect(isHumanGroupSpeaker("vibe replay eng", bots)).toBe(false);
+  });
+
+  it("does not treat lowercase prose before a colon as a speaker turn", () => {
+    const wake = parseGrokBotGroupWake(`[Group chat: "Vibe Replay launch" - with Vibe Replay GTM]
+Participants: Vibe Replay Eng (engineer) Vibe Replay GTM (go-to-market)
+New messages in the room (oldest first):
+User: Let's ship the Grok Bot replay provider this week.
+one thing to note: we should ship
+It's your turn, Vibe Replay Eng.`);
+    expect(wake?.messages).toEqual([
+      {
+        speaker: "User",
+        text: "Let's ship the Grok Bot replay provider this week.\none thing to note: we should ship",
+        mentions: [],
+      },
+    ]);
   });
 });
 
@@ -381,5 +399,66 @@ It's your turn, Vibe Replay Eng.`,
         JSON.stringify(scene).includes("can you confirm the dashboard badge copy"),
       ),
     ).toBe(false);
+  });
+
+  it("keeps discovery session metadata when one group sibling has zero turns", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vibe-replay-grok-bot-empty-sib-"));
+    const engId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const emptyId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const engPath = join(dir, `${engId}.jsonl`);
+    const emptyPath = join(dir, `${emptyId}.jsonl`);
+    try {
+      await writeFile(
+        engPath,
+        `${JSON.stringify({
+          role: "user",
+          message: {
+            content: [
+              {
+                type: "text",
+                text: `[Group chat: "Vibe Replay launch" - with Vibe Replay GTM]
+Participants: Vibe Replay Eng (engineer) Vibe Replay GTM (go-to-market)
+New messages in the room (oldest first):
+User: Let's ship it.
+It's your turn, Vibe Replay Eng.`,
+              },
+            ],
+          },
+        })}\n`,
+      );
+      await writeFile(
+        emptyPath,
+        `${JSON.stringify({
+          role: "user",
+          message: { content: [{ type: "text", text: "[SAND_HIDDEN_PROMPT][first run]" }] },
+        })}\n`,
+      );
+
+      const parsed = await parseGrokBotSession([engPath, emptyPath], {
+        provider: "grok-bot",
+        sessionId: "group-vibe-replay-launch",
+        slug: "group-vibe-replay-launch",
+        title: "Group: Vibe Replay launch",
+        project: "Vibe Replay launch",
+        cwd: "/workspace",
+        version: "1",
+        timestamp: "2026-09-04T00:00:00.000Z",
+        lineCount: 2,
+        fileSize: 100,
+        filePath: engPath,
+        filePaths: [engPath, emptyPath],
+        firstPrompt: "Let's ship it.",
+      });
+      expect(parsed.sessionId).toBe("group-vibe-replay-launch");
+      expect(parsed.slug).toBe("group-vibe-replay-launch");
+      expect(parsed.cwd).toBe("/workspace");
+      expect(parsed.title).toBe("Group: Vibe Replay launch");
+      expect(parsed.sessionId).not.toBe(engId);
+      const humans = parsed.turns.filter((turn) => turn.role === "user" && !turn.subtype);
+      expect(humans).toHaveLength(1);
+      expect(humans[0].blocks[0]).toEqual({ type: "text", text: "Let's ship it." });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -9,6 +9,7 @@ import {
   formatGroupSpeakerMessage,
   isGrokBotGroupChatPayload,
   isHumanGroupSpeaker,
+  mergeGrokBotGroupParses,
   normalizeGroupKey,
   parseGrokBotGroupWake,
   parseGrokBotLines,
@@ -179,11 +180,13 @@ It's your turn, 🧭旅游助手.`);
   it("treats short lowercase names as speakers and keeps function-word prose in the previous turn", () => {
     // Rule: unlisted fallback labels — CJK/emoji/uppercase stay valid; lowercase
     // Latin of 2–3 alphabetic words with no function words (`john smith`) is a
-    // speaker; longer phrases or stop-word prose (`one thing to note`) is not.
+    // speaker; one-word lowercase (`hello: text`), longer phrases, or stop-word
+    // prose (`one thing to note`) stay in the previous turn.
     const wake = parseGrokBotGroupWake(`[Group chat: "Vibe Replay launch" - with Vibe Replay GTM]
 Participants: Vibe Replay Eng (engineer) Vibe Replay GTM (go-to-market)
 New messages in the room (oldest first):
 User: Let's ship the Grok Bot replay provider this week.
+hello: leftover prose
 one thing to note: we should ship
 john smith: hello
 mary jane watson: three-word names are fine
@@ -192,7 +195,7 @@ It's your turn, Vibe Replay Eng.`);
     expect(wake?.messages).toEqual([
       {
         speaker: "User",
-        text: "Let's ship the Grok Bot replay provider this week.\none thing to note: we should ship",
+        text: "Let's ship the Grok Bot replay provider this week.\nhello: leftover prose\none thing to note: we should ship",
         mentions: [],
       },
       {
@@ -476,5 +479,46 @@ It's your turn, Vibe Replay Eng.`,
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("prefers discovery title over the parsed title on a single-member merge", () => {
+    const parsed = mergeGrokBotGroupParses(
+      [
+        {
+          path: "/tmp/eng.jsonl",
+          ownerName: "Vibe Replay Eng",
+          parsed: {
+            sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            slug: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            cwd: "/parsed",
+            title: "Group: parsed room",
+            turns: [
+              {
+                role: "user",
+                blocks: [{ type: "text", text: "Let's ship it." }],
+              },
+            ],
+            dataSource: "jsonl",
+          },
+        },
+      ],
+      {
+        provider: "grok-bot",
+        sessionId: "group-discovery-room",
+        slug: "group-discovery-room",
+        title: "Group: discovery room",
+        project: "discovery room",
+        cwd: "/workspace",
+        version: "1",
+        timestamp: "2026-09-04T00:00:00.000Z",
+        lineCount: 1,
+        fileSize: 10,
+        filePath: "/tmp/eng.jsonl",
+        filePaths: ["/tmp/eng.jsonl"],
+      },
+    );
+    expect(parsed.title).toBe("Group: discovery room");
+    expect(parsed.sessionId).toBe("group-discovery-room");
+    expect(parsed.cwd).toBe("/workspace");
   });
 });

--- a/packages/provider-grok-bot/test/parser.test.ts
+++ b/packages/provider-grok-bot/test/parser.test.ts
@@ -788,6 +788,36 @@ describe("Grok Bot parser", () => {
     expect(JSON.stringify(parsed.turns)).not.toContain("GetMcpTools");
   });
 
+  it("does not attribute nested args.toolName as an MCP card", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "run mystery" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "mystery",
+              toolCallId: "x-1",
+              input: { args: { toolName: "foo" } },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ name: "mystery" });
+    expect(tools[0].type === "tool_use" && tools[0]._mcpServer).toBeUndefined();
+    expect(tools[0].type === "tool_use" && tools[0]._mcpTool).toBeUndefined();
+    expect(JSON.stringify(tools[0])).not.toContain("mcp__");
+  });
+
   it("strips generate_image and computer_use base64 while keeping file paths", () => {
     const imageData = `iVBOR${"A".repeat(120)}`;
     const screenshot = `iVBOR${"B".repeat(120)}`;
@@ -1098,6 +1128,14 @@ describe("Grok Bot tool mapping", () => {
     expect(grokBotMcpAttribution("read", { path: "/tmp/a.ts", name: "readme" })).toBeUndefined();
     expect(grokBotMcpAttribution("mystery", { args: { name: "foo" } })).toBeUndefined();
     expect(grokBotReplayToolName("mystery", { args: { name: "foo" } })).toBe("mystery");
+    expect(grokBotMcpAttribution("mystery", { args: { toolName: "foo" } })).toBeUndefined();
+    expect(grokBotReplayToolName("mystery", { args: { toolName: "foo" } })).toBe("mystery");
+    const flattenedNestedArgs = mapGrokBotToolArgs("mystery", { args: { toolName: "foo" } });
+    expect(flattenedNestedArgs).toMatchObject({ args: { toolName: "foo" }, toolName: "foo" });
+    expect(flattenedNestedArgs.server).toBeUndefined();
+    expect(flattenedNestedArgs.tool).toBeUndefined();
+    expect(grokBotMcpAttribution("mystery", flattenedNestedArgs)).toBeUndefined();
+    expect(grokBotReplayToolName("mystery", flattenedNestedArgs)).toBe("mystery");
     expect(
       grokBotMcpAttribution("mcp", { server: "github", toolName: "pull_request_read" }),
     ).toEqual({

--- a/packages/provider-grok-bot/test/parser.test.ts
+++ b/packages/provider-grok-bot/test/parser.test.ts
@@ -15,6 +15,7 @@ import {
   stripUserDecorators,
 } from "../src/grok-bot/parser.js";
 import {
+  grokBotMcpAttribution,
   grokBotReplayToolName,
   mapGrokBotToolArgs,
   mapGrokBotToolName,
@@ -1088,6 +1089,20 @@ describe("Grok Bot tool mapping", () => {
     });
     expect(mapGrokBotToolArgs("communicate_update", { update: "Scanning inbox…" })).toMatchObject({
       update: "Scanning inbox…",
+    });
+    expect(mapGrokBotToolArgs("read", { path: "/tmp/a.ts", name: "readme" })).toEqual({
+      path: "/tmp/a.ts",
+      name: "readme",
+      file_path: "/tmp/a.ts",
+    });
+    expect(grokBotMcpAttribution("read", { path: "/tmp/a.ts", name: "readme" })).toBeUndefined();
+    expect(grokBotMcpAttribution("mystery", { args: { name: "foo" } })).toBeUndefined();
+    expect(grokBotReplayToolName("mystery", { args: { name: "foo" } })).toBe("mystery");
+    expect(
+      grokBotMcpAttribution("mcp", { server: "github", toolName: "pull_request_read" }),
+    ).toEqual({
+      server: "github",
+      tool: "pull_request_read",
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #581. Keeps both #582’s MCP field gating / group `sessionInfo` overlay and #583’s `communicate_update` flatten, `mcp__<server>__<tool>` cards, attachment mentions, and tests.

Merged latest `main` (`49256cd` / #585 docs) — no code conflicts.

1. **Speaker fallback** — unlisted `Name: text` labels: CJK/emoji/uppercase stay valid (including one-word). Lowercase Latin of **2–3 alphabetic words without function words** (`john smith`, `mary jane watson`) is a speaker. **One-word lowercase Latin** (`hello: text`), longer phrases, or stop-word prose (`one thing to note`) stay in the previous turn.
2. **MCP field copy** — attribution uses **explicit top-level** identifiers only (`serverIdentifier` / `providerIdentifier` / `server` / `toolName` / `tool` / `tool_name`). Nested `args` (including fields `flattenToolArgs` copies up) do **not** count: `grokBotMcpAttribution("mystery", { args: { toolName: "foo" } })` is not MCP. Builtin `read` `{ name: "readme" }` still does not become a phantom MCP card. Parser passes the original unflattened input into attribution.
3. **Group session metadata** — multi-file parse passes `sessionInfo`; a single usable sibling keeps discovery `sessionId`/`slug`/`cwd`, and **prefers `sessionInfo.title` over `parsed.title`**.

## Review follow-up (this push)

Verified against `5435cc77` / current head. All three still-open CodeRabbit notes were valid.

| Comment | Verdict | Fix |
| --- | --- | --- |
| `group-chat.ts` one-word lowercase (`hello: text`) | **Valid** | Treat one-word *lowercase Latin* as prose. Did **not** apply CodeRabbit’s `words.length < 2 → return true` before the Latin check — that would also reject CJK/uppercase one-word names. |
| `group-merge.ts` title overlay | **Valid** | `title: sessionInfo.title \|\| parsed.title` |
| `tool-mapping.ts` flattened `args` MCP (major) | **Valid** | `topLevelMcpIdentifiers()` ignores keys that exist only under `args`; parser attributes from the original input. |
| Codex P2 `john smith:` (`fb78f963`) | **Already fixed** (outdated) | Short lowercase 2–3 word names remain speakers. |

## Validation

- [x] `pnpm --filter @vibe-replay/provider-grok-bot test` (61 tests)
- [x] `pnpm lint:check`
- [x] `tsc --noEmit -p packages/provider-grok-bot/tsconfig.json`
- [ ] `pnpm verify` — sequential full gate left to CI
- [ ] `pnpm test:e2e` — not required (provider/parser only)

Do **not** merge this PR from the agent — Eng merges after CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b4da885-ac51-42c9-8fa1-57117696bcc4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b4da885-ac51-42c9-8fa1-57117696bcc4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group-chat parsing to keep one-word lowercase prose within the preceding speaker’s turn.
  * Preserved supplied session titles when merging transcripts, including single-member cases.
  * Corrected MCP tool attribution and replay naming to use explicit tool identifiers only.
  * Ensured session details are retained consistently across multi-file transcript parsing.
  * Preserved additional read-tool arguments while adding required file paths.

* **Tests**
  * Added coverage for speaker detection, title preservation, MCP attribution, and tool argument mapping.

* **Documentation**
  * Documented MCP mapping and fallback speaker-label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->