### PR TITLE
fix(grok-bot): attachment mentions, MCP cards, and CJK firstPrompt

### DIFF
--- a/packages/cli/src/providers/grok-bot/parser.ts
+++ b/packages/cli/src/providers/grok-bot/parser.ts
@@ -1,1 +1,5 @@
-export { parseGrokBotLines, parseGrokBotSession } from "@vibe-replay/provider-grok-bot/parser";
+export {
+  attachGrokBotSubAgents,
+  parseGrokBotLines,
+  parseGrokBotSession,
+} from "@vibe-replay/provider-grok-bot/parser";

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -76,7 +76,9 @@ import { localDayKey, shortenPath } from "./utils.js";
 // v36: index privacy-safe provider context composition metadata.
 // v37: count concrete SKILL.md reads as skill activations across providers.
 // v38: retain compact per-turn duration/tool/token metrics for distributions.
-export const SCANNER_VERSION = 38;
+// v39: keep short CJK Grok Bot prompts as Explore firstPrompt instead of skipping
+// them for the 10-character English-oriented threshold.
+export const SCANNER_VERSION = 39;
 
 // Keep per-invocation detail bounded in the durable insight store. The full
 // event set is still used to compute usageSummary below; only the retained
@@ -1985,7 +1987,9 @@ function buildScanResultFromParsed(
   const turnMetrics = buildTurnMetrics(parsed.turns, parsed.turnStats);
   const firstPrompt = input.transcriptStatus
     ? ""
-    : firstUserPrompt(parsed.turns) || input.firstPrompt || parsed.title;
+    : firstUserPrompt(parsed.turns, { minLength: input.provider === "grok-bot" ? 1 : 10 }) ||
+      input.firstPrompt ||
+      parsed.title;
   for (const skill of skillActivations) {
     const normalized = skill.trim();
     if (!normalized) continue;
@@ -2073,13 +2077,17 @@ function parseWarningQualityNotes(warnings: ParseWarning[] | undefined): string[
   });
 }
 
-function firstUserPrompt(turns: ProviderParseResult["turns"]): string | undefined {
+function firstUserPrompt(
+  turns: ProviderParseResult["turns"],
+  options: { minLength?: number } = {},
+): string | undefined {
+  const minLength = options.minLength ?? 10;
   for (const turn of turns) {
     if (turn.role !== "user" || turn.subtype) continue;
     for (const block of turn.blocks) {
       if (block.type !== "text") continue;
       const text = block.text.replace(/\s+/g, " ").trim();
-      if (text.length >= 10) return text.slice(0, 200);
+      if (text.length >= minLength) return text.slice(0, 200);
     }
   }
   return undefined;

--- a/packages/cli/src/server-routes/live.ts
+++ b/packages/cli/src/server-routes/live.ts
@@ -7,7 +7,7 @@ import { streamSSE } from "hono/streaming";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import { parseClaudeCodeLines } from "../providers/claude-code/parser.js";
 import { parseCodexLines } from "../providers/codex/parser.js";
-import { parseGrokBotLines } from "../providers/grok-bot/parser.js";
+import { attachGrokBotSubAgents, parseGrokBotLines } from "../providers/grok-bot/parser.js";
 import { parsePiLines } from "../providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
@@ -35,7 +35,8 @@ export async function parseJsonlLiveSession(
     return parseCodexLines(lines, sessionInfo, paths);
   }
   if (providerName === "grok-bot") {
-    return parseGrokBotLines(lines, { sourcePath: paths[0], sessionInfo });
+    const parsed = parseGrokBotLines(lines, { sourcePath: paths[0], sessionInfo });
+    return attachGrokBotSubAgents(parsed, paths[0]);
   }
   return parsePiLines(lines, { sourcePath: paths[0], sessionInfo });
 }

--- a/packages/cli/src/usage-coverage.ts
+++ b/packages/cli/src/usage-coverage.ts
@@ -96,7 +96,9 @@ function providerNotes(provider: string): string[] | undefined {
     ];
   }
   if (provider === "grok-bot") {
-    return ["Grok Bot JSONL does not record token usage or thinking blobs in v1."];
+    return [
+      "Grok Bot JSONL does not record token usage in v1; assistant text is private scratch shown as thinking.",
+    ];
   }
   if (provider === "claude-code" || provider === "claude-desktop") {
     return [

--- a/packages/cli/test/generator.test.ts
+++ b/packages/cli/test/generator.test.ts
@@ -8,6 +8,8 @@ import {
   injectDataScript,
   loadViewerHtml,
 } from "../src/generator.js";
+import { parseGrokBotLines } from "../src/providers/grok-bot/parser.js";
+import { transformToReplay } from "../src/transform.js";
 
 // `loadViewerHtml` reads packages/cli/assets/viewer.html, which is produced
 // by `pnpm build` (viewer → copy → CLI) and is NOT checked into git. The
@@ -371,6 +373,90 @@ describe("loadViewerHtml", () => {
     "throws a descriptive error when viewer.html is missing",
     async () => {
       await expect(loadViewerHtml()).rejects.toThrow(/Could not find viewer\.html/);
+    },
+  );
+});
+
+describe("Grok Bot shareable HTML smoke", () => {
+  const parsed = parseGrokBotLines([
+    JSON.stringify({
+      role: "user",
+      message: { content: [{ type: "text", text: "[t0u]\n一起画画" }] },
+    }),
+    JSON.stringify({
+      role: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "private scratch" },
+          {
+            type: "tool_use",
+            name: "send_message",
+            input: {
+              text: { content: "See ![cat](<file:///home/box/agent-data/attachments/cat.png>)" },
+            },
+          },
+          {
+            type: "tool_use",
+            name: "mcp",
+            toolCallId: "m-1",
+            input: { server: "github", toolName: "pull_request_read" },
+          },
+          {
+            type: "tool_use",
+            name: "generate_image",
+            toolCallId: "img-1",
+            input: { prompt: "a cat" },
+          },
+        ],
+      },
+    }),
+    JSON.stringify({
+      role: "tool",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            name: "mcp",
+            toolCallId: "m-1",
+            result: { success: { content: "PR 1" } },
+          },
+          {
+            type: "tool_result",
+            name: "generate_image",
+            toolCallId: "img-1",
+            result: {
+              success: {
+                filePath: "/home/box/agent-data/assets/cat.png",
+                imageData: `iVBOR${"A".repeat(80)}`,
+              },
+            },
+          },
+        ],
+      },
+    }),
+  ]);
+  const replay = transformToReplay(parsed, "grok-bot", "~/grok-bot");
+  const json = escapeJsonForScript(JSON.stringify(replay));
+
+  it("rewrites file:// images and omits generate_image bytes from injected JSON", () => {
+    const scenes = JSON.stringify(replay.scenes);
+    expect(json).toContain("一起画画");
+    expect(scenes).toContain("[attached image: cat (cat.png)]");
+    expect(scenes).toContain("mcp__github__pull_request_read");
+    expect(scenes).not.toContain("file://");
+    expect(scenes).not.toContain("iVBOR");
+    expect(json).not.toContain("</script>");
+  });
+
+  it.runIf(VIEWER_HTML_AVAILABLE)(
+    "injects the stub into viewer.html without file:// scenes",
+    async () => {
+      const html = await loadViewerHtml();
+      const script = `<script id="vibe-replay-data">window.__VIBE_REPLAY_DATA__ = ${json};</script>`;
+      const result = injectDataScript(html, script);
+      expect(result).toContain("[attached image: cat (cat.png)]");
+      expect(result).toContain("mcp__github__pull_request_read");
+      expect(result).not.toContain("file:///home/box/agent-data/attachments/cat.png");
     },
   );
 });

--- a/packages/cli/test/live.test.ts
+++ b/packages/cli/test/live.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseJsonlLiveSession } from "../src/server-routes/live.js";
 import type { SessionInfo } from "../src/types.js";
@@ -40,5 +43,55 @@ describe("live JSONL parsing", () => {
     expect(parsed.turns).toHaveLength(2);
     expect(parsed.turns[0]?.blocks[0]).toEqual({ type: "text", text: "hello" });
     expect(parsed.turns[1]?.blocks[0]).toEqual({ type: "text", text: "hi there" });
+  });
+
+  it("attaches a sibling sand-subagent onto a live Grok Bot parent task card", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-grok-live-"));
+    const parentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const subId = "sand-subagent-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    await mkdir(join(root, parentId), { recursive: true });
+    await mkdir(join(root, subId), { recursive: true });
+    const parentPath = join(root, parentId, `${parentId}.jsonl`);
+    await writeFile(
+      join(root, subId, `${subId}.jsonl`),
+      `${JSON.stringify({
+        role: "assistant",
+        message: { content: [{ type: "text", text: "opening spec" }] },
+      })}\n`,
+      "utf-8",
+    );
+    try {
+      const parsed = await parseJsonlLiveSession(
+        "grok-bot",
+        [
+          JSON.stringify({
+            role: "user",
+            message: { content: [{ type: "text", text: "explore the UI" }] },
+          }),
+          JSON.stringify({
+            role: "assistant",
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  name: "task",
+                  toolCallId: "t-1",
+                  input: { goal: "explore UI", sessionId: subId },
+                },
+              ],
+            },
+          }),
+        ],
+        { ...sessionInfo, filePath: parentPath, filePaths: [parentPath] },
+        [parentPath],
+      );
+      const agent = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use" && block.name === "Agent");
+      expect(agent?.type === "tool_use" && agent._subAgent?.agentId).toBe(subId);
+      expect(agent?.type === "tool_use" && agent._subAgent?.thinkingBlocks).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/scanner.test.ts
+++ b/packages/cli/test/scanner.test.ts
@@ -392,6 +392,104 @@ describe("scanSession", () => {
     expect(result.usageSummary?.mcpTools).toMatchObject({ "github/pull_request_read": 1 });
   });
 
+  it("keeps a short CJK Grok Bot prompt as firstPrompt and skips background-task wakes", async () => {
+    const grokPath = join(tmpDir, "grok-bot-cjk.jsonl");
+    await writeFile(
+      grokPath,
+      [
+        {
+          role: "user",
+          message: {
+            content: [
+              { type: "text", text: "[A background task just completed]\nWrote a long recap." },
+            ],
+          },
+        },
+        {
+          role: "user",
+          message: { content: [{ type: "text", text: "[t0u]\n一起画画" }] },
+        },
+        {
+          role: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", name: "send_message", input: { text: { content: "好的" } } },
+            ],
+          },
+        },
+      ]
+        .map((line) => `${JSON.stringify(line)}\n`)
+        .join(""),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "grok-bot-cjk",
+      provider: "grok-bot",
+      project: "/home/box",
+      slug: "grok-bot-cjk",
+      filePaths: [grokPath],
+    });
+
+    expect(result.firstPrompt).toBe("一起画画");
+    expect(result.firstPrompt).not.toContain("background");
+    expect(result.promptCount).toBe(1);
+  });
+
+  it("indexes the Grok Bot mcp wrapper as an MCP server/tool, not a generic mcp tool", async () => {
+    const grokPath = join(tmpDir, "grok-bot-mcp-wrapper.jsonl");
+    await writeFile(
+      grokPath,
+      [
+        {
+          role: "user",
+          message: { content: [{ type: "text", text: "[t0u]\ncheck the PR" }] },
+        },
+        {
+          role: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                name: "mcp",
+                toolCallId: "m-1",
+                input: { server: "github", toolName: "pull_request_read" },
+              },
+            ],
+          },
+        },
+        {
+          role: "tool",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                name: "mcp",
+                toolCallId: "m-1",
+                result: { success: { content: "PR 544" } },
+              },
+            ],
+          },
+        },
+      ]
+        .map((line) => `${JSON.stringify(line)}\n`)
+        .join(""),
+      "utf-8",
+    );
+
+    const result = await scanSession({
+      sessionId: "grok-bot-mcp-wrapper",
+      provider: "grok-bot",
+      project: "/home/box",
+      slug: "grok-bot-mcp-wrapper",
+      filePaths: [grokPath],
+    });
+
+    expect(result.usageSummary?.tools).toEqual({});
+    expect(result.usageSummary?.mcpServers).toMatchObject({ github: 1 });
+    expect(result.usageSummary?.mcpTools).toMatchObject({ "github/pull_request_read": 1 });
+  });
+
   it("persists structured Pi compaction diagnostics in scan results", async () => {
     const piPath = join(tmpDir, "pi-diagnostics.jsonl");
     await writeFile(

--- a/packages/provider-grok-bot/AGENTS.md
+++ b/packages/provider-grok-bot/AGENTS.md
@@ -16,7 +16,8 @@ Env (Pi-style, replaces defaults): `GROK_BOT_TRANSCRIPTS_DIR` or
 
 Layout: `<root>/<agentId>/<agentId>.jsonl`. `sand-subagent-<uuid>/` files stay
 in discovery as their own sessions. A parent `task` call attaches a child-run
-card when the result/input names that sibling id (no nested grandchildren).
+card when the result/input names that sibling id (no nested grandchildren). Live
+JSONL parsing attaches the same way when the parent path is on disk.
 Duplicate roots (symlink overlap) are collapsed via `realpath`.
 
 Project/title: sibling `agents/<id>/profile.json` `name` (and `cwd` / `workspace`
@@ -41,15 +42,19 @@ One object per line: `{ role: "user"|"assistant"|"tool", message: { content: [..
     Explore firstPrompt)
   - `<<SAND_AGENT_PROFILE_UPDATE…>>` → skipped (or stripped if other text remains)
   - A meta tag wrapping `[Group chat:` is peeled so the group splitter still runs
-- Assistant `text` is private scratch → `thinking` blocks (not the visible reply)
+- Assistant `text` is private scratch → `thinking` blocks (not the visible reply).
+  The viewer labels those scenes **Scratch** so they are not confused with the
+  `send_message` reply.
 - `send_message` is the user-visible reply (`input.text.content` dict or string,
   widgets). Promote visible text to an assistant `text` block; do **not** emit
-  it as a tool-call scene. Ignore `to` / `attachments` when extracting text.
-  `file://` / data-URL markdown images in that text become a path mention —
-  they are not inlined into shareable HTML
+  it as a tool-call scene. Ignore `to` when extracting text. `file://` /
+  data-URL markdown images and `send_message` attachments become a basename
+  mention (`[attached image: sketch (cat.png)]`) — they are not inlined into
+  shareable HTML. Windows `file:///C:/...` paths are included.
 - `communicate_update` is a high-volume status/memory side-effect. Keep it as a
   `CommunicateUpdate` tool scene (including success). Do **not** promote it to
-  an assistant reply. `_isError` still marks `failure` / `rejected` / `error`
+  an assistant reply. Flatten the status text onto `update` so the tool card
+  has a one-line summary. `_isError` still marks `failure` / `rejected` / `error`
 - `role: "tool"` lines carry `tool_result` (not Claude's user-nested pattern).
   Pair to the preceding `tool_use` by `toolCallId` when present, else by order
   (prefer matching tool name; leave unenriched rather than attaching another
@@ -69,9 +74,8 @@ Sand builtins map onto the viewer vocabulary in `tool-mapping.ts`: `read`→`Rea
 `shell`→`Bash`, `update_todos`→`TodoWrite`, `task`→`Agent`, `await`→`Await`,
 `computer_use`→`ComputerUse`, `generate_image`→`GenerateImage`, plus the usual
 web/edit aliases. `get_mcp_tools` is discovery noise and is omitted from scenes.
-`mcp` keeps its raw name and normalizes `server` / `tool` / `tool_name`. Dynamic
-MCP calls use short names (`pull_request_read`, `search_analytics_query`) plus
-`serverIdentifier` / `providerIdentifier` / `toolName` / `args` and become
+`mcp` and dynamic MCP short names (`pull_request_read`, `search_analytics_query`)
+plus `serverIdentifier` / `providerIdentifier` / `toolName` / `args` become
 `mcp__<server>__<tool>` cards with `_mcpServer` / `_mcpTool`.
 
 ## Group chat
@@ -121,6 +125,9 @@ prefer). `sand-subagent-*` never merges into a group room.
 
 Fixtures: `test/fixtures/sample.jsonl` (DM), `dm-session.jsonl`,
 `group-eng.jsonl`, `group-gtm.jsonl`, `subagent.jsonl`, `meta-wake.jsonl`.
+Edge coverage lives in `test/parser-edges.test.ts` (mismatched results,
+hidden-tool leak, Windows file URLs, attachment-only replies, missing
+subagents, nested grandchildren).
 
 Try with:
 

--- a/packages/provider-grok-bot/src/grok-bot/media.ts
+++ b/packages/provider-grok-bot/src/grok-bot/media.ts
@@ -3,9 +3,10 @@
  * multi-MB base64 payloads next to a filePath/screenshotPath. Replay HTML
  * must stay usable, so strip/truncate binary fields and keep the path.
  *
- * Markdown `![alt](<file:///home/box/...>)` images are rewritten to a path
- * mention. Shareable HTML cannot load `file://` and this repo has no bundle
- * step for those attachments; inlining would reintroduce the size problem.
+ * Markdown `![alt](<file:///home/box/...> "title")` images are rewritten to a
+ * basename mention. Shareable HTML cannot load `file://` and this repo has no
+ * bundle step for those attachments; inlining would reintroduce the size
+ * problem. Windows `file:///C:/...` paths are normalized the same way.
  */
 
 const MEDIA_KEYS = new Set([
@@ -29,7 +30,8 @@ const PATH_KEYS = new Set([
   "image_path",
 ]);
 
-const MARKDOWN_FILE_IMAGE_RE = /!\[([^\]]*)\]\(\s*<?(file:\/\/[^)\s>]+)>?\s*\)/gi;
+const MARKDOWN_FILE_IMAGE_RE =
+  /!\[([^\]]*)\]\(\s*<?(file:\/\/[^)\s>]+)>?(?:\s+(?:"[^"]*"|'[^']*'))?\s*\)/gi;
 const MARKDOWN_DATA_IMAGE_RE = /!\[([^\]]*)\]\(\s*data:image\/[^)]+\)/gi;
 const DATA_URL_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 
@@ -88,28 +90,53 @@ export function mediaPathFromPayload(value: unknown): string | undefined {
   return undefined;
 }
 
+/** Last path segment, accepting `/` and `\\` so Windows paths work on POSIX. */
+export function grokBotPathBasename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "").trim();
+  if (!trimmed) return path.trim() || "image";
+  const parts = trimmed.split(/[\\/]/);
+  return parts[parts.length - 1] || path.trim();
+}
+
+/**
+ * Rewrite a local/data image into a basename mention. Shareable HTML cannot
+ * load `file://`, and inlining the bytes would bloat the replay.
+ */
+export function formatAttachedImageMention(alt: string, urlOrPath: string): string {
+  const path = stripFileUrl(urlOrPath);
+  const base = grokBotPathBasename(path);
+  const label = alt.trim();
+  if (label && base && label !== base) return `[attached image: ${label} (${base})]`;
+  return `[attached image: ${base || label || "image"}]`;
+}
+
 /**
  * Best-effort rewrite so markdown images do not become broken `<img src>` tags
  * in shareable HTML. Local files are not inlined.
  */
 export function rewriteGrokBotShareableText(text: string): string {
   return text
-    .replace(MARKDOWN_FILE_IMAGE_RE, (_match, alt: string, url: string) => {
-      const label = (alt || "image").trim() || "image";
-      const path = stripFileUrl(url);
-      return `[image: ${label} — ${path}]`;
-    })
+    .replace(MARKDOWN_FILE_IMAGE_RE, (_match, alt: string, url: string) =>
+      formatAttachedImageMention(alt, url),
+    )
     .replace(MARKDOWN_DATA_IMAGE_RE, (_match, alt: string) => {
       const label = (alt || "embedded").trim() || "embedded";
-      return `[image: ${label}]`;
+      return `[attached image: ${label}]`;
     });
 }
 
-function stripFileUrl(url: string): string {
+export function stripFileUrl(url: string): string {
   const trimmed = url.trim();
+  if (DATA_URL_RE.test(trimmed)) return "embedded";
+  let path = trimmed;
+  // Windows drive: file:///C:/Users/... or file:///C|\Users\...
+  path = path.replace(/^file:\/\/\/([A-Za-z]):/i, "$1:");
+  // POSIX absolute: file:///home/box/...
+  path = path.replace(/^file:\/\/\/+/i, "/");
+  path = path.replace(/^file:\/\//i, "");
   try {
-    return decodeURIComponent(trimmed.replace(/^file:\/\//i, ""));
+    return decodeURIComponent(path);
   } catch {
-    return trimmed.replace(/^file:\/\//i, "");
+    return path;
   }
 }

--- a/packages/provider-grok-bot/src/grok-bot/parser.ts
+++ b/packages/provider-grok-bot/src/grok-bot/parser.ts
@@ -21,9 +21,12 @@ import {
 } from "./group-merge.js";
 import { classifyGrokBotUserWake, formatAnsweringHeader, peelGrokBotMetaTag } from "./meta-wake.js";
 import {
+  formatAttachedImageMention,
+  grokBotPathBasename,
   mediaPathFromPayload,
   rewriteGrokBotShareableText,
   scrubGrokBotMediaPayload,
+  stripFileUrl,
 } from "./media.js";
 import {
   grokBotMcpAttribution,
@@ -61,7 +64,13 @@ export {
 } from "./group-merge.js";
 export { classifyGrokBotUserWake, parseGrokBotMetaWake, peelGrokBotMetaTag } from "./meta-wake.js";
 export type { ClassifiedGrokBotUserWake, GrokBotMetaWake } from "./meta-wake.js";
-export { rewriteGrokBotShareableText, scrubGrokBotMediaPayload } from "./media.js";
+export {
+  formatAttachedImageMention,
+  grokBotPathBasename,
+  rewriteGrokBotShareableText,
+  scrubGrokBotMediaPayload,
+  stripFileUrl,
+} from "./media.js";
 export { findSandSubagentId } from "./subagent.js";
 
 export const SAND_HIDDEN_PROMPT = "[SAND_HIDDEN_PROMPT]";
@@ -355,7 +364,7 @@ export function parseGrokBotLines(
     "sand-subagent transcripts stay discoverable as their own sessions; parent `task` calls attach a child-run card when the result names a sibling id.",
     "Group-chat wakes split into a room context-injection, human user turns, and assistant-side turns for other bots. Sibling transcripts that share the room title merge into one timeline.",
     "[routine]/[agent] wakes are context-injection; [inbound] remaining text is a user prompt; answering-question wraps are context-injection; background-task wakes are context-injection.",
-    "generate_image / computer_use results keep filePath/screenshotPath and omit embedded imageData. file:// markdown images in send_message are rewritten to a path mention and are not bundled into shareable HTML.",
+    "generate_image / computer_use results keep filePath/screenshotPath and omit embedded imageData. file:// markdown images and send_message attachments become basename mentions and are not bundled into shareable HTML.",
   ];
 
   return {
@@ -396,7 +405,42 @@ export function stripUserDecorators(text: string): string {
 
 export function extractSendMessageText(input: unknown, depth = 0): string {
   const raw = extractSendMessageTextRaw(input, depth);
-  return depth === 0 ? rewriteGrokBotShareableText(raw) : raw;
+  if (depth !== 0) return raw;
+  const rewritten = rewriteGrokBotShareableText(raw);
+  const attachments = formatSendMessageAttachments(input);
+  if (!attachments) return rewritten;
+  if (!rewritten.trim()) return attachments;
+  if (rewritten.includes("[attached image:") || rewritten.includes("[attachment:")) {
+    return rewritten;
+  }
+  return `${rewritten}\n${attachments}`;
+}
+
+function formatSendMessageAttachments(input: unknown): string {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
+  const attachments = (input as Record<string, unknown>).attachments;
+  if (!Array.isArray(attachments) || attachments.length === 0) return "";
+  const mentions: string[] = [];
+  for (const item of attachments) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const obj = item as Record<string, unknown>;
+    const url = firstString(obj.url, obj.path, obj.filePath, obj.file_path, obj.src);
+    const title = firstString(obj.title, obj.name, obj.alt, obj.filename, obj.fileName);
+    if (url && (/^file:/i.test(url) || /^data:image\//i.test(url))) {
+      mentions.push(formatAttachedImageMention(title || "", url));
+      continue;
+    }
+    if (url) {
+      const path = stripFileUrl(url);
+      const base = grokBotPathBasename(path);
+      mentions.push(
+        title && title !== base ? `[attachment: ${title} (${base})]` : `[attachment: ${base}]`,
+      );
+      continue;
+    }
+    if (title) mentions.push(`[attachment: ${title}]`);
+  }
+  return mentions.join("\n");
 }
 
 function extractSendMessageTextRaw(input: unknown, depth = 0): string {
@@ -646,7 +690,7 @@ const SUBAGENT_THINKING_CHARS = 500;
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 type AttachedSubAgent = NonNullable<ToolUseBlock["_subAgent"]>;
 
-async function attachGrokBotSubAgents(
+export async function attachGrokBotSubAgents(
   parsed: ProviderParseResult,
   sourcePath?: string,
 ): Promise<ProviderParseResult> {

--- a/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
+++ b/packages/provider-grok-bot/src/grok-bot/tool-mapping.ts
@@ -5,12 +5,12 @@
  *
  * `send_message` is promoted to assistant text in the parser.
  * `communicate_update` is a status/memory side-effect and stays a
- * `CommunicateUpdate` tool scene (success and failure). `get_mcp_tools` is
- * discovery noise and is omitted from replay scenes. `mcp` keeps its raw
- * name so the scanner's Pi-style `parseMcpUsage` branch can attribute
- * server/tool from args. Dynamic MCP calls use short names plus
- * `serverIdentifier` / `toolName` / `args` and are rewritten to
- * `mcp__<server>__<tool>` cards. Unrecognized non-MCP tools pass through.
+ * `CommunicateUpdate` tool scene (success and failure); its update text is
+ * flattened onto `update` so tool cards have a one-line summary.
+ * `get_mcp_tools` is discovery noise and is omitted from replay scenes.
+ * `mcp` and dynamic short names (`pull_request_read`) both become
+ * `mcp__<server>__<tool>` cards when server+tool are known so Insights and
+ * the 🔌 viewer label stay consistent. Unrecognized non-MCP tools pass through.
  */
 
 const GROK_BOT_TOOL_NAME_MAP: Record<string, string> = {
@@ -153,6 +153,15 @@ export function mapGrokBotToolArgs(toolName: string, input: unknown): Record<str
     if (prompt) obj.prompt = prompt;
   }
 
+  if (normalized === "communicate_update") {
+    const nestedText =
+      obj.text && typeof obj.text === "object" && !Array.isArray(obj.text)
+        ? (obj.text as Record<string, unknown>).content
+        : obj.text;
+    const update = firstString(obj.update, obj.status, nestedText);
+    if (update) obj.update = update;
+  }
+
   const mcp = grokBotMcpFields(obj);
   if (mcp.server) obj.server = mcp.server;
   if (mcp.tool) {
@@ -183,7 +192,6 @@ export function grokBotMcpAttribution(
 
 /** Viewer MCP cards use `mcp__server__tool` so the 🔌 label parses. */
 export function grokBotReplayToolName(rawName: string, input: Record<string, unknown>): string {
-  if (rawName.toLowerCase() === "mcp") return "mcp";
   const mcp = grokBotMcpAttribution(rawName, input);
   if (mcp?.server && mcp.tool) return `mcp__${mcp.server}__${mcp.tool}`;
   return mapGrokBotToolName(rawName);

--- a/packages/provider-grok-bot/test/parser-edges.test.ts
+++ b/packages/provider-grok-bot/test/parser-edges.test.ts
@@ -1,0 +1,405 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  formatAttachedImageMention,
+  grokBotPathBasename,
+  parseGrokBotLines,
+  parseGrokBotSession,
+  rewriteGrokBotShareableText,
+  stripFileUrl,
+} from "../src/grok-bot/parser.js";
+import { transformToReplay } from "./helpers/transform.js";
+
+describe("Grok Bot parser edges", () => {
+  it("does not attach a later tool's result when names mismatch and ids are absent", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "read then maybe shell" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [{ type: "tool_use", name: "read", input: { path: "/a.md" } }],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "shell",
+              result: { success: { stdout: "should not land on Read" } },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ name: "Read" });
+    expect(tools[0].type === "tool_use" && tools[0]._hasResult).toBe(false);
+    expect(tools[0].type === "tool_use" && tools[0]._result).toBeUndefined();
+  });
+
+  it("consumes get_mcp_tools results positionally so they do not leak onto the next tool", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "list then read" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "get_mcp_tools", input: {} },
+            { type: "tool_use", name: "read", input: { path: "/a.md" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "get_mcp_tools",
+              result: { success: { content: "github, slack" } },
+            },
+            {
+              type: "tool_result",
+              name: "read",
+              result: { success: { content: "# doc" } },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ name: "Read", _result: "# doc" });
+    expect(JSON.stringify(parsed.turns)).not.toContain("github, slack");
+  });
+
+  it("keeps empty and error-shaped results without inventing success text", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "partial tools" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", name: "read", toolCallId: "empty", input: { path: "/a.md" } },
+            { type: "tool_use", name: "shell", toolCallId: "err", input: { command: "false" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "read",
+              toolCallId: "empty",
+              result: { success: { timestamp: 1788485460000 } },
+            },
+            {
+              type: "tool_result",
+              name: "shell",
+              toolCallId: "err",
+              result: { error: { message: "boom" } },
+            },
+          ],
+        },
+      }),
+    ]);
+    const tools = parsed.turns
+      .flatMap((turn) => turn.blocks)
+      .filter((block) => block.type === "tool_use");
+    expect(tools[0]).toMatchObject({ name: "Read", _hasResult: true, _result: "" });
+    expect(tools[0].type === "tool_use" && tools[0]._isError).toBeUndefined();
+    expect(tools[1]).toMatchObject({ name: "Bash", _isError: true, _result: "boom" });
+  });
+
+  it("skips non-object JSONL records and keeps a parse warning for truncated lines", () => {
+    const parsed = parseGrokBotLines([
+      "[1,2,3]",
+      '{"role":"user"',
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "survived" }] },
+      }),
+    ]);
+    expect(parsed.parseWarnings?.[0]).toMatchObject({
+      kind: "malformed-json",
+      firstLine: 2,
+    });
+    expect(parsed.turns).toHaveLength(1);
+    expect(parsed.turns[0].blocks[0]).toEqual({ type: "text", text: "survived" });
+  });
+
+  it("rewrites Windows file URLs and titled markdown to basename mentions", () => {
+    expect(stripFileUrl("file:///C:/Users/me/Pictures/cat.png")).toBe(
+      "C:/Users/me/Pictures/cat.png",
+    );
+    expect(grokBotPathBasename("C:\\Users\\me\\Pictures\\cat.png")).toBe("cat.png");
+    expect(formatAttachedImageMention("sketch", "file:///C:/Users/me/Pictures/cat.png")).toBe(
+      "[attached image: sketch (cat.png)]",
+    );
+    expect(
+      rewriteGrokBotShareableText('![cover](<file:///home/box/assets/cover.png> "hero")'),
+    ).toBe("[attached image: cover (cover.png)]");
+    expect(rewriteGrokBotShareableText("![x](file:///home/box/a.png)")).toBe(
+      "[attached image: x (a.png)]",
+    );
+  });
+
+  it("promotes attachment-only send_message instead of dropping the turn", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "send_message",
+              input: {
+                attachments: [
+                  { url: "file:///home/box/agent-data/attachments/cat.png", title: "sketch" },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+    expect(parsed.turns[0].blocks[0]).toEqual({
+      type: "text",
+      text: "[attached image: sketch (cat.png)]",
+    });
+  });
+
+  it("does not throw when a parent task names a missing sibling subagent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-grok-bot-missing-sub-"));
+    const parentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const subId = "sand-subagent-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    await mkdir(join(root, parentId), { recursive: true });
+    await writeFile(
+      join(root, parentId, `${parentId}.jsonl`),
+      `${JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "task",
+              toolCallId: "t-1",
+              input: { goal: "explore", sessionId: subId },
+            },
+          ],
+        },
+      })}\n`,
+      "utf-8",
+    );
+    try {
+      const parsed = await parseGrokBotSession(join(root, parentId, `${parentId}.jsonl`));
+      const agent = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use" && block.name === "Agent");
+      expect(agent?.type === "tool_use" && agent._subAgent).toBeUndefined();
+      expect(parsed.subAgentSummary).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not expand nested grandchildren when attaching a sand-subagent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-grok-bot-nested-sub-"));
+    const parentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const childId = "sand-subagent-bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const grandId = "sand-subagent-cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    await mkdir(join(root, parentId), { recursive: true });
+    await mkdir(join(root, childId), { recursive: true });
+    await mkdir(join(root, grandId), { recursive: true });
+    await writeFile(
+      join(root, parentId, `${parentId}.jsonl`),
+      `${JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "task",
+              toolCallId: "t-1",
+              input: { goal: "explore UI", sessionId: childId },
+            },
+          ],
+        },
+      })}\n`,
+      "utf-8",
+    );
+    await writeFile(
+      join(root, childId, `${childId}.jsonl`),
+      [
+        {
+          role: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                name: "task",
+                toolCallId: "t-2",
+                input: { goal: "nested", sessionId: grandId },
+              },
+            ],
+          },
+        },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+      "utf-8",
+    );
+    await writeFile(
+      join(root, grandId, `${grandId}.jsonl`),
+      `${JSON.stringify({
+        role: "assistant",
+        message: { content: [{ type: "text", text: "grandchild scratch" }] },
+      })}\n`,
+      "utf-8",
+    );
+    try {
+      const parsed = await parseGrokBotSession(join(root, parentId, `${parentId}.jsonl`));
+      const agent = parsed.turns
+        .flatMap((turn) => turn.blocks)
+        .find((block) => block.type === "tool_use" && block.name === "Agent");
+      expect(agent?.type === "tool_use" && agent._subAgent?.agentId).toBe(childId);
+      const nested = agent?.type === "tool_use" ? agent._subAgent?.scenes : undefined;
+      expect(nested?.some((scene) => JSON.stringify(scene).includes("grandchild scratch"))).toBe(
+        false,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("smoke-transforms a live-shaped stub: media scrub, MCP, wake, and status tool", () => {
+    const parsed = parseGrokBotLines([
+      JSON.stringify({
+        role: "user",
+        message: {
+          content: [{ type: "text", text: "[A background task just completed]\nWrote recap." }],
+        },
+      }),
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "[t0u]\n一起画画" }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "private scratch" },
+            {
+              type: "tool_use",
+              name: "communicate_update",
+              toolCallId: "cu-1",
+              input: { text: { content: "Sketching now." } },
+            },
+            {
+              type: "tool_use",
+              name: "mcp",
+              toolCallId: "m-1",
+              input: { server: "github", toolName: "pull_request_read" },
+            },
+            {
+              type: "tool_use",
+              name: "generate_image",
+              toolCallId: "img-1",
+              input: { prompt: "a cat" },
+            },
+            {
+              type: "tool_use",
+              name: "send_message",
+              input: {
+                text: {
+                  content: "See ![cat](<file:///home/box/agent-data/attachments/cat.png>)",
+                },
+              },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        role: "tool",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              name: "communicate_update",
+              toolCallId: "cu-1",
+              result: { success: { timestamp: 1788485600000 } },
+            },
+            {
+              type: "tool_result",
+              name: "mcp",
+              toolCallId: "m-1",
+              result: { success: { timestamp: 1788485601000, content: "PR 1" } },
+            },
+            {
+              type: "tool_result",
+              name: "generate_image",
+              toolCallId: "img-1",
+              result: {
+                success: {
+                  timestamp: 1788485602000,
+                  filePath: "/home/box/agent-data/assets/cat.png",
+                  imageData: `iVBOR${"A".repeat(120)}`,
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ]);
+    const prompts = parsed.turns.filter((turn) => turn.role === "user" && !turn.subtype);
+    expect(prompts[0].blocks[0]).toEqual({ type: "text", text: "一起画画" });
+    expect(parsed.turns.some((turn) => turn.subtype === "context-injection")).toBe(true);
+
+    const replay = transformToReplay(parsed, "grok-bot", "~/grok-bot");
+    const types = replay.scenes.map((scene) => scene.type);
+    expect(types).toContain("context-injection");
+    expect(types).toContain("user-prompt");
+    expect(types).toContain("thinking");
+    expect(types).toContain("text-response");
+    expect(types).toContain("tool-call");
+    const user = replay.scenes.find((scene) => scene.type === "user-prompt");
+    expect(user?.type === "user-prompt" && user.content).toBe("一起画画");
+    expect(
+      replay.scenes.some(
+        (scene) => scene.type === "text-response" && scene.content.includes("[attached image: cat"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(replay.scenes)).not.toContain("iVBOR");
+    expect(JSON.stringify(replay.scenes)).not.toContain("file://");
+    expect(
+      replay.scenes.some(
+        (scene) =>
+          scene.type === "tool-call" && scene.toolName === "mcp__github__pull_request_read",
+      ),
+    ).toBe(true);
+    const status = replay.scenes.find(
+      (scene) => scene.type === "tool-call" && scene.toolName === "CommunicateUpdate",
+    );
+    expect(status?.type === "tool-call" && status.input.update).toBe("Sketching now.");
+  });
+});

--- a/packages/provider-grok-bot/test/parser.test.ts
+++ b/packages/provider-grok-bot/test/parser.test.ts
@@ -267,7 +267,7 @@ describe("Grok Bot parser", () => {
         text: { content: "Visible DM reply" },
         attachments: [{ url: "https://example.invalid/card.png", title: "card" }],
       }),
-    ).toBe("Visible DM reply");
+    ).toBe("Visible DM reply\n[attachment: card (card.png)]");
     expect(extractStatusUpdateText({ update: "Scanning inbox…" })).toBe("Scanning inbox…");
   });
 
@@ -285,7 +285,8 @@ describe("Grok Bot parser", () => {
       .flatMap((turn) => turn.blocks)
       .filter((block) => block.type === "text")
       .map((block) => (block.type === "text" ? block.text : ""));
-    expect(assistantText).toContain("Hey — good to meet you.");
+    expect(assistantText.some((text) => text.includes("Hey — good to meet you."))).toBe(true);
+    expect(assistantText.some((text) => text.includes("[attachment: card.png]"))).toBe(true);
     expect(assistantText).not.toContain("Checking the badge copy now.");
     expect(assistantText).toContain("Badge copy looks good.");
     expect(assistantText.some((text) => text.includes("example.invalid"))).toBe(false);
@@ -299,6 +300,10 @@ describe("Grok Bot parser", () => {
       "TodoWrite",
       "Bash",
     ]);
+    expect(tools[0]).toMatchObject({
+      name: "CommunicateUpdate",
+      input: { update: "Checking the badge copy now." },
+    });
     expect(tools[2]).toMatchObject({
       name: "TodoWrite",
       input: {
@@ -499,7 +504,7 @@ describe("Grok Bot parser", () => {
     expect(tools.map((block) => (block.type === "tool_use" ? block.name : ""))).toEqual([
       "Await",
       "Agent",
-      "mcp",
+      "mcp__github__pull_request_read",
       "ComputerUse",
       "WebSearch",
     ]);
@@ -512,7 +517,7 @@ describe("Grok Bot parser", () => {
       },
     });
     expect(tools[2]).toMatchObject({
-      name: "mcp",
+      name: "mcp__github__pull_request_read",
       input: { server: "github", toolName: "pull_request_read", tool: "pull_request_read" },
       _mcpServer: "github",
       _mcpTool: "pull_request_read",
@@ -673,9 +678,11 @@ describe("Grok Bot parser", () => {
       name: "CommunicateUpdate",
       _isError: true,
       _result: "delivery failed",
+      input: { update: "This ping never landed." },
     });
     expect(tools[1]).toMatchObject({
       name: "CommunicateUpdate",
+      input: { update: "Still working." },
     });
     expect(tools[1].type === "tool_use" && tools[1]._isError).toBeUndefined();
     const texts = parsed.turns
@@ -869,10 +876,10 @@ describe("Grok Bot parser", () => {
       },
     };
     expect(extractSendMessageText(input)).toBe(
-      "See [image: sketch — /home/box/agent-data/attachments/cat.png] and the rest.",
+      "See [attached image: sketch (cat.png)] and the rest.",
     );
     expect(rewriteGrokBotShareableText("![x](file:///home/box/agent-data/assets/a.png)")).toBe(
-      "[image: x — /home/box/agent-data/assets/a.png]",
+      "[attached image: x (a.png)]",
     );
     const parsed = parseGrokBotLines([
       JSON.stringify({
@@ -884,7 +891,7 @@ describe("Grok Bot parser", () => {
     ]);
     expect(parsed.turns[0].blocks[0]).toEqual({
       type: "text",
-      text: "See [image: sketch — /home/box/agent-data/attachments/cat.png] and the rest.",
+      text: "See [attached image: sketch (cat.png)] and the rest.",
     });
   });
 
@@ -1050,6 +1057,12 @@ describe("Grok Bot tool mapping", () => {
       new_string: "b",
     });
     expect(
+      grokBotReplayToolName("mcp", {
+        server: "github",
+        toolName: "pull_request_read",
+      }),
+    ).toBe("mcp__github__pull_request_read");
+    expect(
       grokBotReplayToolName("pull_request_read", {
         serverIdentifier: "github",
         toolName: "pull_request_read",
@@ -1065,6 +1078,16 @@ describe("Grok Bot tool mapping", () => {
       server: "github",
       tool: "pull_request_read",
       pullNumber: 544,
+    });
+    expect(
+      mapGrokBotToolArgs("communicate_update", {
+        text: { content: "Checking the badge copy now." },
+      }),
+    ).toMatchObject({
+      update: "Checking the badge copy now.",
+    });
+    expect(mapGrokBotToolArgs("communicate_update", { update: "Scanning inbox…" })).toMatchObject({
+      update: "Scanning inbox…",
     });
   });
 });

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -45,6 +45,8 @@ interface Props {
   liveCursorDiagnostics?: LiveCursorDiagnostics;
   liveCursorRowsChanged?: boolean;
   liveCursorProbeAt?: number;
+  /** Override the thinking-scene label (Grok Bot uses "Scratch"). */
+  thinkingLabel?: string;
 }
 
 interface TurnGroup {
@@ -209,6 +211,7 @@ export default function ConversationView({
   liveCursorDiagnostics,
   liveCursorRowsChanged,
   liveCursorProbeAt,
+  thinkingLabel = "Thinking",
 }: Props & { onSeek?: (index: number) => void }) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [activeStickyPrompt, setActiveStickyPrompt] = useState<StickyPromptSummary | null>(null);
@@ -432,6 +435,7 @@ export default function ConversationView({
                     overlayActions={overlayActions}
                     turnStats={turnStats}
                     contextLimit={contextLimit}
+                    thinkingLabel={thinkingLabel}
                   />
                 </>
               );
@@ -781,6 +785,7 @@ const GroupCard = memo(function GroupCard({
   overlayActions,
   turnStats,
   contextLimit,
+  thinkingLabel = "Thinking",
 }: {
   group: TurnGroup;
   currentIndex: number;
@@ -794,6 +799,7 @@ const GroupCard = memo(function GroupCard({
   overlayActions?: OverlayActions;
   turnStats?: TurnStat[];
   contextLimit?: number;
+  thinkingLabel?: string;
 }) {
   const [hovered, setHovered] = useState(false);
 
@@ -949,6 +955,7 @@ const GroupCard = memo(function GroupCard({
                   effectiveContent={effectiveContent ?? undefined}
                   highlights={highlightsByScene?.get(index) ?? []}
                   onHighlightClick={onAnnotationClick}
+                  thinkingLabel={thinkingLabel}
                 />
                 {sceneOverlays.length > 0 && (
                   <div className="flex items-center gap-2 mt-1.5">
@@ -1117,6 +1124,7 @@ const GroupCard = memo(function GroupCard({
         onAnnotationClick={onAnnotationClick}
         overlayActions={overlayActions}
         turnStat={turnStat}
+        thinkingLabel={thinkingLabel}
       />
     );
   }
@@ -1173,6 +1181,7 @@ const GroupCard = memo(function GroupCard({
           highlightsByScene={highlightsByScene}
           onAnnotationClick={onAnnotationClick}
           overlayActions={overlayActions}
+          thinkingLabel={thinkingLabel}
         />
       </div>
     </div>
@@ -1200,6 +1209,7 @@ function CompactAssistantGroup({
   onAnnotationClick,
   overlayActions,
   turnStat,
+  thinkingLabel = "Thinking",
 }: {
   /** All scenes in the group — used for stable stats (not affected by playback progress) */
   allScenes: { scene: Scene; index: number }[];
@@ -1217,6 +1227,7 @@ function CompactAssistantGroup({
   onAnnotationClick?: (annotationId: string) => void;
   overlayActions?: OverlayActions;
   turnStat?: TurnStat;
+  thinkingLabel?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -1405,7 +1416,7 @@ function CompactAssistantGroup({
         )}
         {stats.thinking > 0 && (
           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-terminal-thinking-subtle text-terminal-thinking">
-            {stats.thinking} thinking
+            {stats.thinking} {thinkingLabel.toLowerCase()}
           </span>
         )}
         {sortedToolEntries.length > 0 && (
@@ -1465,6 +1476,7 @@ function CompactAssistantGroup({
                   effectiveContent={ec}
                   highlights={highlightsByScene?.get(index) ?? []}
                   onHighlightClick={onAnnotationClick}
+                  thinkingLabel={thinkingLabel}
                 />
                 {onComment && (
                   <button
@@ -1518,6 +1530,7 @@ function BatchedScenes({
   highlightsByScene,
   onAnnotationClick,
   overlayActions,
+  thinkingLabel,
 }: {
   scenes: { scene: Scene; index: number }[];
   currentIndex: number;
@@ -1527,6 +1540,7 @@ function BatchedScenes({
   highlightsByScene?: Map<number, TextHighlight[]>;
   onAnnotationClick?: (annotationId: string) => void;
   overlayActions?: OverlayActions;
+  thinkingLabel?: string;
 }) {
   // Group consecutive tool calls with the same toolName (only batchable ones)
   const batches: { scene: Scene; index: number }[][] = [];
@@ -1576,6 +1590,7 @@ function BatchedScenes({
                 effectiveContent={effectiveContent ?? undefined}
                 highlights={highlightsByScene?.get(index) ?? []}
                 onHighlightClick={onAnnotationClick}
+                thinkingLabel={thinkingLabel}
               />
               {sceneOverlays.length > 0 && (
                 <div className="flex items-center gap-2 mt-1">
@@ -1812,6 +1827,8 @@ function summarizeToolInput(name: string, input: Record<string, any>): string {
       return input.pattern || "";
     case "Agent":
       return input.description || "";
+    case "CommunicateUpdate":
+      return typeof input.update === "string" ? input.update : "";
     default:
       return "";
   }
@@ -1824,6 +1841,7 @@ const SceneBlock = memo(function SceneBlock({
   effectiveContent,
   highlights = NO_HIGHLIGHTS,
   onHighlightClick,
+  thinkingLabel = "Thinking",
 }: {
   scene: Scene;
   isActive: boolean;
@@ -1831,6 +1849,7 @@ const SceneBlock = memo(function SceneBlock({
   effectiveContent?: string;
   highlights?: TextHighlight[];
   onHighlightClick?: (annotationId: string) => void;
+  thinkingLabel?: string;
 }) {
   switch (scene.type) {
     case "user-prompt":
@@ -1869,6 +1888,7 @@ const SceneBlock = memo(function SceneBlock({
           tokens={scene.tokens}
           highlights={highlights}
           onHighlightClick={onHighlightClick}
+          label={thinkingLabel}
         />
       );
     case "text-response":

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -1067,6 +1067,7 @@ export default function Player({
                     overlayActions={overlayActions}
                     turnStats={session.meta.stats.turnStats}
                     contextLimit={session.meta.contextLimit}
+                    thinkingLabel={session.meta.provider === "grok-bot" ? "Scratch" : "Thinking"}
                     isLive={isLive}
                     liveCursorDiagnostics={live?.cursorDiagnostics}
                     liveCursorProbeAt={live?.lastCursorProbe}

--- a/packages/viewer/src/components/ThinkingBlock.tsx
+++ b/packages/viewer/src/components/ThinkingBlock.tsx
@@ -15,6 +15,8 @@ interface Props {
   tokens?: number;
   highlights?: TextHighlight[];
   onHighlightClick?: (annotationId: string) => void;
+  /** Grok Bot maps private scratch onto thinking scenes; those use "Scratch". */
+  label?: string;
 }
 
 export default memo(function ThinkingBlock({
@@ -23,6 +25,7 @@ export default memo(function ThinkingBlock({
   tokens,
   highlights = NO_HIGHLIGHTS,
   onHighlightClick,
+  label = "Thinking",
 }: Props) {
   const [expanded, setExpanded] = useState(false);
   const tokenLabel = formatTokens(tokens);
@@ -40,7 +43,7 @@ export default memo(function ThinkingBlock({
         className="flex items-center gap-2 text-xs text-terminal-dim hover:text-terminal-text transition-colors duration-200 ease-material font-mono"
       >
         <span className={`transition-transform ${expanded ? "rotate-90" : ""}`}>{"▶"}</span>
-        <span className={`text-terminal-purple ${isActive ? "animate-pulse" : ""}`}>Thinking</span>
+        <span className={`text-terminal-purple ${isActive ? "animate-pulse" : ""}`}>{label}</span>
         {tokenLabel ? (
           <span
             className="text-terminal-purple/70 text-[10px]"

--- a/packages/viewer/src/components/ToolCallBlock.tsx
+++ b/packages/viewer/src/components/ToolCallBlock.tsx
@@ -89,6 +89,14 @@ function toolIcon(name: string): string {
       return "🔎";
     case "Agent":
       return "🤖";
+    case "Await":
+      return "⏳";
+    case "ComputerUse":
+      return "🖥";
+    case "GenerateImage":
+      return "🖼";
+    case "CommunicateUpdate":
+      return "📣";
     default:
       return "⚙️";
   }
@@ -541,6 +549,8 @@ export function summarizeInput(name: string, input: Record<string, any>): string
       return input.command || "";
     case "ExitPlanMode":
       return (input.plan || "").slice(0, 80);
+    case "CommunicateUpdate":
+      return typeof input.update === "string" ? input.update.slice(0, 80) : "";
     default:
       // mcp__server__tool — surface the most likely identifying value, or
       // fall back to a short joined string of scalar args.

--- a/packages/viewer/src/components/__tests__/conversation-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/conversation-view.test.tsx
@@ -265,4 +265,25 @@ describe("ConversationView assistant metrics", () => {
     expect(screen.getByText("You")).toBeTruthy();
     expect(screen.getByText("Assistant")).toBeTruthy();
   });
+
+  it("labels Grok Bot scratch as Scratch instead of Thinking", () => {
+    render(
+      <ConversationView
+        scenes={[
+          { type: "user-prompt", content: "一起画画", speaker: "User" },
+          { type: "thinking", content: "private scratch reasoning" },
+          { type: "text-response", content: "好的，我来起草图", speaker: "艺术家" },
+        ]}
+        visibleCount={3}
+        currentIndex={2}
+        effectivePrefs={prefs(false)}
+        thinkingLabel="Scratch"
+      />,
+    );
+
+    expect(screen.getByText("Scratch")).toBeTruthy();
+    expect(screen.queryByText("Thinking")).toBeNull();
+    expect(screen.getByText("You")).toBeTruthy();
+    expect(screen.getByText("艺术家")).toBeTruthy();
+  });
 });

--- a/packages/viewer/src/components/__tests__/tool-summary.test.ts
+++ b/packages/viewer/src/components/__tests__/tool-summary.test.ts
@@ -79,6 +79,13 @@ describe("summarizeInput", () => {
   it("uses shortenScalarSummary fallback for unknown tools (e.g. mcp__*)", () => {
     expect(summarizeInput("mcp__server__tool", { url: "https://x.com" })).toBe("https://x.com");
   });
+
+  it("surfaces CommunicateUpdate status text", () => {
+    expect(summarizeInput("CommunicateUpdate", { update: "Scanning inbox…" })).toBe(
+      "Scanning inbox…",
+    );
+    expect(summarizeInput("CommunicateUpdate", { text: { content: "hidden nested" } })).toBe("");
+  });
 });
 
 describe("shortenScalarSummary", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up quality pass on the Grok Bot path after #581. Does **not** overlap #582 (speaker fallback / MCP field copy / group metadata).

Usability and Insights:
- `file://` markdown images and `send_message` attachments become `[attached image: sketch (cat.png)]` (basename, including Windows `file:///C:/...`) instead of a broken file URI in shareable HTML.
- The `mcp` wrapper now uses `mcp__<server>__<tool>` like dynamic short names, so viewer 🔌 cards and Insights MCP facets stay consistent.
- `communicate_update` input is flattened onto `update`, and the tool card summary shows that status text.
- Grok Bot thinking scenes are labeled **Scratch** so they are not mistaken for the `send_message` reply.
- Insights `firstPrompt` keeps short CJK prompts (`一起画画`) instead of skipping them for the 10-character English threshold; background-task wakes still do not pollute Explore.

Robustness:
- Mismatched tool results stay unenriched; `get_mcp_tools` results do not leak onto the next tool without IDs.
- Empty success and `{ error: { message } }` results are handled; missing sibling subagents do not throw; nested grandchildren stay unexpanded.
- Live JSONL parsing attaches sibling `sand-subagent-*` transcripts from disk, matching generated replays.

## Validation

- [x] `pnpm --filter @vibe-replay/provider-grok-bot test` (57 tests)
- [x] `pnpm --filter vibe-replay exec vitest run test/scanner.test.ts test/live.test.ts test/generator.test.ts` (112 passed, 1 skipped)
- [x] `pnpm --filter @vibe-replay/viewer exec vitest run src/components/__tests__/tool-summary.test.ts src/components/__tests__/conversation-view.test.tsx` (30 tests)
- [x] `pnpm lint:check`
- [x] `tsc --noEmit` for `provider-grok-bot`, `vibe-replay`, and `@vibe-replay/viewer`
- [ ] `pnpm verify` — sequential full gate left to CI
- [ ] `pnpm test:e2e` — not required (parser/scanner/viewer labels; HTML smoke uses existing `generator.test.ts`)

### Self-test rounds

1. **Audit** — compared grok-bot coverage to #581 and a sibling provider. Discarded: background-task firstPrompt (already handled), group You-vs-name labeling (already correct), hiding CommunicateUpdate (AGENTS.md keeps those scenes).
2. **Unit tests** — first grok-bot run failed because the DM greeting now includes `[attachment: card.png]`. Assertion updated to the new visible text; 57/57 green.
3. **HTML smoke** — `escapeJsonForScript` + `injectDataScript` on a tiny live-shaped stub (no multi-MB base64). First assertion failed because `dataSourceInfo.notes` mention `file://`; tightened to scene payloads. Viewer.html inject path green.
4. **Lint/types** — `thinkingLabel` leaked into `ToolBatch` (tool-only). Removed; `tsc --noEmit` and `pnpm lint:check` green.

## Test plan

- [x] Parser edges: mismatched results, hidden-tool leak, Windows file URLs, attachment-only replies, missing/nested subagents
- [x] Scanner: CJK firstPrompt, `mcp` wrapper counted under MCP facets not tools
- [x] Live: parent task attaches sibling subagent from disk
- [x] Viewer: CommunicateUpdate summary, Scratch label
- [ ] `pnpm verify` in CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f86b80e-c1da-482f-bce2-6e15fba2b6b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f86b80e-c1da-482f-bce2-6e15fba2b6b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Grok Bot session support, including attached subagents and short prompts.
  - Grok Bot attachments and images now appear as readable filename-based mentions.
  - MCP tools display clearer server and tool names.
  - Communication updates and additional tool types now have improved summaries and icons.
  - Grok Bot scratch text is labeled “Scratch” in the viewer.

- **Bug Fixes**
  - Improved handling of Windows paths, data URLs, malformed records, tool results, and nested session data.
  - Prevented background wake messages from being indexed as user prompts.

- **Documentation**
  - Updated Grok Bot provider guidance for attachments, scratch text, MCP tools, and live sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->