### PR TITLE
docs: describe Grok Bot multi-party replays

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ curl -o ~/.claude/skills/replay/SKILL.md \
 | OpenCode | Supported (SQLite sessions, tools, reasoning, and compaction) |
 | Hermes | Supported (SQLite sessions, tools, reasoning, and compaction) |
 | Pi | Supported (JSONL tree sessions, branching, compaction summaries) |
-| Grok Bot | Supported (cloud-box JSONL; `send_message` promoted to visible replies; group-chat wakes split per speaker) |
+| Grok Bot | Supported (cloud-box JSONL; `send_message` promoted to visible replies; group-chat wakes split per speaker and related room transcripts merge into one multi-party replay) |
 | More coming soon | — |
 
 Grok Bot sessions live on the cloud box (`/home/box/agent-data/agent-transcripts`, often a symlink to `sand-data`). Point discovery at a copy with `GROK_BOT_TRANSCRIPTS_DIR` (or `VIBE_REPLAY_GROK_BOT_DIR`), or drop files under `~/.grok-bot/agent-transcripts`. Group-chat user lines starting with `[Group chat:` become a room context-injection plus one user turn per `Speaker: message`; Eng and GTM keep separate transcripts:


### PR DESCRIPTION
## Summary

- Document that related Grok Bot room transcripts merge into one multi-party replay.
- Corresponds to the user-visible capability introduced by #565.

## Why now

The supported-provider table described per-speaker group-chat wakes but omitted the new multi-transcript room replay behavior.

## Files touched

- README.md (+1 / -1 lines)

## Out of scope (intentionally)

- No landing page or website changes; those files are outside this routine's allowed scope.
- No blog, screenshot, marketing claim, or product-code changes.

> 🤖 Weekly auto-docs routine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that related room transcripts for Grok Bot merge into a single multi-party replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->