### PR TITLE
chore(release): v0.2.11 — Grok sample, share no-auth fallback, hide sand-subagents

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-replay",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Turn AI coding sessions into animated, interactive web replays. One command, one HTML file, share anywhere.",
   "keywords": [
     "ai",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps the published CLI from **0.2.10 → 0.2.11**. Main already has cold-start fixes that npm `vibe-replay@latest` (0.2.10) does not:

1. **[#589](https://github.com/tuo-lei/vibe-replay/pull/589) — bundled Grok Bot sample + Hero Eng+GTM demo.** Empty-transcript machines (`npx vibe-replay -p grok-bot`) get a tiny Eng+GTM group fixture (`packages/cli/assets/samples/grok-bot.jsonl`) so the grok facet is playable without copying JSONL off a box. Claude welcome sample remains for empty Claude-only discovery. Homepage Watch-demo already points at the English Eng+GTM gist (this PR does **not** change Hero/website CTAs).
2. **[#590](https://github.com/tuo-lei/vibe-replay/pull/590) — `share` local HTML fallback without auth.** Unauthenticated `vibe-replay share` no longer fails before any I/O: it rebuilds a self-contained local `index.html` from `replay.json` with editor overlays + annotations, strips SSH `meta.gitRepo` via `sessionForExternalOutput`, opens the file when possible, and prints the path + `file://` URL plus `vibe-replay auth login` for cloud share. Also **hides `sand-subagent-*` from top-level discovery** so they do not spam the picker/dashboard; parent `task` attach and `--session` parse are unchanged.

Without this version bump, `npx vibe-replay@latest` still looks “fake fixed.” This PR is the version line only (`packages/cli/package.json`).

## Validation

- [x] `pnpm --filter vibe-replay build`
- [x] `node packages/cli/dist/index.js --version` prints `0.2.11` (banner: `vibe-replay v0.2.11`)
- [x] `pnpm verify` (lint, types, unit tests, cloudflare tests, full build)
- [x] `pnpm --filter vibe-replay exec vitest run test/bundled-sample.test.ts test/share-local-fallback.test.ts` (23 passed)
- [x] `e2e/cli-smoke.test.ts` (4 passed, including no-auth `share`)
- [x] CI-equivalent pack smoke: tarball `vibe-replay-0.2.11.tgz` includes `assets/samples/grok-bot.jsonl`, no `workspace:` leaks, packed `npx vibe-replay --version` is `0.2.11`
- [ ] `pnpm test:e2e` not required (version bump only; ran CLI smoke subset)

## Eng handoff — squash-merge, then tag (do not skip)

This agent **does not merge, does not create the git tag, and does not publish to npm**. After CI is green:

1. **Squash-merge** this PR (Eng).
2. Confirm `packages/cli/package.json` on `main` is `0.2.11`.
3. Create a GitHub Release tagged **`v0.2.11`** on that merge commit. `.github/workflows/release.yml` publishes to npm via OIDC (`id-token: write`). The workflow also syncs the packed version from the tag.
4. Smoke: `npx vibe-replay@0.2.11 --version` prints `0.2.11`. Until that tag, `npx vibe-replay@latest` is still **0.2.10** and still lacks #589/#590.
5. Do **not** retag an old 0.2.10 commit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca15e2f8-6c3c-478c-b3b2-8f41f13b9625?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca15e2f8-6c3c-478c-b3b2-8f41f13b9625&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

