### PR TITLE
test(cli): raise GIF export timeout for Windows smoke flake

### DIFF
--- a/packages/cli/test/gif-export.test.ts
+++ b/packages/cli/test/gif-export.test.ts
@@ -1,5 +1,5 @@
 import type { ReplaySession } from "@vibe-replay/types";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { generateGitHubGif } from "../src/formatters/gif.js";
 import { buildSvgFrames, extractPhases, renderStaticFrameSvg } from "../src/formatters/github.js";
 
@@ -105,10 +105,17 @@ describe("renderStaticFrameSvg", () => {
 // ─── GIF generation tests ──────────────────────────────────
 
 describe("generateGitHubGif", () => {
-  it("generates a valid GIF with correct magic bytes", async () => {
-    const session = makeSession();
-    const gif = await generateGitHubGif(session);
+  let gif!: Buffer;
 
+  // First @resvg/resvg-js call plus Windows system-font load can exceed 70s on
+  // windows-smoke (observed 72s). Later generates in the same process are
+  // sub-second. Share the multi-frame GIF across the two assertions so we only
+  // pay that cold start once, and keep a timeout well above the observed cost.
+  beforeAll(async () => {
+    gif = await generateGitHubGif(makeSession());
+  }, 180_000);
+
+  it("generates a valid GIF with correct magic bytes", () => {
     // GIF magic bytes: "GIF89a"
     expect(gif[0]).toBe(0x47); // G
     expect(gif[1]).toBe(0x49); // I
@@ -118,10 +125,7 @@ describe("generateGitHubGif", () => {
     expect(gif[5]).toBe(0x61); // a
   });
 
-  it("produces reasonable file size (under 2MB)", async () => {
-    const session = makeSession();
-    const gif = await generateGitHubGif(session);
-
+  it("produces reasonable file size (under 2MB)", () => {
     // A few frames of 840-wide dark-themed SVG should be well under 2MB
     expect(gif.length).toBeGreaterThan(100);
     expect(gif.length).toBeLessThan(2 * 1024 * 1024);
@@ -136,11 +140,8 @@ describe("generateGitHubGif", () => {
       },
     });
 
-    const gif = await generateGitHubGif(session);
-    expect(gif[0]).toBe(0x47); // G
-    expect(gif.length).toBeGreaterThan(100);
+    const singlePromptGif = await generateGitHubGif(session);
+    expect(singlePromptGif[0]).toBe(0x47); // G
+    expect(singlePromptGif.length).toBeGreaterThan(100);
   });
-  // GIF generation rasterizes several SVG frames and is CPU-heavy; it can take
-  // ~35s on slower Windows CI runners. Keep the timeout generous so these tests
-  // don't flake there.
-}, 60_000);
+}, 180_000);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

windows-smoke on `main` is red after #592, but the failure is **not** from the Grok Bot discovery tests. The only failing assertion was:

`packages/cli/test/gif-export.test.ts > generateGitHubGif > generates a valid GIF with correct magic bytes`

`Error: Test timed out in 60000ms.`

Failed run: https://github.com/tuo-lei/vibe-replay/actions/runs/34528752385 (job `windows-smoke`, step "Test CLI"). 47 other test files / 582 tests passed.

This is a known Windows-slow GIF flake, not a #592 regression:

- The suite timeout was already raised from 30s → 60s in #384 because rasterization can take ~35s on Windows runners.
- On this run the **first** `generateGitHubGif` call took ~72s (`72044ms`) and hit the 60s cap. The two later GIF tests then finished in 314ms and 178ms, which matches a one-time `@resvg/resvg-js` + system-font cold start rather than per-test generation cost.

Fix (coverage kept):

- Generate the multi-frame fixture GIF once in `beforeAll` and reuse it for the magic-byte and size assertions.
- Raise the suite / hook timeout from 60s to 180s so a 70s+ Windows cold start cannot flake CI.

## Validation

- [x] `pnpm lint:check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (incl. CLI gif-export + provider-grok-bot)
- [x] `pnpm test:cloudflare`
- [x] `pnpm build`
- [ ] `pnpm test:e2e` when generated HTML, editor server, CLI flows, or auth changed — N/A (test-only timeout/sharing)
- [x] Relevant manual testing completed, including small and large sessions for viewer changes — N/A (no viewer change). Linux VM cannot reproduce the Windows font-load cost; local gif-export finished in ~0.9s after the shared `beforeAll`.

Please leave unmerged for Eng review. Windows-smoke on this PR is the confirming signal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb316337-5e9e-556c-9396-3d524a496c86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb316337-5e9e-556c-9396-3d524a496c86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GIF export test efficiency by generating shared test output once for related validations.
  * Increased test timeouts to better accommodate slow startup and font-loading conditions across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->