### PR TITLE
refactor(cli): remove unused share path helper

### DIFF
--- a/packages/cli/src/share.ts
+++ b/packages/cli/src/share.ts
@@ -48,10 +48,6 @@ export interface ShareReplayDeps {
   ) => Promise<{ url: string; expiresAt: string }>;
 }
 
-export function replayHtmlPath(outputDir: string): string {
-  return join(outputDir, "index.html");
-}
-
 export function replayJsonPath(outputDir: string): string {
   return join(outputDir, "replay.json");
 }


### PR DESCRIPTION
## Summary

- Remove the unreferenced `replayHtmlPath` helper from the CLI share module.
- Net change: -4 lines.

## Motivation

A repository-wide reference scan found no callers, and `share.ts` is an internal CLI module rather than a published library API. Removing the dead helper does not change runtime behavior.

## Test plan

- [x] `pnpm verify` (lint, full typecheck, unit tests, Cloudflare tests, build)
- [x] `pnpm --filter vibe-replay exec tsc --noEmit`
- [x] `pnpm lint` and pre-commit oxfmt/oxlint hook
- [x] `git diff --check`
- [ ] E2E not run; this is a mechanically provable dead-code deletion.

> 🤖 Daily auto-quality routine. Self-merged after AI review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the exported helper for generating replay HTML file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->