### PR TITLE
fix: harden local session parity

### DIFF
--- a/packages/cli/src/providers/grok-bot/parser.ts
+++ b/packages/cli/src/providers/grok-bot/parser.ts
@@ -1,5 +1,6 @@
 export {
   attachGrokBotSubAgents,
+  parseGrokBotLiveSession,
   parseGrokBotLines,
   parseGrokBotSession,
 } from "@vibe-replay/provider-grok-bot/parser";

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1211,53 +1211,47 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
   // Count subagent files and extract their file modifications
   let subAgentCount = 0;
   if (input.filePaths.length > 0) {
-    const mainFile = input.filePaths[0];
-    const sessionDir = mainFile.replace(/\.jsonl$/, "");
-    const subagentsDir = join(sessionDir, "subagents");
-    try {
-      const files = await readdir(subagentsDir);
-      const jsonlFiles = files.filter((f) => f.endsWith(".jsonl"));
-      subAgentCount = jsonlFiles.length;
+    const subagentPaths = (await relatedSubagentPaths(input.filePaths)).filter((path) =>
+      path.endsWith(".jsonl"),
+    );
+    subAgentCount = subagentPaths.length;
 
-      // Scan sub-agent JSONL files for file modifications
-      for (const saFile of jsonlFiles) {
-        let saContent: string;
+    // Scan sub-agent JSONL files for file modifications
+    for (const subagentPath of subagentPaths) {
+      let saContent: string;
+      try {
+        saContent = await readFile(subagentPath, "utf-8");
+      } catch {
+        continue;
+      }
+      for (const saLine of saContent.split("\n")) {
+        if (!saLine.trim()) continue;
+        let saObj: SubAgentLine;
         try {
-          saContent = await readFile(join(subagentsDir, saFile), "utf-8");
+          saObj = JSON.parse(saLine);
         } catch {
           continue;
         }
-        for (const saLine of saContent.split("\n")) {
-          if (!saLine.trim()) continue;
-          let saObj: SubAgentLine;
-          try {
-            saObj = JSON.parse(saLine);
-          } catch {
-            continue;
-          }
-          const saMsg = saObj?.message;
-          if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
-          for (const block of saMsg.content as SubAgentBlock[]) {
-            if (block.type !== "tool_use") continue;
-            const event = toolUsageEvent(block.name || "Unknown", {
-              input: block.input,
-              parentAgentId: saFile.replace(/\.jsonl$/, ""),
-            });
-            usageEvents.push(event);
-            if (event.mcpServer) mcpServersUsed.add(event.mcpServer);
-            if (block.name && FILE_EDIT_TOOLS.has(block.name)) {
-              const fp = extractToolFilePath(block.input);
-              if (fp) {
-                editCount++;
-                const short = shortenSessionPath(fp, input);
-                fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
-              }
+        const saMsg = saObj?.message;
+        if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
+        for (const block of saMsg.content as SubAgentBlock[]) {
+          if (block.type !== "tool_use") continue;
+          const event = toolUsageEvent(block.name || "Unknown", {
+            input: block.input,
+            parentAgentId: subagentPath.replace(/^.*[/\\]/, "").replace(/\.jsonl$/, ""),
+          });
+          usageEvents.push(event);
+          if (event.mcpServer) mcpServersUsed.add(event.mcpServer);
+          if (block.name && FILE_EDIT_TOOLS.has(block.name)) {
+            const fp = extractToolFilePath(block.input);
+            if (fp) {
+              editCount++;
+              const short = shortenSessionPath(fp, input);
+              fileEditCounts.set(short, (fileEditCounts.get(short) || 0) + 1);
             }
           }
         }
       }
-    } catch {
-      // No subagents directory
     }
   }
 
@@ -2157,6 +2151,20 @@ async function getFileMeta(filePaths: string[]): Promise<{ mtimeMs: number; file
   return { mtimeMs: maxMtime, fileSize: totalSize };
 }
 
+async function relatedSubagentPaths(filePaths: string[]): Promise<string[]> {
+  const paths: string[] = [];
+  for (const mainFilePath of filePaths) {
+    const subagentsDir = join(mainFilePath.replace(/\.jsonl$/, ""), "subagents");
+    const entries = await readdir(subagentsDir).catch(() => []);
+    for (const entry of entries) {
+      if (entry.endsWith(".jsonl") || entry.endsWith(".meta.json")) {
+        paths.push(join(subagentsDir, entry));
+      }
+    }
+  }
+  return [...new Set(paths)];
+}
+
 async function getScanCacheMeta(session: ScanInput): Promise<{
   mtimeMs: number;
   fileSize: number;
@@ -2167,6 +2175,7 @@ async function getScanCacheMeta(session: ScanInput): Promise<{
   if (sourceFilePath && !sourceFilePath.includes("#") && !paths.includes(sourceFilePath)) {
     paths.push(sourceFilePath);
   }
+  paths.push(...(await relatedSubagentPaths(session.filePaths)));
 
   const meta = await getFileMeta([...new Set(paths)]);
   if (session.hasSqlite) {

--- a/packages/cli/src/scanner.ts
+++ b/packages/cli/src/scanner.ts
@@ -1236,6 +1236,7 @@ export async function scanSession(input: ScanInput): Promise<SessionScanResult> 
         if (saMsg?.role !== "assistant" || !Array.isArray(saMsg.content)) continue;
         for (const block of saMsg.content as SubAgentBlock[]) {
           if (block.type !== "tool_use") continue;
+          toolCallCount++;
           const event = toolUsageEvent(block.name || "Unknown", {
             input: block.input,
             parentAgentId: subagentPath.replace(/^.*[/\\]/, "").replace(/\.jsonl$/, ""),

--- a/packages/cli/src/server-core.ts
+++ b/packages/cli/src/server-core.ts
@@ -164,11 +164,12 @@ export function resolveGenerateInputs(
     }
   }
   // Fallback: match by sessionId (covers old JSONL files where slug differs from replay slug)
-  if (!sessionInfo && typeof body.sessionId === "string" && body.sessionId) {
+  const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : undefined;
+  if (!sessionInfo && requestedSessionId) {
     sessionInfo = discoveredSessions.find(
       (s) =>
         s.provider === body.provider &&
-        s.sessionId === body.sessionId &&
+        (s.sessionId === requestedSessionId || s.sessionIds?.includes(requestedSessionId)) &&
         matchesRequestedLocation(s),
     );
   }

--- a/packages/cli/src/server-enrichment.ts
+++ b/packages/cli/src/server-enrichment.ts
@@ -67,14 +67,20 @@ function targetIdOf(value: { location?: SessionLocation } | undefined): string |
 }
 
 export function pickSourceRecordForSession<T extends EnrichmentSourceRecord>(
-  session: Pick<SessionInfo, "provider" | "sessionId" | "project" | "slug" | "location">,
+  session: Pick<
+    SessionInfo,
+    "provider" | "sessionId" | "sessionIds" | "project" | "slug" | "location"
+  >,
   bySessionId: Map<string, T>,
   byKey: Map<string, T>,
 ): T | undefined {
   const targetId = targetIdOf(session);
   const byIdMatch =
-    bySessionId.get(providerSessionKey(session.provider, session.sessionId, targetId)) ??
-    (targetId ? undefined : bySessionId.get(session.sessionId));
+    [session.sessionId, ...(session.sessionIds || [])]
+      .map((sessionId) =>
+        bySessionId.get(providerSessionKey(session.provider, sessionId, targetId)),
+      )
+      .find(Boolean) ?? (targetId ? undefined : bySessionId.get(session.sessionId));
   return (
     (byIdMatch?.provider === session.provider ? byIdMatch : undefined) ??
     byKey.get(sourceSessionKey(session.provider, session.project, session.slug, targetId))

--- a/packages/cli/src/server-replay-catalog.ts
+++ b/packages/cli/src/server-replay-catalog.ts
@@ -170,14 +170,8 @@ export async function loadSessionFromDisk(
   slug: string,
   targetId?: string,
 ): Promise<ReplaySession> {
-  let replayPath = join(baseDir, slug, "replay.json");
-  try {
-    await stat(replayPath);
-  } catch {
-    const fallback = resolve("./vibe-replay", slug, "replay.json");
-    await stat(fallback);
-    replayPath = fallback;
-  }
+  const replayDir = await resolveReplayDir(baseDir, slug);
+  const replayPath = join(replayDir, "replay.json");
   const raw = await readFile(replayPath, "utf-8");
   const session = JSON.parse(raw) as ReplaySession;
   const sessionTargetId =
@@ -188,6 +182,20 @@ export async function loadSessionFromDisk(
   const annotations = await loadAnnotations(baseDir, slug, targetId);
   if (annotations.length > 0) session.annotations = annotations;
   return session;
+}
+
+/** Resolve the directory containing a replay, including the legacy CWD fallback. */
+export async function resolveReplayDir(baseDir: string, slug: string): Promise<string> {
+  const candidates = [join(baseDir, slug), resolve("./vibe-replay", slug)];
+  for (const candidate of candidates) {
+    try {
+      await stat(join(candidate, "replay.json"));
+      return candidate;
+    } catch {
+      // Try the next compatible replay location.
+    }
+  }
+  throw new Error(`Session not found: ${slug}`);
 }
 
 export function normalizeSessionProjectsForHome(

--- a/packages/cli/src/server-replay-catalog.ts
+++ b/packages/cli/src/server-replay-catalog.ts
@@ -170,7 +170,7 @@ export async function loadSessionFromDisk(
   slug: string,
   targetId?: string,
 ): Promise<ReplaySession> {
-  const replayDir = await resolveReplayDir(baseDir, slug);
+  const replayDir = await resolveReplayDir(baseDir, slug, targetId);
   const replayPath = join(replayDir, "replay.json");
   const raw = await readFile(replayPath, "utf-8");
   const session = JSON.parse(raw) as ReplaySession;
@@ -179,23 +179,35 @@ export async function loadSessionFromDisk(
   if (sessionTargetId !== targetId) {
     throw new Error("Session does not belong to the requested SSH source");
   }
-  const annotations = await loadAnnotations(baseDir, slug, targetId);
+  const annotations = await loadAnnotations(resolveReplayBaseDir(replayDir), slug, targetId);
   if (annotations.length > 0) session.annotations = annotations;
   return session;
 }
 
 /** Resolve the directory containing a replay, including the legacy CWD fallback. */
-export async function resolveReplayDir(baseDir: string, slug: string): Promise<string> {
+export async function resolveReplayDir(
+  baseDir: string,
+  slug: string,
+  targetId?: string,
+): Promise<string> {
   const candidates = [join(baseDir, slug), resolve("./vibe-replay", slug)];
   for (const candidate of candidates) {
     try {
-      await stat(join(candidate, "replay.json"));
+      const raw = await readFile(join(candidate, "replay.json"), "utf-8");
+      const session = JSON.parse(raw) as ReplaySession;
+      const candidateTargetId =
+        session.meta.location?.kind === "ssh" ? session.meta.location.id : undefined;
+      if (candidateTargetId !== targetId) continue;
       return candidate;
     } catch {
       // Try the next compatible replay location.
     }
   }
   throw new Error(`Session not found: ${slug}`);
+}
+
+function resolveReplayBaseDir(replayDir: string): string {
+  return resolve(replayDir, "..");
 }
 
 export function normalizeSessionProjectsForHome(

--- a/packages/cli/src/server-replay-matching.ts
+++ b/packages/cli/src/server-replay-matching.ts
@@ -42,6 +42,7 @@ export function findReplayForSource(
   source: {
     provider: string;
     sessionId?: string;
+    sessionIds?: string[];
     slug: string;
     location?: SessionInfo["location"];
   },
@@ -49,9 +50,10 @@ export function findReplayForSource(
   sourceSlugCounts: ReadonlyMap<string, number>,
 ): ReplaySummary | undefined {
   const targetId = source.location?.kind === "ssh" ? source.location.id : undefined;
-  if (source.sessionId) {
+  for (const sessionId of [source.sessionId, ...(source.sessionIds || [])]) {
+    if (!sessionId) continue;
     const bySessionId = maps.bySessionId.get(
-      providerSessionKey(source.provider, source.sessionId, targetId),
+      providerSessionKey(source.provider, sessionId, targetId),
     );
     if (bySessionId) return bySessionId;
   }

--- a/packages/cli/src/server-routes/generation.ts
+++ b/packages/cli/src/server-routes/generation.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import { readGitRepo, shortenPath } from "@vibe-replay/provider-core/utils";
@@ -9,6 +9,7 @@ import { discoverProvidersSafely } from "../provider-discovery.js";
 import { getRemoteHome } from "../remote.js";
 import { scanForSecrets } from "../scan.js";
 import { mergeSameSessions } from "../session-merge.js";
+import { scanSessions } from "../server-replay-catalog.js";
 import {
   getErrorMessage,
   hasReplayableContent,
@@ -130,17 +131,16 @@ export function registerGenerationRoutes(app: Hono, deps: GenerationRouteDeps): 
     const allProviders = getAllProviders();
     const allSessions = mergeSameSessions((await discoverAllProviders()).sessions);
 
-    let entries: string[];
-    try {
-      entries = await readdir(replaysDir);
-    } catch {
+    const replaySummaries = await scanSessions(replaysDir);
+    if (replaySummaries.length === 0) {
       return c.json({ error: "No replays directory" }, 404);
     }
 
-    for (const slug of entries) {
-      if (slug.startsWith(".") || slug === "cache") continue;
+    for (const replaySummary of replaySummaries) {
+      const { slug } = replaySummary;
       try {
-        const replayPath = join(replaysDir, slug, "replay.json");
+        const outputDir = join(replaySummary.baseDir, slug);
+        const replayPath = join(outputDir, "replay.json");
         const raw = await readFile(replayPath, "utf-8").catch(() => null);
         if (!raw) continue;
 
@@ -160,17 +160,12 @@ export function registerGenerationRoutes(app: Hono, deps: GenerationRouteDeps): 
           const sessionTargetId = s.location?.kind === "ssh" ? s.location.id : undefined;
           return (
             s.provider === providerName &&
-            s.sessionId === sessionId &&
+            (s.sessionId === sessionId || s.sessionIds?.includes(sessionId)) &&
             sessionTargetId === replayTargetId
           );
         });
-        if (!sessionInfo || sessionInfo.filePaths.length === 0) {
-          results.push({
-            slug,
-            status: sessionInfo?.transcriptStatus
-              ? `skipped: ${sessionInfo.transcriptStatus}`
-              : "skipped: source not found",
-          });
+        if (!sessionInfo) {
+          results.push({ slug, status: "skipped: source not found" });
           continue;
         }
         if (sessionInfo.transcriptStatus) {
@@ -209,7 +204,6 @@ export function registerGenerationRoutes(app: Hono, deps: GenerationRouteDeps): 
 
         if (oldReplay.meta?.title) replay.meta.title = oldReplay.meta.title;
 
-        const outputDir = join(replaysDir, slug);
         await generateOutput(replay, outputDir);
         results.push({ slug, status: "regenerated", scenes: replay.scenes.length });
       } catch (err) {

--- a/packages/cli/src/server-routes/live.ts
+++ b/packages/cli/src/server-routes/live.ts
@@ -7,7 +7,11 @@ import { streamSSE } from "hono/streaming";
 import { shortenPath } from "@vibe-replay/provider-core/utils";
 import { parseClaudeCodeLines } from "../providers/claude-code/parser.js";
 import { parseCodexLines } from "../providers/codex/parser.js";
-import { attachGrokBotSubAgents, parseGrokBotLines } from "../providers/grok-bot/parser.js";
+import {
+  attachGrokBotSubAgents,
+  parseGrokBotLines,
+  parseGrokBotLiveSession,
+} from "../providers/grok-bot/parser.js";
 import { parsePiLines } from "../providers/pi/parser.js";
 import {
   readCursorLiveDiagnostics,
@@ -29,7 +33,7 @@ export async function parseJsonlLiveSession(
   paths: string[],
 ) {
   if (providerName === "claude-code") {
-    return parseClaudeCodeLines(lines, { subagentsSourcePath: paths[0] });
+    return parseClaudeCodeLines(lines, { subagentsSourcePaths: paths });
   }
   if (providerName === "codex") {
     return parseCodexLines(lines, sessionInfo, paths);
@@ -266,11 +270,15 @@ export function registerLiveRoutes(app: Hono): void {
           let parsed;
           if (isJsonlLiveProvider) {
             const allLines: string[] = [];
+            const grokMembers: Array<{ path: string; lines: string[] }> = [];
             for (const fp of paths) {
               const lines = await tailReadJsonl(fp);
               allLines.push(...lines);
+              if (isGrokBotProvider) grokMembers.push({ path: fp, lines });
             }
-            parsed = await parseJsonlLiveSession(providerName, allLines, info, paths);
+            parsed = isGrokBotProvider
+              ? await parseGrokBotLiveSession(grokMembers, info)
+              : await parseJsonlLiveSession(providerName, allLines, info, paths);
           } else {
             parsed = await provider.parse(paths, info);
           }

--- a/packages/cli/src/server-routes/live.ts
+++ b/packages/cli/src/server-routes/live.ts
@@ -110,7 +110,9 @@ export function registerLiveRoutes(app: Hono): void {
 
       const resolveSessionInfo = async () => {
         const all = await provider.discover();
-        const seed = all.find((s) => s.sessionId === sessionId);
+        const seed = all.find(
+          (s) => s.sessionId === sessionId || s.sessionIds?.includes(sessionId),
+        );
         if (!seed) return undefined;
         const merged = mergeSameSessions(all);
         return merged.find((s) => s.project === seed.project && s.slug === seed.slug);

--- a/packages/cli/src/server-routes/replays.ts
+++ b/packages/cli/src/server-routes/replays.ts
@@ -5,6 +5,7 @@ import { readFileCache, writeFileCache } from "../cache.js";
 import { generateOutput } from "../generator.js";
 import { sessionForExternalOutput } from "../overlays.js";
 import { getErrorMessage, requireSlug, safeSlug, safeTargetId } from "../server-core.js";
+import { resolveReplayDir } from "../server-replay-catalog.js";
 import type { ReplaySummary } from "../server-types.js";
 import type { ReplaySession } from "../types.js";
 import { normalizeTitle } from "../utils.js";
@@ -80,9 +81,9 @@ export function registerReplayRoutes(app: Hono, deps: ReplaysRouteDeps): void {
 
     try {
       const target = await loadSession(slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, slug);
       target.meta.title = normalizeTitle(body.title);
 
-      const targetDir = join(baseDir, slug);
       await writeFile(join(targetDir, "replay.json"), JSON.stringify(target), "utf-8");
       await generateOutput(target, targetDir);
       const updatedReplays = await refreshReplaysCache();
@@ -104,7 +105,7 @@ export function registerReplayRoutes(app: Hono, deps: ReplaysRouteDeps): void {
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
     try {
       await loadSession(slug, targetId);
-      await rm(join(baseDir, slug), { recursive: true });
+      await rm(await resolveReplayDir(baseDir, slug), { recursive: true });
       const updatedReplays = await refreshReplaysCache();
       if (updatedReplays) await syncSourcesCacheWithReplays(updatedReplays);
       return c.json({ ok: true });

--- a/packages/cli/src/server-routes/replays.ts
+++ b/packages/cli/src/server-routes/replays.ts
@@ -81,7 +81,7 @@ export function registerReplayRoutes(app: Hono, deps: ReplaysRouteDeps): void {
 
     try {
       const target = await loadSession(slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, slug);
+      const targetDir = await resolveReplayDir(baseDir, slug, targetId);
       target.meta.title = normalizeTitle(body.title);
 
       await writeFile(join(targetDir, "replay.json"), JSON.stringify(target), "utf-8");
@@ -105,7 +105,7 @@ export function registerReplayRoutes(app: Hono, deps: ReplaysRouteDeps): void {
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
     try {
       await loadSession(slug, targetId);
-      await rm(await resolveReplayDir(baseDir, slug), { recursive: true });
+      await rm(await resolveReplayDir(baseDir, slug, targetId), { recursive: true });
       const updatedReplays = await refreshReplaysCache();
       if (updatedReplays) await syncSourcesCacheWithReplays(updatedReplays);
       return c.json({ ok: true });

--- a/packages/cli/src/server-routes/session-output.ts
+++ b/packages/cli/src/server-routes/session-output.ts
@@ -36,7 +36,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
-      targetDir = await resolveReplayDir(baseDir, result.slug);
+      targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
@@ -54,7 +54,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
-      targetDir = await resolveReplayDir(baseDir, result.slug);
+      targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
@@ -72,7 +72,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
-      targetDir = await resolveReplayDir(baseDir, result.slug);
+      targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
@@ -90,7 +90,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
-      targetDir = await resolveReplayDir(baseDir, result.slug);
+      targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
@@ -123,7 +123,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
-      targetDir = await resolveReplayDir(baseDir, result.slug);
+      targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
@@ -141,7 +141,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, result.slug);
+      const targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),
@@ -177,7 +177,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
 
     try {
       await loadSession(result.slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, result.slug);
+      const targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
       const body = await c.req.json().catch(() => ({}));
       const cloudResult = await publishCloudWithOverlays(targetDir, {
         visibility: body.visibility || "unlisted",
@@ -198,7 +198,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, result.slug);
+      const targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),
@@ -226,7 +226,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
     try {
       await loadSession(result.slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, result.slug);
+      const targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
       const svgPath = join(targetDir, "session-preview.svg");
       const mdPath = join(targetDir, "github-summary.md");
       const gifPath = join(targetDir, "session-preview.gif");
@@ -277,7 +277,7 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
-      const targetDir = await resolveReplayDir(baseDir, result.slug);
+      const targetDir = await resolveReplayDir(baseDir, result.slug, targetId);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),

--- a/packages/cli/src/server-routes/session-output.ts
+++ b/packages/cli/src/server-routes/session-output.ts
@@ -12,6 +12,7 @@ import {
 import { loadSavedCloudInfo, publishCloudWithOverlays } from "../publishers/cloud.js";
 import { checkPublishStatus, loadSavedGistInfo, publishGist } from "../publishers/gist.js";
 import { getErrorMessage, requireSlug, safeTargetId } from "../server-core.js";
+import { resolveReplayDir } from "../server-replay-catalog.js";
 import { scanForSecrets } from "../scan.js";
 import type { ReplaySession } from "../types.js";
 
@@ -32,12 +33,13 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
+    let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
+      targetDir = await resolveReplayDir(baseDir, result.slug);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
-    const targetDir = join(baseDir, result.slug);
     const gist = await loadSavedGistInfo(targetDir);
     if (!gist) return c.json({ gist: null });
     return c.json({ gist });
@@ -49,12 +51,14 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
+    let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
+      targetDir = await resolveReplayDir(baseDir, result.slug);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
-    const metaPath = join(baseDir, result.slug, ".vibe-replay-gist.json");
+    const metaPath = join(targetDir, ".vibe-replay-gist.json");
     await unlink(metaPath).catch(() => {});
     return c.json({ ok: true });
   });
@@ -65,12 +69,13 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
+    let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
+      targetDir = await resolveReplayDir(baseDir, result.slug);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
-    const targetDir = join(baseDir, result.slug);
     const cloud = await loadSavedCloudInfo(targetDir);
     if (!cloud) return c.json({ cloud: null });
     return c.json({ cloud });
@@ -82,12 +87,13 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
+    let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
+      targetDir = await resolveReplayDir(baseDir, result.slug);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
-    const targetDir = join(baseDir, result.slug);
     const body = await c.req.json();
     if (!body.id || !body.url) return c.json({ error: "Missing id/url" }, 400);
     const metaPath = join(targetDir, ".vibe-replay-cloud.json");
@@ -114,12 +120,14 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
+    let targetDir: string;
     try {
       await loadSession(result.slug, targetId);
+      targetDir = await resolveReplayDir(baseDir, result.slug);
     } catch {
       return c.json({ error: "session not found" }, 404);
     }
-    const metaPath = join(baseDir, result.slug, ".vibe-replay-cloud.json");
+    const metaPath = join(targetDir, ".vibe-replay-cloud.json");
     await unlink(metaPath).catch(() => {});
     return c.json({ ok: true });
   });
@@ -130,10 +138,10 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
-    const targetDir = join(baseDir, result.slug);
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, result.slug);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),
@@ -166,10 +174,10 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
-    const targetDir = join(baseDir, result.slug);
 
     try {
       await loadSession(result.slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, result.slug);
       const body = await c.req.json().catch(() => ({}));
       const cloudResult = await publishCloudWithOverlays(targetDir, {
         visibility: body.visibility || "unlisted",
@@ -187,10 +195,10 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
-    const targetDir = join(baseDir, result.slug);
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, result.slug);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),
@@ -216,9 +224,9 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
-    const targetDir = join(baseDir, result.slug);
     try {
       await loadSession(result.slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, result.slug);
       const svgPath = join(targetDir, "session-preview.svg");
       const mdPath = join(targetDir, "github-summary.md");
       const gifPath = join(targetDir, "session-preview.gif");
@@ -266,10 +274,10 @@ export function registerSessionOutputRoutes(app: Hono, deps: SessionOutputRouteD
     if ("error" in result) return c.json({ error: result.error }, 400);
     const targetId = safeTargetId(c.req.query("targetId"));
     if (targetId === null) return c.json({ error: "invalid targetId" }, 400);
-    const targetDir = join(baseDir, result.slug);
 
     try {
       const rawSession = await loadSession(result.slug, targetId);
+      const targetDir = await resolveReplayDir(baseDir, result.slug);
       const overlaysData = await loadOverlays(baseDir, result.slug, targetId);
       const targetSession = sessionForExternalOutput(
         sessionWithEffectiveContent(rawSession, overlaysData),

--- a/packages/cli/src/session-merge.ts
+++ b/packages/cli/src/session-merge.ts
@@ -27,14 +27,8 @@ export function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
 
     group.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
     const latest = group[0];
-    const filePaths = [
-      ...new Set(
-        group
-          .slice()
-          .sort((a, b) => a.timestamp.localeCompare(b.timestamp))
-          .flatMap((session) => session.filePaths),
-      ),
-    ];
+    const chronological = group.slice().sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+    const filePaths = [...new Set(chronological.flatMap((session) => session.filePaths))];
     const promptCount = group.some((session) => session.promptCount != null)
       ? group.reduce((sum, session) => sum + (session.promptCount || 0), 0)
       : undefined;
@@ -52,6 +46,14 @@ export function mergeSameSessions(sessions: SessionInfo[]): SessionInfo[] {
 
     result.push({
       ...latest,
+      sessionIds: [
+        ...new Set(group.flatMap((session) => [session.sessionId, ...(session.sessionIds || [])])),
+      ],
+      title: latest.title || chronological.find((session) => session.title)?.title,
+      model: latest.model || chronological.find((session) => session.model)?.model,
+      firstPrompt:
+        chronological.find((session) => session.firstPrompt.trim())?.firstPrompt ||
+        latest.firstPrompt,
       lineCount: group.reduce((sum, session) => sum + session.lineCount, 0),
       fileSize: group.reduce((sum, session) => sum + session.fileSize, 0),
       filePaths,

--- a/packages/cli/test/replay-schema-validation.test.ts
+++ b/packages/cli/test/replay-schema-validation.test.ts
@@ -27,7 +27,7 @@ function validateReplaySchema(replay: any): string | null {
   if (!Array.isArray(replay.scenes)) {
     return "Missing scenes array";
   }
-  for (let i = 0; i < Math.min(replay.scenes.length, 5); i++) {
+  for (let i = 0; i < replay.scenes.length; i++) {
     const scene = replay.scenes[i];
     if (!scene || typeof scene.type !== "string") {
       return `Invalid scene at index ${i}: missing type`;
@@ -135,13 +135,12 @@ describe("replay schema validation", () => {
     expect(validateReplaySchema(replay)).toBe("Invalid scene at index 0: missing type");
   });
 
-  it("only validates first 5 scenes (performance)", () => {
+  it("rejects malformed scenes after the first five", () => {
     const scenes = Array.from({ length: 10 }, (_, i) =>
       i < 6 ? { type: "text-response", content: `scene ${i}` } : { content: "no type" },
     );
-    // Scene at index 6+ has no type, but validation only checks first 5
     const replay = { meta: { sessionId: "abc", provider: "claude-code" }, scenes };
-    expect(validateReplaySchema(replay)).toBeNull();
+    expect(validateReplaySchema(replay)).toBe("Invalid scene at index 6: missing type");
   });
 
   it("catches invalid scene within first 5", () => {

--- a/packages/cli/test/server-replay-catalog.test.ts
+++ b/packages/cli/test/server-replay-catalog.test.ts
@@ -34,6 +34,11 @@ describe("replay catalog fallback locations", () => {
       }),
       "utf-8",
     );
+    await writeFile(
+      join(replayDir, "annotations.json"),
+      JSON.stringify([{ id: "legacy-annotation", sceneIndex: 0, body: "keep me" }]),
+      "utf-8",
+    );
 
     await expect(resolveReplayDir(baseDir, "legacy-session")).resolves.toBe(
       resolve(process.cwd(), "vibe-replay", "legacy-session"),
@@ -41,6 +46,38 @@ describe("replay catalog fallback locations", () => {
     await expect(loadSessionFromDisk(baseDir, "legacy-session")).resolves.toMatchObject({
       meta: { sessionId: "legacy-session-id" },
       scenes: [],
+      annotations: [{ id: "legacy-annotation" }],
+    });
+  });
+
+  it("selects the replay directory matching the requested SSH source", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-server-replay-catalog-sources-"));
+    roots.push(root);
+    process.chdir(root);
+
+    const baseDir = join(root, "primary");
+    const primaryDir = join(baseDir, "same-slug");
+    const fallbackDir = join(root, "vibe-replay", "same-slug");
+    const replay = (targetId: string) => ({
+      schemaVersion: 1,
+      meta: {
+        sessionId: `session-${targetId}`,
+        slug: "same-slug",
+        provider: "codex",
+        location: { kind: "ssh", id: targetId, label: targetId },
+      },
+      scenes: [],
+    });
+    await mkdir(primaryDir, { recursive: true });
+    await mkdir(fallbackDir, { recursive: true });
+    await writeFile(join(primaryDir, "replay.json"), JSON.stringify(replay("remote-a")), "utf-8");
+    await writeFile(join(fallbackDir, "replay.json"), JSON.stringify(replay("remote-b")), "utf-8");
+
+    await expect(resolveReplayDir(baseDir, "same-slug", "remote-b")).resolves.toBe(
+      resolve(process.cwd(), "vibe-replay", "same-slug"),
+    );
+    await expect(loadSessionFromDisk(baseDir, "same-slug", "remote-b")).resolves.toMatchObject({
+      meta: { sessionId: "session-remote-b" },
     });
   });
 });

--- a/packages/cli/test/server-replay-catalog.test.ts
+++ b/packages/cli/test/server-replay-catalog.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadSessionFromDisk, resolveReplayDir } from "../src/server-replay-catalog.js";
+
+const originalCwd = process.cwd();
+const roots: string[] = [];
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("replay catalog fallback locations", () => {
+  it("resolves and loads legacy CWD replays when the primary directory is absent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-server-replay-catalog-"));
+    roots.push(root);
+    process.chdir(root);
+
+    const baseDir = join(root, "primary");
+    const replayDir = join(root, "vibe-replay", "legacy-session");
+    await mkdir(replayDir, { recursive: true });
+    await writeFile(
+      join(replayDir, "replay.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        meta: {
+          sessionId: "legacy-session-id",
+          slug: "legacy-session",
+          provider: "cursor",
+        },
+        scenes: [],
+      }),
+      "utf-8",
+    );
+
+    await expect(resolveReplayDir(baseDir, "legacy-session")).resolves.toBe(
+      resolve(process.cwd(), "vibe-replay", "legacy-session"),
+    );
+    await expect(loadSessionFromDisk(baseDir, "legacy-session")).resolves.toMatchObject({
+      meta: { sessionId: "legacy-session-id" },
+      scenes: [],
+    });
+  });
+});

--- a/packages/cli/test/server-sources-enrichment.test.ts
+++ b/packages/cli/test/server-sources-enrichment.test.ts
@@ -682,6 +682,36 @@ describe("sources enrichment helpers", () => {
     ).toBeUndefined();
   });
 
+  it("links a replay through a logical session's native ID aliases", () => {
+    type Replay = Parameters<typeof __testables.buildReplayMaps>[0][number];
+    const replay: Replay = {
+      slug: "group-launch-room",
+      baseDir: "/tmp/replays",
+      sessionId: "member-agent-id",
+      provider: "grok-bot",
+      project: "launch room",
+      startTime: "2026-01-01T00:00:00.000Z",
+      stats: { sceneCount: 0, userPrompts: 0, toolCalls: 0 },
+      replaySize: 100,
+      replayOutdated: false,
+      hasAnnotations: false,
+      annotationCount: 0,
+    };
+
+    expect(
+      __testables.findReplayForSource(
+        {
+          provider: "grok-bot",
+          sessionId: "group-launch-room",
+          sessionIds: ["group-launch-room", "member-agent-id"],
+          slug: "group-launch-room",
+        },
+        __testables.buildReplayMaps([replay]),
+        new Map([[providerSlugKey("grok-bot", "group-launch-room"), 1]]),
+      ),
+    ).toBe(replay);
+  });
+
   it("does not use a slug when multiple source sessions share it", () => {
     type Replay = Parameters<typeof __testables.buildReplayMaps>[0][number];
     const replay: Replay = {

--- a/packages/cli/test/session-merge.test.ts
+++ b/packages/cli/test/session-merge.test.ts
@@ -47,6 +47,36 @@ describe("mergeSameSessions", () => {
     });
   });
 
+  it("preserves shard IDs and metadata when the newest shard is sparse", () => {
+    const merged = mergeSameSessions([
+      session({
+        sessionId: "session-old",
+        title: "Original title",
+        model: "claude-sonnet",
+        firstPrompt: "Start from the original shard",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+      session({
+        sessionId: "session-new",
+        title: undefined,
+        model: undefined,
+        firstPrompt: "",
+        timestamp: "2026-01-01T01:00:00.000Z",
+        filePath: "/sessions/two.jsonl",
+        filePaths: ["/sessions/two.jsonl"],
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({
+      sessionId: "session-new",
+      sessionIds: ["session-new", "session-old"],
+      title: "Original title",
+      model: "claude-sonnet",
+      firstPrompt: "Start from the original shard",
+    });
+  });
+
   it("does not merge independent non-resumable sessions with the same slug and project", () => {
     const merged = mergeSameSessions([
       session({ provider: "opencode", sessionId: "ses_one" }),

--- a/packages/provider-claude-code/src/claude-code/parser.ts
+++ b/packages/provider-claude-code/src/claude-code/parser.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type { PrLink, SubAgent, TurnStat, UsageEvent } from "@vibe-replay/types";
 import { isSystemGeneratedMessage } from "@vibe-replay/provider-core/clean-prompt";
 import { estimateActiveDuration, getTimestampBounds } from "@vibe-replay/provider-core/duration";
@@ -19,7 +19,7 @@ export async function parseClaudeCodeSession(
     allLines.push(...content.split("\n"));
   }
 
-  return parseClaudeCodeLines(allLines, { subagentsSourcePath: paths[0] });
+  return parseClaudeCodeLines(allLines, { subagentsSourcePaths: paths });
 }
 
 /** Options for parseClaudeCodeLines. */
@@ -30,6 +30,8 @@ export interface ParseClaudeCodeLinesOptions {
    * omit it for sources (e.g. Cowork audit.jsonl) that don't have subagent files.
    */
   subagentsSourcePath?: string;
+  /** All JSONL shards whose sibling subagent directories should be scanned. */
+  subagentsSourcePaths?: string[];
   /**
    * Derive session bounds from all event timestamps. Cowork disables this so
    * its sibling metadata timestamp keeps the existing overlay semantics.
@@ -529,9 +531,13 @@ export async function parseClaudeCodeLines(
 
   // Read subagent JSONL files: extract full conversations + token usage.
   // Must happen before enrichment so subAgentData is available.
-  const subAgentData = options.subagentsSourcePath
-    ? await readSubagents(options.subagentsSourcePath, usageByMsgId, parseWarnings)
-    : new Map<string, SubAgentParsed>();
+  const subagentSources =
+    options.subagentsSourcePaths ||
+    (options.subagentsSourcePath ? [options.subagentsSourcePath] : []);
+  const subAgentData =
+    subagentSources.length > 0
+      ? await readSubagents(subagentSources, usageByMsgId, parseWarnings)
+      : new Map<string, SubAgentParsed>();
 
   // Build assistant turns with enriched blocks
   const assistantTurns: { turn: ParsedTurn; timestamp: string }[] = [];
@@ -989,7 +995,7 @@ interface SubAgentParsed {
  * Returns Map<agentId, SubAgentParsed> keyed by the agent identifier from the filename.
  */
 async function readSubagents(
-  mainFilePath: string,
+  mainFilePaths: string[],
   usageByMsgId: Map<
     string,
     {
@@ -1003,28 +1009,38 @@ async function readSubagents(
   parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]>,
 ): Promise<Map<string, SubAgentParsed>> {
   const result = new Map<string, SubAgentParsed>();
-  const sessionDir = mainFilePath.replace(/\.jsonl$/, "");
-  const subagentsDir = join(sessionDir, "subagents");
-
-  let files: string[];
-  try {
-    files = await readdir(subagentsDir);
-  } catch {
-    return result; // No subagents directory
+  const subagentFiles: Array<{ path: string; agentId: string }> = [];
+  const seenPaths = new Set<string>();
+  for (const mainFilePath of mainFilePaths) {
+    const sessionDir = mainFilePath.replace(/\.jsonl$/, "");
+    const subagentsDir = join(sessionDir, "subagents");
+    let files: string[];
+    try {
+      files = await readdir(subagentsDir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith(".jsonl")) continue;
+      const path = join(subagentsDir, file);
+      if (seenPaths.has(path)) continue;
+      seenPaths.add(path);
+      subagentFiles.push({
+        path,
+        agentId: file.replace(/\.jsonl$/, "").replace(/^agent-/, ""),
+      });
+    }
   }
 
-  for (const file of files) {
-    if (!file.endsWith(".jsonl")) continue;
+  for (const { path, agentId } of subagentFiles) {
     // Agent ID derived from filename must match data.agentId in progress messages.
     // Convention: filename is "agent-<id>.jsonl", progress has data.agentId = "<id>".
     // If Claude Code changes this convention, subagent data won't be linked (silent miss).
-    const agentId = file.replace(/\.jsonl$/, "").replace(/^agent-/, "");
-
     // Read meta.json for agent type
     let agentType = "unknown";
     let description: string | undefined;
     try {
-      const metaPath = join(subagentsDir, file.replace(/\.jsonl$/, ".meta.json"));
+      const metaPath = join(dirname(path), `${basename(path, ".jsonl")}.meta.json`);
       const metaContent = await readFile(metaPath, "utf-8");
       const meta = JSON.parse(metaContent);
       agentType = meta.agentType || "unknown";
@@ -1033,7 +1049,7 @@ async function readSubagents(
 
     let content: string;
     try {
-      content = await readFile(join(subagentsDir, file), "utf-8");
+      content = await readFile(path, "utf-8");
     } catch {
       continue;
     }

--- a/packages/provider-claude-code/test/cost-estimation.test.ts
+++ b/packages/provider-claude-code/test/cost-estimation.test.ts
@@ -193,6 +193,73 @@ describe("parser — per-model token usage breakdown", () => {
       await rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("reads subagents from every Claude resume shard", async () => {
+    const tempDir = await mkdtemp(resolve(tmpdir(), "vibe-replay-subagent-shards-"));
+    const shard = async (name: string, toolId: string, agentId: string) => {
+      const mainPath = resolve(tempDir, `${name}.jsonl`);
+      const subagentsDir = resolve(tempDir, name, "subagents");
+      await mkdir(subagentsDir, { recursive: true });
+      await writeFile(
+        mainPath,
+        [
+          {
+            type: "assistant",
+            message: {
+              role: "assistant",
+              id: `${name}-parent`,
+              content: [
+                {
+                  type: "tool_use",
+                  id: toolId,
+                  name: "Agent",
+                  input: { prompt: `Inspect ${name}`, subagent_type: "Explore" },
+                },
+              ],
+            },
+          },
+          {
+            type: "progress",
+            parentToolUseID: toolId,
+            data: { type: "agent_progress", agentId },
+          },
+        ]
+          .map((line) => JSON.stringify(line))
+          .join("\n"),
+      );
+      await writeFile(
+        resolve(subagentsDir, `agent-${agentId}.jsonl`),
+        JSON.stringify({
+          type: "assistant",
+          message: {
+            role: "assistant",
+            id: `${agentId}-message`,
+            model: "claude-haiku-4-5-20251001",
+            content: [{ type: "text", text: `Result from ${name}` }],
+          },
+        }),
+      );
+      return mainPath;
+    };
+
+    const firstPath = await shard("first", "tool-first", "agent-first");
+    const secondPath = await shard("second", "tool-second", "agent-second");
+
+    try {
+      const result = await parseClaudeCodeSession([firstPath, secondPath]);
+      expect(result.subAgentSummary?.map((summary) => summary.agentId)).toEqual([
+        "agent-first",
+        "agent-second",
+      ]);
+      expect(
+        result.turns
+          .flatMap((turn) => turn.blocks)
+          .filter((block) => block.type === "tool_use" && block._subAgent),
+      ).toHaveLength(2);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/provider-codex/src/codex/parser.ts
+++ b/packages/provider-codex/src/codex/parser.ts
@@ -101,6 +101,17 @@ export function parseCodexLines(
   const seenUserMessages = new Map<string, number[]>();
   const seenAssistantMessages = new Map<string, number[]>();
   const parseWarnings: NonNullable<ProviderParseResult["parseWarnings"]> = [];
+  let currentLineIndex = 0;
+  const turnOrder = new Map<ParsedTurn, number>();
+  const toolOrder = new Map<string, number>();
+  const pushTurn = (turn: ParsedTurn, order = currentLineIndex): void => {
+    turns.push(turn);
+    turnOrder.set(turn, order);
+  };
+  const registerTool = (id: string, tool: PendingTool): void => {
+    if (!toolOrder.has(id)) toolOrder.set(id, currentLineIndex);
+    tools.set(id, tool);
+  };
 
   // Codex JSONL now carries a sequential `ordinal` envelope field. Sampled
   // rollouts match file order, so we keep JSONL order rather than sorting:
@@ -108,6 +119,7 @@ export function parseCodexLines(
   // would scramble them.
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    currentLineIndex = lineIndex;
     const line = lines[lineIndex];
     if (!line.trim()) continue;
     let obj: any;
@@ -171,7 +183,7 @@ export function parseCodexLines(
         const blocks = userMessageBlocks(p);
         const text = textFromBlocks(blocks);
         if (blocks.length > 0 && shouldRecordMessage(seenUserMessages, obj.timestamp, blocks)) {
-          turns.push({
+          pushTurn({
             role: "user",
             ...(isCompactionSummaryText(text) ? { subtype: "compaction-summary" as const } : {}),
             timestamp: obj.timestamp,
@@ -187,7 +199,7 @@ export function parseCodexLines(
       ) {
         const blocks: ContentBlock[] = [{ type: "text", text: p.message }];
         if (!shouldRecordMessage(seenAssistantMessages, obj.timestamp, blocks)) continue;
-        turns.push({
+        pushTurn({
           role: "assistant",
           timestamp: obj.timestamp,
           blocks,
@@ -195,7 +207,7 @@ export function parseCodexLines(
         continue;
       }
       if (p.type === "agent_reasoning" && typeof p.text === "string" && p.text.trim()) {
-        turns.push({
+        pushTurn({
           role: "assistant",
           timestamp: obj.timestamp,
           blocks: [{ type: "thinking", thinking: p.text }],
@@ -210,7 +222,7 @@ export function parseCodexLines(
             ? durationBetweenTimestamps(existingTool.timestamp, obj.timestamp)
             : undefined;
         if (!tools.has(p.call_id)) {
-          tools.set(p.call_id, {
+          registerTool(p.call_id, {
             id: p.call_id,
             name: "exec_command",
             input: p.command || p.action || {},
@@ -260,7 +272,7 @@ export function parseCodexLines(
             input: {},
             timestamp: obj.timestamp,
           };
-          tools.set(p.call_id, tool);
+          registerTool(p.call_id, tool);
         }
         if (tool && changedFiles.length > 0) {
           tool.input = mergeToolFilePaths(tool.input, changedFiles);
@@ -279,7 +291,7 @@ export function parseCodexLines(
           p.call_id ||
           `web_search:${obj.timestamp}`;
         if (!tools.has(callId)) {
-          tools.set(callId, {
+          registerTool(callId, {
             id: callId,
             name: "web_search",
             input: p.action || { query: p.query },
@@ -321,7 +333,7 @@ export function parseCodexLines(
               mcpServer: server,
               ...(toolName ? { mcpTool: toolName } : {}),
             };
-            tools.set(p.call_id, tool);
+            registerTool(p.call_id, tool);
           } else {
             tool.mcpServer = server;
             if (toolName) {
@@ -332,7 +344,7 @@ export function parseCodexLines(
         } else if (!tool) {
           // The completion event itself proves that Codex attempted an MCP
           // invocation, even when the start payload omitted server metadata.
-          tools.set(p.call_id, {
+          registerTool(p.call_id, {
             id: p.call_id,
             name: "mcp",
             input: {},
@@ -356,7 +368,7 @@ export function parseCodexLines(
       recordCompaction(compactions, obj.timestamp || "", "codex");
       const text = compactedSummaryText(obj.payload);
       if (text) {
-        turns.push({
+        pushTurn({
           role: "user",
           subtype: "compaction-summary",
           timestamp: obj.timestamp,
@@ -382,7 +394,7 @@ export function parseCodexLines(
       if (text.trim()) {
         developerContextBytes += utf8ByteLength(text);
         developerContextCount++;
-        turns.push({
+        pushTurn({
           role: "user",
           subtype: "context-injection",
           timestamp: obj.timestamp,
@@ -396,7 +408,7 @@ export function parseCodexLines(
       const blocks = userMessageBlocksFromContent(p.content);
       const text = textFromBlocks(blocks);
       if (blocks.length > 0 && shouldRecordMessage(seenUserMessages, obj.timestamp, blocks)) {
-        turns.push({
+        pushTurn({
           role: "user",
           ...(isCompactionSummaryText(text) ? { subtype: "compaction-summary" as const } : {}),
           timestamp: obj.timestamp,
@@ -411,7 +423,7 @@ export function parseCodexLines(
       if (text.trim()) {
         const blocks: ContentBlock[] = [{ type: "text", text }];
         if (!shouldRecordMessage(seenAssistantMessages, obj.timestamp, blocks)) continue;
-        turns.push({
+        pushTurn({
           role: "assistant",
           timestamp: obj.timestamp,
           blocks,
@@ -428,7 +440,7 @@ export function parseCodexLines(
     if (p.type === "reasoning") {
       const thinking = reasoningText(p);
       if (thinking.trim()) {
-        turns.push({
+        pushTurn({
           role: "assistant",
           timestamp: obj.timestamp,
           blocks: [{ type: "thinking", thinking }],
@@ -446,7 +458,7 @@ export function parseCodexLines(
         p.call_id || p.id || existingWebSearchId || `${p.type}:${obj.timestamp}:${tools.size}`;
       const name = p.name || normalizeCodexToolName(p.type);
       const input = inputForResponseItem(p);
-      tools.set(callId, { id: callId, name, input, timestamp: obj.timestamp });
+      registerTool(callId, { id: callId, name, input, timestamp: obj.timestamp });
       if (name.startsWith("mcp__")) {
         const server = name.split("__")[1];
         if (server) mcpServersUsed.add(server);
@@ -468,7 +480,7 @@ export function parseCodexLines(
         if (!tools.has(p.call_id)) {
           // Preserve orphan completions as an unknown ordinary tool rather
           // than silently losing a concrete provider event.
-          tools.set(p.call_id, {
+          registerTool(p.call_id, {
             id: p.call_id,
             name: "Unknown",
             input: {},
@@ -494,29 +506,32 @@ export function parseCodexLines(
 
   for (const tool of tools.values()) {
     const tr = toolResults.get(tool.id);
-    turns.push({
-      role: "assistant",
-      timestamp: tool.timestamp,
-      blocks: [
-        {
-          type: "tool_use",
-          id: tool.id,
-          name: normalizeToolName(tool.name),
-          input: normalizeToolInput(tool.name, tool.input),
-          _hasResult: toolResults.has(tool.id),
-          ...(tr ? { _result: tr.result } : {}),
-          ...(tr?.isError ? { _isError: true } : {}),
-          ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
-          ...(tr?.durationSource ? { _durationSource: tr.durationSource } : {}),
-          ...(tool.durationAnchor ? { _durationAnchor: tool.durationAnchor } : {}),
-          ...(tool.mcpServer ? { _mcpServer: tool.mcpServer } : {}),
-          ...(tool.mcpTool ? { _mcpTool: tool.mcpTool } : {}),
-        },
-      ],
-    });
+    pushTurn(
+      {
+        role: "assistant",
+        timestamp: tool.timestamp,
+        blocks: [
+          {
+            type: "tool_use",
+            id: tool.id,
+            name: normalizeToolName(tool.name),
+            input: normalizeToolInput(tool.name, tool.input),
+            _hasResult: toolResults.has(tool.id),
+            ...(tr ? { _result: tr.result } : {}),
+            ...(tr?.isError ? { _isError: true } : {}),
+            ...(tr?.durationMs ? { _durationMs: tr.durationMs } : {}),
+            ...(tr?.durationSource ? { _durationSource: tr.durationSource } : {}),
+            ...(tool.durationAnchor ? { _durationAnchor: tool.durationAnchor } : {}),
+            ...(tool.mcpServer ? { _mcpServer: tool.mcpServer } : {}),
+            ...(tool.mcpTool ? { _mcpTool: tool.mcpTool } : {}),
+          },
+        ],
+      },
+      toolOrder.get(tool.id) ?? lines.length + toolOrder.size,
+    );
   }
 
-  turns.sort((a, b) => (a.timestamp || "").localeCompare(b.timestamp || ""));
+  turns.sort((a, b) => (turnOrder.get(a) || 0) - (turnOrder.get(b) || 0));
 
   const tokenUsage = tokenUsageFromSnapshots(tokenSnapshots);
   const contextLimit = [...tokenSnapshots].toReversed().find((s) => s.contextLimit)?.contextLimit;

--- a/packages/provider-codex/test/parser.test.ts
+++ b/packages/provider-codex/test/parser.test.ts
@@ -122,6 +122,62 @@ describe("Codex parser", () => {
     ).toHaveLength(1);
   });
 
+  it("preserves JSONL order when timestamps move backwards across resumed data", () => {
+    const result = parseCodexLines(
+      [
+        {
+          timestamp: "2026-04-26T10:00:00.000Z",
+          type: "session_meta",
+          payload: { id: "codex-order", cwd: "/Users/test/project" },
+        },
+        {
+          timestamp: "2026-04-26T10:00:10.000Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "later timestamp, earlier source" }],
+          },
+        },
+        {
+          timestamp: "2026-04-26T09:00:00.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "source-order prompt" },
+        },
+        {
+          timestamp: "2026-04-26T08:00:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            call_id: "order-tool",
+            arguments: JSON.stringify({ cmd: "printf ok" }),
+          },
+        },
+        {
+          timestamp: "2026-04-26T08:01:00.000Z",
+          type: "response_item",
+          payload: {
+            type: "function_call_output",
+            call_id: "order-tool",
+            output: "ok",
+          },
+        },
+      ].map((line) => JSON.stringify(line)),
+    );
+
+    expect(result.turns.map((turn) => turn.role)).toEqual(["assistant", "user", "assistant"]);
+    expect(result.turns[0]?.blocks[0]).toMatchObject({
+      type: "text",
+      text: "later timestamp, earlier source",
+    });
+    expect(result.turns[1]?.blocks[0]).toMatchObject({
+      type: "text",
+      text: "source-order prompt",
+    });
+    expect(result.turns[2]?.blocks[0]).toMatchObject({ type: "tool_use", name: "Bash" });
+  });
+
   it("parses Codex rollout JSONL into replay turns", () => {
     const result = parseCodexLines(lines);
 

--- a/packages/provider-contract/src/index.ts
+++ b/packages/provider-contract/src/index.ts
@@ -54,6 +54,8 @@ export function normalizeSubAgentType(agentType: string): string {
 export interface SessionInfo {
   provider: string;
   sessionId: string;
+  /** Additional provider-native IDs that resolve to this logical session. */
+  sessionIds?: string[];
   slug: string;
   title?: string;
   project: string; // decoded project path (e.g. "~/Code/my-project")
@@ -77,6 +79,8 @@ export interface SessionInfo {
   hasSdk?: boolean; // true if a Cursor SDK agent record exists in sdk-agent-store/index.db
   /** Canonical project/workspace identity for dashboard aggregation. */
   projectIdentity?: ProjectIdentity;
+  /** Provider-native group/room identity when a display title is not unique. */
+  groupId?: string;
   firstPrompt: string;
   prompts?: string[]; // first N meaningful user prompts (cleaned)
   promptCount?: number; // total user prompts (counted via lightweight scan)

--- a/packages/provider-cursor/src/cursor/discover.ts
+++ b/packages/provider-cursor/src/cursor/discover.ts
@@ -19,6 +19,7 @@ const TRANSCRIPT_INFO_CONCURRENCY = 6;
 const ENTRY_STAT_CONCURRENCY = 32;
 const decodedProjectDirCache = new Map<string, Promise<string>>();
 const sdkWorkspaceRepoCache = new Map<string, Promise<string | undefined>>();
+const transcriptDelegatedPrompts = new Map<string, string[]>();
 let cursorDiscoveryInFlight: Promise<SessionInfo[]> | null = null;
 
 /** Coalesce dashboard/source scans that request the same local catalog concurrently. */
@@ -52,11 +53,16 @@ async function discoverCursorSessionsOnce(): Promise<SessionInfo[]> {
     sessions.push(...projectSessionList);
   }
   const mergedTranscriptSessions = mergeDuplicateTranscriptSessions(sessions);
+  const hiddenTranscriptSessionIds = findTopLevelSubagentSessionIds(mergedTranscriptSessions);
   sessions.length = 0;
-  sessions.push(...mergedTranscriptSessions);
+  sessions.push(
+    ...mergedTranscriptSessions.filter(
+      (session) => !hiddenTranscriptSessionIds.has(session.sessionId),
+    ),
+  );
 
   // Discover SQLite-only sessions (devcontainer, SSH-remote, etc.)
-  const transcriptSessions = sessions.slice();
+  const transcriptSessions = mergedTranscriptSessions;
   const knownIds = new Set(transcriptSessions.map((s) => s.sessionId));
   const decodedPaths = [...new Set(sessions.map((s) => s.cwd).filter(Boolean))];
   const sqliteOnly = await discoverSqliteOnlySessions(knownIds, decodedPaths, true);
@@ -384,6 +390,7 @@ async function extractSessionInfo(
 ): Promise<SessionInfo | null> {
   try {
     const content = await readFile(filePath, "utf-8");
+    transcriptDelegatedPrompts.set(filePath, extractDelegatedPrompts(content));
 
     const sessionId = basename(filePath, ".jsonl");
     let firstPrompt = "";
@@ -573,5 +580,76 @@ async function mapLimit<T, R>(
 export const __testables = {
   decodeProjectDir,
   extractSessionInfo,
+  findTopLevelSubagentSessionIds,
   mergeDuplicateTranscriptSessions,
 };
+
+function extractDelegatedPrompts(content: string): string[] {
+  const prompts: string[] = [];
+  for (const rawLine of content.split("\n")) {
+    if (!rawLine.trim()) continue;
+    let record: any;
+    try {
+      record = JSON.parse(rawLine);
+    } catch {
+      continue;
+    }
+    const blocks = Array.isArray(record?.message?.content) ? record.message.content : [];
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") continue;
+      const name = typeof block.name === "string" ? block.name.toLowerCase() : "";
+      if (!["agent", "subagent", "task", "task_v2"].includes(name)) continue;
+      const input =
+        block.input && typeof block.input === "object"
+          ? block.input
+          : block.arguments && typeof block.arguments === "object"
+            ? block.arguments
+            : undefined;
+      const prompt =
+        typeof input?.prompt === "string"
+          ? input.prompt
+          : typeof input?.task === "string"
+            ? input.task
+            : "";
+      const normalized = normalizePromptForMatch(prompt);
+      if (normalized && !prompts.includes(normalized)) prompts.push(normalized);
+    }
+  }
+  return prompts;
+}
+
+export function findTopLevelSubagentSessionIds(
+  sessions: SessionInfo[],
+  promptsByPath: ReadonlyMap<string, string[]> = transcriptDelegatedPrompts,
+): Set<string> {
+  const delegated = new Map<string, string[]>();
+  for (const session of sessions) {
+    const prompts = session.filePaths.flatMap((path) => promptsByPath.get(path) || []);
+    if (prompts.length > 0) delegated.set(session.sessionId, prompts);
+  }
+
+  const hidden = new Set<string>();
+  for (const child of sessions) {
+    const firstPrompt = normalizePromptForMatch(child.firstPrompt);
+    if (firstPrompt.length < 32) continue;
+    for (const [parentId, prompts] of delegated) {
+      if (parentId === child.sessionId) continue;
+      if (
+        prompts.some(
+          (prompt) =>
+            prompt === firstPrompt ||
+            (prompt.length >= 32 && (prompt.includes(firstPrompt) || firstPrompt.includes(prompt))),
+        )
+      ) {
+        hidden.add(child.sessionId);
+        break;
+      }
+    }
+  }
+  return hidden;
+}
+
+function normalizePromptForMatch(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return sanitizeCursorUserText(value).replace(/\s+/g, " ").trim();
+}

--- a/packages/provider-cursor/src/cursor/discover.ts
+++ b/packages/provider-cursor/src/cursor/discover.ts
@@ -622,6 +622,7 @@ export function findTopLevelSubagentSessionIds(
   sessions: SessionInfo[],
   promptsByPath: ReadonlyMap<string, string[]> = transcriptDelegatedPrompts,
 ): Set<string> {
+  const sessionsById = new Map(sessions.map((session) => [session.sessionId, session]));
   const delegated = new Map<string, string[]>();
   for (const session of sessions) {
     const prompts = session.filePaths.flatMap((path) => promptsByPath.get(path) || []);
@@ -634,6 +635,8 @@ export function findTopLevelSubagentSessionIds(
     if (firstPrompt.length < 32) continue;
     for (const [parentId, prompts] of delegated) {
       if (parentId === child.sessionId) continue;
+      const parent = sessionsById.get(parentId);
+      if (!parent || cursorWorkspaceIdentity(parent) !== cursorWorkspaceIdentity(child)) continue;
       if (
         prompts.some(
           (prompt) =>
@@ -647,6 +650,10 @@ export function findTopLevelSubagentSessionIds(
     }
   }
   return hidden;
+}
+
+function cursorWorkspaceIdentity(session: SessionInfo): string {
+  return session.projectIdentity?.key || session.workspacePath || session.project || session.cwd;
 }
 
 function normalizePromptForMatch(value: unknown): string {

--- a/packages/provider-cursor/test/discover.test.ts
+++ b/packages/provider-cursor/test/discover.test.ts
@@ -225,10 +225,18 @@ describe("Cursor transcript metadata discovery", () => {
       "Inspect the parser and verify the delegated result thoroughly.",
       "/child.jsonl",
     );
+    const unrelatedChild = {
+      ...child,
+      sessionId: "unrelated-child",
+      filePath: "/other-project/child.jsonl",
+      filePaths: ["/other-project/child.jsonl"],
+      project: "/other-project",
+      cwd: "/other-project",
+    };
 
     expect(
       __testables.findTopLevelSubagentSessionIds(
-        [parent, child],
+        [parent, child, unrelatedChild],
         new Map([
           ["/parent.jsonl", ["Inspect the parser and verify the delegated result thoroughly."]],
         ]),

--- a/packages/provider-cursor/test/discover.test.ts
+++ b/packages/provider-cursor/test/discover.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { SessionInfo } from "@vibe-replay/provider-contract";
 import { __testables } from "../src/cursor/discover.js";
 
 const tempDirs: string[] = [];
@@ -200,5 +201,38 @@ describe("Cursor transcript metadata discovery", () => {
       firstPrompt: "Count this prompt",
       promptCount: 1,
     });
+  });
+
+  it("hides a top-level transcript whose prompt is delegated by another session", () => {
+    const session = (sessionId: string, firstPrompt: string, filePath: string) =>
+      ({
+        provider: "cursor",
+        sessionId,
+        slug: sessionId,
+        project: "/repo",
+        cwd: "/repo",
+        version: "",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        lineCount: 2,
+        fileSize: 100,
+        filePath,
+        filePaths: [filePath],
+        firstPrompt,
+      }) as SessionInfo;
+    const parent = session("parent", "main request", "/parent.jsonl");
+    const child = session(
+      "child",
+      "Inspect the parser and verify the delegated result thoroughly.",
+      "/child.jsonl",
+    );
+
+    expect(
+      __testables.findTopLevelSubagentSessionIds(
+        [parent, child],
+        new Map([
+          ["/parent.jsonl", ["Inspect the parser and verify the delegated result thoroughly."]],
+        ]),
+      ),
+    ).toEqual(new Set(["child"]));
   });
 });

--- a/packages/provider-grok-bot/src/grok-bot/discover.ts
+++ b/packages/provider-grok-bot/src/grok-bot/discover.ts
@@ -106,6 +106,7 @@ async function extractGrokBotSessionInfo(
   const profile = await readAgentProfile(transcriptsRoot, sessionId);
   const group = await readAgentGroup(transcriptsRoot, sessionId, profile);
   const groupTitle = stats.groupTitle || group?.title || profile?.groupTitle;
+  const groupId = group?.id || profile?.groupId;
   const cwd = profile?.cwd || profile?.name || groupTitle || sessionId;
   const gitRepo = resolveGitRepo && looksLikePath(cwd) ? await readGitRepo(cwd) : profile?.gitRepo;
   const title = groupTitle
@@ -121,6 +122,7 @@ async function extractGrokBotSessionInfo(
     project,
     cwd,
     version: "1",
+    ...(groupId ? { groupId } : {}),
     ...(profile?.gitBranch ? { gitBranch: profile.gitBranch } : {}),
     ...(gitRepo ? { gitRepo } : {}),
     timestamp: stats.timestamp || fileMtime,

--- a/packages/provider-grok-bot/src/grok-bot/group-merge.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-merge.ts
@@ -26,9 +26,7 @@ interface GrokBotGroupIdentity {
 
 export function discoveredGroupKey(session: SessionInfo): string | undefined {
   if (isSandSubagentSessionId(session.sessionId)) return undefined;
-  const title = session.title?.trim() ?? "";
-  if (!title.toLowerCase().startsWith("group:")) return undefined;
-  const room = title.slice(title.indexOf(":") + 1).trim();
+  const room = discoveredGroupTitle(session);
   if (!room) return undefined;
   return groupIdentityKey(room, session.groupId).key;
 }
@@ -37,7 +35,7 @@ export function mergeDiscoveredGroupSessions(sessions: SessionInfo[]): SessionIn
   const groups = new Map<string, SessionInfo[]>();
   const passthrough: SessionInfo[] = [];
   for (const session of sessions) {
-    const key = discoveredGroupKey(session);
+    const key = discoveredGroupTitleKey(session);
     if (!key) {
       passthrough.push(session);
       continue;
@@ -46,15 +44,29 @@ export function mergeDiscoveredGroupSessions(sessions: SessionInfo[]): SessionIn
   }
 
   const merged = [...passthrough];
-  for (const [key, members] of groups) {
-    if (members.length === 1) {
-      merged.push(members[0]);
+  for (const [titleKey, members] of groups) {
+    const groupIds = uniqueStrings(members.map((member) => member.groupId || ""));
+    if (groupIds.length <= 1) {
+      merged.push(mergeGroupMembers(titleKey, members));
       continue;
     }
-    merged.push(mergeGroupSessionInfos(key, members));
+
+    const splitGroups = new Map<string, SessionInfo[]>();
+    for (const member of members) {
+      const key = member.groupId ? `id:${member.groupId}` : `title:${titleKey}`;
+      splitGroups.set(key, [...(splitGroups.get(key) || []), member]);
+    }
+    for (const splitMembers of splitGroups.values()) {
+      merged.push(mergeGroupMembers(titleKey, splitMembers));
+    }
   }
   merged.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return merged;
+}
+
+function mergeGroupMembers(titleKey: string, members: SessionInfo[]): SessionInfo {
+  if (members.length === 1) return members[0];
+  return mergeGroupSessionInfos(titleKey, members);
 }
 
 function mergeGroupSessionInfos(key: string, members: SessionInfo[]): SessionInfo {
@@ -137,33 +149,36 @@ export async function expandGroupTranscriptPaths(filePath: string): Promise<stri
     return [filePath];
   }
 
-  const paths = [filePath];
+  const candidates: Array<{ path: string; groupId?: string }> = [];
   for (const entry of entries) {
     if (entry === sessionId || isSandSubagentSessionId(entry)) continue;
     const sibling = join(transcriptsRoot, entry, `${entry}.jsonl`);
     const fileStat = await stat(sibling).catch(() => null);
     if (!fileStat?.isFile()) continue;
-    if (await siblingSharesGroup(sibling, entry, transcriptsRoot, identity)) {
-      paths.push(sibling);
-    }
+    const siblingContent = await readFile(sibling, "utf-8").catch(() => "");
+    const siblingProfile = await readAgentProfile(transcriptsRoot, entry);
+    const siblingGroup = await readAgentGroup(transcriptsRoot, entry, siblingProfile);
+    const siblingTitle =
+      groupTitleFromContent(siblingContent) || siblingGroup?.title || siblingProfile?.groupTitle;
+    if (!siblingTitle || normalizeGroupKey(siblingTitle) !== identity.titleKey) continue;
+    candidates.push({
+      path: sibling,
+      groupId: siblingGroup?.id || siblingProfile?.groupId,
+    });
+  }
+  const knownGroupIds = new Set(
+    [identity.groupId, ...candidates.map((candidate) => candidate.groupId)].filter(
+      (groupId): groupId is string => !!groupId,
+    ),
+  );
+  const paths = [filePath];
+  for (const candidate of candidates) {
+    const sameKnownRoom =
+      knownGroupIds.size <= 1 ||
+      (identity.groupId ? candidate.groupId === identity.groupId : !candidate.groupId);
+    if (sameKnownRoom) paths.push(candidate.path);
   }
   return uniqueStrings(paths);
-}
-
-async function siblingSharesGroup(
-  siblingPath: string,
-  agentId: string,
-  transcriptsRoot: string,
-  identity: GrokBotGroupIdentity,
-): Promise<boolean> {
-  const content = await readFile(siblingPath, "utf-8").catch(() => "");
-  const profile = await readAgentProfile(transcriptsRoot, agentId);
-  const group = await readAgentGroup(transcriptsRoot, agentId, profile);
-  const title = groupTitleFromContent(content) || group?.title || profile?.groupTitle;
-  if (!title) return false;
-  const siblingGroupId = group?.id || profile?.groupId;
-  if (identity.groupId) return siblingGroupId === identity.groupId;
-  return normalizeGroupKey(title) === identity.titleKey && !siblingGroupId;
 }
 
 export async function resolveOwnerName(
@@ -421,9 +436,21 @@ function groupIdentityKey(title: string, groupId?: string): GrokBotGroupIdentity
   };
 }
 
+function discoveredGroupTitle(session: SessionInfo): string | undefined {
+  const title = session.title?.trim() ?? "";
+  if (!title.toLowerCase().startsWith("group:")) return undefined;
+  const room = title.slice(title.indexOf(":") + 1).trim();
+  return room || undefined;
+}
+
+function discoveredGroupTitleKey(session: SessionInfo): string | undefined {
+  const title = discoveredGroupTitle(session);
+  return title ? normalizeGroupKey(title) : undefined;
+}
+
 function groupSessionId(identity: GrokBotGroupIdentity): string {
   return identity.groupId
-    ? `group-${identity.titleKey}-${normalizeGroupKey(identity.groupId)}`
+    ? `group-${identity.titleKey}-${Buffer.from(identity.groupId, "utf8").toString("base64url")}`
     : `group-${identity.titleKey}`;
 }
 

--- a/packages/provider-grok-bot/src/grok-bot/group-merge.ts
+++ b/packages/provider-grok-bot/src/grok-bot/group-merge.ts
@@ -18,12 +18,19 @@ export interface GrokBotParsedMember {
   parsed: ProviderParseResult;
 }
 
+interface GrokBotGroupIdentity {
+  key: string;
+  titleKey: string;
+  groupId?: string;
+}
+
 export function discoveredGroupKey(session: SessionInfo): string | undefined {
   if (isSandSubagentSessionId(session.sessionId)) return undefined;
   const title = session.title?.trim() ?? "";
   if (!title.toLowerCase().startsWith("group:")) return undefined;
   const room = title.slice(title.indexOf(":") + 1).trim();
-  return room ? normalizeGroupKey(room) : undefined;
+  if (!room) return undefined;
+  return groupIdentityKey(room, session.groupId).key;
 }
 
 export function mergeDiscoveredGroupSessions(sessions: SessionInfo[]): SessionInfo[] {
@@ -53,19 +60,36 @@ export function mergeDiscoveredGroupSessions(sessions: SessionInfo[]): SessionIn
 function mergeGroupSessionInfos(key: string, members: SessionInfo[]): SessionInfo {
   const chronological = [...members].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
   const latest = [...members].sort((a, b) => b.timestamp.localeCompare(a.timestamp))[0];
+  const roomTitle =
+    latest.title?.replace(/^Group:\s*/i, "").trim() ||
+    chronological
+      .find((member) => member.title)
+      ?.title?.replace(/^Group:\s*/i, "")
+      .trim() ||
+    key;
+  const groupId = uniqueStrings(members.map((member) => member.groupId || "").filter(Boolean))[0];
+  const identity = groupIdentityKey(roomTitle, groupId);
+  const canonicalSessionId = groupSessionId(identity);
   const filePaths = uniqueStrings(chronological.flatMap((member) => member.filePaths));
   const uniquePrompts = uniqueStrings(
     chronological.flatMap(
       (member) => member.prompts || (member.firstPrompt ? [member.firstPrompt] : []),
     ),
   );
-  const roomTitle = latest.title?.replace(/^Group:\s*/i, "").trim() || key;
+  const legacySessionId = `group-${identity.titleKey}`;
+  const sessionIds = uniqueStrings([
+    canonicalSessionId,
+    legacySessionId,
+    ...members.flatMap((member) => [member.sessionId, ...(member.sessionIds || [])]),
+  ]);
   return {
     ...latest,
-    sessionId: `group-${key}`,
-    slug: `group-${key}`,
+    sessionId: canonicalSessionId,
+    sessionIds,
+    slug: canonicalSessionId,
     title: `Group: ${roomTitle}`,
     project: roomTitle,
+    ...(groupId ? { groupId } : {}),
     filePath: filePaths[0] || latest.filePath,
     filePaths,
     fileSize: members.reduce((sum, member) => sum + member.fileSize, 0),
@@ -104,7 +128,7 @@ export async function expandGroupTranscriptPaths(filePath: string): Promise<stri
   const group = await readAgentGroup(transcriptsRoot, sessionId, profile);
   const title = groupTitleFromContent(content) || group?.title || profile?.groupTitle;
   if (!title) return [filePath];
-  const key = normalizeGroupKey(title);
+  const identity = groupIdentityKey(title, group?.id || profile?.groupId);
 
   let entries: string[];
   try {
@@ -119,7 +143,7 @@ export async function expandGroupTranscriptPaths(filePath: string): Promise<stri
     const sibling = join(transcriptsRoot, entry, `${entry}.jsonl`);
     const fileStat = await stat(sibling).catch(() => null);
     if (!fileStat?.isFile()) continue;
-    if (await siblingSharesGroup(sibling, entry, transcriptsRoot, key)) {
+    if (await siblingSharesGroup(sibling, entry, transcriptsRoot, identity)) {
       paths.push(sibling);
     }
   }
@@ -130,13 +154,16 @@ async function siblingSharesGroup(
   siblingPath: string,
   agentId: string,
   transcriptsRoot: string,
-  key: string,
+  identity: GrokBotGroupIdentity,
 ): Promise<boolean> {
   const content = await readFile(siblingPath, "utf-8").catch(() => "");
   const profile = await readAgentProfile(transcriptsRoot, agentId);
   const group = await readAgentGroup(transcriptsRoot, agentId, profile);
   const title = groupTitleFromContent(content) || group?.title || profile?.groupTitle;
-  return !!title && normalizeGroupKey(title) === key;
+  if (!title) return false;
+  const siblingGroupId = group?.id || profile?.groupId;
+  if (identity.groupId) return siblingGroupId === identity.groupId;
+  return normalizeGroupKey(title) === identity.titleKey && !siblingGroupId;
 }
 
 export async function resolveOwnerName(
@@ -382,6 +409,22 @@ function uniqueStrings(values: string[]): string[] {
     out.push(trimmed);
   }
   return out;
+}
+
+function groupIdentityKey(title: string, groupId?: string): GrokBotGroupIdentity {
+  const titleKey = normalizeGroupKey(title);
+  const normalizedId = groupId?.trim();
+  return {
+    key: normalizedId ? `id:${normalizedId}` : `title:${titleKey}`,
+    titleKey,
+    ...(normalizedId ? { groupId: normalizedId } : {}),
+  };
+}
+
+function groupSessionId(identity: GrokBotGroupIdentity): string {
+  return identity.groupId
+    ? `group-${identity.titleKey}-${normalizeGroupKey(identity.groupId)}`
+    : `group-${identity.titleKey}`;
 }
 
 function applySessionInfo(

--- a/packages/provider-grok-bot/src/grok-bot/parser.ts
+++ b/packages/provider-grok-bot/src/grok-bot/parser.ts
@@ -154,6 +154,36 @@ export async function parseGrokBotSession(
   return mergeGrokBotGroupParses(members, sessionInfo);
 }
 
+export async function parseGrokBotLiveSession(
+  members: Array<{ path: string; lines: string[] }>,
+  sessionInfo?: SessionInfo,
+): Promise<ProviderParseResult> {
+  if (members.length === 0) {
+    return parseGrokBotLines([], { sessionInfo });
+  }
+
+  const parsedMembers = await Promise.all(
+    members.map(async ({ path, lines }) => {
+      const ownerName = await resolveOwnerName(path, sessionInfo);
+      const parsed = await attachGrokBotSubAgents(
+        parseGrokBotLines(lines, {
+          sourcePath: path,
+          sessionInfo,
+          ownerName,
+        }),
+        path,
+      );
+      return {
+        path,
+        ownerName: ownerName || parsed.agentName,
+        parsed,
+      };
+    }),
+  );
+  if (parsedMembers.length === 1) return parsedMembers[0].parsed;
+  return mergeGrokBotGroupParses(parsedMembers, sessionInfo);
+}
+
 interface ParseGrokBotLinesOptions {
   sourcePath?: string;
   sessionInfo?: SessionInfo;

--- a/packages/provider-grok-bot/test/discover.test.ts
+++ b/packages/provider-grok-bot/test/discover.test.ts
@@ -372,6 +372,43 @@ It's your turn, Vibe Replay GTM.`,
     expect(sessions[0].filePaths.some((path) => path.includes(gtmId))).toBe(true);
   });
 
+  it("keeps same-title rooms with different group IDs separate and preserves member IDs", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "vibe-grok-bot-group-id-"));
+    tempDirs.push(dataRoot);
+    const transcripts = join(dataRoot, "agent-transcripts");
+    const firstId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const secondId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const writeRoom = async (agentId: string, groupId: string, prompt: string) => {
+      await writeSession(transcripts, agentId, [
+        {
+          role: "user",
+          message: {
+            content: [
+              {
+                type: "text",
+                text: `[Group chat: "Same room title"]\nNew messages in the room (oldest first):\nUser: ${prompt}\nIt's your turn, Agent.`,
+              },
+            ],
+          },
+        },
+      ]);
+      await mkdir(join(dataRoot, "agents", agentId), { recursive: true });
+      await writeFile(
+        join(dataRoot, "agents", agentId, "profile.json"),
+        JSON.stringify({ name: "Agent", groupTitle: "Same room title", groupId }),
+        "utf-8",
+      );
+    };
+    await writeRoom(firstId, "room-one", "first room prompt");
+    await writeRoom(secondId, "room-two", "second room prompt");
+
+    const sessions = await discoverGrokBotSessions([transcripts], false);
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((session) => session.groupId).sort()).toEqual(["room-one", "room-two"]);
+    expect(sessions.map((session) => session.sessionId).sort()).toEqual([firstId, secondId].sort());
+  });
+
   it("uses group.json / profile groupTitle when the transcript has not named the room yet", async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), "vibe-grok-bot-group-profile-"));
     tempDirs.push(dataRoot);

--- a/packages/provider-grok-bot/test/discover.test.ts
+++ b/packages/provider-grok-bot/test/discover.test.ts
@@ -2,8 +2,10 @@ import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import type { SessionInfo } from "@vibe-replay/provider-contract";
 import { getGrokBotTranscriptRoots } from "../src/grok-bot/config.js";
 import { discoverGrokBotSessions } from "../src/grok-bot/discover.js";
+import { mergeDiscoveredGroupSessions } from "../src/grok-bot/parser.js";
 
 const originalTranscriptsDir = process.env.GROK_BOT_TRANSCRIPTS_DIR;
 const originalVibeDir = process.env.VIBE_REPLAY_GROK_BOT_DIR;
@@ -399,14 +401,80 @@ It's your turn, Vibe Replay GTM.`,
         "utf-8",
       );
     };
-    await writeRoom(firstId, "room-one", "first room prompt");
-    await writeRoom(secondId, "room-two", "second room prompt");
+    await writeRoom(firstId, "agent_a", "first room prompt");
+    await writeRoom(secondId, "agent-a", "second room prompt");
 
     const sessions = await discoverGrokBotSessions([transcripts], false);
 
     expect(sessions).toHaveLength(2);
-    expect(sessions.map((session) => session.groupId).sort()).toEqual(["room-one", "room-two"]);
+    expect(sessions.map((session) => session.groupId).sort()).toEqual(["agent-a", "agent_a"]);
     expect(sessions.map((session) => session.sessionId).sort()).toEqual([firstId, secondId].sort());
+  });
+
+  it("keeps normalized group ID collisions distinct in merged session IDs", () => {
+    const member = (sessionId: string, groupId: string): SessionInfo =>
+      ({
+        provider: "grok-bot",
+        sessionId,
+        slug: sessionId,
+        title: "Group: Same room title",
+        project: "Same room title",
+        cwd: "Same room title",
+        version: "1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        lineCount: 1,
+        fileSize: 1,
+        filePath: `/tmp/${sessionId}.jsonl`,
+        filePaths: [`/tmp/${sessionId}.jsonl`],
+        firstPrompt: "prompt",
+        groupId,
+      }) as SessionInfo;
+
+    const merged = mergeDiscoveredGroupSessions([
+      member("agent-a-1", "agent_a"),
+      member("agent-a-2", "agent_a"),
+      member("agent-b-1", "agent-a"),
+      member("agent-b-2", "agent-a"),
+    ]);
+
+    expect(merged).toHaveLength(2);
+    expect(new Set(merged.map((session) => session.sessionId)).size).toBe(2);
+    expect(merged.every((session) => session.sessionId !== "group-same-room-title")).toBe(true);
+    expect(merged.some((session) => session.sessionIds?.includes("agent-a-1"))).toBe(true);
+    expect(merged.some((session) => session.sessionIds?.includes("agent-b-1"))).toBe(true);
+  });
+
+  it("bridges an ID-less member when one room ID is known", () => {
+    const member = (sessionId: string, groupId?: string): SessionInfo =>
+      ({
+        provider: "grok-bot",
+        sessionId,
+        slug: sessionId,
+        title: "Group: Partially labeled room",
+        project: "Partially labeled room",
+        cwd: "Partially labeled room",
+        version: "1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        lineCount: 1,
+        fileSize: 1,
+        filePath: `/tmp/${sessionId}.jsonl`,
+        filePaths: [`/tmp/${sessionId}.jsonl`],
+        firstPrompt: "prompt",
+        ...(groupId ? { groupId } : {}),
+      }) as SessionInfo;
+
+    const merged = mergeDiscoveredGroupSessions([
+      member("labeled-member", "room-one"),
+      member("unlabeled-member"),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.groupId).toBe("room-one");
+    expect(merged[0]?.sessionId).toBe("group-partially-labeled-room-cm9vbS1vbmU");
+    expect(merged[0]?.filePaths).toHaveLength(2);
+    expect(merged[0]?.sessionIds).toEqual(
+      expect.arrayContaining(["labeled-member", "unlabeled-member"]),
+    );
   });
 
   it("uses group.json / profile groupTitle when the transcript has not named the room yet", async () => {

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   extractGroupMentions,
+  expandGroupTranscriptPaths,
   formatGroupHeader,
   formatGroupSpeakerMessage,
   isGrokBotGroupChatPayload,
@@ -451,6 +452,50 @@ It's your turn, Vibe Replay Eng.`,
 
     expect(liveParsed.turns).toEqual(staticParsed.turns);
     expect(liveParsed.subAgentSummary).toEqual(staticParsed.subAgentSummary);
+  });
+
+  it("bridges an ID-less sibling when expanding an ID-bearing group transcript", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vibe-replay-grok-bot-partial-group-"));
+    const transcriptsRoot = join(root, "agent-transcripts");
+    const firstId = "first-agent";
+    const secondId = "second-agent";
+    const wake = `[Group chat: "Partially labeled room"]\nNew messages in the room (oldest first):\nUser: hello\nIt's your turn, Agent.`;
+    try {
+      const firstDir = join(transcriptsRoot, firstId);
+      const secondDir = join(transcriptsRoot, secondId);
+      await mkdir(firstDir, { recursive: true });
+      await mkdir(secondDir, { recursive: true });
+      const firstPath = join(firstDir, `${firstId}.jsonl`);
+      const secondPath = join(secondDir, `${secondId}.jsonl`);
+      await writeFile(
+        firstPath,
+        `${JSON.stringify({ role: "user", message: { content: [{ type: "text", text: wake }] } })}\n`,
+      );
+      await writeFile(
+        secondPath,
+        `${JSON.stringify({ role: "user", message: { content: [{ type: "text", text: wake }] } })}\n`,
+      );
+      await mkdir(join(root, "agents", firstId), { recursive: true });
+      await mkdir(join(root, "agents", secondId), { recursive: true });
+      await writeFile(
+        join(root, "agents", firstId, "profile.json"),
+        JSON.stringify({
+          name: "Agent",
+          groupTitle: "Partially labeled room",
+          groupId: "room-one",
+        }),
+      );
+      await writeFile(
+        join(root, "agents", secondId, "profile.json"),
+        JSON.stringify({ name: "Agent", groupTitle: "Partially labeled room" }),
+      );
+
+      await expect(expandGroupTranscriptPaths(firstPath)).resolves.toEqual(
+        expect.arrayContaining([firstPath, secondPath]),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps discovery session metadata when one group sibling has zero turns", async () => {

--- a/packages/provider-grok-bot/test/group-chat.test.ts
+++ b/packages/provider-grok-bot/test/group-chat.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,7 @@ import {
   isHumanGroupSpeaker,
   mergeGrokBotGroupParses,
   normalizeGroupKey,
+  parseGrokBotLiveSession,
   parseGrokBotGroupWake,
   parseGrokBotLines,
   parseGrokBotSession,
@@ -418,6 +419,38 @@ It's your turn, Vibe Replay Eng.`,
         JSON.stringify(scene).includes("can you confirm the dashboard badge copy"),
       ),
     ).toBe(false);
+  });
+
+  it("keeps live multi-file parsing aligned with static group parsing", async () => {
+    const paths = [join(fixtures, "group-eng.jsonl"), join(fixtures, "group-gtm.jsonl")];
+    const sessionInfo = {
+      provider: "grok-bot",
+      sessionId: "group-vibe-replay-launch",
+      slug: "group-vibe-replay-launch",
+      title: "Group: Vibe Replay launch",
+      project: "Vibe Replay launch",
+      cwd: "/workspace",
+      version: "1",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      lineCount: 0,
+      fileSize: 0,
+      filePath: paths[0],
+      filePaths: paths,
+      firstPrompt: "Let's ship it.",
+    } as const;
+    const staticParsed = await parseGrokBotSession(paths, sessionInfo);
+    const liveParsed = await parseGrokBotLiveSession(
+      await Promise.all(
+        paths.map(async (path) => ({
+          path,
+          lines: (await readFile(path, "utf-8")).split("\n"),
+        })),
+      ),
+      sessionInfo,
+    );
+
+    expect(liveParsed.turns).toEqual(staticParsed.turns);
+    expect(liveParsed.subAgentSummary).toEqual(staticParsed.subAgentSummary);
   });
 
   it("keeps discovery session metadata when one group sibling has zero turns", async () => {

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -179,7 +179,7 @@ export default function Player({
   const [selectionAnnotatePrompt, setSelectionAnnotatePrompt] =
     useState<SelectionAnnotatePrompt | null>(null);
   const [isOutlineOpen, setIsOutlineOpen] = useState(true);
-  const annotationActions = useAnnotations(session, effectiveViewerMode);
+  const annotationActions = useAnnotations(session, effectiveViewerMode, isLive);
   const overlayActions = useOverlays(session, effectiveViewerMode);
   const { effectiveSession } = overlayActions;
   const { annotations } = annotationActions;

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -136,8 +136,12 @@ export default function Player({
   returnToLandingRef,
   live,
 }: Props) {
-  const isReadOnly = viewerMode === "readonly";
   const isLive = !!live;
+  // Live payloads are editor-streamed, but they have no stable replay slug
+  // for annotation/overlay/export APIs. Keep the stream usable without
+  // presenting controls that would silently target an invalid session.
+  const effectiveViewerMode: ViewerMode = isLive ? "readonly" : viewerMode;
+  const isReadOnly = effectiveViewerMode === "readonly";
   // In live mode, skip the landing hero — the user explicitly asked to tail
   // a running session, so we should drop them straight into the conversation.
   const [landed, setLanded] = useState(isLive);
@@ -168,15 +172,15 @@ export default function Player({
     () => playerDrawerFromUrl() === "comments",
   );
   const [studioDrawerOpen, setStudioDrawerOpen] = useState(
-    () => viewerMode === "editor" && playerDrawerFromUrl() === "ai",
+    () => effectiveViewerMode === "editor" && playerDrawerFromUrl() === "ai",
   );
   const [commentTarget, setCommentTarget] = useState<CommentTarget | null>(null);
   const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
   const [selectionAnnotatePrompt, setSelectionAnnotatePrompt] =
     useState<SelectionAnnotatePrompt | null>(null);
   const [isOutlineOpen, setIsOutlineOpen] = useState(true);
-  const annotationActions = useAnnotations(session, viewerMode);
-  const overlayActions = useOverlays(session, viewerMode);
+  const annotationActions = useAnnotations(session, effectiveViewerMode);
+  const overlayActions = useOverlays(session, effectiveViewerMode);
   const { effectiveSession } = overlayActions;
   const { annotations } = annotationActions;
 
@@ -209,11 +213,11 @@ export default function Player({
     const handlePopState = () => {
       const drawer = playerDrawerFromUrl();
       setCommentDrawerOpen(drawer === "comments");
-      setStudioDrawerOpen(viewerMode === "editor" && drawer === "ai");
+      setStudioDrawerOpen(effectiveViewerMode === "editor" && drawer === "ai");
     };
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [viewerMode]);
+  }, [effectiveViewerMode]);
 
   // Force "all" display mode in live — compact hides thinking and collapses
   // tools, which makes a streaming session look like nothing is happening
@@ -747,7 +751,7 @@ export default function Player({
     seekTo(curr - 1);
   }, [isLive, session.scenes.length, seekTo]);
 
-  const hasAiStudio = viewerMode === "editor";
+  const hasAiStudio = effectiveViewerMode === "editor";
   const hasAiFeedback = useMemo(
     () => annotations.some((a) => a.author === "vibe-feedback"),
     [annotations],
@@ -1130,7 +1134,7 @@ export default function Player({
           {activeView === "export" && (
             <ExportView
               actions={annotationActions}
-              viewerMode={viewerMode}
+              viewerMode={effectiveViewerMode}
               readOnly={isReadOnly}
               session={effectiveSession}
             />
@@ -1160,7 +1164,7 @@ export default function Player({
               onOpenSearch={() => setSearchOpen(true)}
               onOpenOutline={() => setMobileDrawerOpen(true)}
               onShowHelp={() => setShowHelp(true)}
-              reserveAssistantSpace={viewerMode === "editor"}
+              reserveAssistantSpace={effectiveViewerMode === "editor"}
             />
           </div>
         )}

--- a/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
+++ b/packages/viewer/src/hooks/__tests__/useAnnotations.test.tsx
@@ -98,6 +98,33 @@ describe("useAnnotations storage identity", () => {
     expect(result.current.annotations).toEqual([]);
   });
 
+  it("skips local drafts while live and restores embedded annotations afterward", async () => {
+    const draft = [{ ...annotation, body: "Local draft" }];
+    localStorage.setItem(
+      annotationStorageKey("claude-code", "shared-session"),
+      JSON.stringify(draft),
+    );
+    const liveSession = { ...session("claude-code"), annotations: [] };
+    const replaySession = { ...session("claude-code"), annotations: [annotation] };
+
+    const { result, rerender } = renderHook(
+      ({ live }: { live: boolean }) =>
+        useAnnotations(live ? liveSession : replaySession, "readonly", live),
+      { initialProps: { live: true } },
+    );
+
+    expect(result.current.annotations).toEqual([]);
+    expect(localStorage.getItem(annotationStorageKey("claude-code", "shared-session"))).toBe(
+      JSON.stringify(draft),
+    );
+
+    rerender({ live: false });
+    await waitFor(() => expect(result.current.annotations).toEqual([annotation]));
+    expect(localStorage.getItem(annotationStorageKey("claude-code", "shared-session"))).toBe(
+      JSON.stringify(draft),
+    );
+  });
+
   it("does not load local drafts into an SSH session with the same provider and ID", async () => {
     const remote = {
       kind: "ssh" as const,

--- a/packages/viewer/src/hooks/useAnnotations.ts
+++ b/packages/viewer/src/hooks/useAnnotations.ts
@@ -122,9 +122,13 @@ export function annotationStorageKey(
   return `${SCOPED_LS_PREFIX}${encodeURIComponent(provider)}${locationScope}:${encodeURIComponent(sessionId)}`;
 }
 
-function loadAnnotationDraft(session: ReplaySession, isEditor: boolean): Annotation[] {
+function loadAnnotationDraft(
+  session: ReplaySession,
+  isEditor: boolean,
+  isLive: boolean,
+): Annotation[] {
   const embedded = session.annotations ?? [];
-  if (isEditor) return embedded;
+  if (isEditor || isLive) return embedded;
   let drafts: Array<string | null>;
   try {
     drafts = [
@@ -153,13 +157,14 @@ function loadAnnotationDraft(session: ReplaySession, isEditor: boolean): Annotat
 export function useAnnotations(
   session: ReplaySession,
   mode: ViewerMode = "embedded",
+  isLive = false,
 ): AnnotationActions {
   const sessionId = session.meta.sessionId;
   const provider = session.meta.provider;
   const location = session.meta.location;
   const isEditor = mode === "editor";
   const locationIdentity = location?.kind === "ssh" ? `ssh::${location.id}` : "local";
-  const storageIdentity = `${isEditor ? "editor" : "local"}::${locationIdentity}::${provider}::${sessionId}`;
+  const storageIdentity = `${isEditor ? "editor" : "local"}::${isLive ? "live" : "replay"}::${locationIdentity}::${provider}::${sessionId}`;
 
   // Save HTML only works from self-contained production builds (data embedded inline)
   // or in editor mode (server generates it).
@@ -167,21 +172,28 @@ export function useAnnotations(
 
   // Initialize from embedded data, then overlay localStorage draft
   const [annotations, setAnnotations] = useState<Annotation[]>(() =>
-    loadAnnotationDraft(session, isEditor),
+    loadAnnotationDraft(session, isEditor, isLive),
   );
 
   // Track whether we've diverged from embedded/server state
   const [savedSnapshot, setSavedSnapshot] = useState<Annotation[]>(() => session.annotations ?? []);
   const loadedIdentityRef = useRef(storageIdentity);
   const skipAutosaveIdentityRef = useRef<string | null>(null);
+  const skipAutosaveUntilChangeRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (loadedIdentityRef.current === storageIdentity) return;
+    const wasLive = loadedIdentityRef.current.includes("::live::");
     loadedIdentityRef.current = storageIdentity;
     skipAutosaveIdentityRef.current = storageIdentity;
-    setAnnotations(loadAnnotationDraft(session, isEditor));
+    if (wasLive && !isLive) skipAutosaveUntilChangeRef.current = storageIdentity;
+    setAnnotations(
+      wasLive && !isLive
+        ? session.annotations || []
+        : loadAnnotationDraft(session, isEditor, isLive),
+    );
     setSavedSnapshot(session.annotations ?? []);
-  }, [isEditor, session, storageIdentity]);
+  }, [isEditor, isLive, session, storageIdentity]);
 
   const hasUnsaved = hasUnsavedChanges(annotations, savedSnapshot);
 
@@ -189,9 +201,14 @@ export function useAnnotations(
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (isLive) return;
     if (skipAutosaveIdentityRef.current === storageIdentity) {
       skipAutosaveIdentityRef.current = null;
       return;
+    }
+    if (skipAutosaveUntilChangeRef.current === storageIdentity) {
+      if (JSON.stringify(annotations) === JSON.stringify(session.annotations ?? [])) return;
+      skipAutosaveUntilChangeRef.current = null;
     }
     if (isEditor) {
       // Debounced save to server API
@@ -227,7 +244,7 @@ export function useAnnotations(
     } catch {
       /* quota exceeded — silent */
     }
-  }, [annotations, location, provider, sessionId, storageIdentity, isEditor]);
+  }, [annotations, isLive, location, provider, session, sessionId, storageIdentity, isEditor]);
 
   const annotatedScenes = useMemo(() => computeAnnotatedScenes(annotations), [annotations]);
 


### PR DESCRIPTION
## Summary

- Preserve Grok Bot group identity across same-title rooms and make live multi-file parsing match static parsing.
- Preserve Claude resume shard metadata and subagent data, and keep legacy session IDs resolvable.
- Support Cursor SQLite/SDK regeneration, Codex JSONL source order, and Claude subagent cache invalidation.
- Resolve legacy replay directories for editing, export, publish, and regeneration.
- Disable invalid live-session editing controls and hide duplicate top-level Cursor subagent sessions.
- Make replay schema validation cover every scene.

## Validation

- `pnpm verify`
- Local session scan: current parent session retained its subagent count without listing the child as a standalone session.
- No credential patterns found in the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for live Grok Bot group sessions and multi-agent transcripts.
  - Added support for session aliases and group identities, improving replay matching across providers.
  - Added compatibility with legacy replay locations.

- **Bug Fixes**
  - Replay generation, exports, publishing, and editing now locate sessions more reliably.
  - Claude Code subagents are discovered across all resume files.
  - Codex conversations preserve transcript order, even when timestamps differ.
  - Delegated subagent sessions are excluded from top-level session lists.
  - Live sessions now consistently open in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->