### PR TITLE
fix: keep insights heatmaps stable across DST

### DIFF
--- a/packages/viewer/src/components/InsightsPage.tsx
+++ b/packages/viewer/src/components/InsightsPage.tsx
@@ -111,6 +111,13 @@ function dateKey(d: Date): string {
   return localDayKey(d)!;
 }
 
+/** Move by calendar days in the viewer's local timezone, across DST safely. */
+export function localDayOffset(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
 function rangeDays(range: TimeRange): number {
   if (range === "7d") return 7;
   if (range === "30d") return 30;
@@ -227,13 +234,13 @@ function computeWeeklyTrend(sessionsPerDay: Record<string, number>, weeks: numbe
   // Find start of current week (Monday)
   const dayOfWeek = today.getDay();
   const mondayOffset = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
-  const currentMonday = new Date(today.getTime() - mondayOffset * DAY_MS);
+  const currentMonday = localDayOffset(today, -mondayOffset);
 
   for (let w = weeks - 1; w >= 0; w--) {
-    const weekStart = new Date(currentMonday.getTime() - w * 7 * DAY_MS);
+    const weekStart = localDayOffset(currentMonday, -w * 7);
     let sessions = 0;
     for (let d = 0; d < 7; d++) {
-      const day = new Date(weekStart.getTime() + d * DAY_MS);
+      const day = localDayOffset(weekStart, d);
       const key = dateKey(day);
       sessions += sessionsPerDay[key] || 0;
     }
@@ -532,9 +539,9 @@ export function ContributionHeatmap({
 
     // End on Saturday of current week
     const dow = today.getDay();
-    const endDate = new Date(today.getTime() + (6 - dow) * DAY_MS);
+    const endDate = localDayOffset(today, 6 - dow);
     const totalDays = weeks * 7;
-    const startDate = new Date(endDate.getTime() - (totalDays - 1) * DAY_MS);
+    const startDate = localDayOffset(endDate, -(totalDays - 1));
 
     let max = 0;
     const cols: Array<Array<{ date: string; count: number }>> = [];
@@ -542,7 +549,7 @@ export function ContributionHeatmap({
     let lastMonth = -1;
 
     for (let i = 0; i < totalDays; i++) {
-      const d = new Date(startDate.getTime() + i * DAY_MS);
+      const d = localDayOffset(startDate, i);
       const key = dateKey(d);
       const count = sessionsPerDay[key] || 0;
       const wi = Math.floor(i / 7);
@@ -651,7 +658,7 @@ function MiniHeatmap({ sessionsPerDay }: { sessionsPerDay: Record<string, number
     const result: Array<{ key: string; count: number }> = [];
     let max = 0;
     for (let i = totalDays - 1; i >= 0; i--) {
-      const d = new Date(today.getTime() - i * DAY_MS);
+      const d = localDayOffset(today, -i);
       const key = dateKey(d);
       const count = sessionsPerDay[key] || 0;
       if (count > max) max = count;

--- a/packages/viewer/src/components/__tests__/insights-page.test.ts
+++ b/packages/viewer/src/components/__tests__/insights-page.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { localDayOffset } from "../InsightsPage";
+
+describe("Insights calendar helpers", () => {
+  it("moves by local calendar days without mutating the source", () => {
+    const source = new Date(2025, 10, 1, 12, 0, 0);
+
+    const next = localDayOffset(source, 1);
+    const previous = localDayOffset(source, -1);
+
+    expect(next.getFullYear()).toBe(2025);
+    expect(next.getMonth()).toBe(10);
+    expect(next.getDate()).toBe(2);
+    expect(previous.getDate()).toBe(31);
+    expect(source.getDate()).toBe(1);
+  });
+});


### PR DESCRIPTION
## User-flow finding

While exercising the local dashboard as a user, the browser emitted repeated React duplicate-key warnings for heatmap cells around `2025-11-02`. The fixed-millisecond calendar arithmetic crossed a DST boundary and generated the same local date twice.

## Fix

Use local calendar-day increments for Insights weekly and contribution heatmaps, and add a regression test for the date helper.

## Validation

- `pnpm --filter @vibe-replay/viewer test`
- `pnpm lint:check`
- Browser smoke retest: zero duplicate-key warnings and zero console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected weekly trends and heatmaps to maintain accurate local calendar dates across daylight-saving transitions.

* **Tests**
  * Added coverage for advancing and reversing local calendar days without modifying the original date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->