### PR TITLE
fix: clarify dashboard session loading

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -213,6 +213,18 @@ export interface SessionScanIndex {
   bySlug: Map<string, SessionScanData[]>;
 }
 
+export function sessionExplorerCountLabel(
+  isLoading: boolean,
+  hasActiveFilters: boolean,
+  matchingCount: number,
+  totalCount: number,
+): string {
+  if (isLoading) return "Loading…";
+  return hasActiveFilters
+    ? `${matchingCount.toLocaleString()} matching`
+    : `${totalCount.toLocaleString()} sessions`;
+}
+
 function scanLookupKey(provider: string, value: string, location?: SessionLocation): string {
   const targetId = location?.kind === "ssh" ? `${location.id}\0` : "";
   return `${targetId}${provider}\0${value}`;
@@ -3056,7 +3068,7 @@ function SessionsPanel() {
                   : "bg-terminal-surface text-terminal-dimmer"
               }`}
             >
-              {projectFacetSources.length}
+              {showInitialLoading ? "…" : projectFacetSources.length}
             </span>
           </button>
 
@@ -3358,15 +3370,20 @@ function SessionsPanel() {
                     Sessions
                   </h2>
                   <span className="text-xs font-mono text-terminal-dimmer shrink-0">
-                    {hasActiveFilters
-                      ? `${filtered.length.toLocaleString()} matching`
-                      : `${baseSourceCount.toLocaleString()} sessions`}
+                    {sessionExplorerCountLabel(
+                      showInitialLoading,
+                      hasActiveFilters,
+                      filtered.length,
+                      baseSourceCount,
+                    )}
                   </span>
                 </div>
                 <div className="mt-0.5 text-xs font-mono text-terminal-dimmer">
-                  {hasActiveFilters
-                    ? `Filtered from ${baseSourceCount.toLocaleString()} sessions`
-                    : "Use sidebar facets or search to narrow the list"}
+                  {showInitialLoading
+                    ? "Discovering local providers and cached sessions"
+                    : hasActiveFilters
+                      ? `Filtered from ${baseSourceCount.toLocaleString()} sessions`
+                      : "Use sidebar facets or search to narrow the list"}
                   {showArchived && " · including archived"}
                 </div>
               </div>

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -9,6 +9,7 @@ import Dashboard, {
   contextFootprintSummary,
   findSessionScanData,
   getSessionRangeTimestamp,
+  sessionExplorerCountLabel,
   type SessionScanData,
   shouldIncludeSessionForFacets,
   shouldIncludeSessionForProject,
@@ -45,6 +46,12 @@ describe("Dashboard (smoke)", () => {
     // Sidebar facet headers.
     expect(screen.getByText(/Provider/)).toBeTruthy();
     expect(screen.getByText(/Project path/)).toBeTruthy();
+  });
+
+  it("uses an explicit loading count before session data arrives", () => {
+    expect(sessionExplorerCountLabel(true, false, 0, 0)).toBe("Loading…");
+    expect(sessionExplorerCountLabel(false, false, 0, 0)).toBe("0 sessions");
+    expect(sessionExplorerCountLabel(false, true, 12, 40)).toBe("12 matching");
   });
 
   it("kicks off a data fetch on mount", async () => {


### PR DESCRIPTION
## User-flow finding

On a fresh dashboard load, the Sessions explorer briefly displayed `0 sessions` and a zero sidebar count while the source scan was still running. That reads as an empty account rather than an in-progress discovery.

## Fix

Use explicit `Loading…`/discovery copy and an ellipsis count until the first local session list is available. Keep the existing zero count after loading completes.

## Validation

- `pnpm --filter @vibe-replay/viewer exec vitest run src/components/__tests__/dashboard.test.tsx`
- `pnpm lint:check`