### PR TITLE
fix: make empty session search recoverable

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -3698,8 +3698,19 @@ function SessionsPanel() {
               Fetching sessions...
             </div>
           ) : filtered.length === 0 ? (
-            <div className="text-center py-12 text-terminal-dim font-mono text-sm">
-              {hasActiveFilters ? "No sessions match the current filters" : "No sessions found"}
+            <div className="text-center py-12 text-terminal-dim font-mono text-sm space-y-3">
+              <div>
+                {hasActiveFilters ? "No sessions match the current filters" : "No sessions found"}
+              </div>
+              {filter && (
+                <button
+                  type="button"
+                  onClick={() => handleFilterChange("")}
+                  className="rounded-lg border border-terminal-border-subtle bg-terminal-surface px-3 py-1.5 text-xs text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text"
+                >
+                  Clear search
+                </button>
+              )}
             </div>
           ) : (
             <div key={listFilterKey} className="space-y-2.5 px-4 py-3">


### PR DESCRIPTION
## User-flow finding

When searching Sessions for a term with no matches, the list only showed the empty-state sentence. The user had to scroll back to the filter bar to clear the query, especially awkward on a long/mobile list.

## Fix

Add a direct `Clear search` action to the no-results state while preserving the existing global filter controls.

## Validation

- Dashboard component tests
- Browser search flow: `Clear search` appears for a no-match query
- `pnpm lint:check`