### PR TITLE
fix: label replay generation actions

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4230,7 +4230,13 @@ function SessionsPanel() {
                               e.stopPropagation();
                               selectSession(s);
                             }}
-                            aria-label={`Generate replay for ${sourceSuggestedTitle(s)}`}
+                            aria-label={
+                              generatingSessionKey === sessionIdentityKey(s)
+                                ? `Generating replay for ${sourceSuggestedTitle(s)}`
+                                : transcriptStatus
+                                  ? `Replay unavailable for ${sourceSuggestedTitle(s)}`
+                                  : `Generate replay for ${sourceSuggestedTitle(s)}`
+                            }
                             disabled={generatingSessionKey !== null || !!transcriptStatus}
                             title={
                               generatingSessionKey !== null

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4230,6 +4230,7 @@ function SessionsPanel() {
                               e.stopPropagation();
                               selectSession(s);
                             }}
+                            aria-label={`Generate replay for ${sourceSuggestedTitle(s)}`}
                             disabled={generatingSessionKey !== null || !!transcriptStatus}
                             title={
                               generatingSessionKey !== null


### PR DESCRIPTION
## User-flow finding

The Sessions tab renders many identical `Generate` controls. During a real generation flow, the control text does not identify which session it belongs to, making keyboard navigation and assistive-technology use ambiguous.

## Fix

Add session-specific accessible names such as `Generate replay for Check Local Session` while preserving the compact visual label.

## Validation

- Dashboard component tests
- Browser session flow: 93 generation controls expose session-specific accessible names
- `pnpm lint:check`