### PR TITLE
fix: add local replay error recovery

### DIFF
--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -320,6 +320,7 @@ export default function App() {
                   gist: null,
                   cloud: null,
                   url: null,
+                  file: null,
                   live: null,
                   provider: null,
                   sessionId: null,

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -307,6 +307,29 @@ export default function App() {
           <div className="text-terminal-dim font-mono text-xs">
             Use ?gist=&lt;id&gt; or ?url=&lt;replay-json-url&gt; or embed via CLI
           </div>
+          {(isEditor ||
+            window.location.hostname === "localhost" ||
+            window.location.hostname === "127.0.0.1" ||
+            window.location.hostname === "::1") && (
+            <button
+              type="button"
+              onClick={() =>
+                navigateTo({
+                  view: "dashboard",
+                  session: null,
+                  gist: null,
+                  cloud: null,
+                  url: null,
+                  live: null,
+                  provider: null,
+                  sessionId: null,
+                })
+              }
+              className="mt-4 rounded-lg border border-terminal-border-subtle bg-terminal-surface px-3 py-1.5 text-xs font-mono text-terminal-dim transition-colors hover:bg-terminal-surface-hover hover:text-terminal-text"
+            >
+              Back to dashboard
+            </button>
+          )}
         </div>
       </div>
     );

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4230,7 +4230,13 @@ function SessionsPanel() {
                               e.stopPropagation();
                               selectSession(s);
                             }}
-                            aria-label={`Generate replay for ${sourceSuggestedTitle(s)}`}
+                            aria-label={
+                              generatingSessionKey === sessionIdentityKey(s)
+                                ? `Generating replay for ${sourceSuggestedTitle(s)}`
+                                : transcriptStatus
+                                  ? `Replay unavailable for ${sourceSuggestedTitle(s)}`
+                                  : `Generate replay for ${sourceSuggestedTitle(s)}`
+                            }
                             disabled={generatingSessionKey !== null || !!transcriptStatus}
                             title={
                               generatingSessionKey !== null

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -4230,6 +4230,7 @@ function SessionsPanel() {
                               e.stopPropagation();
                               selectSession(s);
                             }}
+                            aria-label={`Generate replay for ${sourceSuggestedTitle(s)}`}
                             disabled={generatingSessionKey !== null || !!transcriptStatus}
                             title={
                               generatingSessionKey !== null


### PR DESCRIPTION
## User-flow finding

Opening a missing local replay showed only the error text and URL hints. In the local dashboard, there was no recovery action, so the user had to edit the query string manually.

## Fix

Add a local-host recovery button that returns directly to the dashboard and clears stale replay parameters.

## Validation

- Browser smoke: `?session=missing-session` now exposes `Back to dashboard`
- `pnpm lint:check`
- Viewer navigation/session-loader tests