### PR TITLE
fix: label replay playback controls

### DIFF
--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -787,6 +787,11 @@ export default function Player({
                   <button
                     onClick={() => overlayActions.toggleAllOriginals()}
                     className="ui-caption hidden md:flex items-center gap-2"
+                    aria-label={
+                      overlayActions.showAllOriginals
+                        ? "Show modified replay content"
+                        : "Show original replay content"
+                    }
                     title={
                       overlayActions.showAllOriginals
                         ? "Showing originals — click to show modified"
@@ -848,6 +853,7 @@ export default function Player({
                     openCommentDrawer();
                   }}
                   className="md:hidden flex items-center gap-1 text-terminal-dim hover:text-terminal-text transition-colors"
+                  aria-label="Open comments"
                   title="Comments"
                 >
                   <svg

--- a/packages/viewer/src/components/Player.tsx
+++ b/packages/viewer/src/components/Player.tsx
@@ -789,8 +789,8 @@ export default function Player({
                     className="ui-caption hidden md:flex items-center gap-2"
                     aria-label={
                       overlayActions.showAllOriginals
-                        ? "Show modified replay content"
-                        : "Show original replay content"
+                        ? "Original; show modified replay content"
+                        : "Modified; show original replay content"
                     }
                     title={
                       overlayActions.showAllOriginals
@@ -853,7 +853,11 @@ export default function Player({
                     openCommentDrawer();
                   }}
                   className="md:hidden flex items-center gap-1 text-terminal-dim hover:text-terminal-text transition-colors"
-                  aria-label="Open comments"
+                  aria-label={`Open comments${
+                    annotationActions.annotations.length > 0
+                      ? `, ${annotationActions.annotations.length} annotation${annotationActions.annotations.length === 1 ? "" : "s"}`
+                      : ""
+                  }`}
                   title="Comments"
                 >
                   <svg


### PR DESCRIPTION
## User-flow finding

On the replay playback screen, compact icon-only controls such as mobile Comments and the original/modified toggle had empty accessible names. A keyboard or screen-reader user could not tell what they did.

## Fix

Add explicit accessible labels while keeping the existing visual controls and titles.

## Validation

- Playback/navigation tests
- Mobile replay browser smoke: zero unlabeled empty buttons
- `pnpm lint:check`