### PR TITLE
fix: label replay comment actions

### DIFF
--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -851,6 +851,11 @@ const GroupCard = memo(function GroupCard({
             ? `${userCommentCount} comment${userCommentCount > 1 ? "s" : ""}`
             : "Add comment"
         }
+        aria-label={
+          userCommentCount > 0
+            ? `${userCommentCount} comment${userCommentCount > 1 ? "s" : ""}`
+            : "Add comment"
+        }
       >
         {"\uD83D\uDCAC"}
         {userCommentCount > 0 && <span>{userCommentCount}</span>}
@@ -1364,6 +1369,11 @@ function CompactAssistantGroup({
               ? `${groupCommentCount} comment${groupCommentCount > 1 ? "s" : ""}`
               : "Add comment"
           }
+          aria-label={
+            groupCommentCount > 0
+              ? `${groupCommentCount} comment${groupCommentCount > 1 ? "s" : ""}`
+              : "Add comment"
+          }
         >
           {"\uD83D\uDCAC"}
           {groupCommentCount > 0 && <span>{groupCommentCount}</span>}
@@ -1490,6 +1500,9 @@ function CompactAssistantGroup({
                         : "text-terminal-dim hover:text-terminal-blue hover:bg-terminal-blue-subtle opacity-0 group-hover/scene:opacity-100"
                     }`}
                     title={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
+                    aria-label={
+                      count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"
+                    }
                   >
                     {"\uD83D\uDCAC"}
                     {count > 0 && <span>{count}</span>}
@@ -1632,6 +1645,7 @@ function BatchedScenes({
                       : "text-terminal-dim hover:text-terminal-blue hover:bg-terminal-blue-subtle opacity-0 group-hover/scene:opacity-100"
                   }`}
                   title={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
+                  aria-label={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
                 >
                   {"\uD83D\uDCAC"}
                   {count > 0 && <span>{count}</span>}
@@ -1803,6 +1817,9 @@ function ToolBatch({
                         : "text-terminal-dim hover:text-terminal-blue hover:bg-terminal-blue-subtle opacity-0 group-hover/scene:opacity-100"
                     }`}
                     title={count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"}
+                    aria-label={
+                      count > 0 ? `${count} comment${count > 1 ? "s" : ""}` : "Add comment"
+                    }
                   >
                     {"\uD83D\uDCAC"}
                     {count > 0 && <span>{count}</span>}

--- a/packages/viewer/src/components/ConversationView.tsx
+++ b/packages/viewer/src/components/ConversationView.tsx
@@ -1783,6 +1783,11 @@ function ToolBatch({
               ? `${batchCommentCount} comment${batchCommentCount > 1 ? "s" : ""}`
               : "Add comment"
           }
+          aria-label={
+            batchCommentCount > 0
+              ? `${batchCommentCount} comment${batchCommentCount > 1 ? "s" : ""}`
+              : "Add comment"
+          }
         >
           {"\uD83D\uDCAC"}
           {batchCommentCount > 0 && <span>{batchCommentCount}</span>}


### PR DESCRIPTION
## User-flow finding

The replay Comments drawer explained that users should hover message cards, but the compact comment buttons themselves exposed only an icon/title and no accessible name. This made adding or finding comments difficult without a mouse.

## Fix

Add count-aware accessible labels to user, assistant, expanded-scene, and tool-batch comment actions.

## Validation

- Conversation view and annotation tests
- `pnpm lint:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to comment buttons across conversation views, improving support for screen readers and other assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->