### PR TITLE
fix: show clipboard export failures

### DIFF
--- a/packages/viewer/src/components/ExportView.tsx
+++ b/packages/viewer/src/components/ExportView.tsx
@@ -49,19 +49,34 @@ function SectionHeader({ title, color }: { title: string; color: string }) {
   );
 }
 
+export function copyButtonLabel(copied: boolean, failed: boolean, label = "Copy"): string {
+  if (copied) return "Copied!";
+  if (failed) return "Copy failed";
+  return label;
+}
+
 function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
   return (
     <button
       onClick={async () => {
-        await navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        try {
+          await navigator.clipboard.writeText(text);
+          setFailed(false);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        } catch {
+          setCopied(false);
+          setFailed(true);
+          setTimeout(() => setFailed(false), 2000);
+        }
       }}
       className="ui-pill-compact text-terminal-dim hover:text-terminal-text transition-colors rounded bg-terminal-surface hover:bg-terminal-surface-hover border border-terminal-border-subtle"
       title="Copy to clipboard"
+      aria-live="polite"
     >
-      {copied ? "Copied!" : label || "Copy"}
+      {copyButtonLabel(copied, failed, label)}
     </button>
   );
 }

--- a/packages/viewer/src/components/__tests__/export-view.test.tsx
+++ b/packages/viewer/src/components/__tests__/export-view.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { copyButtonLabel } from "../ExportView";
+
+describe("export copy feedback", () => {
+  it("distinguishes copied, failed, and ready states", () => {
+    expect(copyButtonLabel(false, false, "Copy MD")).toBe("Copy MD");
+    expect(copyButtonLabel(true, false, "Copy MD")).toBe("Copied!");
+    expect(copyButtonLabel(false, true, "Copy MD")).toBe("Copy failed");
+  });
+});


### PR DESCRIPTION
## User-flow finding

Clicking `Copy MD` in Share & Export gave no feedback when the browser clipboard API rejected the request (as observed in the local headless/browser flow). The user could not tell whether the export copied successfully.

## Fix

Show `Copy failed` on clipboard rejection while preserving the existing `Copied!` success feedback.

## Validation

- Export copy-state unit test
- Browser share/export flow
- `pnpm lint:check`