### PR TITLE
fix: clarify live session startup

### DIFF
--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -287,13 +287,16 @@ export default function App() {
   useOutsideClick(customRef, closeCustom, customOpen);
 
   if (loadState.status === "loading") {
+    const liveRequested = new URLSearchParams(window.location.search).get("live") === "1";
     return (
       <div className="h-screen bg-terminal-bg flex items-center justify-center">
         <div className="text-center space-y-2">
           <div className="text-terminal-green font-sans font-bold text-sm animate-pulse">
-            LOADING SESSION...
+            {liveRequested ? "CONNECTING TO LIVE SESSION..." : "LOADING SESSION..."}
           </div>
-          <div className="text-terminal-dimmer font-mono text-xs">Preparing replay data</div>
+          <div className="text-terminal-dimmer font-mono text-xs">
+            {liveRequested ? "Waiting for the first live snapshot" : "Preparing replay data"}
+          </div>
         </div>
       </div>
     );

--- a/packages/viewer/src/App.tsx
+++ b/packages/viewer/src/App.tsx
@@ -287,7 +287,12 @@ export default function App() {
   useOutsideClick(customRef, closeCustom, customOpen);
 
   if (loadState.status === "loading") {
-    const liveRequested = new URLSearchParams(window.location.search).get("live") === "1";
+    const loadingParams = new URLSearchParams(window.location.search);
+    const liveRequested =
+      loadingParams.get("live") === "1" &&
+      loadingParams.get("view") !== "dashboard" &&
+      !loadingParams.get("session") &&
+      Boolean(loadingParams.get("provider") && loadingParams.get("sessionId"));
     return (
       <div className="h-screen bg-terminal-bg flex items-center justify-center">
         <div className="text-center space-y-2">


### PR DESCRIPTION
## User-flow finding

Opening Live mode can spend several seconds resolving the source and waiting for the first SSE snapshot. The generic `LOADING SESSION...` message did not tell the user that the live stream was connecting.

## Fix

Show live-specific connecting copy while `?live=1` is loading, including that the first live snapshot is being awaited.

## Validation

- Live session browser smoke and SSE response
- Session-loader/navigation tests
- `pnpm lint:check`