### PR TITLE
fix: clarify insights data quality labels

### DIFF
--- a/packages/viewer/src/components/DataQualityIndicator.tsx
+++ b/packages/viewer/src/components/DataQualityIndicator.tsx
@@ -148,7 +148,7 @@ export function DataQualityIndicator({
       <button
         type="button"
         aria-expanded={open}
-        aria-label="Show data quality details"
+        aria-label={`Show data quality details${lines[0] ? `: ${lines[0]}` : ""}`}
         className="inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-terminal-orange/40 bg-terminal-orange/10 px-1 text-[10px] font-sans font-bold leading-none text-terminal-orange transition-colors hover:border-terminal-orange/70 hover:bg-terminal-orange/15 focus:outline-none focus:ring-2 focus:ring-terminal-orange/30"
         onClick={() => setOpen((value) => !value)}
         onFocus={() => setHovered(true)}

--- a/packages/viewer/src/components/__tests__/data-quality-indicator.test.tsx
+++ b/packages/viewer/src/components/__tests__/data-quality-indicator.test.tsx
@@ -1,0 +1,16 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DataQualityIndicator } from "../DataQualityIndicator";
+
+describe("DataQualityIndicator", () => {
+  it("names the metric context for assistive technology", () => {
+    render(<DataQualityIndicator title="Cost estimate is unavailable\nModel is unknown" />);
+
+    expect(
+      screen.getByRole("button", {
+        name: /Show data quality details: Cost estimate is unavailable/,
+      }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## User-flow finding

Insights and replay metric warnings rendered as `!` indicators with the generic accessible name `Show data quality details`. A screen-reader user could not tell which metric the warning belonged to.

## Fix

Include the first data-quality note in the accessible name while retaining the concise visual indicator and tooltip.

## Validation

- Data quality indicator test
- Insights calendar tests
- `pnpm lint:check`