### PR TITLE
fix: expose selected project relationships

### DIFF
--- a/packages/viewer/src/components/SessionRelationshipsView.tsx
+++ b/packages/viewer/src/components/SessionRelationshipsView.tsx
@@ -1110,6 +1110,7 @@ function FileConnectionsView({
                   setSelectedProject(group.key);
                   setSelectedFile(null);
                 }}
+                aria-pressed={isSelected}
                 className={`w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-200 ease-material ${
                   isSelected
                     ? "border-transparent bg-terminal-green-subtle text-terminal-green shadow-layer-sm"


### PR DESCRIPTION
## User-flow finding

In Projects → Hot Files, project relationship choices were visually highlighted but did not expose their selected state to assistive technology. That made it harder to understand which project/file relationship was active.

## Fix

Expose the selected project state with `aria-pressed` while preserving the existing visual selection.

## Validation

- Session relationships test
- `pnpm lint:check`