### PR TITLE
fix: show Ask Replay request errors

### DIFF
--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -759,7 +759,10 @@ export default function LocalChatAssistant({ context }: Props) {
                 ...current.slice(0, -1),
                 { ...last, content: errorMessage, streaming: false, error: true },
               ]
-            : [...current, { role: "assistant", content: errorMessage, error: true }].slice(-40);
+            : [
+                ...current,
+                { role: "assistant" as const, content: errorMessage, error: true },
+              ].slice(-40);
         });
         setError(err instanceof Error ? err.message : "Assistant request failed");
       }

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -753,9 +753,13 @@ export default function LocalChatAssistant({ context }: Props) {
       } else {
         setMessages((current) => {
           const last = current[current.length - 1];
+          const errorMessage = err instanceof Error ? err.message : "Assistant request failed";
           return last?.role === "assistant" && last.streaming
-            ? [...current.slice(0, -1), { ...last, streaming: false, error: true }]
-            : current;
+            ? [
+                ...current.slice(0, -1),
+                { ...last, content: errorMessage, streaming: false, error: true },
+              ]
+            : [...current, { role: "assistant", content: errorMessage, error: true }].slice(-40);
         });
         setError(err instanceof Error ? err.message : "Assistant request failed");
       }

--- a/packages/viewer/src/components/LocalChatAssistant.tsx
+++ b/packages/viewer/src/components/LocalChatAssistant.tsx
@@ -654,7 +654,7 @@ export default function LocalChatAssistant({ context }: Props) {
       const params = new URLSearchParams(window.location.search);
       const body = {
         messages: nextMessages
-          .filter((message) => remoteDataEnabled || !message.remoteDataUsed)
+          .filter((message) => !message.error && (remoteDataEnabled || !message.remoteDataUsed))
           .map(({ role, content: messageContent }) => ({
             role,
             content: messageContent,
@@ -757,7 +757,12 @@ export default function LocalChatAssistant({ context }: Props) {
           return last?.role === "assistant" && last.streaming
             ? [
                 ...current.slice(0, -1),
-                { ...last, content: errorMessage, streaming: false, error: true },
+                {
+                  ...last,
+                  content: last.content ? `${last.content}\n\n${errorMessage}` : errorMessage,
+                  streaming: false,
+                  error: true,
+                },
               ]
             : [
                 ...current,


### PR DESCRIPTION
## User-flow finding

Ask Replay requests could return an SSE error before any assistant delta. The UI kept the conversation unchanged and only exposed an easily missed generic state, so the user could not see why Ask Replay failed.

## Fix

Append the actual request error as an error assistant message when no streaming message exists, while preserving the existing streaming error replacement.

## Validation

- Viewer suite
- Ask Replay request flow against the local gateway
- `pnpm lint:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Assistant request errors are now displayed clearly in chat.
  - Errors replace an in-progress response when streaming has started, or appear as a new message when it has not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->