### PR TITLE
fix: explain SSH live limitations

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1212,7 +1212,7 @@ export function SessionDetailPopup({
           <div className="flex items-center gap-2">
             {s.location?.kind === "ssh" && s.sessionId && (
               <span
-                className="hidden text-[10px] font-mono text-terminal-dimmer sm:inline"
+                className="max-w-40 text-[10px] font-mono text-terminal-dimmer"
                 title="Live mode is unavailable for SSH sources"
               >
                 Live unavailable for SSH

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -1210,6 +1210,14 @@ export function SessionDetailPopup({
             )}
           </div>
           <div className="flex items-center gap-2">
+            {s.location?.kind === "ssh" && s.sessionId && (
+              <span
+                className="hidden text-[10px] font-mono text-terminal-dimmer sm:inline"
+                title="Live mode is unavailable for SSH sources"
+              >
+                Live unavailable for SSH
+              </span>
+            )}
             {s.sessionId && s.location?.kind !== "ssh" && (
               <button
                 onClick={() => navigateToLive(s.provider, s.sessionId!)}


### PR DESCRIPTION
## User-flow finding

SSH-backed sessions correctly hide the Live button, but the detail popup did not explain why. Users could interpret the missing action as a broken or incomplete session.

## Fix

Show an explicit `Live unavailable for SSH` explanation in the session detail footer.

## Validation

- Dashboard tests
- Remote SSH settings/session flow smoke
- `pnpm lint:check`