### PR TITLE
fix: expose active dashboard tab

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -5746,6 +5746,7 @@ export default function Dashboard({
       key={id}
       type="button"
       onClick={() => handleTabChange(id)}
+      aria-current={tab === id ? "page" : undefined}
       className={`px-3.5 py-1.5 text-xs font-sans font-semibold rounded-lg transition-all duration-200 ease-material ${
         tab === id
           ? "bg-terminal-green-subtle text-terminal-green shadow-layer-sm"


### PR DESCRIPTION
## User-flow finding

The desktop dashboard tab strip used color styling for the active tab but did not expose the active page state to assistive technology. Mobile tabs already had this semantic state.

## Fix

Add `aria-current="page"` to the active desktop tab while preserving the responsive layout.

## Validation

- Dashboard tests
- Mobile/desktop navigation smoke
- `pnpm lint:check`