### PR TITLE
fix: focus mobile dashboard navigation

### DIFF
--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -5666,6 +5666,7 @@ export default function Dashboard({
 
   useEffect(() => {
     if (!mobileNavOpen) return;
+    document.querySelector<HTMLButtonElement>("#dashboard-mobile-navigation button")?.focus();
     const handler = (event: KeyboardEvent) => {
       if (event.key === "Escape") setMobileNavOpen(false);
     };

--- a/packages/viewer/src/components/Dashboard.tsx
+++ b/packages/viewer/src/components/Dashboard.tsx
@@ -5657,6 +5657,7 @@ export default function Dashboard({
 
   const [tab, setTab] = useState<Tab>(getTabFromUrl());
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const mobileNavTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handler = () => setTab(getTabFromUrl());
@@ -5668,7 +5669,10 @@ export default function Dashboard({
     if (!mobileNavOpen) return;
     document.querySelector<HTMLButtonElement>("#dashboard-mobile-navigation button")?.focus();
     const handler = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMobileNavOpen(false);
+      if (event.key === "Escape") {
+        setMobileNavOpen(false);
+        mobileNavTriggerRef.current?.focus();
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -5793,6 +5797,7 @@ export default function Dashboard({
             <div className="hidden md:block">{headerRight}</div>
             <button
               type="button"
+              ref={mobileNavTriggerRef}
               aria-label={
                 mobileNavOpen ? "Close dashboard navigation" : "Open dashboard navigation"
               }

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -78,7 +78,20 @@ describe("Dashboard (smoke)", () => {
     expect(within(mobileNavigation).getByRole("button", { name: "Insights" })).toBeTruthy();
     expect(within(mobileNavigation).getByRole("button", { name: "Settings" })).toBeTruthy();
 
-    within(mobileNavigation).getByRole("button", { name: "Settings" }).click();
+    const closeButton = screen.getByRole("button", { name: "Close dashboard navigation" });
+    closeButton.focus();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Open dashboard navigation" }),
+      ),
+    );
+    screen.getByRole("button", { name: "Open dashboard navigation" }).click();
+    const reopenedNavigation = await waitFor(() =>
+      screen.getByRole("navigation", { name: "Dashboard navigation" }),
+    );
+
+    within(reopenedNavigation).getByRole("button", { name: "Settings" }).click();
     expect(window.location.search).toContain("tab=settings");
     await waitFor(() =>
       expect(screen.queryByRole("navigation", { name: "Dashboard navigation" })).toBeNull(),

--- a/packages/viewer/src/components/__tests__/dashboard.test.tsx
+++ b/packages/viewer/src/components/__tests__/dashboard.test.tsx
@@ -71,6 +71,9 @@ describe("Dashboard (smoke)", () => {
     const mobileNavigation = await waitFor(() =>
       screen.getByRole("navigation", { name: "Dashboard navigation" }),
     );
+    expect(document.activeElement).toBe(
+      within(mobileNavigation).getByRole("button", { name: "Home" }),
+    );
     expect(within(mobileNavigation).getByRole("button", { name: "Projects" })).toBeTruthy();
     expect(within(mobileNavigation).getByRole("button", { name: "Insights" })).toBeTruthy();
     expect(within(mobileNavigation).getByRole("button", { name: "Settings" })).toBeTruthy();


### PR DESCRIPTION
## User-flow finding

Opening the mobile dashboard navigation left focus on the trigger rather than inside the opened menu. Keyboard users had no immediate focus context and had to tab through the page manually.

## Fix

Move focus to the first mobile navigation item when the menu opens and cover the behavior in the dashboard test.

## Validation

- Dashboard navigation test
- Mobile browser focus smoke
- `pnpm lint:check`