### PR TITLE
fix: announce session refresh progress

### DIFF
--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -321,12 +321,13 @@ export function SessionLoadingBanner(props: {
   description: string;
 }) {
   return (
-    <output
+    <div
       aria-live="polite"
+      aria-atomic="true"
       className="mb-3 w-full animate-in fade-in slide-in-from-top-2 duration-300"
     >
       <SessionLoadingRibbon {...props} />
-    </output>
+    </div>
   );
 }
 

--- a/packages/viewer/src/components/SessionDataProgress.tsx
+++ b/packages/viewer/src/components/SessionDataProgress.tsx
@@ -321,12 +321,12 @@ export function SessionLoadingBanner(props: {
   description: string;
 }) {
   return (
-    <div
+    <output
       aria-live="polite"
       className="mb-3 w-full animate-in fade-in slide-in-from-top-2 duration-300"
     >
       <SessionLoadingRibbon {...props} />
-    </div>
+    </output>
   );
 }
 


### PR DESCRIPTION
## User-flow finding

Background session discovery and enrichment displayed progress banners visually, but screen readers were not told that the list was still refreshing.

## Fix

Use the semantic `output` status element for page-level session loading banners so refresh progress is announced without changing the visual layout.

## Validation

- Session data progress test
- `pnpm lint:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated the session loading announcement container to use a semantic output element while preserving its existing live updates, animation, and layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->