### PR TITLE
refactor(cursor): silence unused path matcher argument

### DIFF
--- a/packages/provider-cursor/src/cursor/sqlite-reader.ts
+++ b/packages/provider-cursor/src/cursor/sqlite-reader.ts
@@ -1203,7 +1203,7 @@ function hashWorkspacePaths(paths: string[]): string {
 function normalizeComposerPath(pathValue: string): string {
   return pathValue
     .replaceAll("\\", "/")
-    .replace(/\/{2,}/g, (slashes, offset) => (offset === 0 ? "//" : "/"))
+    .replace(/\/{2,}/g, (_slashes, offset) => (offset === 0 ? "//" : "/"))
     .replace(/[)"',]+$/g, "");
 }
 


### PR DESCRIPTION
## Summary

- Rename the unused `String.replace` match argument in Cursor composer path normalization.
- Net diff: -0 +0 semantic lines; one parameter rename.

## Motivation

The callback only needs the replacement offset; prefixing the unused match with `_` satisfies optional TypeScript no-unused diagnostics while preserving the UNC-path `//` behavior.

## Test plan

- [x] `pnpm test` — all workspace unit tests passed
- [x] `pnpm lint:check` — zero warnings/errors and formatting passed
- [x] `pnpm --filter vibe-replay exec tsc --noEmit` — passed
- [x] `pnpm build` — passed
- [x] `pnpm lint` and pre-commit hook — passed

> 🤖 Daily auto-quality routine. Self-merged after AI review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal parameter name without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->